### PR TITLE
When importing domains from the UI pass in the tenant_id

### DIFF
--- a/app/services/automate_import_service.rb
+++ b/app/services/automate_import_service.rb
@@ -14,7 +14,8 @@ class AutomateImportService
     import_options = {
       "import_as" => domain_name_to_import_to.presence || domain_name_to_import_from,
       "overwrite" => true,
-      "zip_file"  => "automate_temporary_zip.zip"
+      "zip_file"  => "automate_temporary_zip.zip",
+      "tenant_id" => User.current_user.current_tenant.id
     }
     ae_import = MiqAeImport.new(domain_name_to_import_from, import_options)
 

--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -32,12 +32,15 @@ describe AutomateImportService do
     let(:miq_ae_import) { double("MiqAeYamlImportZipfs", :import_stats => "import stats") }
     let(:removable_entry) { double(:name => "carrot/something_else/namespace.yaml") }
     let(:removable_class_entry) { double(:name => "carrot/something_else.class/class.yaml") }
+    let(:user) { FactoryGirl.create(:user_with_group) }
 
     before do
+      User.current_user = user
       import_options = {
         "import_as" => "potato",
         "overwrite" => true,
-        "zip_file"  => "automate_temporary_zip.zip"
+        "zip_file"  => "automate_temporary_zip.zip",
+        "tenant_id" => user.current_tenant.id
       }
       allow(MiqAeImport).to receive(:new).with("carrot", import_options).and_return(miq_ae_import)
       allow(miq_ae_import).to receive(:remove_unrelated_entries)
@@ -91,7 +94,8 @@ describe AutomateImportService do
           "carrot",
           "import_as" => "carrot",
           "overwrite" => true,
-          "zip_file"  => "automate_temporary_zip.zip"
+          "zip_file"  => "automate_temporary_zip.zip",
+          "tenant_id" => user.current_tenant.id
         ).and_return(miq_ae_import)
         automate_import_service.import_datastore(import_file_upload, "carrot", "", ["starch"])
       end


### PR DESCRIPTION
When importing Automate Models using the UI
Automate -> Import/Export -> Import Datastore Classes (Choose File) Upload

The Tenant information was not being passed into Import. Without the tenant information the importer would create the model to be owned by the root tenant.

In this case the user had logged in under a specific tenant (distinct from the root tenant) and after the import the domain was locked not owned by the user (was owned by root tenant).


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1401247


Steps for Testing/QA 
-------------------------------

Listed in ticket

(1) Add tenants to your env
(2) Login as a user in a specific tenant
(3) Import from UI
(4) You should be able to delete/edit the newly imported domain