### PR TITLE
[WIP] Proxy support for Google

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => 
 # Modified gems for gems-pending.  Setting sources here since they are git references
 gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
 gem "rubywbem",            :require => false, :git => "https://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
+gem "fog-google",          :require => false, :git => "https://github.com/juliancheal/fog-google", :branch => "proxy_support_part_deux"
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
 unless dependencies.detect { |d| d.name == "manageiq-content" }
@@ -58,7 +59,6 @@ gem "default_value_for",              "~>3.0.2"
 gem "draper",                         "~>3.0.0.pre1"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
-gem "fog-google",                     "~>0.3.0",       :require => false
 gem "fog-vcloud-director",            "~>0.1.8",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -43,7 +43,7 @@ module ManageIQ::Providers::Google::ManagerMixin
         :google_json_key_string => google_json_key,
         :app_name               => I18n.t("product.name"),
         :app_version            => Vmdb::Appliance.VERSION,
-        :google_client_options  => {:proxy_url => proxy_uri}
+        :google_client_options  => {:proxy => proxy_uri}
       }
 
       case options[:service]

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -34,8 +34,7 @@ module ManageIQ::Providers::Google::ManagerMixin
   end
 
   module ClassMethods
-    # TODO: (julian) add proxy_uri back in once supported.
-    def raw_connect(google_project, google_json_key, options, _proxy_uri = nil)
+    def raw_connect(google_project, google_json_key, options, proxy_uri = nil)
       require 'fog/google'
 
       config = {
@@ -44,6 +43,7 @@ module ManageIQ::Providers::Google::ManagerMixin
         :google_json_key_string => google_json_key,
         :app_name               => I18n.t("product.name"),
         :app_version            => Vmdb::Appliance.VERSION,
+        :google_client_options  => {:proxy_url => proxy_uri}
       }
 
       case options[:service]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -967,6 +967,11 @@
     :password:
     :port:
     :user:
+  :gce:
+    :host:
+    :password:
+    :port:
+    :user:
 :ldap_synchronization:
   :ldap_synchronization_schedule: "0 2 * * *"
 :log:


### PR DESCRIPTION
Fog-google now supports a `google_client_options` hash.
Which it will pass along to the google-api-client gem

TODO: Get the google-api-client gem to parse this :(