### PR TITLE
Toolbar refactoring  report

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -205,4 +205,8 @@ module Sandbox
   def edit_typ
     sandbox[:edit_typ]
   end
+
+  def active_tab
+    sandbox[:active_tab]
+  end
 end

--- a/app/helpers/application_helper/button/miq_report_action.rb
+++ b/app/helpers/application_helper/button/miq_report_action.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqReportAction < ApplicationHelper::Button::Basic
+  def visible?
+    @view_context.active_tab != 'saved_reports'
+  end
+end

--- a/app/helpers/application_helper/button/miq_report_edit.rb
+++ b/app/helpers/application_helper/button/miq_report_edit.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::MiqReportEdit < ApplicationHelper::Button::Basic
+  include ApplicationHelper::Button::Mixins::XActiveTreeMixin
+
+  def visible?
+    reports_tree? ? custom_report_info? : true
+  end
+
+  private
+
+  def custom_report_info?
+    @view_context.active_tab == 'report_info' && @record.rpt_type == 'Custom'
+  end
+end

--- a/app/helpers/application_helper/button/miq_report_edit.rb
+++ b/app/helpers/application_helper/button/miq_report_edit.rb
@@ -1,5 +1,6 @@
 class ApplicationHelper::Button::MiqReportEdit < ApplicationHelper::Button::Basic
   include ApplicationHelper::Button::Mixins::XActiveTreeMixin
+  needs :@record
 
   def visible?
     reports_tree? ? custom_report_info? : true

--- a/app/helpers/application_helper/button/mixins/x_active_tree_mixin.rb
+++ b/app/helpers/application_helper/button/mixins/x_active_tree_mixin.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper::Button::Mixins::XActiveTreeMixin
+  # This method basically does the following things:
+  #   - Checks whether the not implemented method's name
+  #     has a "_tree?" suffix or not.
+  #   - In case it does have the suffix, it then looks up
+  #     the active tree in the @view_context and checks it
+  #     against the method's name without ''?'. E.g.:
+  #     in case of method call ':reports_tree?' it will check
+  #     whether @view_context.x_active_tree == :reports_tree.
+  #   - Otherwise it raises an error.
   def method_missing(name, *_args, &_block)
     return active_tree?(name.to_s) if tree_method?(name.to_s)
     raise NoMethodError

--- a/app/helpers/application_helper/button/mixins/x_active_tree_mixin.rb
+++ b/app/helpers/application_helper/button/mixins/x_active_tree_mixin.rb
@@ -1,0 +1,18 @@
+module ApplicationHelper::Button::Mixins::XActiveTreeMixin
+  def method_missing(name, *_args, &_block)
+    return active_tree?(name.to_s) if tree_method?(name.to_s)
+    raise NoMethodError
+  end
+
+  def tree_method?(name)
+    name =~ /^.+_tree\?$/
+  end
+
+  def tree_method(name)
+    name.scan(/^(.+_tree)\?$/).first.first
+  end
+
+  def active_tree?(name)
+    @view_context.x_active_tree == tree_method(name).to_sym
+  end
+end

--- a/app/helpers/application_helper/button/reload.rb
+++ b/app/helpers/application_helper/button/reload.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::Reload < ApplicationHelper::Button::Basic
+  include ApplicationHelper::Button::Mixins::XActiveTreeMixin
+
+  def visible?
+    return saved_report? if reports_tree?
+    return root? if savedreports_tree?
+    true
+  end
+
+  private
+
+  def saved_report?
+    @view_context.active_tab == 'saved_reports'
+  end
+
+  def root?
+    @view_context.x_node == 'root'
+  end
+end

--- a/app/helpers/application_helper/button/saved_report_delete.rb
+++ b/app/helpers/application_helper/button/saved_report_delete.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::SavedReportDelete < ApplicationHelper::Button::Basic
+  include ApplicationHelper::Button::Mixins::XActiveTreeMixin
+
+  def visible?
+    reports_tree? ? saved_report? : true
+  end
+
+  private
+
+  def saved_report?
+    @view_context.active_tab == 'saved_reports'
+  end
+end

--- a/app/helpers/application_helper/button/view_ght.rb
+++ b/app/helpers/application_helper/button/view_ght.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::ViewGHT < ApplicationHelper::Button::Basic
+  include ApplicationHelper::Button::Mixins::XActiveTreeMixin
+
+  def visible?
+    reports_tree? || savedreports_tree? ? proper_type? : true
+  end
+
+  private
+
+  def proper_type?
+    @ght_type != "tabular" || @report.try(:graph).present? || @zgraph
+  end
+end

--- a/app/helpers/application_helper/button/widget_generate_content.rb
+++ b/app/helpers/application_helper/button/widget_generate_content.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Button::WidgetGenerateContent < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @view_context.sandbox[:wtype] != 'm'
+  end
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if @error_message.present?
+  end
+
+  def disabled?
+    @error_message = _('This Widget content generation is already running or queued up') if @widget_running
+    @error_message = _('Widget has to be assigned to a dashboard to generate content') if @record.memberof.count <= 0
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/widget_new.rb
+++ b/app/helpers/application_helper/button/widget_new.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::WidgetNew < ApplicationHelper::Button::Basic
+  def visible?
+    @view_context.x_node != 'root'
+  end
+end

--- a/app/helpers/application_helper/toolbar/miq_report_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_center.rb
@@ -4,7 +4,8 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
       :miq_report_run,
       'fa fa-play-circle-o fa-lg',
       N_('Queue this Report to be generated'),
-      N_('Queue')),
+      N_('Queue'),
+      :klass => ApplicationHelper::Button::MiqReportAction),
   ])
   button_group('report_vmdb', [
     select(
@@ -17,17 +18,20 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
           :miq_report_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Report'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportAction),
         button(
           :miq_report_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Report'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportEdit),
         button(
           :miq_report_copy,
           'fa fa-files-o fa-lg',
           t = N_('Copy this Report'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportAction),
         button(
           :saved_report_delete,
           'pficon pficon-delete fa-lg',
@@ -36,19 +40,22 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
           :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+",
-          :confirm   => N_("Warning: The selected Saved Reports will be permanently removed from the database!")),
+          :confirm   => N_("Warning: The selected Saved Reports will be permanently removed from the database!"),
+          :klass     => ApplicationHelper::Button::SavedReportDelete),
         button(
           :miq_report_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Delete this Report from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: The selected Reports will be permanently removed from the database!")),
+          :confirm   => N_("Warning: The selected Reports will be permanently removed from the database!"),
+          :klass     => ApplicationHelper::Button::MiqReportEdit),
         button(
           :miq_report_schedule_add,
           'fa fa-clock-o fa-lg',
           t = N_('Add a new Schedule'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportAction),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
@@ -10,7 +10,8 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
           :miq_report_schedule_add,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Schedule'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportAction),
         button(
           :miq_report_schedule_edit,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_reports_center.rb
@@ -10,7 +10,8 @@ class ApplicationHelper::Toolbar::MiqReportsCenter < ApplicationHelper::Toolbar:
           :miq_report_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Report'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::MiqReportAction),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_widget_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widget_center.rb
@@ -29,7 +29,8 @@ class ApplicationHelper::Toolbar::MiqWidgetCenter < ApplicationHelper::Toolbar::
           'fa fa-cog fa-lg',
           t = N_('Generate Widget content now'),
           t,
-          :confirm => N_("Are you sure you want initiate content generation for this Widget now?")),
+          :confirm => N_("Are you sure you want initiate content generation for this Widget now?"),
+          :klass   => ApplicationHelper::Button::WidgetGenerateContent),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_widgets_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widgets_center.rb
@@ -17,7 +17,8 @@ class ApplicationHelper::Toolbar::MiqWidgetsCenter < ApplicationHelper::Toolbar:
           :widget_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Widget'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::WidgetNew),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/report_view.rb
+++ b/app/helpers/application_helper/toolbar/report_view.rb
@@ -6,21 +6,24 @@ class ApplicationHelper::Toolbar::ReportView < ApplicationHelper::Toolbar::Basic
       N_('Graph View'),
       nil,
       :url       => "explorer",
-      :url_parms => "?type=graph"),
+      :url_parms => "?type=graph",
+      :klass     => ApplicationHelper::Button::ViewGHT),
     twostate(
       :view_hybrid,
       'fa fa fa-th-list',
       N_('Hybrid View'),
       nil,
       :url       => "explorer",
-      :url_parms => "?type=hybrid"),
+      :url_parms => "?type=hybrid",
+      :klass     => ApplicationHelper::Button::ViewGHT),
     twostate(
       :view_tabular,
       'product product-report',
       N_('Tabular View'),
       nil,
       :url       => "explorer",
-      :url_parms => "?type=tabular"),
+      :url_parms => "?type=tabular",
+      :klass     => ApplicationHelper::Button::ViewGHT),
   ])
   button_group('download_main', [
     select(

--- a/app/helpers/application_helper/toolbar/saved_report_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_report_center.rb
@@ -20,7 +20,8 @@ class ApplicationHelper::Toolbar::SavedReportCenter < ApplicationHelper::Toolbar
           t = N_('Delete this Saved Report from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Saved Report and ALL of its components will be permanently removed!")),
+          :confirm   => N_("Warning: This Saved Report and ALL of its components will be permanently removed!"),
+          :klass     => ApplicationHelper::Button::SavedReportDelete),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -5,7 +5,8 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
       'fa fa-repeat fa-lg',
       N_('Reload selected Reports'),
       nil,
-      :url => "reload"),
+      :url   => "reload",
+      :klass => ApplicationHelper::Button::Reload)
   ])
   button_group('saved_report_vmdb', [
     select(
@@ -32,7 +33,8 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Saved Reports will be permanently removed from the database!"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::SavedReportDelete),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -442,8 +442,7 @@ class ApplicationHelper::ToolbarBuilder
       when "saved_report_delete", "reload"
         return @sb[:active_tab] != "saved_reports"
       when "miq_report_edit", "miq_report_delete"
-        return @sb[:active_tab] == "report_info" && @record.rpt_type == "Custom" ?
-               false : true
+        return @sb[:active_tab] != "report_info" || @record.rpt_type != "Custom"
       when "miq_report_copy", "miq_report_new", "miq_report_run", "miq_report_only", "miq_report_schedule_add"
         return @sb[:active_tab] == "saved_reports"
       when "view_graph", "view_hybrid", "view_tabular"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -422,46 +422,6 @@ class ApplicationHelper::ToolbarBuilder
     end
   end
 
-  def hide_button_report(id)
-    if %w(miq_report_copy miq_report_delete miq_report_edit
-          miq_report_new miq_report_run miq_report_schedule_add).include?(id) ||
-       x_active_tree == :schedules_tree
-      return true unless role_allows?(:feature => id)
-    end
-    case x_active_tree
-    when :widgets_tree
-      case id
-      when "widget_new"
-        return x_node == "root"
-      when "widget_generate_content"
-        return @sb[:wtype] == "m"
-      end
-      return false
-    when :reports_tree
-      case id
-      when "saved_report_delete", "reload"
-        return @sb[:active_tab] != "saved_reports"
-      when "miq_report_edit", "miq_report_delete"
-        return @sb[:active_tab] != "report_info" || @record.rpt_type != "Custom"
-      when "miq_report_copy", "miq_report_new", "miq_report_run", "miq_report_only", "miq_report_schedule_add"
-        return @sb[:active_tab] == "saved_reports"
-      when "view_graph", "view_hybrid", "view_tabular"
-        return @ght_type == "tabular" && @report.try(:graph).nil? && !@zgraph
-      end
-    when :savedreports_tree
-      case id
-      when "saved_report_delete"
-        return !role_allows?(:feature => id)
-      when "reload"
-        return x_node != "root"
-      when "view_graph", "view_hybrid", "view_tabular"
-        return @ght_type == "tabular" && @report.try(:graph).nil? && !@zgraph
-      end
-    else
-      return false
-    end
-  end
-
   # Determine if a button should be hidden
   def hide_button?(id)
     return false if id.start_with?('history_')
@@ -535,11 +495,6 @@ class ApplicationHelper::ToolbarBuilder
 
     if @layout == "ops"
       res = hide_button_ops(id)
-      return res
-    end
-
-    if @layout == "report"
-      res = hide_button_report(id)
       return res
     end
 
@@ -769,12 +724,6 @@ class ApplicationHelper::ToolbarBuilder
         end
       when "restart_workers"
         return N_("Select a worker to restart") if @sb[:selected_worker_id].nil?
-      end
-    when "MiqWidget"
-      case id
-      when "widget_generate_content"
-        return N_("Widget has to be assigned to a dashboard to generate content") if @record.memberof.count <= 0
-        return N_("This Widget content generation is already running or queued up") if @widget_running
       end
     when "MiqWidgetSet"
       case id

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -449,10 +449,9 @@ class ApplicationHelper::ToolbarBuilder
         return @ght_type == "tabular" && @report.try(:graph).nil? && !@zgraph
       end
     when :savedreports_tree
-      if %w(saved_report_delete).include?(id)
-        return true unless role_allows?(:feature => id)
-      end
       case id
+      when "saved_report_delete"
+        return !role_allows?(:feature => id)
       when "reload"
         return x_node != "root"
       when "view_graph", "view_hybrid", "view_tabular"

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -25,9 +25,9 @@ class ApplicationHelper::ToolbarChooser
       'miq_capacity_view_tb'
     elsif @record && @explorer && (%w(services catalogs).include?(@layout) || %w(performance timeline).include?(@display))
       'blank_view_tb'
-    elsif %w(report).include?(@layout)
+    elsif @layout == 'report'
       @report ? "report_view_tb" : "blank_view_tb"
-    elsif %w(provider_foreman).include?(@layout)
+    elsif @layout == 'provider_foreman'
       @showtype == 'main' ? "x_summary_view_tb" : "x_gtl_view_tb"
     else
       'blank_view_tb'

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :relationship do
-    # passed in resource will determine resource_type
+    trait :membership do
+      relationship 'membership'
+    end
   end
 
   factory :relationship_vm_vmware, :parent => :relationship do
@@ -14,4 +16,16 @@ FactoryGirl.define do
   factory :relationship_storage_vmware, :parent => :relationship do
     resource_type  "Storage"
   end
+
+  factory :relationship_miq_widget_set, :parent => :relationship do
+    resource_type 'MiqWidgetSet'
+  end
+
+  factory :relationship_miq_widget, :parent => :relationship do
+    resource_type 'MiqWidget'
+  end
+
+  factory :relationship_miq_widget_set_with_membership, :parent => :relationship_miq_widget_set,
+                                                        :traits => [:membership]
+  factory :relationship_miq_widget_with_membership, :parent => :relationship_miq_widget, :traits => [:membership]
 end

--- a/spec/helpers/application_helper/buttons/miq_report_action_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_report_action_spec.rb
@@ -1,0 +1,15 @@
+describe ApplicationHelper::Button::MiqReportAction do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tab => tab) }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#visible?' do
+    context 'when active_tab == saved_reports' do
+      let(:tab) { 'saved_reports' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when active_tab != saved_reports' do
+      let(:tab) { 'does_not_matter' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/miq_report_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_report_edit_spec.rb
@@ -1,0 +1,32 @@
+describe ApplicationHelper::Button::MiqReportEdit do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tab => tab, :active_tree => tree) }
+  let(:tab) { nil }
+  let(:tree) { nil }
+  let(:record) { nil }
+  subject { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  describe '#visible?' do
+    context 'when active_tree == reports_tree' do
+      let(:tree) { :reports_tree }
+      context 'and active_tab == report_info' do
+        let(:tab) { 'report_info' }
+        context 'and record.rpt_type == Custom' do
+          let(:record) { FactoryGirl.create(:miq_report, :rpt_type => 'Custom') }
+          it { expect(subject.visible?).to be_truthy }
+        end
+        context 'and record.rpt_type != Custom' do
+          let(:record) { FactoryGirl.create(:miq_report) }
+          it { expect(subject.visible?).to be_falsey }
+        end
+      end
+      context 'and active_tab != report_info' do
+        let(:tab) { 'not_report_info' }
+        it { expect(subject.visible?).to be_falsey }
+      end
+    end
+    context 'when active_tree != reports_tree' do
+      let(:tree) { :not_reports_tree }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/reload_spec.rb
+++ b/spec/helpers/application_helper/buttons/reload_spec.rb
@@ -1,0 +1,38 @@
+describe ApplicationHelper::Button::Reload do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tree => tree, :active_tab => tab) }
+  let(:x_node) { nil }
+  let(:tree) { nil }
+  let(:tab) { nil }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  before { allow(view_context).to receive(:x_node).and_return(x_node) }
+
+  describe '#visible?' do
+    context 'when active_tree == reports_tree' do
+      let(:tree) { :reports_tree }
+      context 'and active_tab == saved_reports' do
+        let(:tab) { 'saved_reports' }
+        it { expect(subject.visible?).to be_truthy }
+      end
+      context 'and active_tab != saved_reports' do
+        let(:tab) { 'not_saved_reports' }
+        it { expect(subject.visible?).to be_falsey }
+      end
+    end
+    context 'when active_tree == savedreports_tree' do
+      let(:tree) { :savedreports_tree }
+      context 'and x_node == root' do
+        let(:x_node) { 'root' }
+        it { expect(subject.visible?).to be_truthy }
+      end
+      context 'and x_node != root' do
+        let(:x_node) { 'not_root' }
+        it { expect(subject.visible?).to be_falsey }
+      end
+    end
+    context 'when active_tree != reports_tree && active_tree != savedreports_tree' do
+      let(:tree) { :not_any_of_reports_trees }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/saved_report_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/saved_report_delete_spec.rb
@@ -1,0 +1,23 @@
+describe ApplicationHelper::Button::SavedReportDelete do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tree => tree, :active_tab => tab) }
+  let(:tab) { nil }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#visible?' do
+    context 'when active_tree == reports_tree' do
+      let(:tree) { :reports_tree }
+      context 'and active_tab == saved_reports' do
+        let(:tab) { 'saved_reports' }
+        it { expect(subject.visible?).to be_truthy }
+      end
+      context 'and active_tab != saved_reports' do
+        let(:tab) { 'not_saved_reports' }
+        it { expect(subject.visible?).to be_falsey }
+      end
+    end
+    context 'when active_tree != reports_tree' do
+      let(:tree) { :savedreports_tree }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/view_ght_spec.rb
+++ b/spec/helpers/application_helper/buttons/view_ght_spec.rb
@@ -1,0 +1,42 @@
+describe ApplicationHelper::Button::ViewGHT do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tree => tree) }
+  let(:ght_type) { 'tabular' }
+  let(:report) { FactoryGirl.create(:miq_report) }
+  let(:zgraph) { nil }
+  let(:graph) { nil }
+  subject do
+    described_class.new(view_context, {},
+                        { 'ght_type' => ght_type,
+                          'report'   => report,
+                          'zgraph'   => zgraph }, {})
+  end
+
+  before { allow(report).to receive(:graph).and_return(graph) }
+
+  describe '#visible?' do
+    %w(reports_tree savedreports_tree).each do |tree|
+      context "when x_active_tree == #{tree}" do
+        let(:tree) { tree.to_sym }
+        context 'when ght_type != tabular' do
+          let(:ght_type) { 'hybrid' }
+          it { expect(subject.visible?).to be_truthy }
+        end
+        context 'when report has graph' do
+          let(:graph) { true }
+          it { expect(subject.visible?).to be_truthy }
+        end
+        context 'when zgraph is available' do
+          let(:zgraph) { true }
+          it { expect(subject.visible?).to be_truthy }
+        end
+        context 'when ght_type == tabular && report does not have graph && not a zgraph' do
+          it { expect(subject.visible?).to be_falsey }
+        end
+      end
+    end
+    context 'when !%w(reports_tree savedreports_tree).include?(x_active_tree)' do
+      let(:tree) { :not_any_of_reports_trees }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
+++ b/spec/helpers/application_helper/buttons/widget_generate_content_spec.rb
@@ -1,0 +1,40 @@
+describe ApplicationHelper::Button::WidgetGenerateContent do
+  let(:view_context) { setup_view_context_with_sandbox(:wtype => wtype) }
+  let(:record) do
+    rec = FactoryGirl.create(:miq_widget)
+    set = FactoryGirl.create(:miq_widget_set)
+    w_set_rel = FactoryGirl.create(:relationship_miq_widget_set_with_membership, :resource_id => set.id)
+    FactoryGirl.create(:relationship_miq_widget_with_membership, :resource_id => rec.id, :ancestry => w_set_rel.id)
+    rec
+  end
+  let(:widget_running) { false }
+  let(:wtype) { 'not_m' }
+  subject { described_class.new(view_context, {}, {'record' => record, 'widget_running' => widget_running}, {}) }
+
+  describe '#visible?' do
+    context 'when it is a menu widget' do
+      let(:wtype) { 'm' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when it is not a menu widget' do
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+
+  describe '#disabled?' do
+    context 'when widget is not assigned to any dashboard' do
+      let(:record) { FactoryGirl.create(:miq_widget) }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+    context 'when widget is assigned to some dashboards' do
+      it { expect(subject.disabled?).to be_falsey }
+    end
+    context 'when widget is running' do
+      let(:widget_running) { true }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+    context 'when widget is not running' do
+      it { expect(subject.disabled?).to be_falsey }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/widget_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/widget_new_spec.rb
@@ -1,0 +1,17 @@
+describe ApplicationHelper::Button::WidgetNew do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  before { allow(view_context).to receive(:x_node).and_return(x_node) }
+
+  describe '#visible?' do
+    context 'when x_node == root' do
+      let(:x_node) { 'root' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when x_node != root' do
+      let(:x_node) { 'not_root' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -970,25 +970,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when record class = MiqWidget" do
-      context "and id = widget_generate_content" do
-        before do
-          @id = "widget_generate_content"
-          @record = FactoryGirl.create(:miq_widget)
-        end
-        it "when not member of a widgetset" do
-          expect(subject).to eq("Widget has to be assigned to a dashboard to generate content")
-        end
-
-        it "when Widget content generation is already running or queued up" do
-          @widget_running = true
-          db = FactoryGirl.create(:miq_widget_set)
-          db.replace_children([@record])
-          expect(subject).to eq("This Widget content generation is already running or queued up")
-        end
-      end
-    end
-
     context "when record class = ServiceTemplate" do
       context "and id = svc_catalog_provision" do
         before do
@@ -1346,44 +1327,6 @@ describe ApplicationHelper do
     end
 
     %w(rbac_group_edit rbac_role_edit).each do |id|
-      context "when with #{id} button should not be visible as user does not have access to these features" do
-        before { @id = id }
-        it "and record_id" do
-          expect(subject).to be_truthy
-        end
-      end
-    end
-  end
-
-  describe "#hide_button_report saved_report admin" do
-    subject { hide_button_report(@id) }
-    before do
-      @record = FactoryGirl.create(:miq_report_result)
-      feature = EvmSpecHelper.specific_product_features(%w(saved_report_delete))
-      login_as FactoryGirl.create(:user, :features => feature)
-      @sb = {:active_tree => :savedreports_tree}
-    end
-
-    %w(saved_report_delete).each do |id|
-      context "when with #{id} button should be visible" do
-        before { @id = id }
-        it "and record_id" do
-          expect(subject).to be_falsey
-        end
-      end
-    end
-  end
-
-  describe "#hide_button_report with saved_report view only" do
-    subject { hide_button_report(@id) }
-    before do
-      @record = FactoryGirl.create(:miq_report_result)
-      feature = EvmSpecHelper.specific_product_features(%w(miq_report_saved_reports_view))
-      login_as FactoryGirl.create(:user, :features => feature)
-      @sb = {:active_tree => :savedreports_tree}
-    end
-
-    %w(saved_report_delete).each do |id|
       context "when with #{id} button should not be visible as user does not have access to these features" do
         before { @id = id }
         it "and record_id" do


### PR DESCRIPTION
Deleted the `hide_button_report` method and its [calling block](https://github.com/ManageIQ/manageiq/blob/aac988fcb41cd2c78555be976a5f9c50ba294ca3/app/helpers/application_helper/toolbar_builder.rb#L567-L570) and created separate button classes for the respective buttons.

`@layout == "report"` does not need to be checked, since all the toolbars related to report buttons are rendered only if that condition is evaluated as true - that condition is already checked in [`toolbar_chooser.rb`](https://github.com/ManageIQ/manageiq/blob/aac988fcb41cd2c78555be976a5f9c50ba294ca3/app/helpers/application_helper/toolbar_chooser.rb#L125).

| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| widget_new | WidgetNew < Basic |
| widget_generate_content | WidgetGenerateContent < Basic |
| saved_report_delete | SavedReportDelete < Basic |
| reload | Reload < Basic |
| miq_report_edit, miq_report_delete | MiqReportEdit < Basic |
| miq_report_copy, miq_report_new, miq_report_run, miq_report_schedule_add | MiqReportAction < Basic |
| view_graph, view_hybrid, view_tabular | ViewGHT < Basic |

The button `miq_report_only` could not be found in any of the toolbars. I assumed the it was a typo, since the button report_only exists. However, it had not been necessary to assign it the class `MiqReportAction`, since the toolbar it is a part of only appears in the `:savedreports_tree`.

A new mixin module has also been created for the use of buttons whose visibility is dependant on the `x_active_tree` property.

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/134854899
