### PR TITLE
[EUWE] tree_autoload - don't assume we're always autoloading the active tree

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -612,7 +612,7 @@ function miqInitTree(options, tree) {
   }
 
   if (options.add_nodes) {
-    miqAddNodeChildren(options.active_tree, options.add_node_key, options.select_node, options.children);
+    miqAddNodeChildren(options.tree_name, options.add_node_key, options.select_node, options.children);
   }
 
   // Tree state persistence correction after the tree is completely loaded

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -37,7 +37,18 @@ module ApplicationController::TreeSupport
   end
 
   def tree_add_child_nodes(id)
-    nodes = TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id, controller_name)
+    tree_name = (params[:tree] || x_active_tree).to_sym
+    tree_type = tree_name.to_s.sub(/_tree$/, '').to_sym
+    tree_klass = x_tree(tree_name)[:klass_name]
+
+    # FIXME after euwe: build_ae_tree
+    tree_type = :catalog if controller_name == 'catalog' && tree_type == :automate
+
+    nodes = TreeBuilder.tree_add_child_nodes(:sandbox    => @sb,
+                                             :klass_name => tree_klass,
+                                             :name       => tree_name,
+                                             :type       => tree_type,
+                                             :id         => id)
     TreeBuilder.convert_bs_tree(nodes)
   end
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -134,13 +134,14 @@ class TreeBuilder
     nodes
   end
 
-  # Add child nodes to the active tree below node 'id'
-  def self.tree_add_child_nodes(sandbox, klass_name, id, controller)
-    args = [sandbox[:active_tree].to_s, sandbox[:active_tree].to_s.sub(/_tree$/, ''), sandbox, false]
+  # Add child nodes to a tree below node 'id'
+  def self.tree_add_child_nodes(sandbox:, klass_name:, name:, type:, id:)
+    args = [name, type, sandbox, false]
     if klass_name == 'TreeBuilderAutomate'
-      args << { :node_builder => TreeBuilderAutomate.select_node_builder(controller) }
+      args << { :node_builder => TreeBuilderAutomate.select_node_builder(type.to_s) }
     end
     tree = klass_name.constantize.new(*args)
+
     tree.x_get_child_nodes(id)
   end
 


### PR DESCRIPTION
This is an euwe version of https://github.com/ManageIQ/manageiq/pull/12986 - heed `params[:tree]` for `tree_autoload`, instead of relying on `x_active_tree`

https://bugzilla.redhat.com/show_bug.cgi?id=1398239
