### PR TITLE
Don't queue ntp reload on newly created zones

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -25,7 +25,7 @@ class Zone < ApplicationRecord
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
 
   before_destroy :check_zone_in_use_on_destroy
-  after_save     :queue_ntp_reload_if_changed
+  after_update   :queue_ntp_reload_if_changed
 
   include AuthenticationMixin
 


### PR DESCRIPTION
When you create a new zone, no reason to ask all active servers to reload their ntp settings.

you see, when creating a zone, the old settings were blank, so it always thinks the settings have changed.

@Fryguy / @carbonin not sure if you feel safer always kicking it off.
In test, these queries get called for every zone created (which is a bunch)
In production, probably not so many.

(but this PR is because it was causing problems for me in tests)