### PR TITLE
[Ad hoc metrics for OPS] Remove the apply button

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -40,6 +40,14 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
         $scope.filtersText += filter.title + " : " + filter.value + "\n";
         $scope.tags[filter.id] = filter.value;
       });
+
+      if (Object.keys($scope.tags).length > 0) {
+        $scope.doApply();
+      } else {
+        $scope.items = [];
+        $scope.applied = false;
+        $scope.filterConfig.resultsCount = 0;
+      }
     };
 
     var selectionChange = function() {

--- a/app/services/hawkular_proxy_service.rb
+++ b/app/services/hawkular_proxy_service.rb
@@ -33,7 +33,9 @@ class HawkularProxyService
   def metric_definitions
     tags = @params['tags'].blank? ? nil : JSON.parse(@params['tags'])
     tags = nil if tags == {}
-    client.gauges.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"].downcase <=> b["id"].downcase }
+    definitions = client.gauges.query(tags).compact.map { |m| m.json if m.json }.sort { |a, b| a["id"] <=> b["id"] }
+
+    definitions[0..100]
   end
 
   def metric_tags
@@ -45,12 +47,14 @@ class HawkularProxyService
     starts = @params['starts'] || (ends - 8 * 60 * 60 * 1000)
     bucket_duration = @params['bucket_duration'] || nil
     order = @params['order'] || 'ASC'
+    limit = @params['limit'].to_i || 500
 
-    client.gauges.get_data(id,
-                           :limit          => @params['limit'] || 100,
-                           :starts         => starts.to_i,
-                           :ends           => ends.to_i,
-                           :bucketDuration => bucket_duration,
-                           :order          => order)
+    data = client.gauges.get_data(id,
+                                  :limit          => limit,
+                                  :starts         => starts.to_i,
+                                  :ends           => ends.to_i,
+                                  :bucketDuration => bucket_duration,
+                                  :order          => order)
+    data[0..(limit - 1)]
   end
 end

--- a/app/views/ems_container/_show_ad_hoc_metrics.html.haml
+++ b/app/views/ems_container/_show_ad_hoc_metrics.html.haml
@@ -4,11 +4,6 @@
   %div{"ng-if" => "!viewGraph"}
     %div{"pf-toolbar" => "", "id" => "exampleToolbar", "config" => "toolbarConfig", "ng-if" => "tagsLoaded"}
       %actions
-        %button.btn.btn-primary{"type" => "button",
-                                "ng-click" => "doApply()",
-                                "ng-if" => "toolbarConfig.filterConfig",
-                                "ng-disabled" => "!filterChanged"}
-          = _("Apply")
         %button.btn.btn-default{"type" => "button",
                                 "ng-click" => "doViewGraph()",
                                 "ng-disabled" => "!itemSelected"}


### PR DESCRIPTION
**Description**
Refactor https://github.com/ManageIQ/manageiq/pull/12165 

- [x] Apply filters immediately, no need to push apply.
- [x] Remove the apply button
- [x] Limit the maximum number of items in one page.

**Screenshots**
Before we set tags, we have no items:
![screenshot-localhost 3000-2016-12-07-20-30-26](https://cloud.githubusercontent.com/assets/2181522/20981260/930a6b36-bcbc-11e6-9357-43cd948b9d13.png)

After we added a filter, a spinner apear:
![screenshot-localhost 3000-2016-12-07-20-33-11](https://cloud.githubusercontent.com/assets/2181522/20981262/9319b852-bcbc-11e6-8450-7bd1df99f11d.png)

After we get the items:
![screenshot-localhost 3000-2016-12-07-20-31-41](https://cloud.githubusercontent.com/assets/2181522/20981261/93164456-bcbc-11e6-9417-9ab8a114d6b0.png)

If we clear the tags again we have no items:
![screenshot-localhost 3000-2016-12-07-20-30-26](https://cloud.githubusercontent.com/assets/2181522/20981260/930a6b36-bcbc-11e6-9357-43cd948b9d13.png)
