### PR TITLE
Remove on-the-fly creating of VimPerformanceOperatingRanges

### DIFF
--- a/app/models/metric/ci_mixin/long_term_averages.rb
+++ b/app/models/metric/ci_mixin/long_term_averages.rb
@@ -10,22 +10,25 @@ module Metric::CiMixin::LongTermAverages
     end
   end
 
+  def generate_vim_performance_operating_ranges
+    # TODO: Support generation for all known TimeProfiles
+    generate_vim_performance_operating_range(TimeProfile.default_time_profile)
+  end
+
   private
 
+  def generate_vim_performance_operating_range(time_profile)
+    vpor = vim_performance_operating_ranges
+           .create_with(:days => Metric::LongTermAverages::AVG_DAYS)
+           .find_or_create_by(:time_profile => time_profile)
+    vpor.recalculate_values
+    vpor.save!
+  end
+
   def averages_over_time_period(col, typ)
-    # there is only ever 1 of these. It has days = 30 (AVG_DAYS)
-    vpor = vim_performance_operating_ranges.detect do |rec|
-      rec.days == Metric::LongTermAverages::AVG_DAYS
-    end
-
-    if vpor.nil? || vpor.updated_at.utc < 1.day.ago.utc
-      vpor ||= vim_performance_operating_ranges.build(:days => Metric::LongTermAverages::AVG_DAYS)
-      options = {:avg_days => Metric::LongTermAverages::AVG_DAYS}
-      averages = Metric::LongTermAverages.get_averages_over_time_period(self, options)
-
-      vpor.update_attributes(:values => averages)
-    end
-
-    vpor.values_to_metrics["#{col}_#{typ}_over_time_period"]
+    # TODO: Deal with choosing the right TimeProfile.  See #generate_vim_performance_operating_ranges
+    #   For now just use the one vpor which is tied to the default TimeProfile.
+    vpor = vim_performance_operating_ranges.first
+    vpor.nil? ? 0 : vpor.values_to_metrics["#{col}_#{typ}_over_time_period"]
   end
 end

--- a/app/models/metric/ci_mixin/rollup.rb
+++ b/app/models/metric/ci_mixin/rollup.rb
@@ -99,7 +99,12 @@ module Metric::CiMixin::Rollup
       Benchmark.realtime_block(:db_update_perf) { perf.update_attributes(new_perf) }
       Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
 
-      Benchmark.realtime_block(:process_bottleneck) { BottleneckEvent.generate_future_events(self) } if interval_name == 'hourly'
+      case interval_name
+      when "hourly"
+        Benchmark.realtime_block(:process_bottleneck) { BottleneckEvent.generate_future_events(self) }
+      when "daily"
+        Benchmark.realtime_block(:process_operating_ranges) { generate_vim_performance_operating_ranges }
+      end
 
       perf_rollup_to_parents(interval_name, time)
     end

--- a/app/models/vim_performance_operating_range.rb
+++ b/app/models/vim_performance_operating_range.rb
@@ -6,6 +6,14 @@ class VimPerformanceOperatingRange < ApplicationRecord
 
   DEFAULT_STD_DEV_MULT = 1
 
+  def recalculate_values
+    self.values = Metric::LongTermAverages.get_averages_over_time_period(
+      resource,
+      :avg_days    => days,
+      :ext_options => {:time_profile => time_profile}
+    )
+  end
+
   def values_to_metrics(options = {})
     options[:std_dev_mult] ||= DEFAULT_STD_DEV_MULT
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -611,7 +611,7 @@ describe Metric do
         end
       end
 
-      context "testing operating ranges and right-sizing with Vm daily performances for several days" do
+      context "#generate_vim_performance_operating_ranges" do
         before do
           Timecop.travel(Time.parse("2010-05-01T00:00:00Z"))
           cases = [
@@ -644,12 +644,17 @@ describe Metric do
         end
 
         it "should calculate the correct normal operating range values" do
+          @vm1.generate_vim_performance_operating_ranges
+
           expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.692)
           expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.085)
         end
 
         it "should calculate the correct right-size values" do
           allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:mem_recommendation_minimum).and_return(0)
+
+          @vm1.generate_vim_performance_operating_ranges
+          @vm2.generate_vim_performance_operating_ranges
 
           expect(@vm1.recommended_vcpus).to eq(1)
           expect(@vm1.recommended_mem).to eq(4)

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -465,58 +465,6 @@ describe Metric do
           end
         end
 
-        context "testing operating ranges and right-sizing with Vm daily performances for several days" do
-          before(:each) do
-            Timecop.travel(Time.parse("2010-05-01T00:00:00Z"))
-            cases = [
-              "2010-04-13T21:00:00Z",  9.14, 32.85,
-              "2010-04-14T18:00:00Z", 10.23, 28.76,
-              "2010-04-14T19:00:00Z", 18.92, 39.11,
-              "2010-04-14T20:00:00Z",  7.34, 28.87,
-              "2010-04-14T21:00:00Z",  8.00, 29.99,
-              "2010-04-14T22:00:00Z", 15.00, 41.59,
-              "2010-04-15T21:00:00Z", 27.22, 30.43,
-            ]
-            cases.each_slice(3) do |t, cpu, mem|
-              [@vm1, @vm2].each do |vm|
-                vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_daily,
-                                                        :timestamp                  => t,
-                                                        :cpu_usage_rate_average     => cpu,
-                                                        :mem_usage_absolute_average => mem,
-                                                        :min_max                    => {
-                                                          :max_cpu_usage_rate_average     => cpu,
-                                                          :max_mem_usage_absolute_average => mem,
-                                                        },
-                                                        :time_profile               => @time_profile
-                                                       )
-              end
-            end
-          end
-
-          after(:each) do
-            Timecop.return
-          end
-
-          it "should calculate the correct normal operating range values" do
-            expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.692)
-            expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.085)
-          end
-
-          it "should calculate the correct right-size values" do
-            allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:mem_recommendation_minimum).and_return(0)
-
-            expect(@vm1.recommended_vcpus).to eq(1)
-            expect(@vm1.recommended_mem).to eq(4)
-            expect(@vm1.overallocated_vcpus_pct).to eq(0)
-            expect(@vm1.overallocated_mem_pct).to eq(0)
-
-            expect(@vm2.recommended_vcpus).to eq(1)
-            expect(@vm2.recommended_mem).to eq(1356)
-            expect(@vm2.overallocated_vcpus_pct).to be_within(0.01).of(50.0)
-            expect(@vm2.overallocated_mem_pct).to   be_within(0.01).of(66.9)
-          end
-        end
-
         context "and Host realtime performances" do
           before(:each) do
             cases = [
@@ -660,6 +608,58 @@ describe Metric do
               expect(@host1.get_performance_metric(:realtime, :cpu_usage_rate_average, "2010-04-14T20:52:40Z".to_time(:utc), :max)).to eq(100.0)
             end
           end
+        end
+      end
+
+      context "testing operating ranges and right-sizing with Vm daily performances for several days" do
+        before do
+          Timecop.travel(Time.parse("2010-05-01T00:00:00Z"))
+          cases = [
+            "2010-04-13T21:00:00Z",  9.14, 32.85,
+            "2010-04-14T18:00:00Z", 10.23, 28.76,
+            "2010-04-14T19:00:00Z", 18.92, 39.11,
+            "2010-04-14T20:00:00Z",  7.34, 28.87,
+            "2010-04-14T21:00:00Z",  8.00, 29.99,
+            "2010-04-14T22:00:00Z", 15.00, 41.59,
+            "2010-04-15T21:00:00Z", 27.22, 30.43,
+          ]
+          cases.each_slice(3) do |t, cpu, mem|
+            [@vm1, @vm2].each do |vm|
+              vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_daily,
+                                                      :timestamp                  => t,
+                                                      :cpu_usage_rate_average     => cpu,
+                                                      :mem_usage_absolute_average => mem,
+                                                      :min_max                    => {
+                                                        :max_cpu_usage_rate_average     => cpu,
+                                                        :max_mem_usage_absolute_average => mem,
+                                                      },
+                                                      :time_profile               => @time_profile
+                                                     )
+            end
+          end
+        end
+
+        after do
+          Timecop.return
+        end
+
+        it "should calculate the correct normal operating range values" do
+          expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.692)
+          expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.085)
+        end
+
+        it "should calculate the correct right-size values" do
+          allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:mem_recommendation_minimum).and_return(0)
+
+          expect(@vm1.recommended_vcpus).to eq(1)
+          expect(@vm1.recommended_mem).to eq(4)
+          expect(@vm1.overallocated_vcpus_pct).to eq(0)
+          expect(@vm1.overallocated_mem_pct).to eq(0)
+
+          expect(@vm2.recommended_vcpus).to eq(1)
+          expect(@vm2.recommended_mem).to eq(1356)
+          expect(@vm2.overallocated_vcpus_pct).to be_within(0.01).of(50.0)
+          expect(@vm2.overallocated_mem_pct).to   be_within(0.01).of(66.9)
         end
       end
     end


### PR DESCRIPTION
Instead, favor their creation at the end of daily rollups.

This PR moves the creating of VimPerformanceOperatingRanges as part of the daily rollups.  Since the records are essentially calculations on the latest daily rollups, this seems like a good place to do it.  By removing it being calculated and saved on the fly, we are also removing it from report generation time, which is an expensive time to do it as all calculations are done serially at that moment.  That is, if you create a report with thousands of VMs, every Vm has to calculate and create a VimPerformanceOperatingRange, and it is done serially.  In this PR, you benefit from the paralellism that the rollup mechanism provides, and then at report time, you expect the VimPerformanceOperatingRange record to just exist.

@NickLaMuro Please review.  This code is WIP as there are a couple of outstanding questions I have, plus I need to add a lot of specs.  However, can you run this through your Voldereport and see what kind of benefit you get?  I would love to see the Before/After chart you have from your other PRs.

### Links

- #12968 - [WIP] Faster MetricRollup min_max value lookup when computing averages/standard deviations ( #ROFLCOPTERSCALE )
- #12955 - [WIP] Add virtual_attributes to VimPerformanceOperatingRange (#ROFLSCALE)
- #12737 - [WIP] Cache TimeProfiles when building reports (kinda a hack...)

My thinking is that this PR might obviate #12737 and minimize the impact of #12955 and #12968, but I'm not 100% sure.

### Questions

- [x] In Metric::CiMixin::LongTermAverages#averages_over_time_period, why don't we care about TimeProfiles?
- [x] In Metric::CiMixin::LongTermAverages#averages_over_time_period, how do we deal with vpors that are not updating (say, C&U is broken). The old code checked `vpor.nil? || vpor.updated_at.utc < 1.day.ago.utc` but we need to rely on the vpor's existence.  Perhaps we can create a schedule to update any vpors that are older than a day old?
- [x]  In Metric::CiMixin::LongTermAverages#averages_over_time_period, I am defaulting a missing vpor to 0.  Is that right?