### PR TITLE
Use ::Settings in /lib and /tools

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,6 @@
   :ldaphost:
   :ldapport: '389'
   :mode: database
-  :resolve_ldap_host: false
   :search_timeout: 30
   :user_suffix:
   :user_type: userprincipalname

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,11 +6,15 @@
   :basedn:
   :bind_dn:
   :bind_pwd:
+  :bind_timeout: 30
+  :follow_referrals: false
   :get_direct_groups: true
   :group_memberships_max_depth: 2
   :ldaphost:
   :ldapport: '389'
   :mode: database
+  :resolve_ldap_host: false
+  :search_timeout: 30
   :user_suffix:
   :user_type: userprincipalname
   :amazon_key:

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -4,8 +4,6 @@ class MiqLdap
   include Vmdb::Logging
   DEFAULT_LDAP_PORT      = 389
   DEFAULT_LDAPS_PORT     = 636
-  DEFAULT_BIND_TIMEOUT   = 30
-  DEFAULT_SEARCH_TIMEOUT = 30
 
   attr_accessor :basedn
 
@@ -32,24 +30,21 @@ class MiqLdap
   end
 
   def initialize(options = {})
-    @auth = options[:auth] || VMDB::Config.new("vmdb").config[:authentication]
-
+    @auth = options[:auth] || ::Settings.authentication
+    
     log_auth = Vmdb::Settings.mask_passwords!(@auth.deep_clone)
     _log.info("Server Settings: #{log_auth.inspect}")
 
-    mode              = options.delete(:mode) || @auth[:mode]
-    @basedn           = options.delete(:basedn) || @auth[:basedn]
-    @user_type        = options.delete(:user_type) || @auth[:user_type]
-    @user_suffix      = options.delete(:user_suffix) || @auth[:user_suffix]
-    @domain_prefix    = options.delete(:domain_prefix) || @auth[:domain_prefix]
-    @bind_timeout     = options.delete(:bind_timeout) || @auth[:bind_timeout] || self.class.default_bind_timeout
-    @search_timeout   = options.delete(:search_timeout) || @auth[:search_timeout] || self.class.default_search_timeout
-    @follow_referrals = options.delete(:follow_referrals) || @auth[:follow_referrals] || false
-    defaults = {
-      :host => @auth[:ldaphost],
-      :port => @auth[:ldapport],
-    }
-    options = defaults.merge(options)
+    mode              = options.delete(:mode) || ::Settings.authentication.mode
+    @basedn           = options.delete(:basedn) || ::Settings.authentication.basedn
+    @user_type        = options.delete(:user_type) || ::Settings.authentication.user_type
+    @user_suffix      = options.delete(:user_suffix) || ::Settings.authentication.user_suffix
+    @domain_prefix    = options.delete(:domain_prefix) || ::Settings.authentication.domain_prefix
+    @bind_timeout     = options.delete(:bind_timeout) || ::Settings.authentication.bind_timeout.to_i_with_method
+    @search_timeout   = options.delete(:search_timeout) || ::Settings.authentication.search_timeout.to_i_with_method
+    @follow_referrals = options.delete(:follow_referrals) || ::Settings.authentication.follow_referrals
+    options[:host] ||= ::Settings.authentication.ldaphost
+    options[:port] ||= ::Settings.authentication.ldapport
     options[:encryption] = {:method => :simple_tls} if mode == "ldaps"
 
     options[:host] = resolve_host(options[:host], options[:port])
@@ -434,29 +429,8 @@ class MiqLdap
     end
   end
 
-  def self.default_bind_timeout
-    value = ::Settings.authentication.bind_timeout || DEFAULT_BIND_TIMEOUT
-    value = value.to_i_with_method if value.respond_to?(:to_i_with_method)
-    value
-  end
-
-  def self.default_search_timeout
-    value = ::Settings.authentication.search_timeout || DEFAULT_SEARCH_TIMEOUT
-    value = value.to_i_with_method if value.respond_to?(:to_i_with_method)
-    value
-  end
-
   def self.using_ldap?
     ::Settings.authentication.mode.include?('ldap')
-  end
-
-  def self.resolve_ldap_host?
-    if @resolve_ldap_host.nil?
-      @resolve_ldap_host = ::Settings.authentication.resolve_ldap_host
-      @resolve_ldap_host = false if @resolve_ldap_host.nil?
-    end
-
-    @resolve_ldap_host
   end
 
   def self.sid_to_s(data)

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -31,7 +31,7 @@ class MiqLdap
 
   def initialize(options = {})
     @auth = options[:auth] || ::Settings.authentication
-    
+
     log_auth = Vmdb::Settings.mask_passwords!(@auth.deep_clone)
     _log.info("Server Settings: #{log_auth.inspect}")
 

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -35,7 +35,7 @@ module Vmdb
       fh.info "RAILS Environment: #{Rails.env} version #{Rails.version}"
 
       fh.info "VMDB settings:"
-      VMDBLogger.log_hashes(fh, VMDB::Config.new("vmdb").config, :filter => Vmdb::Settings::PASSWORD_FIELDS)
+      VMDBLogger.log_hashes(fh, ::Settings, :filter => Vmdb::Settings::PASSWORD_FIELDS)
       fh.info "VMDB settings END"
       fh.info "---"
 

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -3,18 +3,13 @@ module VMDB
     def self.http_proxy_uri(proxy_config = :default)
       # TODO: (julian) This looks really messy. Need to make it look nicer.
 
-      vmdb_proxy = VMDB::Config.new("vmdb").config[:http_proxy]
-
-      return nil unless vmdb_proxy
-
-      if vmdb_proxy[proxy_config].nil?
+      if ::Settings.http_proxy[proxy_config].nil?
         $log.warn("Could not find proxy setting for #{proxy_config}")
+        proxy = ::Settings.http_proxy.to_h
+      else
+        proxy = ::Settings.http_proxy[proxy_config].to_h
       end
-
-      proxy = vmdb_proxy[proxy_config] || vmdb_proxy
-
       return nil unless proxy[:host]
-      proxy = proxy.dup
 
       user     = proxy.delete(:user)
       user &&= CGI.escape(user)

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -3,12 +3,7 @@ module VMDB
     def self.http_proxy_uri(proxy_config = :default)
       # TODO: (julian) This looks really messy. Need to make it look nicer.
 
-      if ::Settings.http_proxy[proxy_config].nil?
-        $log.warn("Could not find proxy setting for #{proxy_config}")
-        proxy = ::Settings.http_proxy.to_h
-      else
-        proxy = ::Settings.http_proxy[proxy_config].to_h
-      end
+      proxy = (::Settings.http_proxy[proxy_config] || ::Settings.http_proxy).to_h
       return nil unless proxy[:host]
 
       user     = proxy.delete(:user)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -6,52 +6,62 @@ describe VMDB::Util do
     end
 
     it "returns proxy for old settings" do
-      stub_server_configuration(:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil})
+      stub_settings(:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4"))
     end
 
     it "without a host" do
-      stub_server_configuration(:http_proxy => {:default => {}})
+      stub_settings(:http_proxy => {:default => {}})
       expect(described_class.http_proxy_uri).to be_nil
     end
 
     it "with host" do
-      stub_server_configuration(:http_proxy => {:default => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
+      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4"))
     end
 
     it "with host, port" do
-      stub_server_configuration(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil}})
-      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321))
+      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil}})
+      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
+                                                                      :port   => 4321))
     end
 
     it "with host, port, user" do
-      stub_server_configuration(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => nil}})
-      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser"))
+      stub_settings(:http_proxy => {:default => {:host     => "1.2.3.4", :port => 4321, :user => "testuser",
+                                                 :password => nil}})
+      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
+                                                                      :port   => 4321, :userinfo => "testuser"))
     end
 
     it "with host, port, user, password" do
-      stub_server_configuration(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"}})
-      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser:secret"))
+      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
+                                                 :user => "testuser", :password => "secret"}})
+      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
+                                                                      :port => 4321, :userinfo => "testuser:secret"))
     end
 
     it "with user missing" do
-      stub_server_configuration(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => "secret"}})
-      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4", :port => 4321))
+      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
+                                                 :user => nil, :password => "secret"}})
+      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
+                                                                      :port => 4321))
     end
 
     it "with unescaped user value" do
       password = "secret#"
-      config = {:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => "testuser", :password => password}}}
-      stub_server_configuration(config)
+      config = {:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
+                                             :user => "testuser", :password => password}}}
+      stub_settings(config)
       userinfo = "testuser:secret%23"
       uri_parts = {:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => userinfo}
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(uri_parts))
     end
 
     it "with scheme overridden" do
-      stub_server_configuration(:http_proxy => {:default => {:scheme => "https", :host => "1.2.3.4", :port => 4321, :user => "testuser", :password => "secret"}})
-      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "https", :host => "1.2.3.4", :port => 4321, :userinfo => "testuser:secret"))
+      stub_settings(:http_proxy => {:default => {:scheme => "https", :host => "1.2.3.4", :port => 4321,
+                                                 :user => "testuser", :password => "secret"}})
+      expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "https", :host => "1.2.3.4",
+                                                                      :port   => 4321, :userinfo => "testuser:secret"))
     end
   end
 

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -200,6 +200,10 @@ describe MiqWorker do
 
     it "uses passed in config" do
       settings.store_path(:workers, :worker_base, :queue_worker_base, :ems_refresh_worker,
+                          :ems_refresh_worker_amazon, :memory_threshold, "5.terabyte")
+      stub_settings(settings)
+
+      settings.store_path(:workers, :worker_base, :queue_worker_base, :ems_refresh_worker,
                           :ems_refresh_worker_amazon, :memory_threshold, "1.terabyte")
       actual = ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
                .worker_settings(:config => settings)[:memory_threshold]

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -140,7 +140,8 @@ describe MiqWorker do
               }
             }
           }
-        }
+        },
+        :ems     => {:ems_amazon => {}}
       }
     end
 
@@ -198,11 +199,10 @@ describe MiqWorker do
     end
 
     it "uses passed in config" do
-      settings.store_path(:workers, :worker_base, :queue_worker_base, :ems_refresh_worker, :ems_refresh_worker_amazon, :memory_threshold, "1.terabyte")
-      stub_settings(settings)
-
-      config = VMDB::Config.new("vmdb")
-      actual = ManageIQ::Providers::Amazon::CloudManager::RefreshWorker.worker_settings(:config => config)[:memory_threshold]
+      settings.store_path(:workers, :worker_base, :queue_worker_base, :ems_refresh_worker,
+                          :ems_refresh_worker_amazon, :memory_threshold, "1.terabyte")
+      actual = ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
+               .worker_settings(:config => settings)[:memory_threshold]
       expect(actual).to eq(1.terabyte)
     end
   end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -122,8 +122,6 @@ describe "Authentication API" do
   end
 
   context "Token Based Authentication" do
-    let(:ui_token_ttl) { VMDB::Config.new("vmdb").config[:session][:timeout].to_i_with_method }
-
     it "gets a token based identifier" do
       api_basic_authorize
 
@@ -179,13 +177,11 @@ describe "Authentication API" do
 
     it "gets a token based identifier with the default API based token_ttl" do
       api_basic_authorize
-
-      api_token_ttl = VMDB::Config.new("vmdb").config[:api][:token_ttl].to_i_with_method
       run_get auth_url
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response.parsed_body["token_ttl"]).to eq(api_token_ttl)
+      expect(response.parsed_body["token_ttl"]).to eq(::Settings.api.token_ttl.to_i_with_method)
     end
 
     it "gets a token based identifier with an invalid requester_type" do
@@ -203,7 +199,7 @@ describe "Authentication API" do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response.parsed_body["token_ttl"]).to eq(ui_token_ttl)
+      expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
     end
 
     it "forgets the current token when asked to" do
@@ -224,7 +220,7 @@ describe "Authentication API" do
         run_get auth_url, :requester_type => 'ws'
         expect(response).to have_http_status(:ok)
         expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-        expect(response.parsed_body["token_ttl"]).to eq(ui_token_ttl)
+        expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
       end
 
       it 'cannot authorize user to api based on token that is dedicated for web sockets' do

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -100,8 +100,6 @@ RSpec.describe "tenants API" do
     end
 
     context "query root tenant that uses configuration settings" do
-      let(:config_attributes) { VMDB::Config.new("vmdb").config.fetch_path(:server) }
-
       before do
         root_tenant.use_config_for_attributes = true
         root_tenant.name = 'Some other name'
@@ -115,7 +113,7 @@ RSpec.describe "tenants API" do
         expect_result_to_match_hash(response.parsed_body,
                                     "href" => tenants_url(root_tenant.id),
                                     "id"   => root_tenant.id,
-                                    "name" => config_attributes[:company],
+                                    "name" => ::Settings.server.company,
                                    )
         expect(response).to have_http_status(:ok)
       end

--- a/tools/ldap_ping.rb
+++ b/tools/ldap_ping.rb
@@ -25,17 +25,10 @@ class MiqLdap
   end
 end
 
-authentication = VMDB::Config.new("vmdb").config[:authentication]
-
-if authentication.nil?
-  log(:info, "Authentication Section Not Configured")
-  exit
-end
-
-ldap_hosts   = authentication[:ldaphost]
-username     = authentication[:bind_dn]
-password     = authentication[:bind_pwd]
-bind_timeout = authentication[:bind_timeout] || MiqLdap.default_bind_timeout
+ldap_hosts   = ::Settings.authentication.ldaphost
+username     = ::Settings.authentication.bind_dn
+password     = ::Settings.authentication.bind_pwd
+bind_timeout = ::Settings.authentication.bind_timeout.to_i_with_method
 if ldap_hosts.to_s.strip.empty?
   log(:info, "LDAP Host cannot be blank")
   exit


### PR DESCRIPTION
Continue to remove deprecated calls to ```VMDB::Config.new``` in ```/lib``` and ```/tools```. Default values related to ```miq_ldap``` were moved from code to ```settings.yml```

@miq-bot add-label wip, core