### PR TITLE
Enhance API to authorize users with system token authenticated requests.

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -146,7 +146,7 @@ module Api
         validate_system_token_server(@miq_token_hash[:server_guid])
         validate_system_token_timestamp(@miq_token_hash[:timestamp])
 
-        User.authorize_by_userid(@miq_token_hash[:userid])
+        User.authorize_user(@miq_token_hash[:userid])
 
         @auth_user     = @miq_token_hash[:userid]
         @auth_user_obj = userid_to_userobj(@auth_user)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -61,7 +61,7 @@ module Api
       end
 
       def userid_to_userobj(userid)
-        User.find_by_userid(userid)
+        User.lookup_by_identity(userid)
       end
 
       def authorize_user_group(user_obj)
@@ -145,6 +145,8 @@ module Api
 
         validate_system_token_server(@miq_token_hash[:server_guid])
         validate_system_token_timestamp(@miq_token_hash[:timestamp])
+
+        User.authorize_by_userid(@miq_token_hash[:userid])
 
         @auth_user     = @miq_token_hash[:userid]
         @auth_user_obj = userid_to_userobj(@auth_user)

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -34,17 +34,13 @@ module Authenticator
       false
     end
 
-    def can_authorize_user_by_userid?
+    def user_authorizable_without_authentication?
       false
     end
 
-    def authorize_user_by_userid(userid)
-      return unless can_authorize_user_by_userid?
-      options = {
-        :require_user   => true,
-        :authorize_only => true
-      }
-      authenticate(userid, "", {}, options)
+    def authorize_user(userid)
+      return unless user_authorizable_without_authentication?
+      authenticate(userid, "", {}, {:require_user => true, :authorize_only => true})
     end
 
     def authenticate(username, password, request = nil, options = {})
@@ -60,7 +56,8 @@ module Authenticator
 
         username = normalize_username(username)
 
-        if options[:authorize_only] || _authenticate(username, password, request)
+        authenticated = options[:authorize_only] || _authenticate(username, password, request)
+        if authenticated
           AuditEvent.success(audit.merge(:message => "User #{username} successfully validated by #{self.class.proper_name}"))
 
           if authorize?

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -34,12 +34,12 @@ module Authenticator
       false
     end
 
-    def authorize_user_by_userid?
+    def can_authorize_user_by_userid?
       false
     end
 
     def authorize_user_by_userid(userid)
-      return unless authorize_user_by_userid?
+      return unless can_authorize_user_by_userid?
       options = {
         :require_user   => true,
         :authorize_only => true

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -268,7 +268,7 @@ module Authenticator
       return [] if external_group_names.empty?
       external_group_names = external_group_names.collect(&:downcase)
 
-      internal_groups = MiqGroup.order(:sequence).to_a
+      internal_groups = MiqGroup.in_my_region.order(:sequence).to_a
 
       external_group_names.each { |g| _log.debug("External Group: #{g}") }
       internal_groups.each      { |g| _log.debug("Internal Group: #{g.description.downcase}") }

--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -34,9 +34,23 @@ module Authenticator
       false
     end
 
+    def authorize_user_by_userid?
+      false
+    end
+
+    def authorize_user_by_userid(userid)
+      return unless authorize_user_by_userid?
+      options = {
+        :require_user   => true,
+        :authorize_only => true
+      }
+      authenticate(userid, "", {}, options)
+    end
+
     def authenticate(username, password, request = nil, options = {})
       options = options.dup
       options[:require_user] ||= false
+      options[:authorize_only] ||= false
       fail_message = _("Authentication failed")
 
       user_or_taskid = nil
@@ -46,11 +60,11 @@ module Authenticator
 
         username = normalize_username(username)
 
-        if _authenticate(username, password, request)
+        if options[:authorize_only] || _authenticate(username, password, request)
           AuditEvent.success(audit.merge(:message => "User #{username} successfully validated by #{self.class.proper_name}"))
 
           if authorize?
-            user_or_taskid = authorize_queue(username, request)
+            user_or_taskid = authorize_queue(username, request, options)
           else
             # If role_mode == database we will only use the external system for authentication. Also, the user must exist in our database
             # otherwise we will fail authentication
@@ -205,7 +219,7 @@ module Authenticator
       config[:bind_pwd] = MiqPassword.try_encrypt(config[:bind_pwd])
     end
 
-    def authorize_queue(username, _request, *args)
+    def authorize_queue(username, _request, _options, *args)
       task = MiqTask.create(:name => "#{self.class.proper_name} User Authorization of '#{username}'", :userid => username)
       if authorize_queue?
         encrypt_ldap_password(config) if MiqLdap.using_ldap?

--- a/app/models/authenticator/amazon.rb
+++ b/app/models/authenticator/amazon.rb
@@ -58,7 +58,7 @@ module Authenticator
       end
     end
 
-    def find_external_identity(username)
+    def find_external_identity(username, *_args)
       # Amazon IAM will be used for authentication and role assignment
       _log.info("AWS key: [#{config[:amazon_key]}]")
       _log.info(" User: [#{username}]")

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -4,21 +4,56 @@ module Authenticator
       'External httpd'
     end
 
-    def authorize_queue(username, request)
-      user_attrs = {:username  => username,
-                    :fullname  => request.headers['X-REMOTE-USER-FULLNAME'],
-                    :firstname => request.headers['X-REMOTE-USER-FIRSTNAME'],
-                    :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
-                    :email     => request.headers['X-REMOTE-USER-EMAIL']}
-      membership_list = (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)
+    def authorize_queue(username, request, options, *_args)
+      if options[:authorize_only] == true
+        ext_user_attrs = get_user_attrs(username)
+        user_attrs = {:username  => username,
+                      :fullname  => ext_user_attrs["displayname"],
+                      :firstname => ext_user_attrs["givenname"],
+                      :lastname  => ext_user_attrs["sn"],
+                      :email     => ext_user_attrs["mail"]}
+        membership_list = MiqGroup.get_httpd_groups_by_user(username)
+      else
+        user_attrs = {:username  => username,
+                      :fullname  => request.headers['X-REMOTE-USER-FULLNAME'],
+                      :firstname => request.headers['X-REMOTE-USER-FIRSTNAME'],
+                      :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
+                      :email     => request.headers['X-REMOTE-USER-EMAIL']}
+        membership_list = (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)
+      end
 
-      super(username, request, user_attrs, membership_list)
+      super(username, request, {}, user_attrs, membership_list)
     end
 
     # We don't talk to an external system in #find_external_identity /
     # #groups_for, so no need to enqueue the work
     def authorize_queue?
       false
+    end
+
+    def authorize_user_by_userid?
+      true
+    end
+
+    def get_user_attrs(username)
+      return unless username
+      require "dbus"
+
+      attrs_needed = %w(mail givenname sn displayname)
+
+      sysbus = DBus.system_bus
+      ifp_service   = sysbus["org.freedesktop.sssd.infopipe"]
+      ifp_object    = ifp_service.object "/org/freedesktop/sssd/infopipe"
+      ifp_object.introspect
+      ifp_interface = ifp_object["org.freedesktop.sssd.infopipe"]
+      begin
+        user_attrs = ifp_interface.GetUserAttr(username, attrs_needed).first
+      rescue => err
+        raise _("Unable to get attributes for external user %{user_name} - %{error}") %
+              {:user_name => username, :error => err}
+      end
+
+      attrs_needed.each_with_object({}) { |attr, hash| hash[attr] = Array(user_attrs[attr]).first }
     end
 
     def _authenticate(_username, _password, request)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -9,7 +9,7 @@ module Authenticator
         find_or_create_by_ldap(username)
     end
 
-    def authorize_user_by_userid?
+    def can_authorize_user_by_userid?
       true
     end
 

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -9,6 +9,10 @@ module Authenticator
         find_or_create_by_ldap(username)
     end
 
+    def authorize_user_by_userid?
+      true
+    end
+
     private
 
     def ldap
@@ -76,7 +80,7 @@ module Authenticator
         ldap_bind(username, password)
     end
 
-    def find_external_identity(username)
+    def find_external_identity(username, *_args)
       # Ldap will be used for authentication and role assignment
       _log.info("Bind DN: [#{config[:bind_dn]}]")
       _log.info(" User FQDN: [#{username}]")

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -9,7 +9,7 @@ module Authenticator
         find_or_create_by_ldap(username)
     end
 
-    def can_authorize_user_by_userid?
+    def user_authorizable_without_authentication?
       true
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,9 +163,9 @@ class User < ApplicationRecord
     authenticator(username).lookup_by_identity(username)
   end
 
-  def self.authorize_by_userid(userid)
+  def self.authorize_user(userid)
     return if userid.blank? || admin?(userid)
-    authenticator(userid).authorize_user_by_userid(userid)
+    authenticator(userid).authorize_user(userid)
   end
 
   def logoff

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,6 +163,11 @@ class User < ApplicationRecord
     authenticator(username).lookup_by_identity(username)
   end
 
+  def self.authorize_by_userid(userid)
+    return if userid.blank? || admin?(userid)
+    authenticator(userid).authorize_user_by_userid(userid)
+  end
+
   def logoff
     self.lastlogoff = Time.now.utc
     save
@@ -194,6 +199,10 @@ class User < ApplicationRecord
   end
 
   def admin?
+    self.class.admin?(userid)
+  end
+
+  def self.admin?(userid)
     userid == "admin"
   end
 

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -29,9 +29,9 @@ describe Authenticator::Httpd do
     end
   end
 
-  describe '.can_authorize_user_by_userid?' do
+  describe '.user_authorizable_without_authentication?' do
     it "is true" do
-      expect(subject.can_authorize_user_by_userid?).to be_truthy
+      expect(subject.user_authorizable_without_authentication?).to be_truthy
     end
   end
 
@@ -297,7 +297,7 @@ describe Authenticator::Httpd do
         end
       end
 
-      describe ".get_user_attrs" do
+      describe ".user_attrs_from_external_directory" do
         before do
           require "dbus"
           sysbus = double('sysbus')
@@ -313,7 +313,7 @@ describe Authenticator::Httpd do
         end
 
         it "should return nil for unspecified user" do
-          expect(subject.get_user_attrs(nil)).to be_nil
+          expect(subject.send(:user_attrs_from_external_directory, nil)).to be_nil
         end
 
         it "should return user attributes hash for valid user" do
@@ -331,7 +331,7 @@ describe Authenticator::Httpd do
 
           allow(@ifp_interface).to receive(:GetUserAttr).with('jdoe', requested_attrs).and_return(jdoe_attrs)
 
-          expect(subject.get_user_attrs('jdoe')).to eq(expected_jdoe_attrs)
+          expect(subject.send(:user_attrs_from_external_directory, 'jdoe')).to eq(expected_jdoe_attrs)
         end
       end
     end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -98,6 +98,12 @@ describe Authenticator::Ldap do
     end
   end
 
+  describe ".can_authorize_user_by_userid?" do
+    it "is true" do
+      expect(subject.can_authorize_user_by_userid?).to be_truthy
+    end
+  end
+
   describe '#lookup_by_identity' do
     it "finds existing users" do
       expect(subject.lookup_by_identity('alice')).to eq(alice)

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -98,9 +98,9 @@ describe Authenticator::Ldap do
     end
   end
 
-  describe ".can_authorize_user_by_userid?" do
+  describe ".user_authorizable_without_authentication?" do
     it "is true" do
-      expect(subject.can_authorize_user_by_userid?).to be_truthy
+      expect(subject.user_authorizable_without_authentication?).to be_truthy
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -538,13 +538,13 @@ describe User do
     end
   end
 
-  context ".authorize_by_userid" do
+  context ".authorize_user" do
     it "returns nil with blank userid" do
-      expect(User.authorize_by_userid("")).to be_nil
+      expect(User.authorize_user("")).to be_nil
     end
 
     it "returns nil with admin userid" do
-      expect(User.authorize_by_userid("admin")).to be_nil
+      expect(User.authorize_user("admin")).to be_nil
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -527,4 +527,24 @@ describe User do
       expect(User.super_admin).to be_super_admin_user
     end
   end
+
+  context ".admin?" do
+    it "admin? succeeds with admin account" do
+      expect(User.admin?("admin")).to be_truthy
+    end
+
+    it "admin? fails with non-admin account" do
+      expect(User.admin?("regular_user")).to be_falsey
+    end
+  end
+
+  context ".authorize_by_userid" do
+    it "returns nil with blank userid" do
+      expect(User.authorize_by_userid("")).to be_nil
+    end
+
+    it "returns nil with admin userid" do
+      expect(User.authorize_by_userid("admin")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION

This capability is needed for MiqLdap and External Authentication
Authentication Modes so users are authorized and auto-created
with system token authenticated requests.

- Added a User.admin?(userid) method
- Added a User.authorize_by_userid method
- Add support for authorize_user_by_userid for ldap, ldaps
- Add support for authorize_user_by_userid for httpd
- Add support to fetch user attrs for httpd

This solves the following BZ's:
https://bugzilla.redhat.com/show_bug.cgi?id=1400349
https://bugzilla.redhat.com/show_bug.cgi?id=1400350