### PR TITLE
Reintroduce start_url w/o using the session.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -82,6 +82,10 @@ class DashboardController < ApplicationController
     render :action => "show"
   end
 
+  def start_url
+    redirect_to start_url_for_user(nil)
+  end
+
   def show
     @layout    = "dashboard"
     @dashboard = true

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -7,7 +7,7 @@
       %span.icon-bar
       %span.icon-bar
       %span.icon-bar
-    %a.navbar-brand{:href => '#', :style => "cursor: default"}
+    %a.navbar-brand{:href => '/dashboard/start_url', :title => _("Go to my start page")}
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
@@ -17,7 +17,7 @@
           %span.fa{"ng-class" => "{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"}
           %span.badge.info{"ng-show" => "vm.newNotifications"}
             -# Small circle
-            &#8226
+            &#8226;
       %li.dropdown
         %a{:class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu1",  "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}
           %span.fa.pficon-help{:title => _("Help")}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -975,6 +975,7 @@ Vmdb::Application.routes.draw do
         timeline
         timeline_data
         widget_to_pdf
+        start_url
       ),
       :post => %w(
         external_authenticate


### PR DESCRIPTION
Reimplement feature from https://github.com/ManageIQ/manageiq/commit/4f9fbe9b4512c732ddb13d9fc88451f8414a8ae5
reverted in https://github.com/ManageIQ/manageiq/pull/11675 

w/o using the session.

@chrisarcand : please, review?

@epwinchell : I guess the icons should be now the hand, right?