### PR TITLE
fix test warning for server_roles

### DIFF
--- a/spec/factories/assigned_server_role.rb
+++ b/spec/factories/assigned_server_role.rb
@@ -3,4 +3,9 @@ FactoryGirl.define do
     active          { true }
     priority        { AssignedServerRole::HIGH_PRIORITY }
   end
+
+  factory :assigned_server_role_in_master_region, :parent => :assigned_server_role do
+    # GOAL: master_supported? = true, regional_role? = true
+    server_role { FactoryGirl.create(:server_role, :role_scope => "region", :max_concurrent => 1) }
+  end
 end

--- a/spec/factories/server_role.rb
+++ b/spec/factories/server_role.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :server_role do
+    sequence(:name) { |i| "role#{i}"}
   end
 end

--- a/spec/helpers/application_helper/buttons/server_demote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_demote_spec.rb
@@ -1,9 +1,8 @@
 describe ApplicationHelper::Button::ServerDemote do
   describe '#visible?' do
-    context "is assigned server role and master is supported" do
+    context "with master supported server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role)
-        allow(@record).to receive(:master_supported?).and_return(true)
+        @record = FactoryGirl.create(:assigned_server_role_in_master_region)
       end
 
       it "will not be skipped for this record" do
@@ -15,9 +14,9 @@ describe ApplicationHelper::Button::ServerDemote do
 			end
     end
 
-    context "record is server role" do
+    context "without server role" do
       before do
-        @record = FactoryGirl.create(:server_role, :name => "pooh")
+        @record = FactoryGirl.create(:server_role)
       end
 
       it "will be skipped for this record" do
@@ -31,11 +30,9 @@ describe ApplicationHelper::Button::ServerDemote do
   end
 
   describe '#disabled?' do
-    context "record has priority == 2" do
+    context "with medium prioirity server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role, :priority => 2)
-        allow(@record).to receive(:master_supported?).and_return(true)
-        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 2)
       end
 
       it "disables the button and returns the error message" do

--- a/spec/helpers/application_helper/buttons/server_promote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_promote_spec.rb
@@ -1,10 +1,8 @@
 describe ApplicationHelper::Button::ServerPromote do
   describe '#disabled?' do
-    context "record has priority == 2" do
+    context "with medium priority server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role, :priority => 2)
-        allow(@record).to receive(:master_supported?).and_return(true)
-        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 2)
       end
 
       it "disables the button and returns the error message" do
@@ -17,11 +15,9 @@ describe ApplicationHelper::Button::ServerPromote do
       end
     end
 
-    context "record has priority == 1" do
+    context "with high priority server role" do
       before do
-        @record = FactoryGirl.create(:assigned_server_role, :priority => 1)
-        allow(@record).to receive(:master_supported?).and_return(true)
-        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+        @record = FactoryGirl.create(:assigned_server_role_in_master_region, :priority => 1)
       end
 
       it "disables the button and returns the error message" do


### PR DESCRIPTION
Remove 3 similar warnings:

```
WARNING: An expectation of `:regional_role?` was set on `nil`
```

/cc @romanblanco could you verify that this matches your intent for these specs?