### PR TITLE
Added a missing default memory threshold setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1254,6 +1254,7 @@
       :ems_metrics_collector_worker:
         :defaults:
           :count: 2
+          :memory_threshold: 400.megabytes
           :nice_delta: 3
           :poll_method: :escalate
         :ems_metrics_collector_worker_azure: {}


### PR DESCRIPTION
Added a missing default memory threshold setting for C & U Data Collectors that was causing drop down to the first item in list as selected value by default.

https://bugzilla.redhat.com/show_bug.cgi?id=1296638

before:
![before](https://cloud.githubusercontent.com/assets/3450808/20904376/3a180836-bb0d-11e6-827e-63607cb5843d.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/20904389/4e532f38-bb0d-11e6-8e99-1302a2d0e861.png)

@dclarizio please review
