### PR TITLE
Load Balancers API

### DIFF
--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class InstancesController < BaseController
+    include Subcollections::LoadBalancers
+
     def terminate_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for terminating a #{type} resource" unless id
 

--- a/app/controllers/api/load_balancers_controller.rb
+++ b/app/controllers/api/load_balancers_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class LoadBalancersController < BaseController
+  end
+end

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -15,6 +15,7 @@ module Api
     include Subcollections::Tags
     include Subcollections::CloudNetworks
     include Subcollections::CustomAttributes
+    include Subcollections::LoadBalancers
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)

--- a/app/controllers/api/subcollections/load_balancers.rb
+++ b/app/controllers/api/subcollections/load_balancers.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module LoadBalancers
+      def load_balancers_query_resource(object)
+        object.respond_to?(:load_balancers) ? object.load_balancers : []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -631,11 +631,14 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *g
+    :verbs: *gp
     :klass: LoadBalancer
     :collection_actions:
       :get:
       - :name: read
+        :identifier: load_balancer_show_list
+      :post:
+      - :name: query
         :identifier: load_balancer_show_list
     :resource_actions:
       :get:

--- a/config/api.yml
+++ b/config/api.yml
@@ -576,6 +576,8 @@
     :verbs: *gp
     :options:
     - :collection
+    :subcollections:
+    - :load_balancers
     :collection_actions:
       :get:
       - :name: read
@@ -620,6 +622,25 @@
         :identifier: instance_guest_restart
       - :name: reset
         :identifier: instance_reset
+    :load_balancers_subcollection_actions:
+      :get:
+      - :name: show
+        :identifier: load_balancer_show
+  :load_balancers:
+    :description: Load Balancers
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *g
+    :klass: LoadBalancer
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show
   :notifications:
     :description: "User's past notifications"
     :options:
@@ -800,6 +821,7 @@
     - :policy_profiles
     - :cloud_networks
     - :custom_attributes
+    - :load_balancers
     :collection_actions:
       :get:
       - :name: read
@@ -863,6 +885,10 @@
       :get:
       - :name: show
       - :identifier: miq_cloud_networks_view
+    :load_balancers_subcollection_actions:
+      :get:
+      - :name: show
+        :identifier: load_balancer_show
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -294,6 +294,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:arbitration_rule)
       test_collection_query(:arbitration_rules, arbitration_rules_url, ArbitrationRule)
     end
+
+    it 'query LoadBalancers' do
+      FactoryGirl.create(:load_balancer)
+      test_collection_query(:load_balancers, load_balancers_url, LoadBalancer)
+    end
   end
 
   context "Collections Bulk Queries" do
@@ -544,6 +549,11 @@ describe "Rest API Collections" do
     it "bulk query Zones" do
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_bulk_query(:zones, zones_url, Zone)
+    end
+
+    it 'bulk query LoadBalancers' do
+      FactoryGirl.create(:load_balancer)
+      test_collection_bulk_query(:load_balancers, load_balancers_url, LoadBalancer)
     end
   end
 end

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -441,4 +441,40 @@ RSpec.describe "Instances API" do
       expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
+
+  context 'load balancers subcollection' do
+    before do
+      @vm = FactoryGirl.create(:vm_amazon)
+      @load_balancer = FactoryGirl.create(:load_balancer_amazon)
+      load_balancer_listener = FactoryGirl.create(:load_balancer_listener_amazon)
+      load_balancer_pool = FactoryGirl.create(:load_balancer_pool_amazon)
+      load_balancer_pool_member = FactoryGirl.create(:load_balancer_pool_member_amazon)
+      @load_balancer.load_balancer_listeners << load_balancer_listener
+      load_balancer_listener.load_balancer_pools << load_balancer_pool
+      load_balancer_pool.load_balancer_pool_members << load_balancer_pool_member
+      @vm.load_balancer_pool_members << load_balancer_pool_member
+    end
+
+    it 'queries all load balancers on an instance' do
+      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      expected = {
+        'name'      => 'load_balancers',
+        'resources' => [
+          { 'href' => a_string_matching("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}") }
+        ]
+      }
+      run_get("#{instances_url(@vm.id)}/load_balancers")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'queries a single load balancer on an instance' do
+      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('id' => @load_balancer.id)
+    end
+  end
 end

--- a/spec/requests/api/load_balancers_spec.rb
+++ b/spec/requests/api/load_balancers_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe 'LoadBalancers API' do
+  describe 'GET /api/load_balancers' do
+    it 'lists all load balancers with an appropriate role' do
+      load_balancer = FactoryGirl.create(:load_balancer)
+      api_basic_authorize collection_action_identifier(:load_balancers, :read, :get)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'load_balancers',
+        'resources' => [
+          hash_including('href' => a_string_matching(load_balancers_url(load_balancer.id)))
+        ]
+      }
+      run_get(load_balancers_url)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids access to load balancers without an appropriate role' do
+      api_basic_authorize
+
+      run_get(load_balancers_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/load_balancers/:id' do
+    it 'will show a load balancer with an appropriate role' do
+      load_balancer = FactoryGirl.create(:load_balancer)
+      api_basic_authorize action_identifier(:load_balancers, :read, :resource_actions, :get)
+
+      run_get(load_balancers_url(load_balancer.id))
+
+      expect(response.parsed_body).to include('href' => a_string_matching(load_balancers_url(load_balancer.id)))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'forbids access to a blueprint without an appropriate role' do
+      load_balancer = FactoryGirl.create(:load_balancer)
+      api_basic_authorize
+
+      run_get(load_balancers_url(load_balancer.id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -754,6 +754,45 @@ describe "Providers API" do
     end
   end
 
+  context 'load balancers subcollection' do
+    before do
+      @provider = FactoryGirl.create(:ems_amazon_network)
+      @load_balancer = FactoryGirl.create(:load_balancer_amazon, :ext_management_system => @provider)
+      load_balancer_listener = FactoryGirl.create(:load_balancer_listener_amazon,
+                                                  :ext_management_system => @provider)
+      load_balancer_pool = FactoryGirl.create(:load_balancer_pool_amazon,
+                                              :ext_management_system => @provider)
+      load_balancer_pool_member = FactoryGirl.create(:load_balancer_pool_member_amazon,
+                                                     :ext_management_system => @provider)
+      @load_balancer.load_balancer_listeners << load_balancer_listener
+      load_balancer_listener.load_balancer_pools << load_balancer_pool
+      load_balancer_pool.load_balancer_pool_members << load_balancer_pool_member
+    end
+
+    it 'queries all load balancers' do
+      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+      expected = {
+        'resources' => [
+          { 'href' => a_string_matching("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}") }
+        ]
+
+      }
+      run_get("#{providers_url(@provider.id)}/load_balancers")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'queries a single load balancer' do
+      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+
+      run_get("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('id' => @load_balancer.id)
+    end
+  end
+
   describe 'edit custom_attributes on providers' do
     context 'provider_class=provider' do
       let(:generic_provider) { FactoryGirl.create(:provider) }


### PR DESCRIPTION
The SUI needed an endpoint to retrieve load balancer information. This PR adds the following:
* Adds load balancer show / show list 
* Adds load balancer show subcollection to providers and instances collections

[Pivotal tracker ticket](https://www.pivotaltracker.com/story/show/135723459)

cc: @chalettu 
@miq-bot add_label enhancement, api, euwe/no
@miq-bot assign @abellotti 
