### PR TITLE
Eliminate angular $q dependency injection if it is not needed by ng services

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_service.js
@@ -1,10 +1,9 @@
 ManageIQ.angular.app.service('mwAddDatasourceService', MwAddDatasourceService);
 
-MwAddDatasourceService.$inject = ['$http', '$q'];
+MwAddDatasourceService.$inject = ['$http'];
 
-function MwAddDatasourceService($http, $q) {
-
-   var datasources = [
+function MwAddDatasourceService($http) {
+  var datasources = [
     {id: 'H2', label: 'H2', name: 'H2DS', jndiName: 'java:jboss/datasources/H2DS',
       driverName: 'h2', driverModuleName: 'com.h2database.h2', driverClass: 'org.h2.Driver',
       connectionUrl: ':mem:test;DB_CLOSE_DELAY=-1'},


### PR DESCRIPTION
If we are not using Angular $q promises then let's remove the dependency injection.

Clean up #12820.
