### PR TITLE
Adding new report and widgets

### DIFF
--- a/product/dashboard/widgets/chart_number_of_nodes_per_cpu_cores.yaml
+++ b/product/dashboard/widgets/chart_number_of_nodes_per_cpu_cores.yaml
@@ -1,0 +1,17 @@
+description: Number of Nodes per CPU Cores Chart
+title: Number of Nodes per CPU Cores Chart
+content_type: chart
+options: {}
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Number of Nodes per CPU Cores
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/chart_pods_per_ready.yaml
+++ b/product/dashboard/widgets/chart_pods_per_ready.yaml
@@ -1,0 +1,17 @@
+description: Pods per Ready Status Chart
+title: Pods per Ready Status Chart
+content_type: chart
+options:
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Pods per Ready Status
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: false

--- a/product/dashboard/widgets/nodes_by_cpu_capacity.yaml
+++ b/product/dashboard/widgets/nodes_by_cpu_capacity.yaml
@@ -1,0 +1,22 @@
+description: Nodes by Capacity
+title: Nodes by Capacity
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - computer_system.hardware.cpu_total_cores
+  - computer_system.hardware.memory_mb
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Nodes By Capacity
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/nodes_by_cpu_usage.yaml
+++ b/product/dashboard/widgets/nodes_by_cpu_usage.yaml
@@ -1,0 +1,21 @@
+description: Nodes By CPU Usage
+title: Nodes By CPU Usage
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - max_cpu_usage_rate_average_avg_over_time_period
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Nodes By CPU Usage
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/nodes_by_memory_usage.yaml
+++ b/product/dashboard/widgets/nodes_by_memory_usage.yaml
@@ -1,0 +1,21 @@
+description: Nodes By Memory Usage
+title: Nodes By Memory Usage
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - max_mem_usage_absolute_average_avg_over_time_period
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Nodes By Memory Usage
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/pods_per_ready.yaml
+++ b/product/dashboard/widgets/pods_per_ready.yaml
@@ -1,0 +1,21 @@
+description: Pods per Ready Status
+title: Pods per Ready Status
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - ready_condition_status
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Pods per Ready Status
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true        
+read_only: true

--- a/product/dashboard/widgets/projects_by_cpu_usage.yaml
+++ b/product/dashboard/widgets/projects_by_cpu_usage.yaml
@@ -1,0 +1,21 @@
+description: Projects By CPU Usage
+title: Projects By CPU Usage
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - max_cpu_usage_rate_average_avg_over_time_period
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Projects By CPU Usage
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/projects_by_memory_usage.yaml
+++ b/product/dashboard/widgets/projects_by_memory_usage.yaml
@@ -1,0 +1,21 @@
+description: Projects By Memory Usage
+title: Projects By Memory Usage
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - max_mem_usage_absolute_average_avg_over_time_period
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Projects By Memory Usage
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/projects_by_number_of_containers.yaml
+++ b/product/dashboard/widgets/projects_by_number_of_containers.yaml
@@ -1,0 +1,21 @@
+description: Projects by Number of Containers
+title: Projects by Number of Containers
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - containers_count
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Projects by Number of Containers
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/projects_by_number_of_pods.yaml
+++ b/product/dashboard/widgets/projects_by_number_of_pods.yaml
@@ -1,0 +1,21 @@
+description: Projects by Number of Pods
+title: Projects by Number of Pods
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - groups_count
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_name: Projects by Number of Pods
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/dashboard/widgets/recently_discovered_pods.yaml
+++ b/product/dashboard/widgets/recently_discovered_pods.yaml
@@ -1,0 +1,22 @@
+description: Recently Discovered Pods
+title: Recently Discovered Pods
+content_type: report
+options:
+  :row_count: 10
+  :col_order:
+  - name
+  - ready_condition_status
+  - ems_created_on
+visibility:
+  :roles:
+  - _ALL_
+user_id: 
+resource_id: 198
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
+++ b/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
@@ -16,7 +16,7 @@ col_order:
 - name
 - computer_system.hardware.cpu_total_cores
 headers:
-- Number of Nodes per CPU Cores
+- Name
 - Hardware Number of CPU Cores
 conditions:
 order: Descending

--- a/product/reports/170_Configuration Management - Containers/120_Projects by Number of Containers.yaml
+++ b/product/reports/170_Configuration Management - Containers/120_Projects by Number of Containers.yaml
@@ -1,0 +1,44 @@
+---
+title: Projects by Number of Containers
+rpt_group: Custom
+rpt_type: Custom
+priority:
+db: ContainerProject
+cols:
+- name
+- containers_count
+include: {}
+col_order:
+- name
+- containers_count
+headers:
+- Project Name
+- Containers Count
+conditions:
+order: Descending
+sortby:
+- containers_count
+group:
+graph:
+dims:
+filename:
+file_mtime:
+categories: []
+timeline:
+template_type: report
+where_clause:
+db_options: {}
+generate_cols:
+generate_rows:
+col_formats:
+-
+-
+tz:
+time_profile_id:
+display_filter:
+col_options: {}
+rpt_options:
+  :pdf:
+    :page_size: us-letter
+  :queue_timeout:
+menu_name: Projects by Number of Containers

--- a/product/reports/170_Configuration Management - Containers/130_Pods per Ready Status.yaml
+++ b/product/reports/170_Configuration Management - Containers/130_Pods per Ready Status.yaml
@@ -1,0 +1,46 @@
+---
+title: Pods per Ready Status
+rpt_group: Configuration Management - Containers
+rpt_type: Default
+priority: 60
+db: ContainerGroup
+cols:
+- name
+- ready_condition_status
+include: {}
+col_order:
+- name
+- ready_condition_status
+headers:
+- "# Pods per Ready Status"
+- Ready Condition Status
+conditions: 
+order: Ascending
+sortby:
+- ready_condition_status
+group: 
+graph:
+  :type: PieThreed
+  :count: 10
+  :other: true
+dims: 1
+filename: 170_Configuration Management - Containers/060_Container Groups per Ready Status.yaml
+categories: []
+timeline: 
+template_type: report
+where_clause: 
+db_options: {}
+generate_cols: 
+generate_rows: 
+col_formats:
+- 
+- 
+tz: 
+time_profile_id: 
+display_filter: 
+col_options: {}
+rpt_options:
+  :pdf:
+    :page_size: us-letter
+  :queue_timeout: 
+menu_name: Pods per Ready Status

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 141)
+    include_examples(".seed called multiple times", 142)
   end
 end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,5 +1,5 @@
 describe MiqWidget do
-  include_examples(".seed called multiple times", 10)
+  include_examples(".seed called multiple times", 21)
 
   before(:each) do
     EvmSpecHelper.local_miq_server


### PR DESCRIPTION
I have added a new report and a new widget as per request of a client.
It is the first widget in a series of widgets suggested by this client in order to support our existing and new container reports.

cc: @simon3z @zeari 

Additional Reports:
- [x] Projects by Number of Containers
- [x] Pods per Ready Status

Additional Widgets:
- [x] Pods per Ready widget
- [x] Pods per Ready chart
- [x] Nodes by Memory usage
- [x] Nodes By CPU Usage Widget
- [x] Recently Discovered Pods Widget
- [x] Nodes By CPU Capacity
- [x] Projects By CPU Usage Widget
- [x] Projects by Number of Pods Widget
- [x] Projects By Memory Usage Widget
- [x] Number of Nodes per CPU Cores Chart
- [x] Projects by Number of Containers