### PR TITLE
Toolbar refactoring:  Instance buttons

### DIFF
--- a/app/helpers/application_helper/button/instance_check_compare.rb
+++ b/app/helpers/application_helper/button/instance_check_compare.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::InstanceCheckCompare < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    !@record.kind_of?(OrchestrationStack) || @display != 'instances'
+  end
+
+  def disabled?
+    @error_message = _('No Compliance Policies assigned to this virtual machine') unless
+        @record.has_compliance_policies?
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/instance_check_compare.rb
+++ b/app/helpers/application_helper/button/instance_check_compare.rb
@@ -1,13 +1,11 @@
 class ApplicationHelper::Button::InstanceCheckCompare < ApplicationHelper::Button::Basic
-  needs :@record
-
   def visible?
     !@record.kind_of?(OrchestrationStack) || @display != 'instances'
   end
 
   def disabled?
     @error_message = _('No Compliance Policies assigned to this virtual machine') unless
-        @record.has_compliance_policies?
+        @record.try(:has_compliance_policies?)
     @error_message.present?
   end
 end

--- a/app/helpers/application_helper/button/instance_retire.rb
+++ b/app/helpers/application_helper/button/instance_retire.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::InstanceRetire < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    @error_message = _('Instance is already retired') if @record.retired
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -108,7 +108,8 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           'fa fa-search fa-lg',
           N_('Check Compliance of the last known configuration for this Instance'),
           N_('Check Compliance of Last Known Configuration'),
-          :confirm => N_("Initiate Check Compliance of the last known configuration for this Instance?")),
+          :confirm => N_("Initiate Check Compliance of the last known configuration for this Instance?"),
+          :klass   => ApplicationHelper::Button::InstanceCheckCompare),
       ]
     ),
   ])
@@ -123,13 +124,15 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :instance_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this Instance'),
-          N_('Set Retirement Date')),
+          N_('Set Retirement Date'),
+          :klass   => ApplicationHelper::Button::InstanceRetire),
         button(
           :instance_retire_now,
           'fa fa-clock-o fa-lg',
           t = N_('Retire this Instance'),
           t,
-          :confirm => N_("Retire this Instance?")),
+          :confirm => N_("Retire this Instance?"),
+          :klass   => ApplicationHelper::Button::InstanceRetire),
         button(
           :instance_live_migrate,
           'product product-migrate fa-lg',

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -34,7 +34,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Compare Selected items'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "2+"),
+          :onwhen    => "2+",
+          :klass     => ApplicationHelper::Button::InstanceCheckCompare),
         separator,
         button(
           :instance_edit,
@@ -115,7 +116,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :url_parms => "main_div",
           :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::InstanceCheckCompare),
       ]
     ),
   ])
@@ -140,7 +142,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           N_('Set Retirement Dates'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::InstanceRetire),
         button(
           :instance_retire_now,
           'fa fa-clock-o fa-lg',
@@ -149,7 +152,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :url_parms => "main_div",
           :confirm   => N_("Retire the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::InstanceRetire),
         button(
           :instance_live_migrate,
           'product product-migrate fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -73,7 +73,8 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'fa fa-search fa-lg',
           N_('Check Compliance of the last known configuration for this Instance'),
           N_('Check Compliance of Last Known Configuration'),
-          :confirm => N_("Initiate Check Compliance of the last known configuration for this Instance?")),
+          :confirm => N_("Initiate Check Compliance of the last known configuration for this Instance?"),
+          :klass   => ApplicationHelper::Button::InstanceCheckCompare),
       ]
     ),
   ])
@@ -88,13 +89,15 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           :instance_retire,
           'fa fa-clock-o fa-lg',
           N_('Set Retirement Dates for this Instance'),
-          N_('Set Retirement Date')),
+          N_('Set Retirement Date'),
+          :klass   => ApplicationHelper::Button::InstanceRetire),
         button(
           :instance_retire_now,
           'fa fa-clock-o fa-lg',
           t = N_('Retire this Instance'),
           t,
-          :confirm => N_("Retire this Instance?")),
+          :confirm => N_("Retire this Instance?"),
+          :klass   => ApplicationHelper::Button::InstanceRetire),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -427,10 +427,6 @@ class ApplicationHelper::ToolbarBuilder
     return false if id.start_with?('history_')
     return true if id == "blank_button" # Always hide the blank button placeholder
 
-    # hide compliance check and comparison buttons rendered for orchestration stack instances
-    return true if @record.kind_of?(OrchestrationStack) && @display == "instances" &&
-                   %w(instance_check_compliance instance_compare).include?(id)
-
     # need to hide add buttons when on sub-list view screen of a CI.
     return true if id.ends_with?("_new", "_discover") &&
                    @lastaction == "show" && !["main", "vms"].include?(@display)
@@ -692,8 +688,7 @@ class ApplicationHelper::ToolbarBuilder
       case id
       when "instance_perf", "vm_perf", "container_perf"
         return N_("No Capacity & Utilization data has been collected for this VM") unless @record.has_perf_data?
-      when "instance_check_compliance", "vm_check_compliance"
-        model = model_for_vm(@record).to_s
+      when "vm_check_compliance"
         unless @record.has_compliance_policies?
           return N_("No Compliance Policies assigned to this virtual machine")
         end
@@ -718,8 +713,6 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
-      when "instance_retire", "instance_retire_now"
-        return N_("Instance is already retired") if @record.retired
       when "vm_timeline"
         unless @record.has_events? || @record.has_events?(:policy_events)
           return N_("No Timeline data has been collected for this VM")

--- a/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
@@ -1,0 +1,34 @@
+describe ApplicationHelper::Button::InstanceCheckCompare do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:display) { nil }
+  let(:record) { FactoryGirl.create(:vm) }
+  subject { described_class.new(view_context, {}, {'record' => record, 'display' => display}, {}) }
+
+  describe '#visible?' do
+    context 'when display != instances' do
+      it { expect(subject.visible?).to be_truthy }
+    end
+    context 'when record is not OrchestrationStack' do
+      let(:record) { FactoryGirl.create(:orchestration_stack) }
+      it { expect(subject.visible?).to be_truthy }
+    end
+    context 'when display == instances && record is an OrchestrationStack' do
+      let(:record) { FactoryGirl.create(:orchestration_stack) }
+      let(:display) { 'instances' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+  end
+
+  describe '#disabled?' do
+    before { allow(record).to receive(:has_compliance_policies?).and_return(has_policies) }
+
+    context 'when record has compliance policies' do
+      let(:has_policies) { true }
+      it { expect(subject.disabled?).to be_falsey }
+    end
+    context 'when record does not have compliance policies' do
+      let(:has_policies) { false }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_check_compare_spec.rb
@@ -5,14 +5,14 @@ describe ApplicationHelper::Button::InstanceCheckCompare do
   subject { described_class.new(view_context, {}, {'record' => record, 'display' => display}, {}) }
 
   describe '#visible?' do
-    context 'when display != instances' do
+    context 'when record is not kind of OrchestrationStack && display != instances' do
       it { expect(subject.visible?).to be_truthy }
     end
-    context 'when record is not OrchestrationStack' do
+    context 'when record is kind of OrchestrationStack && display != instances' do
       let(:record) { FactoryGirl.create(:orchestration_stack) }
       it { expect(subject.visible?).to be_truthy }
     end
-    context 'when display == instances && record is an OrchestrationStack' do
+    context 'when record is an OrchestrationStack && display == instances' do
       let(:record) { FactoryGirl.create(:orchestration_stack) }
       let(:display) { 'instances' }
       it { expect(subject.visible?).to be_falsey }

--- a/spec/helpers/application_helper/buttons/instance_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_retire_spec.rb
@@ -1,0 +1,13 @@
+describe ApplicationHelper::Button::InstanceRetire do
+  let(:record) { FactoryGirl.create(:vm, :retired => retired) }
+  subject { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
+
+  describe '#disabled?' do
+    [true, false].each do |retired|
+      context "when record.retired == #{retired}" do
+        let(:retired) { retired }
+        it { expect(subject.disabled?).to eq(retired) }
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1096,15 +1096,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
     end # end of Vm class
 
-    context "Disable Retire button for already retired VMs and Instances" do
-      it "button instance_retire_now" do
-        @record = FactoryGirl.create(:vm_amazon, :retired => true)
-        res = toolbar_builder.disable_button("instance_retire_now")
-        expect(res).to be_truthy
-        expect(res).to include("already retired")
-      end
-    end
-
     context "and id = miq_request_delete" do
       let(:server) { double("MiqServer", :logon_status => :ready) }
       let(:user)   { FactoryGirl.create(:user_admin) }


### PR DESCRIPTION
Created separate classes for the `instance_` prefixed buttons in `#hide_button?`. I couldn't manage to test the `instance_retire` buttons in UI because an instance could not be made retired.
Nothing happens after this message appears:
![instance_retire_successful](https://cloud.githubusercontent.com/assets/5737996/21041875/3be46c5c-bdee-11e6-9c8e-bc89c827371b.png)


| Toolbar button id | Toolbar buttons class created |
| --- | --- |
| instance_check_compliance, instance_compare | InstanceCheckCompare < Basic |
| instance_retire, instance_retire_now | InstanceRetire < Basic |

# How to review

### instance_check_compliance

1. Create a **Compliance Policy** in *Control -> Explorer -> Policies tree -> Vm and Compliance Policies subtree -> Configuration -> Add a new VM and Instance Compliance Policy*
2. Assign the **Policy to a Policy profile** in *Control -> Explorer -> Policy Profile tree -> Select a policy profile -> Configuration -> Edit this Policy Profile*
3. Assign the **Policy profile to an Openstack Cloud Instance** in *Compute -> Clouds -> Instances -> Select an openstack instance -> Policy -> Manage policies -> Select and add the policy profile from the previous step*
4. Policy -> Check Compliance of Last Known Configuration **should be enabled**.

### instance_compare

1. Compute -> Clouds -> Instances -> Select the Openstack provider
2. Mark two checkboxes there and the button should be visible under the *Configuration* select button.

### instance_retire, instance_retire_now

I was not able to make the instances retire.

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135535379
