### PR TITLE
Add alerts api

### DIFF
--- a/app/controllers/api/alerts_controller.rb
+++ b/app/controllers/api/alerts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class AlertsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -647,6 +647,21 @@
       :get:
       - :name: read
         :identifier: load_balancer_show
+  :alerts:
+    :description: Alerts
+    :identifier: alert
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: MiqAlertStatus
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: alert_status_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: alert_status_show
   :notifications:
     :description: "User's past notifications"
     :options:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1932,7 +1932,26 @@
         :feature_type: admin
         :hidden: true
         :identifier: alert_delete
-
+  - :name: Alerts Statuses
+    :description: Everything under Alerts Statuses
+    :protected: true
+    :feature_type: node
+    :hidden: true
+    :identifier: alert_status
+    :children:
+    - :name: View
+      :description: View Alerts Statuses
+      :feature_type: view
+      :identifier: alert_status_view
+      :children:
+      - :name: List
+        :description: Display Lists of Alert Statuses
+        :feature_type: view
+        :identifier: alert_status_show_list
+      - :name: Show
+        :description: Display Individual Alert Status
+        :feature_type: view
+        :identifier: alert_status_show
 # Policy Simulation
 - :name: Simulation
   :description: Policy Simulation

--- a/spec/factories/miq_alert_status.rb
+++ b/spec/factories/miq_alert_status.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_alert_status do
+  end
+end

--- a/spec/requests/api/alerts_spec.rb
+++ b/spec/requests/api/alerts_spec.rb
@@ -1,0 +1,47 @@
+describe "Alerts API" do
+  let(:alert_definition) { FactoryGirl.create(:miq_alert, :severity => "info") }
+
+  it "forbids access to alerts list without an appropriate role" do
+    api_basic_authorize
+    run_get(alerts_url)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "reads 2 alerts as a collection" do
+    api_basic_authorize collection_action_identifier(:alerts, :read, :get)
+    alert_statuses = FactoryGirl.create_list(:miq_alert_status, 2)
+    run_get(alerts_url)
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to eq(
+      "name"      => "alerts",
+      "count"     => 2,
+      "subcount"  => 2,
+      "resources" => [
+        {
+          "href" => "http://www.example.com/api/alerts/#{alert_statuses[0].id}"
+        },
+        {
+          "href" => "http://www.example.com/api/alerts/#{alert_statuses[1].id}"
+        }
+      ]
+    )
+  end
+
+  it "forbids access to an alert resource without an appropriate role" do
+    api_basic_authorize
+    alert_status = FactoryGirl.create(:miq_alert_status)
+    run_get(alerts_url(alert_status.id))
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "reads an alert as a resource" do
+    api_basic_authorize action_identifier(:alerts, :read, :resource_actions, :get)
+    alert_status = FactoryGirl.create(:miq_alert_status)
+    run_get(alerts_url(alert_status.id))
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to have_attributes(
+      "href" => "http://www.example.com/api/alerts/#{alert_status.id}",
+      "id"   => alert_status.id
+    )
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -299,6 +299,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:load_balancer)
       test_collection_query(:load_balancers, load_balancers_url, LoadBalancer)
     end
+
+    it 'query Alerts' do
+      FactoryGirl.create(:miq_alert_status)
+      test_collection_query(:alerts, alerts_url, MiqAlertStatus)
+    end
   end
 
   context "Collections Bulk Queries" do


### PR DESCRIPTION
GET /api/alerts
GET /api/alerts/:id

Adds an api to view MiqAlertStatuses The entity is renamed to `alerts` since that is thought to be the most useful name for users. When adding MiqAlert in the future the intention is to use the name `alert_definitions` - that is consistent with miq_event/miq_event_definition.

The new api is used in  #11962