### PR TITLE
Toolbar refactoring: History buttons

### DIFF
--- a/app/helpers/application_helper/button/history_item.rb
+++ b/app/helpers/application_helper/button/history_item.rb
@@ -6,6 +6,10 @@ class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::Button
     end
   end
 
+  def disabled?
+    history_item_id == 1 && @view_context.x_tree_history.length < 2
+  end
+
   # History toolbar is a strange beast. The yaml definition contains bunch of pre-defined
   # buttons and these are then hidden one by one by the following code.
   # TODO: Generate the buttons from the history instead.

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -424,7 +424,6 @@ class ApplicationHelper::ToolbarBuilder
 
   # Determine if a button should be hidden
   def hide_button?(id)
-    return false if id.start_with?('history_')
     return true if id == "blank_button" # Always hide the blank button placeholder
 
     # hide compliance check and comparison buttons rendered for orchestration stack instances
@@ -496,7 +495,6 @@ class ApplicationHelper::ToolbarBuilder
   def disable_button(id)
     return true if id.starts_with?("view_") && id.ends_with?("textual")  # Summary view buttons
     return true if @gtl_type && id.starts_with?("view_") && id.ends_with?(@gtl_type)  # GTL view buttons
-    return true if id == "history_1" && x_tree_history.length < 2 # Need 1 child button to show parent
     return true if id == "view_dashboard" && (@showtype == "dashboard")
     return true if id == "view_summary" && (@showtype != "dashboard")
 

--- a/spec/helpers/application_helper/buttons/history_item_spec.rb
+++ b/spec/helpers/application_helper/buttons/history_item_spec.rb
@@ -1,32 +1,49 @@
 describe ApplicationHelper::Button::HistoryItem do
-  describe '#visible?' do
-    subject do
-      sandbox = @sandbox || {
-        :history     => {:testing => %w(some thing to test with)},
-        :active_tree => :testing
-      }
+  let(:sandbox) do
+    {:history     => {:testing => testing_history},
+     :active_tree => :testing}
+  end
+  let(:view_context) { setup_view_context_with_sandbox(sandbox) }
+  let(:button) { described_class.new(view_context, {}, {}, {:id => id}) }
 
-      view_context = setup_view_context_with_sandbox(sandbox)
-      button = described_class.new(view_context, {}, {}, :id => @id)
-      button.visible?
-    end
+  describe '#visible?' do
+    let(:testing_history) { %w(some thing to test with) }
+    subject { button.visible? }
 
     %w(1 2 3 4).each do |n|
-      it "when with existing history_#{n}" do
-        @id = "history_#{n}".to_sym
-        expect(subject).to be_truthy
+      context "when with existing history_#{n}" do
+        let(:id) { "history_#{n}".to_sym }
+        it { expect(subject).to be_truthy }
       end
     end
-
-    it "when not history_1 and the tree history not exist" do
-      @id = :history_10
-      expect(subject).to be_falsey
+    context 'when not history_1 and the tree history not exist' do
+      let(:id) { :history_10 }
+      it { expect(subject).to be_falsey }
     end
+  end
 
-    it "when with history_1" do
-      @id = :history_1
-      expect(subject).to be_truthy
+  describe '#disabled?' do
+    subject { button.disabled? }
+
+    context 'when history_item_id == 1' do
+      let(:id) { :history_1 }
+      (0...2).each do |n|
+        context "when x_tree_history.length == #{n}" do
+          let(:testing_history) { [*0...n] }
+          it { expect(subject).to be_truthy }
+        end
+      end
+      (2..4).each do |n|
+        context "when x_tree_history.length == #{n}" do
+          let(:testing_history) { [*0...n] }
+          it { expect(subject).to be_falsey }
+        end
+      end
+    end
+    context 'when history_item_id != 1' do
+      let(:id) { :history_2 }
+      let(:testing_history) { [nil] }
+      it { expect(subject).to be_falsey }
     end
   end
 end
-

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -187,24 +187,6 @@ describe ApplicationHelper do
       }
     end
 
-    %w(
-      history_1
-      history_2
-      history_3
-      history_4
-      history_5
-      history_6
-      history_7
-      history_8
-      history_9
-      history_10
-    ).each do |item|
-      it "when with history item #{item}" do
-        @id = item
-        expect(subject).to be_falsey
-      end
-    end
-
     it "when id likes old_dialogs_*" do
       @id = "old_dialogs_some_thing"
       expect(subject).to be_truthy


### PR DESCRIPTION
The history buttons have already had their own button class implemented. Only the mentions of history buttons have been deleted from `#hide_button?` and `#disable_button` methods. Except for [one case](https://github.com/ManageIQ/manageiq/blob/817882c8ff89fd887c1e19f464d286129c9b6b97/app/helpers/application_helper/toolbar_builder.rb#L558). I could not delete it because then it would hide the buttons due to the Rbac check despite of the `HistoryItem` button class inheriting from `ButtonWithoutRbacCheck`.

The [whole block](https://github.com/ManageIQ/manageiq/blob/817882c8ff89fd887c1e19f464d286129c9b6b97/app/helpers/application_helper/toolbar_builder.rb#L555-L560) should be refactored first, in a separate PR.

The `#disabled?` method got implemented and the old spec examples also got deleted. The `HistoryItem` spec file got refactored and extended by new examples as well.

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135531855