### PR TITLE
Add validation for charts with values

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -856,6 +856,9 @@ module ReportController::Reports::Editor
             @edit[:new][:sortby2] = NOTHING_STRING
           end
 
+          # Clear out selected chart data column
+          @edit[:new][:chart_column] = nil if @edit[:new][:chart_column] == nf.last
+
           @edit[:new][:col_options].delete(field_to_col(nf.last)) # Remove this column from the col_options hash
         end
       end

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -234,7 +234,7 @@ module ReportController::Reports::Editor
       if options.empty?
         @edit[:new][:chart_column] = nil
       else
-        options[0][1] unless options.detect { |_, v| v == @edit[:new][:chart_column] }
+        @edit[:new][:chart_column] = options[0][1] unless options.detect { |_, v| v == @edit[:new][:chart_column] }
       end
 
     when "6"  # Timeline

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1623,6 +1623,8 @@ module ReportController::Reports::Editor
       end
     end
 
+    active_tab = 'edit_5' unless valid_chart_data_column?
+
     # Validate column styles
     unless rpt.col_options.blank? || @edit[:new][:field_order].nil?
       @edit[:new][:field_order].each do |f| # Go thru all of the cols in order
@@ -1660,6 +1662,14 @@ module ReportController::Reports::Editor
     end
     @sb[:miq_tab] = active_tab if flash_errors?
     @flash_array.nil?
+  end
+
+  def valid_chart_data_column?
+    is_valid = !(@edit[:new][:graph_type] && @edit[:new][:chart_mode] == 'values' && @edit[:new][:chart_column].blank?)
+
+    add_flash(_('Data column must be selected when chart mode is set to "Values"'), :error) unless is_valid
+
+    is_valid
   end
 
   # Check for valid report configuration in @edit[:new]
@@ -1747,6 +1757,8 @@ module ReportController::Reports::Editor
       elsif Chargeback.db_is_chargeback?(@edit[:new][:model]) && !valid_chargeback_fields
         add_flash(_('Preview tab is not available until Chargeback Filters has been configured'), :error)
         active_tab = 'edit_3'
+      elsif !valid_chart_data_column?
+        active_tab = 'edit_5'
       end
     when '9'
       if @edit[:new][:fields].empty?

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -27,29 +27,30 @@ module ReportHelper
   end
 
   def chart_fields_options
-    if @edit[:new][:group] != 'No'
-      groupings = @edit[:new][:col_options].find_all do |_field, col_options|
-        col_options[:grouping].present? && !col_options[:grouping].empty?
-      end
-      groupings.each_with_object([]) do |(field, col_options), options|
-        model = @edit[:new][:model]
-        col_options[:grouping].each do |fun|
-          field_key = if field =~ /\./
-                        f = field.sub('.', '-')
-                        "#{model}.#{f}"
-                      else
-                        "#{model}-#{field}"
-                      end
-          field_label = @edit[:new][:headers][field_key]
-          options << ["#{field_label} (#{fun.to_s.titleize})", "#{model}-#{field}:#{fun}"]
-        end
-      end
-    else
-      @edit[:new][:field_order].find_all do |f|
-        ci = MiqReport.get_col_info(f.last.split("__").first)
-        ci[:numeric]
-      end
-    end
+    chart_data_columns = if @edit[:new][:group] != 'No'
+                           groupings = @edit[:new][:col_options].find_all do |_field, col_options|
+                             col_options[:grouping].present? && !col_options[:grouping].empty?
+                           end
+                           groupings.each_with_object([]) do |(field, col_options), options|
+                             model = @edit[:new][:model]
+                             col_options[:grouping].each do |fun|
+                               field_key = if field =~ /\./
+                                             f = field.sub('.', '-')
+                                             "#{model}.#{f}"
+                                           else
+                                             "#{model}-#{field}"
+                                           end
+                               field_label = @edit[:new][:headers][field_key]
+                               options << ["#{field_label} (#{fun.to_s.titleize})", "#{model}-#{field}:#{fun}"]
+                             end
+                           end
+                         else
+                           @edit[:new][:field_order].find_all do |f|
+                             ci = MiqReport.get_col_info(f.last.split("__").first)
+                             ci[:numeric]
+                           end
+                         end
+    [[_("Nothing selected"), nil]] + chart_data_columns
   end
 
   def filter_performance_start_options

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -31,8 +31,13 @@ describe ReportHelper do
       }
 
       options = chart_fields_options
+      expected_array = [
+        ["Nothing selected", nil],
+        ["Memory (Total)", "Vm-mem_cpu:total"],
+        ["Allocated Disk Storage (Total)", "Vm-allocated_disk_storage:total"]
+      ]
 
-      expect(options).to eq([["Memory (Total)", "Vm-mem_cpu:total"], ["Allocated Disk Storage (Total)", "Vm-allocated_disk_storage:total"]])
+      expect(options).to eq(expected_array)
     end
 
     it 'should return numeric fields from report with models when "Show Sort Breaks" is "No"' do
@@ -51,7 +56,13 @@ describe ReportHelper do
 
       options = chart_fields_options
 
-      expect(options).to eq([[" Memory", "Vm-mem_cpu"], [" Allocated Disk Storage", "Vm-allocated_disk_storage"]])
+      expected_array = [
+        ["Nothing selected", nil],
+        [" Memory", "Vm-mem_cpu"],
+        [" Allocated Disk Storage", "Vm-allocated_disk_storage"]
+      ]
+
+      expect(options).to eq(expected_array)
     end
   end
 end


### PR DESCRIPTION

![screen shot 2016-12-09 at 10 44 48](https://cloud.githubusercontent.com/assets/14937244/21044491/928e7b34-bdfc-11e6-8aef-c5b5d968c789.png)

- This is PR is adding validation message for chart with values that data column have to be selected in this [commit](https://github.com/ManageIQ/manageiq/commit/34563539e7ca30d525d3397c50aaeee955b0f81d).

- Also I added "Nothing selected" to data column in this [commit](https://github.com/ManageIQ/manageiq/commit/22540d6b005f726b993420218c0fa146a96ef405). Then user is forced to select any data column and before fix it was done automatically and selected first numeric field.
For some manipulation with this field in selected fields (removing, adding), variable `@edit[:new][:chart_mode]` was not updated properly. So I decided to add "Nothing selected" and clean this variable always and force use to selected data column always when data column is [removed](https://github.com/ManageIQ/manageiq/commit/278465bae2709a7f164fd60a1cb08885baa2c2ca).

- this [commit](https://github.com/ManageIQ/manageiq/commit/21174ba72ef65406fedad4ffd678c02a59b5b931)  is updating  variable `@edit[:new][:chart_mode]` when data column is selected.


Scenario 1:
To be able selected any data column you have to have selected any numeric field in selected fields in first tab of report definition. But when you will set 'Chart mode' to 'Values' then you were able to save report even if don't have selected any data column. 

Scenario 2:
- Add numeric field and any other field in report.
- set other field in summary tab and set chart data column in chart tab. chart mode and values
- remove the numeric field from selected field 
- save report -> this case is validated now.


@miq-bot add_label ui, bug, euwe/yes
@miq_bot assign @mzazrivec 
cc @PanSpagetka 


 