### PR TITLE
Notifications: use initiator's tenant when subject lacks tenant relationship

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -20,7 +20,11 @@ class NotificationType < ApplicationRecord
     when AUDIENCE_GROUP
       subject.try(:requester).try(:current_group).try(:user_ids)
     when AUDIENCE_TENANT
-      subject.tenant.user_ids
+      if subject.respond_to? :tenant
+        subject.tenant
+      elsif initiator.kind_of? User
+        initiator.current_tenant
+      end.try(:user_ids)
     when AUDIENCE_SUPERADMIN
       User.superadmins.pluck(:id)
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -52,6 +52,17 @@ describe Notification, :type => :model do
           expect(subject.recipients).to match_array([requester, peer])
         end
       end
+
+      context 'subject does not have tenant' do
+        let!(:peer) { FactoryGirl.create(:user_with_group, :tenant => tenant) }
+        let!(:non_peer) { FactoryGirl.create(:user) }
+
+        subject { Notification.create(:initiator => user, :type => 'automate_tenant_info') }
+
+        it 'sends notification to the tenant of initiator' do
+          expect(subject.recipients).to match_array([user, peer])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1400246

Automate users may pass in a `$subject` that lacks tenant relationship. In that case we should use initiators' tenant to determine audience of given notification.

Note: We still need to amend automate code to pass in automate user as initiator.

/cc @tinaafitz 

@miq-bot add_label core, enhancement, euwe/yes
@miq-bot assign @gtanzillo 
