### PR TITLE
Filter attempt from the authentication_check options

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -265,7 +265,7 @@ module AuthenticationMixin
     types = args.first                  if types.blank?
     types = [nil]                       if types.blank?
     Array(types).each do |t|
-      success = authentication_check(t, options).first
+      success = authentication_check(t, options.except(:attempt)).first
       retry_scheduled_authentication_check(t, options) unless success
     end
   end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -248,6 +248,12 @@ describe AuthenticationMixin do
             expect(messages.count).to eq(1)
             expect(messages.first.args.last).to eq(:attempt => 2)
           end
+
+          it "filters out attempt from the authentication_check call" do
+            expect(@host1).to receive(:authentication_check).with(nil, hash_excluding(:attempt)).and_return([true, ""])
+            expect(@host1).to receive(:authentication_check).with(nil, hash_including(:attempt)).and_return([true, ""]).never
+            @host1.authentication_check_types(:attempt => 1)
+          end
         end
       end
     end


### PR DESCRIPTION
Various implementations of verify_credentials aren't expecting an
:attempt => 1 hash key/value.

It's only used at a higher layer so exclude it from the
authentication_check call.

https://bugzilla.redhat.com/show_bug.cgi?id=1402035

This was a regression introduced in #11964