### PR TITLE
Notify only a group of users when notifying about MiqRequest

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -1,12 +1,15 @@
 class NotificationType < ApplicationRecord
   AUDIENCE_USER = 'user'.freeze
+  AUDIENCE_GROUP = 'group'.freeze
   AUDIENCE_TENANT = 'tenant'.freeze
   AUDIENCE_GLOBAL = 'global'.freeze
   AUDIENCE_SUPERADMIN = 'superadmin'.freeze
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
-  validates :audience, :inclusion => { :in => [AUDIENCE_USER, AUDIENCE_TENANT, AUDIENCE_GLOBAL, AUDIENCE_SUPERADMIN] }
+  validates :audience, :inclusion => {
+    :in => [AUDIENCE_USER, AUDIENCE_GROUP, AUDIENCE_TENANT, AUDIENCE_GLOBAL, AUDIENCE_SUPERADMIN]
+  }
 
   def subscriber_ids(subject, initiator)
     case audience
@@ -14,6 +17,8 @@ class NotificationType < ApplicationRecord
       User.pluck(:id)
     when AUDIENCE_USER
       [initiator.id]
+    when AUDIENCE_GROUP
+      subject.try(:requester).try(:current_group).try(:user_ids)
     when AUDIENCE_TENANT
       subject.tenant.user_ids
     when AUDIENCE_SUPERADMIN

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -38,12 +38,12 @@
   :message: Request %{subject} has been approved.
   :expires_in: 14.days
   :level: :success
-  :audience: tenant
+  :audience: group
 - :name: request_denied
   :message: Request %{subject} has been denied.
   :expires_in: 14.days
   :level: :warning
-  :audience: tenant
+  :audience: group
 - :name: automate_user_success
   :message: '%{message}'
   :expires_in: 24.hours

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -35,6 +35,23 @@ describe Notification, :type => :model do
           expect(subject.recipients).to match_array([user])
         end
       end
+
+      context 'emiting for MiqRequest' do
+        let(:friends) { FactoryGirl.create(:miq_group) }
+        let(:requester) { FactoryGirl.create(:user, :miq_groups => [friends]) }
+        let!(:peer) { FactoryGirl.create(:user, :miq_groups => [friends]) }
+        let!(:non_peer) { FactoryGirl.create(:user) }
+        let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'vm', :location => 'abc/def.vmx') }
+        let(:request) do
+          FactoryGirl.create(:miq_provision_request, :requester => requester, :src_vm_id => vm.id,
+                             :options => {:owner_email => 'tester@miq.com'})
+        end
+        subject { Notification.create(:subject => request, :type => 'request_approved') }
+
+        it 'subscribes only users of the group' do
+          expect(subject.recipients).to match_array([requester, peer])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## The problem
https://bugzilla.redhat.com/show_bug.cgi?id=1397465

Consider tenant with two groups. Each group has a user. Both have a role limiting the vms they see by ownership. When one user orders a vm, the other one does not see it.

The problem was that the notification was created previously to both users.

## The Cause
The root cause was that both user can see the given MiqProvisionRequest.

## The Fix
We cannot fix the root cause directly. As we cannot tell up-front what users are gonna see the VM, before it is created -> thus we cannot tell what users shall see the given MiqProvisionRequest.

The MiqProvisionRequest are still seen by both users. However only relevant users are notified about it.

@miq-bot add_label blocker, bug, core, euwe/yes
@miq-bot assign @gtanzillo 