### PR TITLE
Make a link from User/Group/Role screens text in Access Control

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -42,7 +42,7 @@
             - else
               - params = {}
             %i.product.product-role{params}
-            = h(@group.miq_user_role.name)
+            = link_to(@group.miq_user_role.name, "#", params)
         - else
           = select_tag('group_role',
               options_for_select(@edit[:roles].sort, @edit[:new][:role]),

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -52,7 +52,7 @@
                 - else
                   - params = {}
                 %i.product.product-group{params}
-                = h(g.description)
+                = link_to(g.description, "#", params)
     .col-md-12.col-lg-6
       %hr
       - if @edit

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -99,7 +99,7 @@
             - if role_allows?(:feature => "rbac_group_show")
               - params = {:class => "pointer", :onclick => "miqTreeActivateNode('rbac_tree', 'g-#{to_cid(@user.current_group.id)}');", :title => _("View this Group")}
             %i.product.product-group{params}
-            = h(@user.current_group.description)
+            = link_to(@user.current_group.description, "#", params)
         - else
           - if disabled
             %p.form-control-static
@@ -123,7 +123,7 @@
             - else
               - params = {}
             %i.product.product-role{params}
-            = h(@user.miq_user_role_name)
+            = link_to(@user.miq_user_role_name, "#", params)
           - else
             %p.form-control-static
               = h(@user.miq_user_role_name)


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1374845

Make a link from User/Group/Role summary screens text to respective
screens in Configure -> Configuration -> Access Control similar to icons.

Before:
![access_before](https://cloud.githubusercontent.com/assets/13417815/20933971/f2d728e4-bbd9-11e6-9ffa-41b840defe8b.png)

After:
![access_after](https://cloud.githubusercontent.com/assets/13417815/20933978/f5577f24-bbd9-11e6-82fe-17b5cd5f3cbf.png)
