### PR TITLE
Toolbar refactoring: View buttons

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -502,9 +502,6 @@ class ApplicationHelper::ToolbarBuilder
     return true if @record.kind_of?(OrchestrationStack) && @display == "instances" &&
                    %w(instance_check_compliance instance_compare).include?(id)
 
-    # don't hide view buttons in toolbar
-    return false if id == 'common_drift'
-
     # dont hide back to summary button button when not in explorer
     return false if id == "show_summary" && !@explorer
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -503,7 +503,7 @@ class ApplicationHelper::ToolbarBuilder
                    %w(instance_check_compliance instance_compare).include?(id)
 
     # don't hide view buttons in toolbar
-    return false if %w(refresh_log fetch_log common_drift download_view).include?(id) &&
+    return false if %w(common_drift download_view).include?(id) &&
                     !%w(miq_policy_rsop ops).include?(@layout)
 
     # dont hide back to summary button button when not in explorer

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -503,8 +503,7 @@ class ApplicationHelper::ToolbarBuilder
                    %w(instance_check_compliance instance_compare).include?(id)
 
     # don't hide view buttons in toolbar
-    return false if id == 'common_drift' &&
-                    !%w(miq_policy_rsop ops).include?(@layout)
+    return false if id == 'common_drift'
 
     # dont hide back to summary button button when not in explorer
     return false if id == "show_summary" && !@explorer

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -503,7 +503,7 @@ class ApplicationHelper::ToolbarBuilder
                    %w(instance_check_compliance instance_compare).include?(id)
 
     # don't hide view buttons in toolbar
-    return false if %w(common_drift download_view).include?(id) &&
+    return false if id == 'common_drift' &&
                     !%w(miq_policy_rsop ops).include?(@layout)
 
     # dont hide back to summary button button when not in explorer

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -504,8 +504,8 @@ class ApplicationHelper::ToolbarBuilder
 
     # don't hide view buttons in toolbar
     return false if %w(view_grid view_tile view_list view_dashboard view_summary view_topology
-      refresh_log fetch_log common_drift download_text download_csv download_pdf download_view vm_download_pdf
-      tree_large tree_small).include?(id) && !%w(miq_policy_rsop ops).include?(@layout)
+      refresh_log fetch_log common_drift download_text download_csv download_pdf download_view
+      vm_download_pdf).include?(id) && !%w(miq_policy_rsop ops).include?(@layout)
 
     # dont hide back to summary button button when not in explorer
     return false if id == "show_summary" && !@explorer

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -503,9 +503,8 @@ class ApplicationHelper::ToolbarBuilder
                    %w(instance_check_compliance instance_compare).include?(id)
 
     # don't hide view buttons in toolbar
-    return false if %w(view_grid view_tile view_list view_dashboard view_summary view_topology
-      refresh_log fetch_log common_drift download_text download_csv download_pdf download_view
-      vm_download_pdf).include?(id) && !%w(miq_policy_rsop ops).include?(@layout)
+    return false if %w(refresh_log fetch_log common_drift download_view).include?(id) &&
+                    !%w(miq_policy_rsop ops).include?(@layout)
 
     # dont hide back to summary button button when not in explorer
     return false if id == "show_summary" && !@explorer

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -486,29 +486,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with EmsCluster" do
-      before do
-        @record = EmsCluster.new
-        stub_user(:features => :all)
-      end
-
-      context "and id = common_drift" do
-        before do
-          @id = 'common_drift'
-          @lastaction = 'drift_history'
-        end
-
-        it "and lastaction = drift_history" do
-          expect(subject).to be_falsey
-        end
-      end
-
-      it "and id != common_drift" do
-        @id = 'ems_cluster_view'
-        expect(subject).to be_falsey
-      end
-    end
-
     context "when with Host" do
       before do
         @record = Host.new

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -188,24 +188,6 @@ describe ApplicationHelper do
     end
 
     %w(
-      view_grid
-      view_tile
-      view_list
-      download_text
-      download_csv
-      download_pdf
-      download_view
-      vm_download_pdf
-      refresh_log
-      fetch_log
-    ).each do |item|
-      it "when with #{item}" do
-        @id = item
-        expect(subject).to be_falsey
-      end
-    end
-
-    %w(
       history_1
       history_2
       history_3


### PR DESCRIPTION
Removed the buttons from `#hide_button?`'s condition. The toolbars, in which the buttons are situated, have been checked in `toolbar_chooser.rb` whether they get rendered when `%w(miq_policy_rsop ops).include(@layout)`.

Neither of the buttons removed in `#hide_button?` would get rendered in `miq_policy_rsop`, nor the `ops` layout. That's why the second part of the condition could be deleted.
Also the first part can be deleted because:
- either the buttons are not used anywhere in the project (not assigned to any toolbar),
- the buttons' visibility condition is checked further in the code,
- the buttons would be evaluated as `false` anyway (Rbac check does not do a difference, these are view buttons).

# Notes

1. To have the `@layout == "miq_policy_rsop"`, go to **Control -> Simulation**

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135542935
