### PR TITLE
tree_autoload - don't assume we're always autoloading the active tree

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -612,7 +612,7 @@ function miqInitTree(options, tree) {
   }
 
   if (options.add_nodes) {
-    miqAddNodeChildren(options.active_tree, options.add_node_key, options.select_node, options.children);
+    miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.children);
   }
 
   // Tree state persistence correction after the tree is completely loaded

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -37,9 +37,14 @@ module ApplicationController::TreeSupport
   end
 
   def tree_add_child_nodes(id)
-    tree_type = @sb[:active_tree].to_s.sub(/_tree$/, '')
+    tree_name = params[:tree] || x_active_tree
+    tree_type = tree_name.to_s.sub(/_tree$/, '')
+    tree_klass = x_tree(tree_name)[:klass_name]
+
+    # FIXME after euwe: build_ae_tree
     tree_type = 'catalog' if controller_name == 'catalog' && tree_type == 'automate'
-    nodes = TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id, tree_type)
+
+    nodes = TreeBuilder.tree_add_child_nodes(@sb, tree_klass, id, tree_type)
     TreeBuilder.convert_bs_tree(nodes)
   end
 

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -39,16 +39,16 @@ module ApplicationController::TreeSupport
   def tree_add_child_nodes(id)
     tree_name = (params[:tree] || x_active_tree).to_sym
     tree_type = tree_name.to_s.sub(/_tree$/, '').to_sym
-    tree_klass = x_tree(tree_name)[:klass_name].constantize
+    tree_klass = x_tree(tree_name)[:klass_name]
 
     # FIXME after euwe: build_ae_tree
     tree_type = :catalog if controller_name == 'catalog' && tree_type == :automate
 
-    nodes = TreeBuilder.tree_add_child_nodes(:sandbox => @sb,
-                                             :klass   => tree_klass,
-                                             :name    => tree_name,
-                                             :type    => tree_type,
-                                             :id      => id)
+    nodes = TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
+                                             :klass_name => tree_klass,
+                                             :name       => tree_name,
+                                             :type       => tree_type,
+                                             :id         => id)
     TreeBuilder.convert_bs_tree(nodes)
   end
 

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -37,12 +37,12 @@ module ApplicationController::TreeSupport
   end
 
   def tree_add_child_nodes(id)
-    tree_name = (params[:tree] || x_active_tree).to_s
-    tree_type = tree_name.sub(/_tree$/, '')
+    tree_name = (params[:tree] || x_active_tree).to_sym
+    tree_type = tree_name.to_s.sub(/_tree$/, '').to_sym
     tree_klass = x_tree(tree_name)[:klass_name].constantize
 
     # FIXME after euwe: build_ae_tree
-    tree_type = 'catalog' if controller_name == 'catalog' && tree_type == 'automate'
+    tree_type = :catalog if controller_name == 'catalog' && tree_type == :automate
 
     nodes = TreeBuilder.tree_add_child_nodes(:sandbox => @sb,
                                              :klass   => tree_klass,

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -37,14 +37,18 @@ module ApplicationController::TreeSupport
   end
 
   def tree_add_child_nodes(id)
-    tree_name = params[:tree] || x_active_tree
-    tree_type = tree_name.to_s.sub(/_tree$/, '')
-    tree_klass = x_tree(tree_name)[:klass_name]
+    tree_name = (params[:tree] || x_active_tree).to_s
+    tree_type = tree_name.sub(/_tree$/, '')
+    tree_klass = x_tree(tree_name)[:klass_name].constantize
 
     # FIXME after euwe: build_ae_tree
     tree_type = 'catalog' if controller_name == 'catalog' && tree_type == 'automate'
 
-    nodes = TreeBuilder.tree_add_child_nodes(@sb, tree_klass, id, tree_type)
+    nodes = TreeBuilder.tree_add_child_nodes(:sandbox => @sb,
+                                             :klass   => tree_klass,
+                                             :name    => tree_name,
+                                             :type    => tree_type,
+                                             :id      => id)
     TreeBuilder.convert_bs_tree(nodes)
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -135,8 +135,8 @@ class TreeBuilder
   end
 
   # Add child nodes to a tree below node 'id'
-  def self.tree_add_child_nodes(sandbox:, klass:, name:, type:, id:)
-    tree = klass.new(name, type, sandbox, false)
+  def self.tree_add_child_nodes(sandbox:, klass_name:, name:, type:, id:)
+    tree = klass_name.constantize.new(name, type, sandbox, false)
     tree.x_get_child_nodes(id)
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -134,9 +134,9 @@ class TreeBuilder
     nodes
   end
 
-  # Add child nodes to the active tree below node 'id'
-  def self.tree_add_child_nodes(sandbox, klass_name, id, tree_type)
-    tree = klass_name.constantize.new(sandbox[:active_tree].to_s, tree_type, sandbox, false)
+  # Add child nodes to a tree below node 'id'
+  def self.tree_add_child_nodes(sandbox:, klass:, name:, type:, id:)
+    tree = klass.new(name, type, sandbox, false)
     tree.x_get_child_nodes(id)
   end
 


### PR DESCRIPTION
The `tree_autoload` request sends the tree name in `params[:tree]`, but we're completely ignoring it, and using the active tree instead. 

Fixing to use the right one.

https://bugzilla.redhat.com/show_bug.cgi?id=1398239