### PR TITLE
Introduce purge timer for drift states

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -105,6 +105,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "Metric::Purging", :method_name => "purge_rollup_timer", :zone => nil)
   end
 
+  def drift_state_purge_timer
+    queue_work(:class_name => "DriftState", :method_name => "purge_timer", :zone => nil)
+  end
+
   def ems_event_purge_timer
     queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -182,6 +182,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue :storage_authentication_check_schedule
     end
 
+    every = worker_setting_or_default(:drift_state_purge_interval, 1.day)
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue :drift_state_purge_timer
+    end
+
     # Schedule - Check for session timeouts
     scheduler.schedule_every(worker_setting_or_default(:session_timeout_interval)) do
       # Session is global to the region, therefore, run it only once on the scheduler's server

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1362,6 +1362,7 @@
     :schedule_worker:
       :authentication_check_interval: 1.hour
       :db_diagnostics_interval: 30.minutes
+      :drift_state_purge_interval: 1.day
       :ems_events_purge_interval: 1.day
       :evm_snapshot_delete_delay_for_job_not_found: 1.hour
       :evm_snapshot_interval: 1.hour


### PR DESCRIPTION
This schedules purging drift states

This is contintinuing the trend of #13044 that is addressing

https://bugzilla.redhat.com/show_bug.cgi?id=1348625

Fixes #11868

numbers
----

in my test, purging 116,576 drift states (with default 10k batch sizes) takes 9 seconds
