### PR TITLE
Fix selection of a node in Snapshot tree

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -262,6 +262,7 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+      @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @active = !['root', nil].include?(@snapshot_tree.selected_node)
       @button_group = "snapshot"

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -264,7 +264,12 @@ module VmCommon
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
       @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
-      @active = !['root', nil].include?(@snapshot_tree.selected_node)
+      @active = if @snapshot_tree.selected_node
+                  snap_selected = Snapshot.find_by_id(from_cid(@snapshot_tree.selected_node.split('-').last))
+                  snap_selected.current?
+                else
+                  false
+                end
       @button_group = "snapshot"
     elsif @display == "devices"
       drop_breadcrumb(:name => @record.name + _(" (Devices)"),
@@ -447,7 +452,7 @@ module VmCommon
                                               true,
                                               :root          => @record,
                                               :selected_node => session[:snap_selected])
-    @active = @snap_selected.current.to_i == 1 if @snap_selected
+    @active = @snap_selected.current? if @snap_selected
     @button_group = "snapshot"
     @explorer = true
     c_tb = build_toolbar("x_vm_center_tb")

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -12,7 +12,7 @@ class TreeBuilderSnapshots < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true}
+    {:full_ids => true, :selected_node => @selected_node}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -430,7 +430,8 @@ class TreeNodeBuilder
 
   def snapshot_node
     generic_node(object.name, 'snapshot.png', object.name)
-    if (options[:selected_node].present? && @node[:key] == options[:selected_node]) || object.children.empty?
+    if (options[:selected_node].present? && @node[:key] == options[:selected_node]) ||
+       (options[:selected_node].nil? && object.children.empty?)
       @node[:highlighted] = true
     end
     @node[:title] += _(' (Active)') if object.current?

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -430,6 +430,9 @@ class TreeNodeBuilder
 
   def snapshot_node
     generic_node(object.name, 'snapshot.png', object.name)
+    if (options[:selected_node].present? && @node[:key] == options[:selected_node]) || object.children.empty?
+      @node[:highlighted] = true
+    end
     @node[:title] += _(' (Active)') if object.current?
   end
 

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -905,7 +905,8 @@ describe TreeNodeBuilder do
         :title   => snapshot.name,
         :icon    => "100/snapshot.png",
         :tooltip => snapshot.name,
-        :expand  => false
+        :expand  => false,
+        :highlighted => true
       )
     end
 
@@ -913,10 +914,10 @@ describe TreeNodeBuilder do
       storage = FactoryGirl.build(:storage)
       node = TreeNodeBuilder.build(storage, nil, {})
       expect(node).to eq(
-        :key    => "-#{storage.name}",
-        :title  => storage.name,
-        :icon   => "100/storage.png",
-        :expand => false
+        :key         => "-#{storage.name}",
+        :title       => storage.name,
+        :icon        => "100/storage.png",
+        :expand      => false,
       )
     end
 

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -901,11 +901,11 @@ describe TreeNodeBuilder do
       snapshot = FactoryGirl.build(:snapshot, :name => "Polaroid Picture")
       node = TreeNodeBuilder.build(snapshot, nil, {})
       expect(node).to eq(
-        :key     => "-#{snapshot.name}",
-        :title   => snapshot.name,
-        :icon    => "100/snapshot.png",
-        :tooltip => snapshot.name,
-        :expand  => false,
+        :key         => "-#{snapshot.name}",
+        :title       => snapshot.name,
+        :icon        => "100/snapshot.png",
+        :tooltip     => snapshot.name,
+        :expand      => false,
         :highlighted => true
       )
     end
@@ -914,10 +914,10 @@ describe TreeNodeBuilder do
       storage = FactoryGirl.build(:storage)
       node = TreeNodeBuilder.build(storage, nil, {})
       expect(node).to eq(
-        :key         => "-#{storage.name}",
-        :title       => storage.name,
-        :icon        => "100/storage.png",
-        :expand      => false,
+        :key    => "-#{storage.name}",
+        :title  => storage.name,
+        :icon   => "100/storage.png",
+        :expand => false,
       )
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1398239

Before:
node is not selected at init

After:
node is selected at init

- [x] selection of a node
- [x] lazy loading will be solved for every tree by https://github.com/ManageIQ/manageiq/pull/12986

@miq-bot  add_label wip, ui, bug, euwe/yes