### PR TITLE
Fix issue: Unable to add new button group in Automate Customization

### DIFF
--- a/app/helpers/application_helper/button/ab_group_delete.rb
+++ b/app/helpers/application_helper/button/ab_group_delete.rb
@@ -1,0 +1,6 @@
+class ApplicationHelper::Button::AbGroupDelete < ApplicationHelper::Button::AbGroupEdit
+  def disabled?
+    @error_message = _('Selected Custom Button Group cannot be deleted') if unassigned_button_group?
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/ab_group_edit.rb
+++ b/app/helpers/application_helper/button/ab_group_edit.rb
@@ -1,17 +1,11 @@
 class ApplicationHelper::Button::AbGroupEdit < ApplicationHelper::Button::Basic
-  def initialize(view_context, view_binding, instance_data, props)
-    super
-    @action = props[:options][:action]
-  end
-
   def calculate_properties
     super
     self[:title] = @error_message if @error_message.present?
   end
 
   def disabled?
-    @error_message = _('Selected Custom Button Group cannot be %{action}') %
-                     {:action => @action} if unassigned_button_group?
+    @error_message = _('Selected Custom Button Group cannot be edited') if unassigned_button_group?
     @error_message.present?
   end
 

--- a/app/helpers/application_helper/button/ab_group_reorder.rb
+++ b/app/helpers/application_helper/button/ab_group_reorder.rb
@@ -1,6 +1,7 @@
 class ApplicationHelper::Button::AbGroupReorder < ApplicationHelper::Button::AbGroupEdit
   def disabled?
-    @error_message = _('Only more than 1 Custom Button Groups can be reordered') unless reorderable?
+    @error_message = _('Only more than 1 Custom Button Groups can be %{action}') %
+                     {:action => @action} unless reorderable?
     @error_message.present?
   end
 

--- a/app/helpers/application_helper/button/ab_group_reorder.rb
+++ b/app/helpers/application_helper/button/ab_group_reorder.rb
@@ -1,7 +1,6 @@
 class ApplicationHelper::Button::AbGroupReorder < ApplicationHelper::Button::AbGroupEdit
   def disabled?
-    @error_message = _('Only more than 1 Custom Button Groups can be %{action}') %
-                     {:action => @action} unless reorderable?
+    @error_message = _('Only more than 1 Custom Button Groups can be reordered') unless reorderable?
     @error_message.present?
   end
 

--- a/app/helpers/application_helper/toolbar/custom_button_set_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_button_set_center.rb
@@ -28,7 +28,8 @@ class ApplicationHelper::Toolbar::CustomButtonSetCenter < ApplicationHelper::Too
             end
           end,
           N_('Reorder'),
-          :klass     => ApplicationHelper::Button::AbGroupReorder),
+          :klass   => ApplicationHelper::Button::AbGroupReorder,
+          :options => {:action => 'reordered'}),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/custom_button_set_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_button_set_center.rb
@@ -28,8 +28,7 @@ class ApplicationHelper::Toolbar::CustomButtonSetCenter < ApplicationHelper::Too
             end
           end,
           N_('Reorder'),
-          :klass   => ApplicationHelper::Button::AbGroupReorder,
-          :options => {:action => 'reordered'}),
+          :klass   => ApplicationHelper::Button::AbGroupReorder),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/custom_buttons_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_buttons_center.rb
@@ -12,8 +12,7 @@ class ApplicationHelper::Toolbar::CustomButtonsCenter < ApplicationHelper::Toolb
           t = N_('Edit this Button Group'),
           t,
           :url_parms => "main_div",
-          :klass     => ApplicationHelper::Button::AbGroupEdit,
-          :options   => {:action => 'edited'}),
+          :klass     => ApplicationHelper::Button::AbGroupEdit),
         button(
           :ab_button_new,
           'pficon pficon-add-circle-o fa-lg',
@@ -27,8 +26,7 @@ class ApplicationHelper::Toolbar::CustomButtonsCenter < ApplicationHelper::Toolb
           t,
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Button Group will be permanently removed!"),
-          :klass     => ApplicationHelper::Button::AbGroupEdit,
-          :options   => {:action => 'deleted'}),
+          :klass     => ApplicationHelper::Button::AbGroupDelete),
       ]
     ),
   ])


### PR DESCRIPTION
Fixes issue described in #12935. The bug was caused by the following error:

![error-group-edit](https://cloud.githubusercontent.com/assets/5737996/20962363/4a84c580-bc69-11e6-884c-795613ea109e.png)

This error occurred at all CI nodes and it messed up the way the x_node was set up for all the other CI nodes - they received the x_node of the last correctly loaded tree node's x_node property. For example the node `VM and Instance` received an x_node equal to `["xx-ab", "Vm", "cbg-10r20"]` instead of the expected `["xx-ab"]` in case that  the Ansible Actions tree node had been selected before. And so the `toolbar_chooser.rb` had chosen the wrong toolbar_center - `custom_buttons_center_tb` instead of `custom_button_set_center_tb`.

It also made the page to load the wrong data - more specifically, it stucked at showing the last successfully loaded screen. Notice it in the following pictures:

(Stuck at the root screen)
![error-group-edit-0](https://cloud.githubusercontent.com/assets/5737996/20962640/6a597df0-bc6a-11e6-93c4-183930ba61d5.png)

(Stuck at the Ansible Actions screen)
![error-group-edit-1](https://cloud.githubusercontent.com/assets/5737996/20962665/84ca99f8-bc6a-11e6-8cda-2b7136229ac3.png)

This error has been introduced in #12208.

# Links
Related issue: #12935
Bug introduced in: #12208