### PR TITLE
Enable deployment actions in server deployments list view

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -289,7 +289,10 @@ class MiddlewareServerController < ApplicationController
     end
 
     op = mw_manager.public_method operation
-    if params
+
+    if mw_server.instance_of? MiddlewareDeployment
+      op.call(path, mw_server.name)
+    elsif params
       op.call(path, params)
     else
       op.call(path)


### PR DESCRIPTION
Currently there's an exception when trying to run actions on server deployments list (Provider > Server > Deployments):

![image](https://cloud.githubusercontent.com/assets/1737954/20895560/d6676afc-bb11-11e6-8246-781a8c2d0fb9.png)

This fixes by passing the proper arguments to the operation call.