### PR TITLE
[Ad hoc metrics for OPS] Add an autocomplete input box for changing the tenant

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -68,11 +68,10 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       $scope.refresh();
     };
 
-    var doRefreshTenant = function (action) {
-      $scope.tenant = action.tenant;
+    $scope.doRefreshTenant = function() {
+      $scope.tenant = $("#ad-hoc-tenant").val();
 
       initialization();
-      filterChange();
       getMetricTags();
     };
 
@@ -209,6 +208,14 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       }
     };
 
+    $scope.getTenenats = function(prefix) {
+      return $http.get($scope.url + "&query=get_tenants&prefix=" + prefix).then(function(response){
+        return response.data.tenants.map(function(item){
+          return item.id;
+        });
+      });
+    }
+
     $scope.timeRanges = [
       {title: _("Hours"), value: 1},
       {title: _("Days"), value: 24},
@@ -260,21 +267,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     $scope.actionsConfig = {
-      actionsInclude: true,
-      moreActions: [
-        {
-          name: 'System',
-          tenant: '_system',
-          title: __("Use the System Tenant Metrics"),
-          actionFn: doRefreshTenant
-        },
-        {
-          name: 'Ops',
-          tenant: '_ops',
-          title: __("Use the Ops Tenant Metrics"),
-          actionFn: doRefreshTenant
-        }
-      ]
+      actionsInclude: true
     };
 
     $scope.graphToolbarConfig = {

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -1,8 +1,8 @@
 /* global miqHttpInject */
 
 miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'patternfly', 'patternfly.charts']))
-  .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window',
-  function ($scope, pfViewUtils, $http, $interval, $timeout, $window) {
+  .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window', '$element',
+  function ($scope, pfViewUtils, $http, $interval, $timeout, $window, $element) {
     $scope.tenant = '_ops';
 
     // get the pathname and remove trailing / if exist
@@ -69,7 +69,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     $scope.doRefreshTenant = function() {
-      $scope.tenant = $("#ad-hoc-tenant").val();
+      $scope.tenant = $element.find("#ad-hoc-tenant").val();
 
       initialization();
       getMetricTags();
@@ -208,7 +208,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       }
     };
 
-    $scope.getTenenats = function(prefix) {
+    $scope.getTenants = function(prefix) {
       return $http.get($scope.url + "&query=get_tenants&limit=7&prefix=" + prefix).then(function(response){
         return response.data.tenants;
       });

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -209,10 +209,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     $scope.getTenenats = function(prefix) {
-      return $http.get($scope.url + "&query=get_tenants&prefix=" + prefix).then(function(response){
-        return response.data.tenants.map(function(item){
-          return item.id;
-        });
+      return $http.get($scope.url + "&query=get_tenants&limit=7&prefix=" + prefix).then(function(response){
+        return response.data.tenants;
       });
     }
 

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -10,6 +10,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     var id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);
 
     var initialization = function() {
+      $scope.tenantChanged = false;
+
       $scope.filtersText = '';
       $scope.definitions = [];
       $scope.items = [];
@@ -209,6 +211,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
     };
 
     $scope.getTenants = function(prefix) {
+      $scope.tenantChanged = true;
       return $http.get($scope.url + "&query=get_tenants&limit=7&prefix=" + prefix).then(function(response){
         return response.data.tenants;
       });

--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -210,9 +210,9 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       }
     };
 
-    $scope.getTenants = function(prefix) {
+    $scope.getTenants = function(include) {
       $scope.tenantChanged = true;
-      return $http.get($scope.url + "&query=get_tenants&limit=7&prefix=" + prefix).then(function(response){
+      return $http.get($scope.url + "&query=get_tenants&limit=7&include=" + include).then(function(response) {
         return response.data.tenants;
       });
     }

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -55,4 +55,15 @@
   .timeline-date-input {
     width: 250px;
   }
+  .ad-hoc-tenant {
+    margin-left: 5px;
+    margin-bottom: 10px;
+  }
+  .ad-hoc-tenant-button{
+    vertical-align: top;
+  }
+  #ad-hoc-tenant {
+    display: inline;
+    width: 200px;
+  }
 }

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -58,10 +58,10 @@ class HawkularProxyService
 
   def tenants
     tenants = client.hawkular_client.http_get('/tenants')
-    tenants = if @params['prefix'].blank?
+    tenants = if @params['include'].blank?
                 tenants.map { |x| x["id"] }.compact
               else
-                tenants.map { |x| x["id"] if x["id"].start_with?(@params['prefix']) }.compact
+                tenants.map { |x| x["id"] if x["id"].include?(@params['include']) }.compact
               end
 
     limit = @params['limit'].to_i || 7

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -59,11 +59,12 @@ class HawkularProxyService
   def tenants
     tenants = client.hawkular_client.http_get('/tenants')
     tenants = if @params['prefix'].blank?
-                tenants
+                tenants.map { |x| x["id"] }.compact
               else
-                tenants.map { |x| x if x["id"].start_with?(@params['prefix']) }.compact
+                tenants.map { |x| x["id"] if x["id"].start_with?(@params['prefix']) }.compact
               end
 
-    tenants[0..8]
+    limit = @params['limit'].to_i || 7
+    tenants[0..limit]
   end
 end

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -23,6 +23,8 @@ class HawkularProxyService
     when 'get_data'
       { :id   => @params['metric_id'],
         :data => get_data(@params['metric_id']).compact }
+    when 'get_tenants'
+      { :tenants => tenants }
     else
       {}
     end
@@ -52,5 +54,16 @@ class HawkularProxyService
                            :ends           => ends.to_i,
                            :bucketDuration => bucket_duration,
                            :order          => order)
+  end
+
+  def tenants
+    tenants = client.hawkular_client.http_get('/tenants')
+    tenants = if @params['prefix'].blank?
+                tenants
+              else
+                tenants.map { |x| x if x["id"].start_with?(@params['prefix']) }.compact
+              end
+
+    tenants[0..8]
   end
 end

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -1,6 +1,24 @@
 = render :partial => "layouts/flash_msg"
 
 .containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController"}
+
+  .col-md-12.ad-hoc-tenant{"ng-if" => "!viewGraph"}
+    %button.btn.btn-default.ad-hoc-tenant-button{"type" => "button",
+                                                 "ng-click" => "doRefreshTenant()"}
+      = _("Set tenant")
+    %input.form-control{"id"                   => "ad-hoc-tenant",
+                        "type"                 => "text",
+                        "ng-model"             => "tenant",
+                        "placeholder"          => _("Choos Tenenats"),
+                        "typeahead"            => "tenenat for tenenat in getTenenats($viewValue)",
+                        "typeahead-loading"    => "loadingTenenats",
+                        "typeahead-no-results" => "noResults",
+                        "typeahead-wait-ms"    => 1000}
+    %i.glyphicon.glyphicon-refresh{"ng-show" => "loadingTenenats"}
+    %div{"ng-show" => "noResults"}
+      %i.glyphicon.glyphicon-remove
+      = _("No Results Found")
+
   %div{"ng-if" => "!viewGraph"}
     %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "toolbarConfig", "ng-if" => "tagsLoaded"}
       %actions

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -3,7 +3,8 @@
 .containers-live-dashboard.row.miq-dashboard-view.miq-metrics{"ng-controller" => "containerLiveDashboardController"}
 
   .col-md-12.ad-hoc-tenant{"ng-if" => "!viewGraph"}
-    %button.btn.btn-default.ad-hoc-tenant-button{"type" => "button",
+    %button.btn.btn-primary.ad-hoc-tenant-button{"type" => "button",
+                                                 "ng-disabled" => "!tenantChanged",
                                                  "ng-click" => "doRefreshTenant()"}
       = _("Set tenant")
     %input.form-control{"id"                   => "ad-hoc-tenant",

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -9,12 +9,12 @@
     %input.form-control{"id"                   => "ad-hoc-tenant",
                         "type"                 => "text",
                         "ng-model"             => "tenant",
-                        "placeholder"          => _("Choos Tenenats"),
-                        "typeahead"            => "tenenat for tenenat in getTenenats($viewValue)",
-                        "typeahead-loading"    => "loadingTenenats",
+                        "placeholder"          => _("Choose Tenants"),
+                        "typeahead"            => "tenenat for tenenat in getTenants($viewValue)",
+                        "typeahead-loading"    => "loadingTenants",
                         "typeahead-no-results" => "noResults",
                         "typeahead-wait-ms"    => 1000}
-    %i.glyphicon.glyphicon-refresh{"ng-show" => "loadingTenenats"}
+    %i.glyphicon.glyphicon-refresh{"ng-show" => "loadingTenants"}
     %div{"ng-show" => "noResults"}
       %i.glyphicon.glyphicon-remove
       = _("No Results Found")

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -9,8 +9,12 @@ describe('containerLiveDashboardController', function() {
 
   beforeEach(function() {
     var $window = {location: { pathname: '/ems_container/42' }};
+    var $element = function() {
+      this.find = function() { return "_ops" };
+    };
     module(function($provide) {
       $provide.value('$window', $window);
+      $provide.value('$element', $element);
     });
   });
 
@@ -47,7 +51,7 @@ describe('containerLiveDashboardController', function() {
     });
   });
 
-  describe('count increment', function() {    
+  describe('count increment', function() {
     it('should increment the count', function() {
       $scope.countIncrement();
       expect($scope.timeFilter.range_count).toBe(2);
@@ -60,7 +64,7 @@ describe('containerLiveDashboardController', function() {
     });
   });
 
-  describe('check numeric formater', function() {    
+  describe('check numeric formater', function() {
     it('should fomrat numbers correctly', function() {
       expect($scope.items[0].lastValues[1480424640000]).toBe("10.00");
       expect($scope.items[0].lastValues[1480424630000]).toBe("1.01k");


### PR DESCRIPTION
**Description**
Refactor #12165
- [x] Add support to change tenent in ad-hoc metrics page

**Screenshots**
Autocomplete input box
![screenshot-2016-12-07-18-42-15](https://cloud.githubusercontent.com/assets/2181522/20977361/053da04c-bcae-11e6-8c7b-0eefd34bc5ec.png)

Autocomplete input box drop down options
![screenshot-localhost 3000-2016-12-08-08-16-26](https://cloud.githubusercontent.com/assets/2181522/20999815/e239e17e-bd1f-11e6-8a5e-cda0610f0d24.png)



