### PR TITLE
annotate hostname as empty string as fallback

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -362,7 +362,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
           'manageiq.org' => "true"
         },
         :annotations => {
-          'manageiq.org/hostname' => options[:miq_server_host],
+          # in case hostname is not set and options[:miq_server_host] is nil, change ""
+          'manageiq.org/hostname' => options[:miq_server_host] || "unknown",
           'manageiq.org/guid'     => options[:miq_server_guid],
           'manageiq.org/image'    => options[:image_full_name],
           'manageiq.org/jobid'    => jobid,


### PR DESCRIPTION
Sometimes the server can be setup without a hostname and this will cause the SSA to fail (a nil there will cause kubernetes to reject this pod creation)

This is a simple fix for this situation.

cc @moolitayer @simon3z 