### PR TITLE
Toolbar refactoring: Summary buttons

### DIFF
--- a/app/helpers/application_helper/button/show_summary.rb
+++ b/app/helpers/application_helper/button/show_summary.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::ShowSummary < ApplicationHelper::Button::ButtonWithoutRbacCheck
+  def visible?
+    !@explorer
+  end
+end

--- a/app/helpers/application_helper/button/summary_reload.rb
+++ b/app/helpers/application_helper/button/summary_reload.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::SummaryReload < ApplicationHelper::Button::ButtonWithoutRbacCheck
+  def visible?
+    @explorer && ((@record && proper_layout? && proper_showtype?) || @lastaction == 'show_list')
+  end
+
+  private
+
+  def proper_layout?
+    @layout != 'miq_policy_rsop'
+  end
+
+  def proper_showtype?
+    !%w(details item).include?(@showtype)
+  end
+end

--- a/app/helpers/application_helper/toolbar/summary_center.rb
+++ b/app/helpers/application_helper/toolbar/summary_center.rb
@@ -9,6 +9,7 @@ class ApplicationHelper::Toolbar::SummaryCenter < ApplicationHelper::Toolbar::Ba
       end,
       nil,
       :url       => "/show",
-      :url_parms => "?id=\#{@record.id}"),
+      :url_parms => "?id=\#{@record.id}",
+      :klass     => ApplicationHelper::Button::ShowSummary),
   ])
 end

--- a/app/helpers/application_helper/toolbar/summary_center_restful.rb
+++ b/app/helpers/application_helper/toolbar/summary_center_restful.rb
@@ -9,6 +9,7 @@ class ApplicationHelper::Toolbar::SummaryCenterRestful < ApplicationHelper::Tool
       end,
       nil,
       :url       => "/",
-      :url_parms => "?id=\#{@record.id}"),
+      :url_parms => "?id=\#{@record.id}",
+      :klass     => ApplicationHelper::Button::ShowSummary),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_history.rb
+++ b/app/helpers/application_helper/toolbar/x_history.rb
@@ -23,6 +23,6 @@ class ApplicationHelper::Toolbar::XHistory < ApplicationHelper::Toolbar::Basic
       N_('Reload current display'),
       nil,
       :url => "reload",
-      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
+      :klass => ApplicationHelper::Button::SummaryReload),
   ])
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -460,21 +460,9 @@ class ApplicationHelper::ToolbarBuilder
     return true if @record.kind_of?(OrchestrationStack) && @display == "instances" &&
                    %w(instance_check_compliance instance_compare).include?(id)
 
-    # dont hide back to summary button button when not in explorer
-    return false if id == "show_summary" && !@explorer
-
     # need to hide add buttons when on sub-list view screen of a CI.
     return true if id.ends_with?("_new", "_discover") &&
                    @lastaction == "show" && !["main", "vms"].include?(@display)
-
-    if id == "summary_reload"                             # Show reload button if
-      return @explorer && # we are in explorer and
-        ((@record && #    1) we are on a record and
-         !["miq_policy_rsop"].include?(@layout) && # @layout is not one of these
-         !["details", "item"].include?(@showtype)) || #       not showing list or single sub screen item i.e VM/Users
-         @lastaction == "show_list") ? # or 2) selected node shows a list of records
-        false : true
-    end
 
     # user can see the buttons if they can get to Policy RSOP/Automate Simulate screen
     return false if ["miq_ae_tools"].include?(@layout)
@@ -502,7 +490,8 @@ class ApplicationHelper::ToolbarBuilder
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) && !["miq_request_approve", "miq_request_deny"].include?(id) &&
                      id !~ /^history_\d*/ &&
-                     !id.starts_with?("dialog_") && !id.starts_with?("miq_task_")
+                     !id.starts_with?("dialog_") && !id.starts_with?("miq_task_") &&
+                     !(id == "show_summary" && !@explorer) && id != "summary_reload"
     end
 
     # Check buttons with other restriction logic

--- a/spec/helpers/application_helper/buttons/show_summary_spec.rb
+++ b/spec/helpers/application_helper/buttons/show_summary_spec.rb
@@ -1,0 +1,12 @@
+describe ApplicationHelper::Button::ShowSummary do
+  subject { described_class.new(setup_view_context_with_sandbox({}), {}, {'explorer' => explorer}, {}) }
+
+  describe '#visible?' do
+    [true, false].each do |explorer|
+      context "when explorer evals as #{explorer}" do
+        let(:explorer) { explorer }
+        it { expect(subject.visible?).to eq(!explorer) }
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/summary_reload_spec.rb
+++ b/spec/helpers/application_helper/buttons/summary_reload_spec.rb
@@ -1,0 +1,55 @@
+describe ApplicationHelper::Button::SummaryReload do
+  let(:explorer) { true }
+  let(:record) { true }
+  let(:layout) { 'not_miq_policy_rsop' }
+  let(:showtype) { true }
+  let(:lastaction) { nil }
+  let(:button) do
+    described_class.new(setup_view_context_with_sandbox({}), {},
+                        {'record' => record, 'explorer' => explorer, 'layout' => layout,
+                         'showtype' => showtype, 'lastaction' => lastaction}, {})
+  end
+
+  shared_examples 'lastaction_examples' do
+    context 'when lastaction == show_list' do
+      let(:lastaction) { 'show_list' }
+      it { expect(subject).to be_truthy }
+    end
+    context 'when lastaction != show_list' do
+      let(:lastaction) { 'not_show_list' }
+      it { expect(subject).to be_falsey }
+    end
+  end
+
+  describe '#visible?' do
+    subject { button.visible? }
+
+    context 'when in explorer' do
+      context 'when record set' do
+        context 'when layout != miq_policy_rsop' do
+          context 'when showtype not in %w(details item)' do
+            it { expect(subject).to be_truthy }
+          end
+          %w(details item).each do |showtype|
+            context "when showtype == #{showtype}" do
+              let(:showtype) { showtype }
+              include_examples 'lastaction_examples'
+            end
+          end
+        end
+        context 'when layout == miq_policy_rsop' do
+          let(:layout) { 'miq_policy_rsop' }
+          include_examples 'lastaction_examples'
+        end
+      end
+      context 'when record not set' do
+        let(:record) { false }
+        include_examples 'lastaction_examples'
+      end
+    end
+    context 'when not in explorer' do
+      let(:explorer) { false }
+      it { expect(subject).to be_falsey }
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -205,18 +205,6 @@ describe ApplicationHelper do
       end
     end
 
-    it "when with show_summary and not explorer" do
-      @id = "show_summary"
-      @explorer = false
-      expect(subject).to be_falsey
-    end
-
-    it "when with show_summary and explorer" do
-      @id = "show_summary"
-      @explorer = true
-      expect(subject).to be_truthy
-    end
-
     it "when id likes old_dialogs_*" do
       @id = "old_dialogs_some_thing"
       expect(subject).to be_truthy


### PR DESCRIPTION
Refactored `show_summary` and `summary_reload` buttons. They both show the behavior of the `ButtonWithoutRbacCheck` button class. However, the Rbac should be checked on `show_summary` button, when `@explorer == true`.

| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| show_summary | ShowSummary < ButtonWithoutRbacCheck |
| summary_reload | SummaryReload  < ButtonWithoutRbacCheck |

I've been forced to extend the condition of [this code, here](https://github.com/ManageIQ/manageiq/blob/a8e77311912fe4155b596265f36e3282cdfaa0cc/app/helpers/application_helper/toolbar_builder.rb#L555-L560). That code block can be deleted after all the buttons before are also converted into separate button classes.

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135543219