### PR TITLE
Do not create empty menu sections

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -117,8 +117,6 @@ module Menu
             Menu::Item.new('ems_datawarehouse', N_('Providers'), 'ems_datawarehouse',
                            {:feature => 'ems_datawarehouse_show_list'}, '/ems_datawarehouse')
             ])
-        else
-          empty_menu_section
         end
       end
 
@@ -200,10 +198,6 @@ module Menu
                                            {:feature => 'cloud_object_store_object_show_list'},
                                            '/cloud_object_store_object'),
                           ])
-      end
-
-      def empty_menu_section
-        Menu::Section.new(nil, nil, nil, nil)
       end
 
       def netapp_storage_menu_section


### PR DESCRIPTION
These menu sections does not render nicely in the role editor.

Introduced in https://github.com/ManageIQ/manageiq/pull/12205

## Before
![before](https://cloud.githubusercontent.com/assets/6666052/21013968/4f41c03e-bd5c-11e6-8f28-e236be99b64d.jpg)

## After
![after](https://cloud.githubusercontent.com/assets/6666052/21013974/549d1aba-bd5c-11e6-89d4-8473cb25acf8.jpg)

@miq-bot add_label ui, bug
@miq-bot assign @martinpovolny 