### PR TITLE
remove outdated css / update expression editor toolbar styling

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -1,5 +1,3 @@
-html { padding: 0 0 /*25*/px 0;  /* create area for notification */}
-legend { display: none;}
 textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1.5em}
 
 fieldset {
@@ -8,8 +6,6 @@ fieldset {
   padding: 10px;
   border:1px solid #e9e8e8;
 }
-
-nobr { white-space: nowrap;}
 
 /*Centering for Hovered VMs*/
 #outer { position: absolute;top: 50%;left: 0;overflow: visible;width: 100%;height: 1px;}
@@ -45,18 +41,6 @@ nobr { white-space: nowrap;}
   text-shadow: #000 2px 2px 0;
 }
 
-/************ Tabs ************/
-
-ul.searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px;}
-.searchtoolbar li { margin-right: 7px;padding: 0 4px 1px 4px; height:22px; width: 30px;float: left;display: inline;border: 1px solid #7e7e7e;}
-.searchtoolbar li:hover { background: #aeaeae;}
-.searchtoolbar li img.dimmed { background: none;}
-
-/* Automate Specific */
-.checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */
-
-/* End Automate Specific */
-
 /************ Hover Buttons ************/
 .rollover img, input.rollover { display:block;}
 .rollover img:hover, img.rollover:hover, input.rollover:hover, i.rollover:hover { background:#e4e4e4;}
@@ -69,8 +53,6 @@ img.tiny { margin: 0; padding: 0;width:20px;height:20px; border: 0; vertical-ali
 
 .quadicon { position:relative;float:left;padding: 0 1px 1px 0;width: 72px; height: 80px;color: #e3e4e4;text-transform: none;}
 .quadicon:hover{ padding: 1px 0 0 1px;}
-
-div.panecontent .flobj { margin-left: 40px;}
 
 .flobj { position: absolute;z-index: auto;width: 72px;}
 .flobj p { margin: 5px 0 0 0;padding: 0;color: #e3e4e4;vertical-align: middle;text-align:center;text-transform: none;text-shadow: 0 0 3px #000;font: normal 16px OpenSansSemibold,Arial,Helvetica,sans-serif !important;}

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -7,41 +7,42 @@
   = javascript_tag("ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';")
 
 #exp_editor_div
-  %fieldset{:style => "width: auto; padding-left: 6px; padding-top: 6px"}
-    %ul.searchtoolbar
-      - if @edit[@expkey].history.idx > 0
-        %li
-          = link_to(image_tag(image_path('toolbars/undo.png'),
-                              :alt => _('Undo the last change')),
-                    {:action  => 'exp_button',
-                     :pressed => 'undo'},
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :title                 => _('Undo the last change'))
-      - else
-        %li.dimmed
-          = image_tag(image_path('toolbars/undo.png'))
+  %fieldset
+    .toolbar-pf-actions
+      .form-group
+        - if @edit[@expkey].history.idx > 0
+          %button.btn.btn-default
+            = link_to(image_tag(image_path('toolbars/undo.png'),
+                                :alt => _('Undo the last change')),
+                      {:action  => 'exp_button',
+                       :pressed => 'undo'},
+                      "data-miq_sparkle_on"  => true,
+                      "data-miq_sparkle_off" => true,
+                      :remote                => true,
+                      "data-method"          => :post,
+                      :title                 => _('Undo the last change'))
+        - else
+          %button.btn.btn-default.disabled
+            = image_tag(image_path('toolbars/undo.png'))
 
-      - if @edit[@expkey].history.idx < @edit[@expkey].history.array.length - 1
-        %li
-          = link_to(image_tag(image_path('toolbars/redo.png'),
-                              :alt => _('Re-apply the previous change')),
-                    {:action  => 'exp_button',
-                     :pressed => 'redo'},
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :title                 => _('Re-apply the previous change'))
-      - else
-        %li.dimmed
-          = image_tag(image_path('toolbars/redo.png'))
+        - if @edit[@expkey].history.idx < @edit[@expkey].history.array.length - 1
+          %button
+            = link_to(image_tag(image_path('toolbars/redo.png'),
+                                :alt => _('Re-apply the previous change')),
+                      {:action  => 'exp_button',
+                       :pressed => 'redo'},
+                      "data-miq_sparkle_on"  => true,
+                      "data-miq_sparkle_off" => true,
+                      :remote                => true,
+                      "data-method"          => :post,
+                      :title                 => _('Re-apply the previous change'))
+        - else
+          %button.btn.btn-default.disabled
+            = image_tag(image_path('toolbars/redo.png'))
 
       %span#exp_buttons_off
         - %w(and or not discard).each do |image|
-          %li.dimmed
+          %button.btn.btn-default.disabled
             = image_tag(image_path("toolbars/#{image}.png"))
 
       %span#exp_buttons_not{:style => "display: none"}
@@ -50,10 +51,10 @@
            ["",                                     'not',     ''],
            [_("Remove this expression element"),    'discard', 'remove']].each do |title, image, pressed|
           - if title.empty?
-            %li.dimmed
+            %button.btn.btn-default.disabled
               = link_to(image_tag(image_path("toolbars/#{image}.png")))
           - else
-            %li
+            %button.btn.btn-default
               = link_to(image_tag(image_path("toolbars/#{image}.png"),
                                   :alt => title),
                         {:action  => "exp_button",
@@ -69,7 +70,7 @@
            [_("OR with a new expression element"),        'or',      'or'],
            [_("Wrap this expression element with a NOT"), 'not',     'not'],
            [_("Remove this expression element"),          'discard', 'remove']].each do |title, image, pressed|
-          %li
+          %button.btn.btn-default
             = link_to(image_tag(image_path("toolbars/#{image}.png"), :alt => title), {:action => 'exp_button', :pressed => pressed},
                       "data-miq_sparkle_on"  => true,
                       "data-miq_sparkle_off" => true,
@@ -77,32 +78,31 @@
                       "data-method"          => :post,
                       :title                 => title)
 
-    %div{:style => "padding: 10px"}
-      - @edit[@expkey][:exp_table].each do |token|
-        - if ! %w(AND OR ( ) ???).include?([token].flatten.first)
-          = link_to(token.first,
-                    {:action => 'exp_token_pressed',
-                     :token  => token.last},
-                    :style                 => "color: black",
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :id                    => "exp_#{token.last}")
-        - elsif [token].flatten.first == "???"
-          = link_to(token.first,
-                    {:action => 'exp_token_pressed',
-                     :token  => token.last},
-                    :style                 => "color: black; background-color: yellow",
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :id                    => "exp_#{token.last}")
-        - else
-          %font{:color => "red"}
-            %b
-              = token
+    - @edit[@expkey][:exp_table].each do |token|
+      - if ! %w(AND OR ( ) ???).include?([token].flatten.first)
+        = link_to(token.first,
+                  {:action => 'exp_token_pressed',
+                   :token  => token.last},
+                  :style                 => "color: black",
+                  "data-miq_sparkle_on"  => true,
+                  "data-miq_sparkle_off" => true,
+                  :remote                => true,
+                  "data-method"          => :post,
+                  :id                    => "exp_#{token.last}")
+      - elsif [token].flatten.first == "???"
+        = link_to(token.first,
+                  {:action => 'exp_token_pressed',
+                   :token  => token.last},
+                  :style                 => "color: black; background-color: yellow",
+                  "data-miq_sparkle_on"  => true,
+                  "data-miq_sparkle_off" => true,
+                  :remote                => true,
+                  "data-method"          => :post,
+                  :id                    => "exp_#{token.last}")
+      - else
+        %font{:color => "red"}
+          %b
+            = token
 
   - if @edit[@expkey][:exp_token]
     = render(:partial => 'layouts/exp_atom/editor')

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -40,43 +40,43 @@
           %button.btn.btn-default.disabled
             = image_tag(image_path('toolbars/redo.png'))
 
-      %span#exp_buttons_off
-        - %w(and or not discard).each do |image|
-          %button.btn.btn-default.disabled
-            = image_tag(image_path("toolbars/#{image}.png"))
-
-      %span#exp_buttons_not{:style => "display: none"}
-        - [[_("AND with a new expression element"), 'and',     'and'],
-           [_("OR with a new expression element"),  'or',      'or'],
-           ["",                                     'not',     ''],
-           [_("Remove this expression element"),    'discard', 'remove']].each do |title, image, pressed|
-          - if title.empty?
+        %span#exp_buttons_off
+          - %w(and or not discard).each do |image|
             %button.btn.btn-default.disabled
-              = link_to(image_tag(image_path("toolbars/#{image}.png")))
-          - else
+              = image_tag(image_path("toolbars/#{image}.png"))
+
+        %span#exp_buttons_not{:style => "display: none"}
+          - [[_("AND with a new expression element"), 'and',     'and'],
+             [_("OR with a new expression element"),  'or',      'or'],
+             ["",                                     'not',     ''],
+             [_("Remove this expression element"),    'discard', 'remove']].each do |title, image, pressed|
+            - if title.empty?
+              %button.btn.btn-default.disabled
+                = link_to(image_tag(image_path("toolbars/#{image}.png")))
+            - else
+              %button.btn.btn-default
+                = link_to(image_tag(image_path("toolbars/#{image}.png"),
+                                    :alt => title),
+                          {:action  => "exp_button",
+                           :pressed => pressed},
+                          "data-miq_sparkle_on"  => true,
+                          "data-miq_sparkle_off" => true,
+                          :remote                => true,
+                          "data-method"          => :post,
+                          :title                 => title)
+
+        %span#exp_buttons_on{:style => "display: none"}
+          - [[_("AND with a new expression element"),       'and',     'and'],
+             [_("OR with a new expression element"),        'or',      'or'],
+             [_("Wrap this expression element with a NOT"), 'not',     'not'],
+             [_("Remove this expression element"),          'discard', 'remove']].each do |title, image, pressed|
             %button.btn.btn-default
-              = link_to(image_tag(image_path("toolbars/#{image}.png"),
-                                  :alt => title),
-                        {:action  => "exp_button",
-                         :pressed => pressed},
+              = link_to(image_tag(image_path("toolbars/#{image}.png"), :alt => title), {:action => 'exp_button', :pressed => pressed},
                         "data-miq_sparkle_on"  => true,
                         "data-miq_sparkle_off" => true,
                         :remote                => true,
                         "data-method"          => :post,
                         :title                 => title)
-
-      %span#exp_buttons_on{:style => "display: none"}
-        - [[_("AND with a new expression element"),       'and',     'and'],
-           [_("OR with a new expression element"),        'or',      'or'],
-           [_("Wrap this expression element with a NOT"), 'not',     'not'],
-           [_("Remove this expression element"),          'discard', 'remove']].each do |title, image, pressed|
-          %button.btn.btn-default
-            = link_to(image_tag(image_path("toolbars/#{image}.png"), :alt => title), {:action => 'exp_button', :pressed => pressed},
-                      "data-miq_sparkle_on"  => true,
-                      "data-miq_sparkle_off" => true,
-                      :remote                => true,
-                      "data-method"          => :post,
-                      :title                 => title)
 
     - @edit[@expkey][:exp_table].each do |token|
       - if ! %w(AND OR ( ) ???).include?([token].flatten.first)

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -20,62 +20,63 @@
     - unless MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds).length > 0
       - exptypes -= [[_(EXP_FIND_TYPE[0]), EXP_FIND_TYPE[1]]]
   #exp_atom_editor_div
-    %fieldset{:style => "width:auto; padding-left: 6px; padding-top: 6px;"}
-      %ul.searchtoolbar
-        %li
-          - t = _('Commit expression element changes')
-          = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
-            {:action => 'exp_button', :pressed => 'commit'},
-            "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            :remote                => true,
-            "data-method"          => :post,
-            :title                 => t)
-        %li
-          - t = _("Discard expression element changes")
-          = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
-            {:action => 'exp_button', :pressed  => 'discard'},
-            "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            :remote                => true,
-            "data-method"          => :post,
-            :title                 => t)
-      %div{:style => "padding: 10px;"}
-        - if @edit[@expkey][:exp_key] == "NOT"
-          %font{:color => "black"}
-            = _('NOT')
+    %fieldset
+      .toolbar-pf-actions
+        .form-group
+          %button
+            - t = _('Commit expression element changes')
+            = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
+              {:action => 'exp_button', :pressed => 'commit'},
+              "data-miq_sparkle_on"  => true,
+              "data-miq_sparkle_off" => true,
+              :remote                => true,
+              "data-method"          => :post,
+              :title                 => t)
+          %button
+            - t = _("Discard expression element changes")
+            = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
+              {:action => 'exp_button', :pressed  => 'discard'},
+              "data-miq_sparkle_on"  => true,
+              "data-miq_sparkle_off" => true,
+              :remote                => true,
+              "data-method"          => :post,
+              :title                 => t)
+
+      - if @edit[@expkey][:exp_key] == "NOT"
+        %font{:color => "black"}
+          = _('NOT')
+      - else
+        - opts = ["<#{_('Choose')}>"]
+        - case exp_model
+        - when 'Vm'
+          - opts += exptypes + VM_EXP_TYPES.map { |x| [_(x[0]), x[1]] }
+        - when 'AuditEvent'
+          - opts += [[_('Field'), 'field']]
+        - when '_display_filter_'
+          - unless @edit[@expkey][:exp_available_fields].empty?
+            - opts.push([_('Field'), 'field'])
+          - unless @edit[@expkey][:exp_available_tags] && @edit[@expkey][:exp_available_tags].empty? || exp_available_tags(exp_model, @edit[@expkey][:use_mytags]).empty?
+            - opts.push([_('Tag'), 'tag'])
         - else
-          - opts = ["<#{_('Choose')}>"]
-          - case exp_model
-          - when 'Vm'
-            - opts += exptypes + VM_EXP_TYPES.map { |x| [_(x[0]), x[1]] }
-          - when 'AuditEvent'
-            - opts += [[_('Field'), 'field']]
-          - when '_display_filter_'
-            - unless @edit[@expkey][:exp_available_fields].empty?
-              - opts.push([_('Field'), 'field'])
-            - unless @edit[@expkey][:exp_available_tags] && @edit[@expkey][:exp_available_tags].empty? || exp_available_tags(exp_model, @edit[@expkey][:use_mytags]).empty?
-              - opts.push([_('Tag'), 'tag'])
-          - else
-            - opts += exptypes
+          - opts += exptypes
 
-          = select_tag('chosen_typ', options_for_select(opts, @edit[@expkey][:exp_typ]),
-            :multiple              => false,
-            :class                 => 'selectpicker',
-            'data-miq_sparkle_on'  => true,
-            'data-miq_sparkle_off' => true,
-            'data-miq_observe'     => {:url => url}.to_json)
+        = select_tag('chosen_typ', options_for_select(opts, @edit[@expkey][:exp_typ]),
+          :multiple              => false,
+          :class                 => 'selectpicker',
+          'data-miq_sparkle_on'  => true,
+          'data-miq_sparkle_off' => true,
+          'data-miq_observe'     => {:url => url}.to_json)
 
-        %br
-        - if @edit[@expkey][:exp_typ]
-          = render :partial => "layouts/exp_atom/edit_#{@edit[@expkey][:exp_typ]}", :locals => {:exp_model => exp_model}
-        - if qs_show_user_input_checkbox?
-          = check_box_tag("user_input", "1", @edit[@expkey][:exp_value] == :user_input,
-            :style                      => "width: 20px",
-            "data-miq_sparkle_on"       => true,
-            "data-miq_sparkle_off"      => true,
-            "data-miq_observe_checkbox" => {:url => url}.to_json)
-          = _('User will input the value')
+      %br
+      - if @edit[@expkey][:exp_typ]
+        = render :partial => "layouts/exp_atom/edit_#{@edit[@expkey][:exp_typ]}", :locals => {:exp_model => exp_model}
+      - if qs_show_user_input_checkbox?
+        = check_box_tag("user_input", "1", @edit[@expkey][:exp_value] == :user_input,
+          :style                      => "width: 20px",
+          "data-miq_sparkle_on"       => true,
+          "data-miq_sparkle_off"      => true,
+          "data-miq_observe_checkbox" => {:url => url}.to_json)
+        = _('User will input the value')
   %script{:type => "text/javascript"}
     -# Set the expression value prefill images and hover text
     miqExpressionPrefill(ManageIQ.expEditor, true);


### PR DESCRIPTION
- General cleanup of unused css
- replaced old "searchtoolbar" class with PF toolbar styling in expression editor

https://www.pivotaltracker.com/n/projects/1613907/stories/129462395

Old
<img width="1132" alt="screen shot 2016-12-05 at 4 22 03 pm" src="https://cloud.githubusercontent.com/assets/1287144/20903002/bbe8e48a-bb07-11e6-9ebe-a03206ace95c.png">
New
<img width="1129" alt="screen shot 2016-12-05 at 4 30 57 pm" src="https://cloud.githubusercontent.com/assets/1287144/20903166/3e95b9a8-bb08-11e6-9140-7506517bdedf.png">

