### PR TITLE
Remove extraneous character from chart definition

### DIFF
--- a/product/charts/layouts/hourly_tag_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
+++ b/product/charts/layouts/hourly_tag_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
@@ -23,7 +23,7 @@
   - Timeline-Current-Hourly:Hourly events on this Cluster
   - Display-Hosts-bytag:Hosts for <cat> that were running
   - Display-VMs-bytag:VMs for <cat> that were running
-q
+
 - :title: Disk I/O (blocks per second)
   :type: Line
   :columns:


### PR DESCRIPTION
Introduced in commit 596fcd28cea2130dd5a0bacc3de83c5548bff927