### PR TITLE
[WIP] Service dialog for Cloudformation orchestration

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationServiceOptionConverter
   require_nested :OrchestrationStack
+  require_nested :OrchestrationTemplateHotDialogService
   require_nested :Provision
   require_nested :ProvisionWorkflow
   require_nested :Refresher
@@ -49,6 +50,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   before_validation :ensure_managers,
                     :ensure_cinder_managers,
                     :ensure_swift_managers
+
+  # OrchestrationTemplateCfnDialogService is just an alias of OrchestrationTemplateHotDialogService
+  # so that it can create dialogs for Cloudformation templates used by OpenStack
+  OrchestrationTemplateCfnDialogService = OrchestrationTemplateHotDialogService
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template_hot_dialog_service.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_template_hot_dialog_service.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplateHotDialogService < ::OrchestrationTemplateDialogService
+  def add_deployment_options(dialog_group, position)
+    add_on_failure_field(dialog_group, position)
+    add_timeout_field(dialog_group, position + 1)
+  end
+
+  def add_on_failure_field(group, position)
+    group.dialog_fields.build(
+      :type          => "DialogFieldDropDownList",
+      :name          => "stack_onfailure",
+      :description   => "Select what to do if stack creation failed",
+      :data_type     => "string",
+      :display       => "edit",
+      :required      => true,
+
+      # %w(DELETE Delete\ stack) is available with aws-sdk v2
+      :values        => [%w(ROLLBACK Rollback), %w(DO_NOTHING Do\ nothing)],
+      :default_value => "ROLLBACK",
+      :options       => {:sort_by => :description, :sort_order => :ascending},
+      :label         => "On Failure",
+      :position      => position,
+      :dialog_group  => group
+    )
+  end
+
+  def add_timeout_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextBox",
+      :name         => "stack_timeout",
+      :description  => "Abort the creation if it does not complete in a proper time window",
+      :data_type    => "integer",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Timeout(minutes, optional)",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :OrchestrationServiceOptionConverter
   require_nested :OrchestrationStack
   require_nested :OrchestrationTemplate
+  require_nested :OrchestrationTemplateDialogService
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :RefreshParser

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template_dialog_service.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template_dialog_service.rb
@@ -1,0 +1,24 @@
+class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplateDialogService < ::OrchestrationTemplateDialogService
+  private
+
+  def add_deployment_options(group, position)
+    add_availability_zone_field(group, position)
+  end
+
+  def add_availability_zone_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldDropDownList",
+      :name         => "availability_zone",
+      :description  => "Availability zone where the stack will be deployed",
+      :data_type    => "string",
+      :dynamic      => true,
+      :display      => "edit",
+      :required     => true,
+      :label        => "Availability zone",
+      :position     => position,
+      :dialog_group => group
+    ).tap do |dialog_field|
+      dialog_field.resource_action.fqname = "/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones"
+    end
+  end
+end

--- a/app/services/orchestration_template_azure_dialog_service.rb
+++ b/app/services/orchestration_template_azure_dialog_service.rb
@@ -1,0 +1,65 @@
+class OrchestrationTemplateAzureDialogService < OrchestrationTemplateDialogService
+  private
+
+  def add_deployment_options(dialog_group, position)
+    add_resource_group_list(dialog_group, position)
+    add_new_resource_group_field(dialog_group, position + 1)
+    add_mode_field(dialog_group, position + 2)
+  end
+
+  def add_mode_field(group, position)
+    description = "Select deployment mode.\n"\
+                  "WARNING: Complete mode will delete all resources from "\
+                  "the group that are not in the template."
+
+    group.dialog_fields.build(
+      :type          => "DialogFieldDropDownList",
+      :name          => "deploy_mode",
+      :description   => description,
+      :data_type     => "string",
+      :display       => "edit",
+      :required      => true,
+      :values        => [["Incremental", "Incremental (Default)"],
+                         ["Complete",    "Complete (Delete other resources in the group)"]],
+      :default_value => "Incremental",
+      :options       => {:sort_by => :description, :sort_order => :ascending},
+      :label         => "Mode",
+      :position      => position,
+      :dialog_group  => group
+    )
+  end
+
+  def add_resource_group_list(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldDropDownList",
+      :name         => "resource_group",
+      :description  => "Select an existing resource group for deployment",
+      :data_type    => "string",
+      :display      => "edit",
+      :dynamic      => true,
+      :required     => false,
+      :label        => "Existing Resource Group",
+      :position     => position,
+      :dialog_group => group
+    ).tap do |dialog_field|
+      dialog_field.resource_action.fqname = "/Cloud/Orchestration/Operations/Methods/Available_Resource_Groups"
+    end
+  end
+
+  def add_new_resource_group_field(group, position)
+    group.dialog_fields.build(
+      :type           => "DialogFieldTextBox",
+      :name           => "new_resource_group",
+      :description    => "Create a new resource group upon deployment",
+      :data_type      => "string",
+      :display        => "edit",
+      :required       => false,
+      :options        => {:protected => false},
+      :validator_type => 'regex',
+      :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$',
+      :label          => "(or) New Resource Group",
+      :position       => position,
+      :dialog_group   => group
+    )
+  end
+end

--- a/app/services/orchestration_template_cfn_dialog_service.rb
+++ b/app/services/orchestration_template_cfn_dialog_service.rb
@@ -1,0 +1,42 @@
+class OrchestrationTemplateCfnDialogService < OrchestrationTemplateDialogService
+  private
+
+  def add_deployment_options(dialog_group, position)
+    add_on_failure_field(dialog_group, position)
+    add_timeout_field(dialog_group, position + 1)
+  end
+
+  def add_on_failure_field(group, position)
+    group.dialog_fields.build(
+      :type          => "DialogFieldDropDownList",
+      :name          => "stack_onfailure",
+      :description   => "Select what to do if stack creation failed",
+      :data_type     => "string",
+      :display       => "edit",
+      :required      => true,
+
+      # %w(DELETE Delete\ stack) is available with aws-sdk v2
+      :values        => [%w(ROLLBACK Rollback), %w(DO_NOTHING Do\ nothing)],
+      :default_value => "ROLLBACK",
+      :options       => {:sort_by => :description, :sort_order => :ascending},
+      :label         => "On Failure",
+      :position      => position,
+      :dialog_group  => group
+    )
+  end
+
+  def add_timeout_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextBox",
+      :name         => "stack_timeout",
+      :description  => "Abort the creation if it does not complete in a proper time window",
+      :data_type    => "integer",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Timeout(minutes, optional)",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+end

--- a/app/services/orchestration_template_cfn_dialog_service.rb
+++ b/app/services/orchestration_template_cfn_dialog_service.rb
@@ -4,6 +4,12 @@ class OrchestrationTemplateCfnDialogService < OrchestrationTemplateDialogService
   def add_deployment_options(dialog_group, position)
     add_on_failure_field(dialog_group, position)
     add_timeout_field(dialog_group, position + 1)
+    add_notifications_field(dialog_group, position + 2)
+    add_capabilities_field(dialog_group, position + 3)
+    add_resource_types_field(dialog_group, position + 4)
+    add_role_field(dialog_group, position + 5)
+    add_tags_field(dialog_group, position + 6)
+    add_policy_field(dialog_group, position + 7)
   end
 
   def add_on_failure_field(group, position)
@@ -14,9 +20,7 @@ class OrchestrationTemplateCfnDialogService < OrchestrationTemplateDialogService
       :data_type     => "string",
       :display       => "edit",
       :required      => true,
-
-      # %w(DELETE Delete\ stack) is available with aws-sdk v2
-      :values        => [%w(ROLLBACK Rollback), %w(DO_NOTHING Do\ nothing)],
+      :values        => [%w(ROLLBACK Rollback), %w(DO_NOTHING Do\ nothing), %w(DELETE Delete\ stack)],
       :default_value => "ROLLBACK",
       :options       => {:sort_by => :description, :sort_order => :ascending},
       :label         => "On Failure",
@@ -34,7 +38,99 @@ class OrchestrationTemplateCfnDialogService < OrchestrationTemplateDialogService
       :display      => "edit",
       :required     => false,
       :options      => {:protected => false},
-      :label        => "Timeout(minutes, optional)",
+      :label        => "Timeout(minutes)",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+
+  def add_notifications_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextAreaBox",
+      :name         => "stack_notifications",
+      :description  => "Notification SNS topic ARNs, one ARN per line",
+      :data_type    => "string",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Notification ARNs",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+
+  def add_capabilities_field(group, position)
+    group.dialog_fields.build(
+      :type          => "DialogFieldDropDownList",
+      :name          => "stack_capabilities",
+      :description   => "Choose one or both capabilities",
+      :data_type     => "string",
+      :display       => "edit",
+      :required      => false,
+      :values        => [['', '<default>'], %w(CAPABILITY_IAM CAPABILITY_IAM), %w(CAPABILITY_NAMED_IAM CAPABILITY_NAMED_IAM)],
+      :default_value => "",
+      :options       => {:sort_by => :description, :sort_order => :ascending},
+      :label         => "Capabilities",
+      :position      => position,
+      :dialog_group  => group
+    )
+  end
+
+  def add_resource_types_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextAreaBox",
+      :name         => "stack_resource_types",
+      :description  => "Grand permissions to selected types, one type per line",
+      :data_type    => "string",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Permitted resource types",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+
+  def add_role_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextBox",
+      :name         => "stack_role",
+      :description  => "ARN of an IAM role used to create the stack",
+      :data_type    => "string",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Role ARN",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+
+  def add_tags_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextAreaBox",
+      :name         => "stack_tags",
+      :description  => "Key-value pairs with format key1=>val1, one pair per line",
+      :data_type    => "string",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "AWS Tags",
+      :position     => position,
+      :dialog_group => group
+    )
+  end
+
+  def add_policy_field(group, position)
+    group.dialog_fields.build(
+      :type         => "DialogFieldTextAreaBox",
+      :name         => "stack_policy",
+      :description  => "URL of an policy file or the actual content of the policy",
+      :data_type    => "string",
+      :display      => "edit",
+      :required     => false,
+      :options      => {:protected => false},
+      :label        => "Policy",
       :position     => position,
       :dialog_group => group
     )

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -659,4 +659,17 @@ describe CatalogController do
       expect(assigns(:edit)[:new][:retire_fqname]).to include("Default")
     end
   end
+
+  describe "#service_dialog_generator" do
+    it "gets the right service dialog generator based on the orchestration template type" do
+      expect(controller.send(:service_dialog_generator, OrchestrationTemplateAzure.new))
+        .to eq(OrchestrationTemplateAzureDialogService)
+      expect(controller.send(:service_dialog_generator, OrchestrationTemplateCfn.new))
+        .to eq(OrchestrationTemplateCfnDialogService)
+      expect(controller.send(:service_dialog_generator, OrchestrationTemplateHot.new))
+        .to eq(ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplateHotDialogService)
+      expect(controller.send(:service_dialog_generator, ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.new))
+        .to eq(ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplateDialogService)
+    end
+  end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -408,7 +408,7 @@ describe Dialog do
   end
 
   describe "#deep_copy" do
-    let(:dialog_service) { OrchestrationTemplateDialogService.new }
+    let(:dialog_service) { ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplateHotDialogService.new }
     let(:template_hot)   { FactoryGirl.create(:orchestration_template_hot_with_content) }
     let(:dialog) { dialog_service.create_dialog('test', template_hot) }
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_template_hot_dialog_service_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_template_hot_dialog_service_spec.rb
@@ -1,0 +1,24 @@
+require Rails.root.join('spec/shared/services/assert_dialog_field')
+RSpec.configure { |c| c.include Helpers }
+
+describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplateHotDialogService do
+  let(:empty_template) do
+    FactoryGirl.create(:orchestration_template).tap { |t| allow(t).to receive(:parameter_groups).and_return([]) }
+  end
+
+  describe "#create_dialog" do
+    it "creates a dialog with AWS stack options" do
+      dialog = subject.create_dialog("test", empty_template)
+      tabs = dialog.dialog_tabs
+      group = tabs[0].dialog_groups[0] # stack options group
+      fields = group.dialog_fields
+      expect(fields.size).to eq(4)
+
+      expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+      assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
+      assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+      assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+      assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
+    end
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_dialog_service_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_dialog_service_spec.rb
@@ -1,0 +1,42 @@
+require Rails.root.join('spec/shared/services/assert_dialog_field')
+RSpec.configure { |c| c.include Helpers }
+
+describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplateDialogService do
+  let(:template_vapp) { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from VMware vCloud vApp template with stack basic info and parameters" do
+      dialog = subject.create_dialog("test", template_vapp)
+
+      tabs = dialog.dialog_tabs
+      expect(tabs[0].dialog_groups.size).to eq(2)
+      assert_vmware_cloud_stack_group(tabs[0].dialog_groups[0])
+      assert_vmware_cloud_parameters_group(tabs[0].dialog_groups[1])
+    end
+  end
+
+
+  def assert_vmware_cloud_stack_group(group)
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",       :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",        :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    expect(fields[2].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones")
+    assert_field(fields[2], DialogFieldDropDownList, :name => "availability_zone", :dynamic => true)
+  end
+
+  def assert_vmware_cloud_parameters_group(group)
+    expect(group).to have_attributes(
+      :label   => "vApp Parameters",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(2)
+
+    assert_field(fields[0], DialogFieldCheckBox, :name => "param_deploy",  :default_value => "t", :data_type => "boolean")
+    assert_field(fields[1], DialogFieldCheckBox, :name => "param_powerOn", :default_value => "f", :data_type => "boolean")
+  end
+end

--- a/spec/services/orchestration_template_azure_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_azure_dialog_service_spec.rb
@@ -1,0 +1,29 @@
+require Rails.root.join('spec/shared/services/assert_dialog_field')
+RSpec.configure { |c| c.include Helpers }
+
+describe OrchestrationTemplateAzureDialogService do
+  let(:empty_template) do
+    FactoryGirl.create(:orchestration_template).tap { |t| allow(t).to receive(:parameter_groups).and_return([]) }
+  end
+
+  describe "#create_dialog" do
+    it "creates a dialog with Azure stack options" do
+      dialog = subject.create_dialog("test", empty_template)
+      tabs = dialog.dialog_tabs
+      group = tabs[0].dialog_groups[0] # stack options group
+      fields = group.dialog_fields
+      expect(fields.size).to  eq(5)
+
+      expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+      assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",        :dynamic => true)
+      assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+      assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
+      assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
+
+      mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
+                     ["Incremental", "Incremental (Default)"]]
+      assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
+      expect(fields[4].default_value).to eq("Incremental")
+    end
+  end
+end

--- a/spec/services/orchestration_template_cfn_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_cfn_dialog_service_spec.rb
@@ -12,13 +12,19 @@ describe OrchestrationTemplateCfnDialogService do
       tabs = dialog.dialog_tabs
       group = tabs[0].dialog_groups[0] # stack options group
       fields = group.dialog_fields
-      expect(fields.size).to eq(4)
+      expect(fields.size).to eq(10)
 
       expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
-      assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
-      assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-      assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
-      assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
+      assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",          :dynamic => true)
+      assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",           :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+      assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure",      :values => [%w(DELETE Delete\ stack), %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+      assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",        :data_type => 'integer')
+      assert_field(fields[4], DialogFieldTextAreaBox,  :name => "stack_notifications",  :data_type => 'string')
+      assert_field(fields[5], DialogFieldDropDownList, :name => "stack_capabilities",   :values => [['', '<default>'], %w(CAPABILITY_IAM CAPABILITY_IAM), %w(CAPABILITY_NAMED_IAM CAPABILITY_NAMED_IAM)])
+      assert_field(fields[6], DialogFieldTextAreaBox,  :name => "stack_resource_types", :data_type => 'string')
+      assert_field(fields[7], DialogFieldTextBox,      :name => "stack_role",           :data_type => 'string')
+      assert_field(fields[8], DialogFieldTextAreaBox,  :name => "stack_tags",           :data_type => 'string')
+      assert_field(fields[9], DialogFieldTextAreaBox,  :name => "stack_policy",         :data_type => 'string')
     end
   end
 end

--- a/spec/services/orchestration_template_cfn_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_cfn_dialog_service_spec.rb
@@ -1,0 +1,24 @@
+require Rails.root.join('spec/shared/services/assert_dialog_field')
+RSpec.configure { |c| c.include Helpers }
+
+describe OrchestrationTemplateCfnDialogService do
+  let(:empty_template) do
+    FactoryGirl.create(:orchestration_template).tap { |t| allow(t).to receive(:parameter_groups).and_return([]) }
+  end
+
+  describe "#create_dialog" do
+    it "creates a dialog with AWS stack options" do
+      dialog = subject.create_dialog("test", empty_template)
+      tabs = dialog.dialog_tabs
+      group = tabs[0].dialog_groups[0] # stack options group
+      fields = group.dialog_fields
+      expect(fields.size).to eq(4)
+
+      expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+      assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
+      assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+      assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+      assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
+    end
+  end
+end

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -1,59 +1,50 @@
+require Rails.root.join('spec/shared/services/assert_dialog_field')
+RSpec.configure { |c| c.include Helpers }
+
 describe OrchestrationTemplateDialogService do
-  let(:dialog_service) { described_class.new }
-  let(:template_hot)   { FactoryGirl.create(:orchestration_template_hot_with_content) }
-  let(:template_azure) { FactoryGirl.create(:orchestration_template_azure_with_content) }
-  let(:empty_template) { FactoryGirl.create(:orchestration_template_cfn) }
-  let(:template_vapp)  { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
+  let(:empty_template) { FactoryGirl.create(:orchestration_template) }
 
-  describe "#create_dialog" do
-    it "creates a dialog from hot template with stack basic info and parameters" do
-      dialog = dialog_service.create_dialog("test", template_hot)
+  describe "creating of stack option tab" do
+    before do
+      allow(empty_template).to receive(:parameter_groups).and_return([1, 2].collect do |n|
+        OrchestrationTemplate::OrchestrationParameterGroup.new(
+          :label      => "Parameter Group#{n}",
+          :parameters => [OrchestrationTemplate::OrchestrationParameter.new(
+            :name      => "param#{n}",
+            :label     => "Parameter",
+            :data_type => "string")
+          ])
+      end)
+    end
 
-      expect(dialog).to have_attributes(
-        :label   => "test",
-        :buttons => "submit,cancel"
-      )
+    it "creates a dialog with stack basic info and common options and parameters" do
+      dialog = subject.create_dialog("test", empty_template)
+
+      expect(dialog).to have_attributes(:label => "test", :buttons => "submit,cancel")
 
       tabs = dialog.dialog_tabs
       expect(tabs.size).to eq(1)
-      assert_stack_tab(tabs[0])
-    end
+      assert_dialog_attributes(tabs[0], "Basic Information")
 
-    it "creates a dialog from azure template with stack basic info and parameters" do
-      dialog = dialog_service.create_dialog("test", template_azure)
-
-      tabs = dialog.dialog_tabs
-      assert_tab_attributes(tabs[0])
-      assert_azure_stack_group(tabs[0].dialog_groups[0])
-    end
-
-    it "creates a dialog from a template without parameters" do
-      dialog = dialog_service.create_dialog("test", empty_template)
-
-      tabs = dialog.dialog_tabs
-      assert_tab_attributes(tabs[0])
-      assert_aws_openstack_stack_group(tabs[0].dialog_groups[0])
-    end
-
-    it "creates a dialog from VMware vCloud vApp template with stack basic info and parameters" do
-      dialog = dialog_service.create_dialog("test", template_vapp)
-
-      tabs = dialog.dialog_tabs
-      assert_tab_attributes(tabs[0])
-      expect(tabs[0].dialog_groups.size).to eq(2)
-      assert_vmware_cloud_stack_group(tabs[0].dialog_groups[0])
-      assert_vmware_cloud_parameters_group(tabs[0].dialog_groups[1])
+      groups = tabs[0].dialog_groups
+      expect(groups.size).to eq(3)
+      assert_stack_option_group(groups[0])
+      assert_parameter_group(groups[1], '1')
+      assert_parameter_group(groups[2], '2')
     end
   end
 
   describe "creation of dropdown parameter fields" do
     context "when allowed values are given" do
-      it "creates a dropdown field with pairs of values" do
+      before do
         # Create a simple dialog with one dropdown parameter.
         constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(val1 val2))
         param_groups = create_dropdown_param(constraint)
         allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
-        dialog = dialog_service.create_dialog("test", empty_template)
+      end
+
+      it "creates a dropdown field with pairs of values" do
+        dialog = subject.create_dialog("test", empty_template)
 
         # Get the dropdown field
         field = dropdown_field(dialog)
@@ -63,12 +54,15 @@ describe OrchestrationTemplateDialogService do
     end
 
     context "when a hash of allowed values is given" do
-      it "creates pairs from hashes" do
+      before do
         # Create a simple dialog with one dropdown parameter.
         constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => {"key1" => "val1", "key2" => "val2"})
         param_groups = create_dropdown_param(constraint)
         allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
-        dialog = dialog_service.create_dialog("test", empty_template)
+      end
+
+      it "creates pairs from hashes" do
+        dialog = subject.create_dialog("test", empty_template)
 
         # Get the dropdown field
         field = dropdown_field(dialog)
@@ -78,12 +72,15 @@ describe OrchestrationTemplateDialogService do
     end
 
     context "when automate method is given" do
-      it "creates a dropdown field requested resource_action" do
+      before do
         # Create a simple dialog with one dropdown parameter.
         constraint = OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(:fqname => "/Path/To/Method")
         param_groups = create_dropdown_param(constraint)
         allow(empty_template).to receive(:parameter_groups).and_return(param_groups)
-        dialog = dialog_service.create_dialog("test", empty_template)
+      end
+
+      it "creates a dropdown field requested resource_action" do
+        dialog = subject.create_dialog("test", empty_template)
 
         # Get the dropdown field
         field = dropdown_field(dialog)
@@ -94,121 +91,27 @@ describe OrchestrationTemplateDialogService do
     end
   end
 
-  def assert_stack_tab(tab)
-    assert_tab_attributes(tab)
-
-    groups = tab.dialog_groups
-    expect(groups.size).to eq(3)
-
-    assert_aws_openstack_stack_group(groups[0])
-    assert_parameter_group1(groups[1])
-    assert_parameter_group2(groups[2])
+  def assert_dialog_attributes(component, label)
+    expect(component).to have_attributes(:label => label, :display => "edit")
   end
 
-  def assert_tab_attributes(tab)
-    expect(tab).to have_attributes(
-      :label   => "Basic Information",
-      :display => "edit"
-    )
-  end
-
-  def assert_aws_openstack_stack_group(group)
-    expect(group).to have_attributes(
-      :label   => "Options",
-      :display => "edit",
-    )
-
-    fields = group.dialog_fields
-    expect(fields.size).to eq(4)
-
-    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
-    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
-    assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
-  end
-
-  def assert_azure_stack_group(group)
-    expect(group).to have_attributes(
-      :label   => "Options",
-      :display => "edit",
-    )
-
-    fields = group.dialog_fields
-    expect(fields.size).to eq(5)
-
-    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
-    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",        :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",         :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
-    assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
-
-    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
-                   ["Incremental", "Incremental (Default)"]]
-    assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
-    expect(fields[4].default_value).to eq("Incremental")
-  end
-
-  def assert_vmware_cloud_stack_group(group)
-    expect(group).to have_attributes(
-      :label   => "Options",
-      :display => "edit",
-    )
-
-    fields = group.dialog_fields
-    expect(fields.size).to eq(3)
-
-    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
-    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",       :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",        :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    expect(fields[2].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones")
-    assert_field(fields[2], DialogFieldDropDownList, :name => "availability_zone", :dynamic => true)
-  end
-
-  def assert_vmware_cloud_parameters_group(group)
-    expect(group).to have_attributes(
-      :label   => "vApp Parameters",
-      :display => "edit",
-    )
+  def assert_stack_option_group(group)
+    assert_dialog_attributes(group, "Options")
 
     fields = group.dialog_fields
     expect(fields.size).to eq(2)
 
-    assert_field(fields[0], DialogFieldCheckBox, :name => "param_deploy",  :default_value => "t", :data_type => "boolean")
-    assert_field(fields[1], DialogFieldCheckBox, :name => "param_powerOn", :default_value => "f", :data_type => "boolean")
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name", :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",  :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
   end
 
-  def assert_field(field, clss, attributes)
-    expect(field).to be_kind_of clss
-    expect(field).to have_attributes(attributes)
-  end
-
-  def assert_parameter_group1(group)
-    expect(group).to have_attributes(
-      :label   => "General parameters",
-      :display => "edit",
-    )
+  def assert_parameter_group(group, id)
+    assert_dialog_attributes(group, "Parameter Group#{id}")
 
     fields = group.dialog_fields
-    expect(fields.size).to eq(3)
-
-    assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
-    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
-    assert_field(fields[2], DialogFieldTextBox,      :name => "param_cartridges", :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby")
-  end
-
-  def assert_parameter_group2(group)
-    expect(group).to have_attributes(
-      :label   => "Parameter Group2",
-      :display => "edit",
-    )
-
-    fields = group.dialog_fields
-    expect(fields.size).to eq(3)
-
-    assert_field(fields[0], DialogFieldTextBox,     :name => "param_admin_pass", :validator_rule => '[a-zA-Z0-9]+')
-    assert_field(fields[1], DialogFieldTextBox,     :name => "param_db_port",    :label => 'Port Number')
-    assert_field(fields[2], DialogFieldTextAreaBox, :name => "param_metadata")
+    expect(fields.size).to eq(1)
+    assert_field(fields[0], DialogFieldTextBox, :name => "param_param#{id}")
   end
 
   def dropdown_field(dialog)

--- a/spec/shared/services/assert_dialog_field.rb
+++ b/spec/shared/services/assert_dialog_field.rb
@@ -1,0 +1,6 @@
+module Helpers
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+end


### PR DESCRIPTION
This work enhances the existing service dialog to include all available options for Cloudformation orchestration.

The backend support is https://github.com/ManageIQ/manageiq-providers-amazon/pull/88

It has a dependency on #12448