### PR TITLE
Filter undercloud resource query for performance

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -96,7 +96,10 @@ module ManageIQ
         # TODO(lsmola) loading this from already obtained nested stack hierarchy will be more effective. This is one
         # extra API call. But we will need to change order of loading, so we have all resources first.
         # Nested depth 50 just for sure, although nobody should nest templates that much
-        @orchestration_service.list_resources(:stack => stack, :nested_depth => 50).body['resources']
+        # To further speed up the query we only search for those resources we care about - those whose
+        # physical_resource_id matches the id of a nova server
+        server_ids = servers.map{|s| s.id}
+        @orchestration_service.list_resources(:stack => stack, :nested_depth => 50, :physical_resource_id => server_ids).body['resources']
       end
 
       def servers


### PR DESCRIPTION
The openstack infra refresher queries the nested stack resources of the undercloud,
which can take a long time and even timeout.  This fix adds a filter to the query, reducing
the running time from over a minute to less than ten seconds.

https://bugzilla.redhat.com/show_bug.cgi?id=1402028