### PR TITLE
Set different, undeleteable default rate for container image chargeback

### DIFF
--- a/app/helpers/application_helper/button/chargeback_rate_remove.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_remove.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Butto
   needs :@record
 
   def disabled?
-    if @record.default?
+    if @record.default? || @record.description == 'Default Container Image Rate'
       @error_message = _("Default Chargeback Rate cannot be removed.")
     end
     @error_message.present?

--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -13,7 +13,7 @@ class Chargeback
                                                      :parents  => metric_rollup_record.parents_determining_rate)
 
       if metric_rollup_record.resource_type == Container.name && rates.empty?
-        rates = [ChargebackRate.find_by(:description => "Default", :rate_type => "Compute")]
+        rates = [ChargebackRate.find_by(:description => "Default Container Image Rate", :rate_type => "Compute")]
       end
 
       metric_rollup_record_tags = metric_rollup_record.tag_names.split("|")

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -256,7 +256,7 @@ class ChargebackRateDetail < ApplicationRecord
     fixture_file = File.join(FIXTURE_DIR, "chargeback_rates.yml")
     fixture = File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
     fixture.each do |chargeback_rate|
-      next unless chargeback_rate[:rate_type] == rate_type
+      next unless chargeback_rate[:rate_type] == rate_type && chargeback_rate[:description] == "Default"
 
       chargeback_rate[:rates].each do |detail|
         detail_new = ChargebackRateDetail.new(detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES))

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -168,3 +168,121 @@
           :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.0
+- :description: Default Container Image Rate
+  :guid: b47a0ef0-4335-11df-aba8-001d09066d99
+  :rate_type: Compute
+  :default: false
+  :rates:
+    - :description: Used CPU
+      :group: cpu
+      :source: used
+      :metric: cpu_usagemhz_rate_average
+      :per_time: hourly
+      :per_unit: megahertz
+      :measure: Hz Units
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.02
+    - :description: Used CPU Cores
+      :group: cpu_cores
+      :source: used
+      :metric: v_derived_cpu_total_cores_used
+      :per_time: hourly
+      :per_unit: cpu core
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 1.0
+          :variable_rate: 0.02
+    - :description: Allocated CPU Count
+      :group: cpu
+      :source: allocated
+      :metric: derived_vm_numvcpus
+      :per_time: hourly
+      :per_unit: cpu
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 1.0
+          :variable_rate: 0.0
+    - :description: Used Memory
+      :group: memory
+      :source: used
+      :metric: derived_memory_used
+      :per_time: hourly
+      :per_unit: megabytes
+      :measure: Bytes Units
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.02
+    - :description: Allocated Memory
+      :group: memory
+      :source: allocated
+      :metric: derived_memory_available
+      :per_time: hourly
+      :per_unit: megabytes
+      :measure: Bytes Units
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
+    - :description: Used Network I/O
+      :group: net_io
+      :source: used
+      :metric: net_usage_rate_average
+      :per_time: hourly
+      :per_unit: kbps
+      :measure: Bytes per Second Units
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: 100
+          :fixed_rate: 0.5
+          :variable_rate: 0.0
+        - :start: 100
+          :finish: Infinity
+          :fixed_rate: 0.5
+          :variable_rate: 0.005
+    - :description: Used Disk I/O
+      :group: disk_io
+      :source: used
+      :metric: disk_usage_rate_average
+      :per_time: hourly
+      :per_unit: kbps
+      :measure: Bytes per Second Units
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.005
+    - :description: Fixed Compute Cost 1
+      :group: fixed
+      :source: compute_1
+      :per_time: hourly
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0
+    - :description: Fixed Compute Cost 2
+      :group: fixed
+      :source: compute_2
+      :per_time: hourly
+      :type_currency: Dollars
+      :tiers:
+        - :start: 0
+          :finish: Infinity
+          :fixed_rate: 0.0
+          :variable_rate: 0.0


### PR DESCRIPTION
Setting a different, editable, undeleteable fallback rate for Container Image chargeback as suggested by @Loicavenel

cc @simon3z @bazulay 

Im adding this to #13030 as well

@miq-bot add_label chargeback, providers/containers, euwe/yes 

![screencapture-localhost-3000-chargeback-explorer-1481215955175](https://cloud.githubusercontent.com/assets/11256940/21018918/691cdc94-bd77-11e6-80e0-db4d57223fd6.png)

`Default Container Image Rate` being the new fallback rate and `My Rate` being a rate I set on a docker label
![screencapture-localhost-3000-report-explorer-1481215433588](https://cloud.githubusercontent.com/assets/11256940/21018920/69c3151e-bd77-11e6-8a96-2c88809f7344.png)
