### PR TITLE
Do not copy dev v2_key during docker appliance builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,8 +119,10 @@ WORKDIR ${APP_ROOT}
 RUN source /etc/default/evm && \
     export RAILS_USE_MEMORY_STORE="true" && \
     npm install gulp bower yarn -g && \
-    gem install bundler -v ">=1.8.4" && \
-    bin/setup --no-db --no-tests && \
+    gem install bundler --conservative && \
+    bower install --allow-root -F --silent --config.analytics=false && \
+    bundle install && \
+    bin/rails log:clear tmp:clear && \
     rake evm:compile_assets && \
     rake evm:compile_sti_loader && \
     # Cleanup install artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
     mkdir ${APP_ROOT}/log/apache && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf && \
+    cp ${APP_ROOT}/config/cable.yml.sample ${APP_ROOT}/config/cable.yml && \
     echo "export APP_ROOT=${APP_ROOT}" >> /etc/default/evm && \
     echo "export CONTAINER=true" >> /etc/default/evm
 

--- a/docker-assets/appliance-initialize.sh
+++ b/docker-assets/appliance-initialize.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 [[ -d /var/opt/rh/rh-postgresql95/lib/pgsql/data/base ]] && exit 0
 [[ -s /etc/default/evm ]] && source /etc/default/evm
-echo "Initializing Appliance, please wait ..." > /dev/tty1
-appliance_console_cli --region 0 --internal --password smartvm
+echo "Initializing Appliance, please wait ..."
+appliance_console_cli --region 0 --internal --password smartvm --key


### PR DESCRIPTION
@simaishi @carbonin @bazulay @Fryguy Please review, this has been hiding under the call to bin/setup on container builds for a while.

- Removed bin/setup call from Dockerfile, only relevant parts from bin/setup were kept on install deps layer
- Added --key to appliance_console_cli on /bin/appliance-initialize.sh to generate a legitimate key during first boot
- Removed unnecessary echo redirection to /dev/tty1 , not applicable on containers