### PR TITLE
Extract ViewsShared helper module

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,6 @@
 module ApplicationHelper
-  include_concern 'Dialogs'
-  include_concern 'Discover'
+  include_concern 'ViewsShared'
   include_concern 'PageLayouts'
-  include_concern 'FormTags'
   include_concern 'Tasks'
   include Sandbox
   include CompressedIds

--- a/app/helpers/application_helper/views_shared.rb
+++ b/app/helpers/application_helper/views_shared.rb
@@ -1,0 +1,9 @@
+module ApplicationHelper
+  module ViewsShared
+    # Methods here are only used from app/views/shared
+    # Other methods from ApplicationHelper might be used from controllers as well.
+    include Dialogs
+    include Discover
+    include FormTags
+  end
+end


### PR DESCRIPTION
The `ApplicationHelper` is included into every controller. A lot of methods in ApplicationHelper are only used by `app/views/shared`. Many others are kinda global methods.

We need to decouple global methods from these used only in app/views/shared -> that will decrease weight of each controller. For instance consider every controller in the API that has a burden of all the used in `app/views/shared`.

I am not yet prepared to monster move of each and every method here. But I want to introduce right place to put these methods as we keep introducing them.

@miq-bot add_label ui, refactoring, euwe/no
@miq-bot assign @mzazrivec 