### PR TITLE
[WIP] Faster MetricRollup min_max value lookup when computing averages/standard deviations ( #ROFLCOPTERSCALE )

### DIFF
--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -39,8 +39,10 @@ module Metric::LongTermAverages
     avg_days = options[:avg_days] || AVG_DAYS
     avg_cols = options[:avg_cols] || AVG_COLS
 
-    ext_options = ext_options.merge(:only_cols => avg_cols)
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(obj, "daily", :end_date => Time.now.utc, :days => avg_days, :ext_options => ext_options)
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(obj,"daily", :end_date => Time.now.utc,
+                                                                          :days => avg_days,
+                                                                          :ext_options => ext_options,
+                                                                          :select => avg_cols)
     perfs.each do |p|
       if ext_options[:time_profile] && !ext_options[:time_profile].ts_day_in_profile?(p.timestamp.in_time_zone(tz))
         next


### PR DESCRIPTION
Prevents unnecessary de-serialization of the min_max column on `MetricRollup` when fetching values for calculating averages and standard deviations across multiple `MetricRollup` records.


Metrics
-------

|        |       ms |  queries |  query (ms) |     rows |
|   ---: |     ---: |     ---: |        ---: |     ---: |
| before |   47,443 |   17,520 |      23,850 |   81,530 |
|  after |   37,654 |   17,520 |      21,705 |   81,530 |


```
Before                                              After

:rows_by_class:                              |      :rows_by_class:
  MiqQueue: 2                                |        MiqQueue: 2
  MiqTask: 2                                 |        MiqTask: 2
  User: 8                                    |        User: 8
  MiqGroup: 4                                |        MiqGroup: 4
  Entitlement: 4                             |        Entitlement: 4
  Tenant: 2                                  |        Tenant: 2
  MiqUserRole: 2                             |        MiqUserRole: 2
  Vm: 18984                                  |        Vm: 18984
  Hardware: 2290                             |        Hardware: 2290
  VimPerformanceOperatingRange: 2304         |        VimPerformanceOperatingRange: 2304
  Disk: 9056                                 |        Disk: 9056
  TimeProfile: 64                            |        TimeProfile: 64
  MetricRollup: 16660                        |        MetricRollup: 16660
  Classification: 32144                      |        Classification: 32144
  MiqReportResult: 4                         |        MiqReportResult: 4
  BinaryBlob: 0                              |        BinaryBlob: 0
:total_queries: 17520                        |      :total_queries: 17520
:total_rows: 81530                           |      :total_rows: 81530
```

A few notes about these metrics:

* These metrics were taken before #12955 was applied
* I am pretty sure (kinda forget... sorry...) these were taken but always "live updating" the VimPerformanceOperatingRange values (setting the conditional to true in `averages_over_time_period`).
* The metrics from #12955 were taken with these changes applied
* They look too perfect... I need to get some new ones again...


Overview
--------
Since the "how" is basically explained in #12955, I will direct you to that if you want an explanation of the SQL that is being done here.  Essential the same concept was used here, just less SQL hackery was needed because the values aren't derived and it is a flat yaml file.

What is necessary to note is how these are affected in a report.  Currently, [`Metric::CiMixin::LongTermAverages.averages_over_time_period`](https://github.com/ManageIQ/manageiq/blob/2d3e2f7a/app/models/metric/ci_mixin/long_term_averages.rb#L15-L30) will make a call to [`Metric::LongTermAverages.get_averages_over_time_period`](https://github.com/ManageIQ/manageiq/blob/2d3e2f7/app/models/metric/long_term_averages.rb#L33-L59) if the `VimPerformanceOperatingRange` is over a day old.

This means if the report is run multiple times a day, the performance improvements seen in this PR will be less noticeable on subsequent runs (best case), but will almost always be noticeable if this is run daily (worst case, and probably more likely), though they will both most likely contribute to performance improvements as a whole.

Also, not all metrics from `VmOrTemplate::RightSizing` (where a lot of calls originate from), flow through `VimPerformanceOperatingRange`, so the updates here are still providing value outside of #12955 (at least I am pretty sure... but don't quote me on that...).


Considerations
--------------
* From what I can tell, `VimPerformanceOperatingRange` is basically caching layer for the values and calculations of the `MetricRollup`, and could potentially be removed given we make fetching those values fast.
* We could consider avoiding the "live update" of `VimPerformanceOperatingRange` 
* Both this PR and #12955 are still making fixes under the assumption that we grab each metric individual for each report record, and many improvements could be if we find ways to bulk fetch metric data (I expand upon this further here:  https://github.com/ManageIQ/manageiq/pull/12955#issuecomment-264504552 ).  In short:  changing the column type may or/may not be the right course of action or provide more improvement.
* Both this and #12955 are hacks, more fixing an existing hotspots, and short term solutions, but are comparatively easy to backport and revert when compared to other suggestions that have been proposed where a database migration is necessary.


Long term we want to try and fetch these metrics together instead of one by one (this comes with it's own problems if you are fetching 25k records in a single swoop that join 20 different tables to get your data values).  There is some ground work here that slightly changes what we have in place and can potentially make strides toward that goal, but the proper solution might be rethinking how we are approaching gathering data for reports in future releases.  Being that this is meant to be a spot fix, this is out of scope for this PR.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/12955/commits
* https://bugzilla.redhat.com/show_bug.cgi?id=1395743#c13
* https://github.com/ManageIQ/manageiq/blob/2d3e2f7a/app/models/metric/ci_mixin/long_term_averages.rb#L15-L30
* https://github.com/ManageIQ/manageiq/blob/2d3e2f7/app/models/metric/long_term_averages.rb#L33-L59