### PR TITLE
Add root password validation regex for Azure dialog

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -69,7 +69,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def update_field_visibility
-    show_dialog(:customize, :show, "disabled")
+    show_dialog(:customize, :show, "enabled")
     super(:force_platform => 'linux')
   end
 

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -355,9 +355,13 @@
           :data_type: :string
         :root_password:
           :description: Password
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /[(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[\W\D].*?]{12,72}$/
           :required: true
           :display: :edit
           :data_type: :string
+          :min_length: 12
+          :max_length: 72
         :hostname:
           :description: Host Name
           :required: false

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -357,6 +357,7 @@
           :description: Password
           :required_method: :validate_regex
           :required_regex: !ruby/regexp /[(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[\W\D].*?]{12,72}$/
+          :required_regex_fail_details: The password must be 12-72 characters, contain at least one lowercase English character, one uppercase English character, and one number.
           :required: true
           :display: :edit
           :data_type: :string


### PR DESCRIPTION
This attempts to add password validation for Azure VM admin/root passwords. The password for a VM must be 12-72 characters long, and contain at least one uppercase character, one lowercase character, and one number.

https://bugzilla.redhat.com/show_bug.cgi?id=1377890

Marked as a WIP for now since the UI doesn't seem to honor the required restrictions, even without this PR.