### PR TITLE
Never remember dashboard/maintab as the last visited URL.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1900,6 +1900,15 @@ class ApplicationController < ActionController::Base
     prov_redirect("publish")
   end
 
+  def handle_remember_tab
+    return if request.xml_http_request? || !request.get? || request.format != Mime[:html] ||
+      request.headers['X-Angular-Request'].present?
+
+    return if controller_name == 'dashboard' && action_name == 'maintab'
+
+    remember_tab
+  end
+
   def remember_tab
     section_id = menu_section_id(params)
     return if section_id.nil?
@@ -1948,7 +1957,7 @@ class ApplicationController < ActionController::Base
     session[:host_url] = request.host_with_port
     session[:tab_url] ||= {}
 
-    remember_tab if !request.xml_http_request? && request.get? && request.format == Mime[:html] && request.headers['X-Angular-Request'].nil?
+    handle_remember_tab
 
     # Get all of the global variables used by most of the controllers
     @pp_choices = PPCHOICES


### PR DESCRIPTION
dashboard/maintab is used to go to the last remembered URL under a section so it makes no sense to remember that as the last URL

previously I rewrote the remembering code to be generic, this action needs to be an exception from the generic behavior

fixes https://github.com/ManageIQ/manageiq/issues/12624

Steps for Testing/QA
-------------------------------

Be careful that this fix prevents the wrong value from being remembered. So when you test and the wrong value is already in the session the error will be still there. You need a clean session and start again to properly test this PR.

@hayesr : I think we discussed this on Gitter. Please, take a look.
