### PR TITLE
Remove default consumption admin user

### DIFF
--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -3,7 +3,3 @@
   :userid: admin
   :password: smartvm
   :group: EvmGroup-super_administrator
-- :name: Consumption Administrator
-  :userid: consumption_admin
-  :password: smartvm
-  :group: EvmGroup-consumption_administrator

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -364,7 +364,7 @@ describe User do
   end
 
   context ".seed" do
-    include_examples(".seed called multiple times", 2)
+    include_examples(".seed called multiple times", 1)
 
     include_examples("seeding users with", [])
 

--- a/spec/support/examples_group/shared_examples_for_seeding.rb
+++ b/spec/support/examples_group/shared_examples_for_seeding.rb
@@ -6,7 +6,7 @@ shared_examples_for ".seed called multiple times" do |count = 1|
 end
 
 shared_examples_for "seeding users with" do |klasses|
-  let(:users) { {"admin" => "super_administrator", "consumption_admin" => "consumption_administrator"} }
+  let(:users) { {'admin' => 'super_administrator' } }
 
   it "seeds users #{klasses.present? ? 'with' : ''} #{klasses.collect(&:to_s).join(', ')}" do
     klasses.push(User)


### PR DESCRIPTION
We offer consumption-role. Anyone who has a use-case to oversee the consumption should create their own user based on the consumption role.

@miq-bot add_label bug, core