### PR TITLE
Retry getting api supported versions when empty

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -192,6 +192,20 @@ describe ManageIQ::Providers::Redhat::InfraManager do
         it 'returns from cache' do
           expect(supported_api_versions).to match_array([3])
         end
+
+        context "when the stored value is empty" do
+          let(:cached_api_versions) do
+            {
+              :created_at => Time.now.utc,
+              :value      => []
+            }
+          end
+
+          it "fetches new values by calling the probe" do
+            expect(OvirtSDK4::Probe).to receive(:probe).and_return([])
+            supported_api_versions
+          end
+        end
       end
     end
 


### PR DESCRIPTION
If the stored supported_api_versions is empty try
to fetch it even if cache is not stale.

https://bugzilla.redhat.com/show_bug.cgi?id=1401312