### PR TITLE
Don't try to access the database when validating a new subscription

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -198,6 +198,7 @@ class PglogicalSubscription < ActsAsArModel
 
   # sets this instance's password field to the one in the subscription dsn in the database
   def find_password
+    return password if password.present?
     s = pglogical.subscription_show_status(id).symbolize_keys
     dsn_hash = PG::DSNParser.parse(s.delete(:provider_dsn))
     self.password = dsn_hash[:password]

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -404,5 +404,18 @@ describe PglogicalSubscription do
         .with("another-example.net", 5423, "root", "p=as' s'", "vmdb's_test")
       sub.validate('host' => "another-example.net", 'port' => 5423)
     end
+
+    it "validates a subscription that has not been saved without accessing the database" do
+      sub = described_class.new
+      sub.host     = "my.example.com"
+      sub.password = "thepassword"
+      sub.user     = "root"
+      sub.dbname   = "vmdb_production"
+
+      expect(pglogical).not_to receive(:subscription_show_status)
+      expect(MiqRegionRemote).to receive(:validate_connection_settings)
+        .with("my.example.com", nil, "root", "thepassword", "vmdb_production")
+      sub.validate
+    end
   end
 end


### PR DESCRIPTION
The change made in bd9bb193edb19d0870efcbd0ed99c3a44dfd3226 to combine validating a new and existing subscription made us attempt to fetch the password from the database when validating a subscription that didn't exist in the database yet.

https://bugzilla.redhat.com/show_bug.cgi?id=1395826

@gtanzillo please review
/cc @yrudman 