### PR TITLE
Update Cloud Image View to Differentiate Between Snapshots and Non-Snapshots

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,6 +1,14 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
   default_value_for :cloud, true
 
+  def image?
+    genealogy_parent.nil?
+  end
+
+  def snapshot?
+    !genealogy_parent.nil?
+  end
+
   def self.eligible_for_provisioning
     super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
                             ManageIQ::Providers::Openstack::CloudManager::Template

--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -24,6 +24,7 @@ cols:
 - allocated_disk_storage
 - last_scan_on
 - region_description
+- image?
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -46,6 +47,7 @@ include_for_find:
 col_order:
 - name
 - ext_management_system.name
+- image?
 - last_compliance_status
 - allocated_disk_storage
 - hardware.bitness
@@ -58,6 +60,7 @@ col_order:
 headers:
 - Name
 - Provider
+- Type
 - Compliant
 - Allocated Size
 - Architecture
@@ -67,7 +70,7 @@ headers:
 - Region
 
 # Condition(s) string for the SQL query
-conditions: 
+conditions:
 
 # Order string for the SQL query
 order: Ascending
@@ -90,8 +93,8 @@ group: n
 #   StackedColumn
 #   StackedThreedColumn
 
-graph: 
+graph:
 
 # Dimensions of graph (1 or 2)
 #   Note: specifying 2 for a single dimension graph may not return expected results
-dims: 
+dims:

--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -41,6 +41,7 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
+  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)


### PR DESCRIPTION
This PR updates the Cloud Image view with a Type column that identifies Cloud Images as Snapshots if they descend from a parent VM.

![screenshot at 2016-12-02 15 51 48](https://cloud.githubusercontent.com/assets/628956/20850033/5eb71e7e-b8a7-11e6-86f1-cf889413ba46.png)

@tzumainn 