### PR TITLE
Distinguish model/field from plain strings in MiqExpression::Field.valid_field?

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -640,7 +640,7 @@ class MiqExpression
   end
 
   def value_in_sql?(value)
-    !Field.valid_field?(value) || Field.parse(value).attribute_supported_by_sql?
+    !Field.is_field?(value) || Field.parse(value).attribute_supported_by_sql?
   end
 
   def field_in_sql?(field)
@@ -962,7 +962,7 @@ class MiqExpression
   end
 
   def self.quote(val, typ)
-    if Field.valid_field?(val)
+    if Field.is_field?(val)
       ref, value = value2tag(val)
       col_type = get_col_type(val) || "string"
       return ref ? "<value ref=#{ref}, type=#{col_type}>#{value}</value>" : "<value type=#{col_type}>#{value}</value>"
@@ -1643,7 +1643,7 @@ class MiqExpression
   def to_arel(exp, tz)
     operator = exp.keys.first
     field = Field.parse(exp[operator]["field"]) if exp[operator].kind_of?(Hash) && exp[operator]["field"]
-    if(exp[operator].kind_of?(Hash) && exp[operator]["value"] && Field.valid_field?(exp[operator]["value"]))
+    if(exp[operator].kind_of?(Hash) && exp[operator]["value"] && Field.is_field?(exp[operator]["value"]))
       parsed_value = Field.parse(exp[operator]["value"]).arel_attribute
     elsif exp[operator].kind_of?(Hash)
       parsed_value = exp[operator]["value"]

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -25,7 +25,7 @@ class MiqExpression::Field
     column_type == :date
   end
 
-  def self.valid_field?(field)
+  def self.is_field?(field)
     if field.kind_of?(String)
       match = FIELD_REGEX.match(field)
       match.present? && match[:model_name].safe_constantize.present?

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -26,7 +26,10 @@ class MiqExpression::Field
   end
 
   def self.valid_field?(field)
-    FIELD_REGEX.match(field).present? if field.kind_of?(String)
+    if field.kind_of?(String)
+      match = FIELD_REGEX.match(field)
+      match.present? && match[:model_name].safe_constantize.present?
+    end
   end
 
   def datetime?

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -159,13 +159,13 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
-  describe "#valid_field?" do
+  describe "#is_field?" do
     it "detects a valid field" do
-      expect(MiqExpression::Field.valid_field?("Vm-name")).to be_truthy
+      expect(MiqExpression::Field.is_field?("Vm-name")).to be_truthy
     end
 
     it "does not detect a string to looks like a field but isn't" do
-      expect(MiqExpression::Field.valid_field?("NetworkManager-team")).to be_falsey
+      expect(MiqExpression::Field.is_field?("NetworkManager-team")).to be_falsey
     end
   end
 end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -158,4 +158,14 @@ RSpec.describe MiqExpression::Field do
       expect(MiqExpression::Field.parse("Vm-name").attribute_supported_by_sql?).to be_truthy
     end
   end
+
+  describe "#valid_field?" do
+    it "detects a valid field" do
+      expect(MiqExpression::Field.valid_field?("Vm-name")).to be_truthy
+    end
+
+    it "does not detect a string to looks like a field but isn't" do
+      expect(MiqExpression::Field.valid_field?("NetworkManager-team")).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Fixes bug where a string value in an expression was incorrectly quoted because it incorrectly identified the string as "model_name-field_name".

We are using only a regular expression to for this validation. However, there are string values that will also match this pattern that are not model and field names and are instead, plain strings. So, as an additional check, we are now validating that the model_name portion of the string is an actual class.

This bug was causing the OOTB report "VMware Tools Versions" to blow up because the conditions include: `{"field"=>"Vm.guest_applications-name", "value"=>"VMware"}`.

In this case the guest application name is ""NetworkManager-team". This change will not detect this as a model and field.