### PR TITLE
Rebuild api version cache on connection validation

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -171,6 +171,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   end
 
   def verify_credentials(auth_type = nil, options = {})
+    options[:skip_supported_api_validation] = true
     auth_type ||= 'default'
     case auth_type.to_s
     when 'default' then verify_credentials_for_rhevm(options)


### PR DESCRIPTION
When trying to validate credentials rebuild the supported api versions
cache.

https://bugzilla.redhat.com/show_bug.cgi?id=1399622