### PR TITLE
Remove cache_with_timeout from job_proxy_dispatcher.rb

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -313,10 +313,6 @@ class JobProxyDispatcher
     end
   end
 
-  cache_with_timeout(:coresident_miqproxy, 30.seconds) do
-    MiqServer.my_server.get_config("vmdb").config.fetch_path(:coresident_miqproxy)
-  end
-
   def embedded_resource_limit_exceeded?(job)
     return false unless job.target_class == "VmOrTemplate"
 
@@ -326,10 +322,10 @@ class JobProxyDispatcher
     end
 
     if @vm.scan_via_ems?
-      count_allowed = self.class.coresident_miqproxy[:concurrent_per_ems].to_i
+      count_allowed = ::Settings.coresident_miqproxy.concurrent_per_ems.to_i
     else
       return false if @vm.host_id.nil?  # e.g. EC2 images do not have hosts
-      count_allowed = self.class.coresident_miqproxy[:concurrent_per_host].to_i
+      count_allowed = ::Settings.coresident_miqproxy.concurrent_per_host.to_i
     end
 
     return false if busy_resources_for_embedded_scanning.blank?

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -68,33 +68,22 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
         end
 
         context "and embedded scans on ems" do
-          before(:each) do
-            allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:scan_via_ems?).and_return(true)
-          end
-
           context "and scans against ems limited to 2 and up to 10 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 2})
-            end
-
             it "should dispatch only 2 scan jobs per ems"  do
+              allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:scan_via_ems?).and_return(true)
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(2, :ems)
             end
 
             it "should signal 2 jobs to start" do
+              stub_settings(:coresident_miqproxy => {:concurrent_per_ems => 2},
+                            :ems                 => {:ems_amazon => {}})
               JobProxyDispatcher.dispatch
               expect(MiqQueue.count).to eq(2)
             end
           end
 
           context "and scans against ems limited to 4 and up to 10 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
-            end
-
             it "should dispatch only 4 scan jobs per ems"  do
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(4, :ems)
@@ -102,11 +91,6 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
           end
 
           context "and scans against ems limited to 4 and up to 2 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(2)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_ems => 4})
-            end
-
             it "should dispatch up to 4 per ems and 2 per miqserver"  do
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(4, :ems)
@@ -121,11 +105,6 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
           end
 
           context "and scans against host limited to 2 and up to 10 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 2})
-            end
-
             it "should dispatch only 2 scan jobs per host"  do
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(2, :host)
@@ -133,11 +112,6 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
           end
 
           context "and scans against host limited to 4 and up to 10 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(10)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
-            end
-
             it "should dispatch only 4 scan jobs per host"  do
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(4, :host)
@@ -145,11 +119,6 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
           end
 
           context "and scans against host limited to 4 and up to 2 scans per miqserver" do
-            before(:each) do
-              allow_any_instance_of(MiqServer).to receive(:concurrent_job_max).and_return(2)
-              allow(JobProxyDispatcher).to receive(:coresident_miqproxy).and_return({:concurrent_per_host => 4})
-            end
-
             it "should dispatch up to 4 per host and 2 per miqserver"  do
               JobProxyDispatcher.dispatch
               assert_at_most_x_scan_jobs_per_y_resource(4, :host)


### PR DESCRIPTION
Instead of caching configuration parameter call ```::Settings``` directly since ther ae already in memory.

@miq-bot add-label wip, core