### PR TITLE
[Ad hoc metrics for OPS] Remove tooltips and add spinners

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -55,4 +55,7 @@
   .timeline-date-input {
     width: 250px;
   }
+  h3 {
+    margin-top: 5px;
+  }
 }

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -18,30 +18,34 @@
       .spinner.spinner-lg.loading{"ng-if" => "loadingMetrics"}
       .col-md-12{"pf-list-view" => "", "config" => "listConfig", "items" => "items"}
         .list-view-pf-body.row
-          .col-md-2.col-sm-6.no-wrap{"tooltip" => "{{item.tags.group_id}}", "tooltip-placement" => "bottom"}
-            {{item.tags.group_id}}
-          .col-md-4.col-sm-6.no-wrap{"tooltip" => "{{item.id}}", "tooltip-placement" => "bottom"}
+          .col-md-6.col-sm-6.no-wrap
             {{item.id}}
           .col-md-6.col-sm-12.no-wrap
             .row
-              .col-md-7.col-sm-6.no-wrap{"tooltip" => "{{item.maxTimestamp | date:'yyyy-MM-dd hh:mm:ss'}}", "tooltip-placement" => "bottom"}
+              .col-md-7.col-sm-6.no-wrap
                 %strong
                   = _("Most Recent")
                 %span.time-stamp
                   {{item.last_timestamp | date:'yyyy-MM-dd hh:mm:ss'}}
-              .col-md-5.col-sm-6.no-wrap{"tooltip" => "{{item.last_value || '-'}}", "tooltip-placement" => "bottom"}
-                %span.last-value
-                  {{item.last_value || "-"}}
-                %span.last-value
-                  {{item.percent_change}}
+              .col-md-5.col-sm-6.no-wrap
+                .spinner.spinner-sm.loading{"ng-if" => "!item.last_value"}
+                %span.last-value{"ng-if" => "item.last_value"}
+                  {{item.last_value}}
         %list-expanded-content
+          .row
+            .col-md-8.col-sm-12.no-wrap
+              %h3
+                = _("Tag list")
+            .col-md-4.col-sm-12.no-wrap
+              %h3
+                = _("Recent values")
           .row
             .col-md-8.col-sm-12.no-wrap
               .row{"ng-repeat" => "(key, value) in $parent.item.tags"}
                 .col-md-3.col-sm-6.no-wrap.metric-no-padding
                   %strong.pull-right
                     {{key}}
-                .col-md-9.col-sm-9.no-wrap{"tooltip" => "{{value}}", "tooltip-placement" => "bottom"}
+                .col-md-9.col-sm-6.no-wrap
                   {{value}}
             .col-md-4.col-sm-12.no-wrap
               .row{"ng-repeat" => "(timestamp, value) in $parent.item.lastValues"}


### PR DESCRIPTION
**Description**
Refactor https://github.com/ManageIQ/manageiq/pull/12165 

- [x] Add spinners when data is loading
- [x] Add titles for tables in the expanded list veiw
- [x] Remove tooltips that are just verbatim copy of the labels.

**Screenshots**
Spinners
![screenshot-2016-12-07-11-14-20](https://cloud.githubusercontent.com/assets/2181522/20961692/d3043b3e-bc6e-11e6-8bd3-c84a46946dd7.png)

Titles
![screenshot-2016-12-07-11-14-45](https://cloud.githubusercontent.com/assets/2181522/20961693/d3072268-bc6e-11e6-9ce1-9b1d7a746acd.png)
