### PR TITLE
Simplify translations in _x_custom_form_buttons_angular.html.haml

### DIFF
--- a/app/views/host_aggregate/add_host_select.html.haml
+++ b/app/views/host_aggregate/add_host_select.html.haml
@@ -19,7 +19,7 @@
       %td{:align => 'right'}
         #buttons_on
           = render :partial => "layouts/angular/x_custom_form_buttons_angular",
-                   :locals  => {:button_label           => N_("Add"),
+                   :locals  => {:button_label           => _("Add"),
                                 :button_click           => "addHostClicked()"}
 
 :javascript

--- a/app/views/host_aggregate/remove_host_select.html.haml
+++ b/app/views/host_aggregate/remove_host_select.html.haml
@@ -19,7 +19,7 @@
       %td{:align => 'right'}
         #buttons_on
           = render :partial => "layouts/angular/x_custom_form_buttons_angular",
-                   :locals  => {:button_label           => N_("Remove"),
+                   :locals  => {:button_label           => _("Remove"),
                                 :button_click           => "removeHostClicked()"}
 
 :javascript

--- a/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_custom_form_buttons_angular.html.haml
@@ -1,15 +1,15 @@
 .button-group{"ng-controller" => "buttonGroupController"}
-  = button_tag(_(button_label),
+  = button_tag(button_label,
                "class"       => "btn btn-primary disabled",
-               :alt          => _(button_label),
-               :title        => _(button_label),
+               :alt          => button_label,
+               :title        => button_label,
                "ng-click"    => "disabledClick($event)",
                "ng-show"     => "!saveable(angularForm)")
 
   = button_tag(_(button_label),
                :class        => "btn btn-primary",
-               :alt          => _(button_label),
-               :title        => _(button_label),
+               :alt          => button_label,
+               :title        => button_label,
                "ng-click"    => button_click,
                "ng-show"     => "saveable(angularForm)")
 


### PR DESCRIPTION
There's no need to do `label = N_('Button Label')` first and then doing `_(label)` in the nested
haml. We can pass `_('Button Label')` as a local variable right away.