### PR TITLE
Symbolize Dialog Field Options

### DIFF
--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -17,14 +17,11 @@ class DialogGroup < ApplicationRecord
   def update_dialog_fields(fields)
     updated_fields = []
     fields.each do |field|
+      field['options'].try(:symbolize_keys!)
       if field.key?('id')
         DialogField.find(field['id']).tap do |dialog_field|
           resource_action_fields = field.delete('resource_action') || {}
-          if resource_action_fields.key?('id')
-            dialog_field.resource_action.update_attributes(resource_action_fields.except('id'))
-          elsif resource_action_fields.present?
-            dialog_field.resource_action = ResourceAction.create(resource_action_fields)
-          end
+          update_resource_fields(resource_action_fields, dialog_field)
           dialog_field.update_attributes(field)
           updated_fields << dialog_field
         end
@@ -51,6 +48,16 @@ class DialogGroup < ApplicationRecord
   def deep_copy
     dup.tap do |new_group|
       new_group.dialog_fields = dialog_fields.collect(&:deep_copy)
+    end
+  end
+
+  private
+
+  def update_resource_fields(resource_action_fields, dialog_field)
+    if resource_action_fields.key?('id')
+      dialog_field.resource_action.update_attributes(resource_action_fields.except('id'))
+    elsif resource_action_fields.present?
+      dialog_field.resource_action = ResourceAction.create(resource_action_fields)
     end
   end
 end

--- a/app/services/dialog_import_service.rb
+++ b/app/services/dialog_import_service.rb
@@ -76,6 +76,7 @@ class DialogImportService
 
   def build_dialog_fields(dialog_group)
     dialog_group["dialog_fields"].collect do |dialog_field|
+      dialog_field["options"].try(:symbolize_keys!)
       @dialog_field_importer.import_field(dialog_field)
     end
   end

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -72,5 +72,20 @@ describe DialogGroup do
         end.to change(dialog_group.reload.dialog_fields, :count).by(-1)
       end
     end
+
+    context 'it symbolizes a dialog fields options' do
+      let(:updated_fields) do
+        [{ 'name' => 'new', 'label' => 'new field label', 'type' => 'DialogFieldTagControl', 'options' =>
+          { 'name' => 'foo', 'description' => 'bar'} }]
+      end
+
+      it 'dialog_field.options has symbolized keys' do
+        dialog_group.update_dialog_fields(updated_fields)
+        dialog_group.reload
+        expect(dialog_group.dialog_fields.first.options).to eq(:name        => 'foo',
+                                                               :description => 'bar',
+                                                               :category_id => nil)
+      end
+    end
   end
 end

--- a/spec/services/dialog_import_service_spec.rb
+++ b/spec/services/dialog_import_service_spec.rb
@@ -409,7 +409,7 @@ describe DialogImportService do
       let(:dialog_fields) do
         {
           'dialog_fields' => [
-            {'name' => 'field name', 'label' => 'field label'}
+            {'name' => 'field name', 'label' => 'field label', 'options' => {'name' => 'foo'}}
           ]
         }
       end
@@ -418,6 +418,11 @@ describe DialogImportService do
         expect do
           DialogImportService.new.build_dialog_fields(dialog_fields)
         end.to change(DialogField, :count).by(1)
+      end
+
+      it 'symbolizes the dialog field options' do
+        fields = DialogImportService.new.build_dialog_fields(dialog_fields)
+        expect(fields.first.options).to eq(:name => 'foo')
       end
     end
   end


### PR DESCRIPTION
When creating a `DialogFieldTagControl`, the `options` were not being symbolized. When returning the content of a `DialogField`, it was then raising a 'NoMethodError' because `category` was returning `nil` since it is looking for a symbolized `category_id`, not a string. 

Let me know if this fixes the problem @romanblanco! 
@miq-bot add_label bug, euwe/yes
@miq-bot assign @gmcculloug 


