### PR TITLE
Upgrade pglogical to 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ ENV APP_ROOT /var/www/miq/vmdb
 ENV APPLIANCE_ROOT /opt/manageiq/manageiq-appliance
 ENV SUI_ROOT /opt/manageiq/manageiq-ui-service
 
-# Fetch pglogical and manageiq repo
-RUN curl -sSLko /etc/yum.repos.d/ncarboni-pglogical-SCL-epel-7.repo \
-      https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
-RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-epel-7.repo \
-      https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ/repo/epel-7/manageiq-ManageIQ-epel-7.repo
+# Fetch and manageiq release repo
+RUN curl -sSLko /etc/yum.repos.d/manageiq-ManageIQ-Fine-epel-7.repo \
+      https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Fine/repo/epel-7/manageiq-ManageIQ-Fine-epel-7.repo
 
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
@@ -41,7 +39,6 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    patch                   \
                    rh-postgresql95-postgresql-server \
                    rh-postgresql95-postgresql-devel  \
-                   rh-postgresql95-postgresql-pglogical-output \
                    rh-postgresql95-postgresql-pglogical \
                    rh-postgresql95-repmgr  \
                    readline-devel          \

--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -295,7 +295,7 @@ class PgLogicalRaw
   def tables_in_replication_set(set_name)
     typed_exec(<<-SQL, set_name).values.flatten
       SELECT set_reloid
-      FROM pglogical.replication_set_table
+      FROM pglogical.replication_set_relation
       JOIN pglogical.replication_set
         USING (set_id)
       WHERE set_name = $1

--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -21,8 +21,8 @@ class PgLogicalRaw
 
   # Enables pglogical postgres extensions
   def enable
-    connection.enable_extension("pglogical")
     connection.enable_extension("pglogical_origin") if connection.postgresql_version < 90_500
+    connection.enable_extension("pglogical")
   end
 
   def disable


### PR DESCRIPTION
This PR makes changes to be compatible with the new versions of pglogical.

One table changed names and the extensions need to be enabled in a different order.

This PR also changes the Dockerfile to use the new repo to pull the new pglogical package from.

Requires https://github.com/ManageIQ/manageiq-appliance-build/pull/186

@gtanzillo please review
https://www.pivotaltracker.com/story/show/125274621