### PR TITLE
Update shared spec to match against actual breadcrumbs

### DIFF
--- a/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
@@ -37,7 +37,7 @@ shared_examples :shared_examples_for_load_balancer_controller do |providers|
           get :show, :params => {:id => @load_balancer.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "load_balancers",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Load Balancers",
                                                 :url  => "/load_balancer/show_list?page=&refresh=y"},
                                                {:name => "Load Balancer (Summary)",
                                                 :url  => "/load_balancer/show/#{@load_balancer.id}"}])


### PR DESCRIPTION
Fixes failing specs in provider repos that test load_balancer controllers to create breadcrumbs

see https://travis-ci.org/ManageIQ/manageiq-providers-amazon/builds/181764628
