### PR TITLE
Rescue failed container annotation attempts

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -176,7 +176,7 @@ module ContainersCommonMixin
     ids = showlist ? find_checked_items : find_current_item(model)
 
     if ids.empty?
-      add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:models => model),
+      add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:models => model.to_s),
                                                               :task  => "Compliance Check"}, :error)
     else
       process_check_compliance(model, ids)
@@ -188,7 +188,7 @@ module ContainersCommonMixin
 
   def find_current_item(model)
     if params[:id].nil? || model.find_by(:id => params[:id].to_i).nil?
-      add_flash(_("%{model} no longer exists") % {:table => ui_lookup(:model => model)}, :error)
+      add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => model.to_s)}, :error)
       []
     else
       [params[:id].to_i]
@@ -217,9 +217,10 @@ module ContainersCommonMixin
       begin
         entity.check_compliance
       rescue => bang
-        add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': ") %
-                  {:model => ui_lookup(:model => model),
-                   :name  => entity.name} << bang.message,
+        add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': %{error}") %
+                  {:model => ui_lookup(:model => model.to_s),
+                   :name  => entity.name,
+                   :error => bang.message},
                   :error) # Push msg and error flag
       else
         add_flash(_("\"%{record}\": Compliance check successfully initiated") % {:record => entity.name})

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -12,6 +12,15 @@ describe ContainerImageController do
     expect(controller.send(:flash_errors?)).not_to be_truthy
   end
 
+  it "when Check Compliance is pressed with no images" do
+    ApplicationController.handle_exceptions = true
+
+    expect(controller).to receive(:check_compliance).and_call_original
+    expect(controller).to receive(:add_flash).with("Container Image no longer exists", :error)
+    expect(controller).to receive(:add_flash).with("No Container Images were selected for Compliance Check", :error)
+    post :button, :params => { :pressed => 'container_image_check_compliance', :format => :js }
+  end
+
   it 'renders edit container image tags' do
     ApplicationController.handle_exceptions = true
 


### PR DESCRIPTION
When failing to annotate a container entity an error is thrown, this caught and will then cause `ui_lookup` to be called with the module instead of its name which will cause another uncaught error in the controller that will be thrown.

Updated all the calls in the file of to `ui_lookup` to send the model's name instead of the model. Also refactored this specific error message.

PS: The flash is not displayed correctly on error but this is out of scope for this patch.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1402349

cc @moolitayer @simon3z @yaacov @nimrodshn  PTAL