### PR TITLE
add ae_service for google auth_key_pair

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-auth_key_pair.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-google-cloud_manager-auth_key_pair.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Google_CloudManager_AuthKeyPair < MiqAeServiceAuthPrivateKey
+  end
+end


### PR DESCRIPTION
PR #12443 is failing in [miq_ae_service_spec:102](https://github.com/ManageIq/manageiq/blob/master/spec/lib/miq_automation_engine/miq_ae_service_spec.rb#L102) because while there is a `ManageIQ::Providers::Google::CloudManager::AuthKeyPair` defined, there is no miq ae service equivalent.

@blomquisg @gmcculloug or @durandom may have an opinion here.

Of note, there are a number of service proxies for auth key pair subclasses.
