### PR TITLE
Fixed content generation for widget when visibility is 'By-Group'

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -428,7 +428,7 @@ class MiqWidget < ApplicationRecord
   end
 
   def available_for_group?(group)
-    group ? has_visibility?(:roles, group.miq_user_role_name) : false
+    group ? has_visibility?(:roles, group.miq_user_role_name) || has_visibility?(:groups, group.description) : false
   end
 
   def self.available_for_user(user)

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -428,7 +428,8 @@ class MiqWidget < ApplicationRecord
   end
 
   def available_for_group?(group)
-    group ? has_visibility?(:roles, group.miq_user_role_name) || has_visibility?(:groups, group.description) : false
+    return false unless group
+    has_visibility?(:roles, group.miq_user_role_name) || has_visibility?(:groups, group.description)
   end
 
   def self.available_for_user(user)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -286,6 +286,23 @@ describe MiqWidget do
       @widget.queue_generate_content
     end
 
+    it "does not generate content if visibility set to group only and there are no users in that group" do
+      @widget.visibility.delete(:roles)
+      @widget.visibility[:groups] = @group2.description
+      @user2.delete
+
+      expect(@widget).not_to receive(:queue_generate_content_for_users_or_group)
+      @widget.queue_generate_content
+    end
+
+    it "generate content if visibility set to group only with users in that group" do
+      @widget.visibility.delete(:roles)
+      @widget.visibility[:groups] = @group2.description
+
+      expect(@widget).to receive(:queue_generate_content_for_users_or_group).once
+      @widget.queue_generate_content
+    end
+
     it "creates a new task when previous task is finished" do
       @widget.queue_generate_content
       MiqTask.first.state_finished


### PR DESCRIPTION
Fixed content generation for widget when visibility is 'By-Group'

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1395518

@miq-bot add-label bug