### PR TITLE
[EUWE] Added exception clases for router add/remove interfaces

### DIFF
--- a/gems/pending/util/miq-exception.rb
+++ b/gems/pending/util/miq-exception.rb
@@ -119,6 +119,8 @@ module MiqException
   class MiqNetworkRouterCreateError < Error; end
   class MiqNetworkRouterUpdateError < Error; end
   class MiqNetworkRouterDeleteError < Error; end
+  class MiqNetworkRouterAddInterfaceError < Error; end
+  class MiqNetworkRouterRemoveInterfaceError < Error; end
 
   class MiqVolumeValidationError < Error; end
   class MiqVolumeCreateError < Error; end


### PR DESCRIPTION
Added exception clases for router add/remove interfaces for euwe

https://bugzilla.redhat.com/show_bug.cgi?id=1394284

This is a euwe-only commit as this class is moved to the manageiq-gems-pending repository on master

This PR is equivalent to https://github.com/ManageIQ/manageiq-gems-pending/pull/18 for master

