### PR TITLE
Not using the variable interpolation in _('${foo}').

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -69,7 +69,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
         button(
           :ems_middleware_recheck_auth_status,
           'fa fa-search fa-lg',
-          N_("Re-check Authentication Status for this #{ui_lookup(:table=>'ems_middleware')}"),
+          N_("Re-check Authentication Status for this %{item}" % {:item => ui_lookup(:table=>'ems_middleware')}),
           N_('Re-check Authentication Status'),
           :klass => ApplicationHelper::Button::GenericFeatureButton,
           :options => {:feature => :authentication_status}),


### PR DESCRIPTION
Trivial change to fix the variable interpolation issue.

@mzazrivec could you pls check?
@miq-bot add_label providers/hawkular, bug, euwe/no, internationalization