### PR TITLE
Introduce report result purging timer

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -117,6 +117,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end
 
+  def miq_report_result_purge_timer
+    queue_work(:class_name => "MiqReportResult", :method_name => "purge_timer", :zone => nil)
+  end
+
   def storage_refresh_metrics
     queue_work(
       :class_name  => "StorageManager",

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -215,6 +215,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue :miq_alert_evaluate_hourly_timer
     end
 
+    # Schedule - Prune old reports Timer
+    every = worker_settings[:report_result_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue :miq_report_result_purge_timer
+    end
+
     # Schedule every 24 hours
     at = worker_settings[:storage_file_collection_time_utc]
     if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1393,6 +1393,7 @@
       :policy_events_purge_interval: 1.day
       :poll: 15.seconds
       :resync_rhn_mirror: 12.hours
+      :report_result_purge_interval: 1.week
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds
       :service_retired_interval: 10.minutes


### PR DESCRIPTION
The resources required to purge report results used to be quite large.
So it was not scheduled

In many databases, report results is the second or third largest table (by memory usage)

before
------

customers manually purged the report results table

after
----

the report results table is checked once per week.

concerns
---------

While these can be run by any worker, I am not sure which worker needs to schedule it.
So I put it under the `schedules_for_scheduler_role`

https://bugzilla.redhat.com/show_bug.cgi?id=1348625