### PR TITLE
Fixed code that sets values of button_image, display & open_url fields

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -843,9 +843,9 @@ module ApplicationController::Buttons
       :target_class   => @resolve[:target_class],
       :name           => @custom_button.name,
       :description    => @custom_button.description,
-      :button_image   => @custom_button.options.try(:button_image).to_s,
-      :display        => @custom_button.options.try(:display) ? @custom_button.options[:display] : true,
-      :open_url       => @custom_button.options.try(:open_url) ? @custom_button.options[:open_url] : false,
+      :button_image   => @custom_button.options.try(:[], :button_image).to_s,
+      :display        => @custom_button.options.try(:[], :display).nil? ? true : @custom_button.options[:display],
+      :open_url       => @custom_button.options.try(:[], :open_url) ? @custom_button.options[:open_url] : false,
       :object_message => @custom_button.uri_message || "create",
     )
     @edit[:current] = copy_hash(@edit[:new])

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -129,7 +129,7 @@ describe ApplicationController do
       #   which, in turn, needs *something* to come back from automate
       allow(MiqAeClass).to receive_messages(:find_distinct_instances_across_domains => [double(:name => "foo")])
 
-      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm")
+      custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Vm", :options => {:display => false, :button_image => "5"})
       custom_button.uri_path, custom_button.uri_attributes, custom_button.uri_message = CustomButton.parse_uri("/test/")
       custom_button.uri_attributes["request"] = "req"
       custom_button.save
@@ -143,6 +143,9 @@ describe ApplicationController do
                                       )
       controller.send(:button_set_form_vars)
       expect(assigns(:edit)[:new][:target_class]).to eq(ui_lookup(:model => "Vm"))
+      expect(assigns(:edit)[:new][:display]).to eq(false)
+      expect(assigns(:edit)[:new][:button_image]).to eq('5')
+      expect(assigns(:edit)[:new][:open_url]).to eq(false)
 
       controller.instance_variable_set(:@sb,
                                        :trees       => {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1401617

@martinpovolny please review, This issue was introduced in commit: 5f31dcf09f158b318bdba348ed54877b3de41d6b in PR https://github.com/ManageIQ/manageiq/pull/10118
lines causing the issue are:
https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller/buttons.rb#L846-L848

custom button summary:
![button_summary](https://cloud.githubusercontent.com/assets/3450808/20905124/865a29a6-bb10-11e6-8c23-dedc12a6a46b.png)

Edit screen - 
before
![before1](https://cloud.githubusercontent.com/assets/3450808/20905158/ab8c613a-bb10-11e6-8150-6e73455f0da3.png)

after
![after1](https://cloud.githubusercontent.com/assets/3450808/20905132/8a248b4e-bb10-11e6-81da-74cb367f1b02.png)
