### PR TITLE
Fix master server failover race condition

### DIFF
--- a/app/models/miq_server/server_monitor.rb
+++ b/app/models/miq_server/server_monitor.rb
@@ -19,17 +19,21 @@ module MiqServer::ServerMonitor
     _log.info "Master server has #{last_master.nil? ? "not been set" : "died, #{last_master.name}"}.  Attempting takeover as new master server, #{name}."
     parent = MiqRegion.my_region
     parent.lock do
-      all_servers = parent.miq_servers
+      # See if an ACTIVE server has already taken over
+      active_servers = parent.active_miq_servers
 
       _log.debug "Double checking that nothing has changed"
-      master = all_servers.detect(&:is_master?)
+      master = active_servers.detect(&:is_master?)
       if (last_master.nil? && !master.nil?) || (!last_master.nil? && !master.nil? && last_master.id != master.id)
         _log.info "Aborting master server takeover as another server, #{master.name}, has taken control first."
         return nil
       end
 
-      all_servers.each do |s|
       _log.debug "Setting this server, #{name}, as master server"
+
+      # Set is_master on self, reset every other server in the region, including
+      # inactive ones.
+      parent.miq_servers.each do |s|
         s.is_master = (id == s.id)
         s.save!
       end

--- a/app/models/miq_server/server_monitor.rb
+++ b/app/models/miq_server/server_monitor.rb
@@ -17,7 +17,7 @@ module MiqServer::ServerMonitor
 
   def make_master_server(last_master)
     _log.info "Master server has #{last_master.nil? ? "not been set" : "died, #{last_master.name}"}.  Attempting takeover as new master server, #{name}."
-    parent = MiqRegion.my_region
+    parent = MiqRegion.my_region(true)
     parent.lock do
       # See if an ACTIVE server has already taken over
       active_servers = parent.active_miq_servers

--- a/app/models/miq_server/server_monitor.rb
+++ b/app/models/miq_server/server_monitor.rb
@@ -16,7 +16,7 @@ module MiqServer::ServerMonitor
   end
 
   def make_master_server(last_master)
-    _log.info "Master server has #{last_master.nil? ? "not been set" : "died"}.  Attempting takeover as new master server."
+    _log.info "Master server has #{last_master.nil? ? "not been set" : "died, #{last_master.name}"}.  Attempting takeover as new master server, #{name}."
     parent = MiqRegion.my_region
     parent.lock do
       all_servers = parent.miq_servers
@@ -24,17 +24,17 @@ module MiqServer::ServerMonitor
       _log.debug "Double checking that nothing has changed"
       master = all_servers.detect(&:is_master?)
       if (last_master.nil? && !master.nil?) || (!last_master.nil? && !master.nil? && last_master.id != master.id)
-        _log.info "Aborting master server takeover as another server has taken control first."
+        _log.info "Aborting master server takeover as another server, #{master.name}, has taken control first."
         return nil
       end
 
-      _log.debug "Setting this server as master server"
       all_servers.each do |s|
+      _log.debug "Setting this server, #{name}, as master server"
         s.is_master = (id == s.id)
         s.save!
       end
     end
-    _log.info "This server is now set as the master server"
+    _log.info "This server #{name} is now set as the master server, last_master: #{last_master.try(:name)}"
     self
   end
 

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -460,7 +460,7 @@ describe "Server Monitor" do
         @miq_server3.reload
       end
 
-      it "handles multiple failover transitions" do
+      it "should support multiple failover transitions from stopped master" do
         # server1 is first to start, becomes master
         @miq_server1.monitor_servers
 
@@ -490,6 +490,23 @@ describe "Server Monitor" do
         expect(@miq_server1.reload.is_master).to be_falsey
         expect(@miq_server2.reload.is_master).to be_truthy
         expect(@miq_server3.reload.is_master).to be_falsey
+      end
+
+      it "should failover from stopped master on startup" do
+        # server 1 is first to start, becomes master
+        @miq_server1.monitor_servers
+
+        # server 1 shuts down
+        @miq_server1.update(:status => "stopped")
+
+        # server 3 boots and hasn't run monitor_servers yet
+        expect(@miq_server1.reload.is_master).to be_truthy
+        expect(@miq_server3.reload.is_master).to be_falsey
+
+        # server 3 runs monitor_servers and becomes master
+        @miq_server3.monitor_servers
+        expect(@miq_server1.reload.is_master).to be_falsey
+        expect(@miq_server3.reload.is_master).to be_truthy
       end
 
       it "should have all roles active after sync between them" do


### PR DESCRIPTION
Abort takeover only if an active master exists

https://bugzilla.redhat.com/show_bug.cgi?id=1402943

Previously, we would abort if a different master existed, even if it was
shut down.

* server 1 is master and shuts down
* server 3 runs monitor_servers, becomes master and shuts down
* server 2 runs monitor_servers AFTER 3 becomes master

server 2 wouldn't take over as master because it sees the inactive
server 3 as master.

Note, commit 2 is the 🍖  of the change.  commit 1 is just logging.