### PR TITLE
Used correct date/time comparison operator for OOTB Policy Events report

### DIFF
--- a/product/reports/520_Events - Policy/120_Policy Events2.yaml
+++ b/product/reports/520_Events - Policy/120_Policy Events2.yaml
@@ -6,7 +6,7 @@ reserved:
 title: Policy Events for the Last 7 Days
 conditions: !ruby/object:MiqExpression
   exp:
-    ">=":
+    "after":
       field: PolicyEvent.miq_policy_sets-created_on
       value: 7 Days Ago
 updated_on: 2009-04-06 20:18:30 Z


### PR DESCRIPTION
Updated deprecated date/time comparison operator ">=" to use the correct operator "after"

That operator was removed for date/time fields in #10295

https://bugzilla.redhat.com/show_bug.cgi?id=1400330