### PR TITLE
Replacing server group and domain with icons from patternfly

### DIFF
--- a/app/assets/stylesheets/middleware_topology.css
+++ b/app/assets/stylesheets/middleware_topology.css
@@ -8,11 +8,3 @@
     font-size: 20px;
     fill: #555;
 }
-
-.middleware .kube-topology g.MiddlewareDomain text.glyph {
-    font-family: IcoMoon;
-}
-
-.middleware .kube-topology g.MiddlewareServerGroup text.glyph {
-    font-family: IcoMoon;
-}

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareDomainDecorator < Draper::Decorator
   include MiddlewareDecoratorMixin
 
   def fonticon
-    'domain'.freeze
+    'pficon-domain'.freeze
   end
 
   # Determine the icon

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -3,7 +3,7 @@ class MiddlewareServerGroupDecorator < Draper::Decorator
   include MiddlewareDecoratorMixin
 
   def fonticon
-    'server-group'.freeze
+    'pficon-server-group'.freeze
   end
 
   # Determine the icon

--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -15,9 +15,9 @@ module UiServiceMixin
       :MiddlewareDeployment    => {:type => "glyph", :icon => "\uE603", :fontfamily => "icomoon"},                 # product-report
       :MiddlewareDeploymentEar => {:type => "glyph", :icon => "\uE626", :fontfamily => "icomoon"},                 # product-file-ear-o
       :MiddlewareDeploymentWar => {:type => "glyph", :icon => "\uE627", :fontfamily => "icomoon"},                 # product-file-war-o
-      :MiddlewareDomain        => {:type => "glyph", :icon => "\uE639", :fontfamily => "icomoon"},
+      :MiddlewareDomain        => {:type => "glyph", :icon => "\uE919", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-domain
       :MiddlewareMessaging     => {:type => "glyph", :icon => "\uF0EC", :fontfamily => "FontAwesome"},             # fa-exchange (placeholder)
-      :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uE638", :fontfamily => "icomoon"},
+      :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uE91a", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-server-group
       :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
       :Openshift               => {:type => "image", :icon => provider_icon(:Openshift)},
       :OpenshiftEnterprise     => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -49,14 +49,14 @@
         %svg.kube-topology
           %g.MiddlewareDomain{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
-            %text{:x => "0", :y => "8", :class => "domain glyph"} &#xE639;
+            %text{:x => "0", :y => "8", :class => "pficon-domain glyph"} &#xE919;
         %label
           = _("Domains")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServerGroup"}
         %svg.kube-topology
           %g.MiddlewareServerGroup{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
-            %text{:x => "0", :y => "8", :class => "server-group glyph"} &#xE638;
+            %text{:x => "0", :y => "8", :class => "pficon-server-group glyph"} &#xE91A;
         %label
           = _("Server Groups")
 


### PR DESCRIPTION
This PR fixes issue #12361 

![screenshot from 2016-12-02 14-20-03](https://cloud.githubusercontent.com/assets/535866/20835461/1d36acb4-b89b-11e6-9408-c42ac4ffaf30.png)

@miq-bot add_label providers/hawkular, ui, euwe/no

Could you please review, Eric?
@miq-bot assign @epwinchell 