### PR TITLE
Use empty string for nil in hardware.bitness in lists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -894,7 +894,7 @@ class ApplicationController < ActionController::Base
         when 'state'
           celltext = row[col].titleize
         when 'hardware.bitness'
-          celltext = row[col].nil? ? row[col] : "#{row[col]} bit"
+          celltext = row[col] ? "#{row[col]} bit" : ''
         else
           # Use scheduled tz for formatting, if configured
           if ['miqschedule'].include?(view.db.downcase)


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/12740
when col `hardware.bitness` is nil then this column
is skipped but its header is still present and
it causes broken table

`root.first[:cells]` should have same columns as is presented in
`view.col_order` 

before
![screen shot 2016-12-05 at 14 38 52](https://cloud.githubusercontent.com/assets/14937244/20886909/a80156c8-baf8-11e6-961e-02dc5f2028b6.png)

after
![screen shot 2016-12-05 at 14 36 16](https://cloud.githubusercontent.com/assets/14937244/20886845/49c82154-baf8-11e6-8d41-5f4e897a5cb0.png)

**Test scenario**
for example
Compute -> Cloud -> Images and list view 
in all places where was column `hardware.bitness` (Architecture)

@miq-bot add_label bug, ui, euwe/yes
@miq-bot assign @mzazrivec 
