### PR TITLE
Fixed code to expect keys as strings instead of symbols.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2181,7 +2181,7 @@ class MiqAeClassController < ApplicationController
     fields = parent_fields(parent)
     highest_priority = fields.count
     @edit[:new][:fields].each_with_index do |fld, i|
-      if fld[:id].nil?
+      if fld["id"].nil?
         new_field = MiqAeField.new
         highest_priority += 1
         new_field.priority  = highest_priority
@@ -2191,12 +2191,11 @@ class MiqAeClassController < ApplicationController
           new_field.class_id = @ae_class.id
         end
       else
-        new_field = parent.nil? ? MiqAeField.find_by_id(fld[:id]) : fields.detect { |f| f.id == fld[:id] }
+        new_field = parent.nil? ? MiqAeField.find_by_id(fld["id"]) : fields.detect { |f| f.id == fld["id"] }
       end
 
       field_attributes.each do |attr|
-        attr = attr.to_sym
-        if attr == :substitute
+        if attr == "substitute"
           new_field.send("#{attr}=", @edit[:new][:fields][i][attr])
         else
           new_field.send("#{attr}=", @edit[:new][:fields][i][attr]) if @edit[:new][:fields][i][attr]
@@ -2206,7 +2205,6 @@ class MiqAeClassController < ApplicationController
         raise StandardError, new_field.errors.full_messages[0] unless fields.push(new_field)
       end
     end
-
     reset_field_priority(fields)
   end
   alias_method :set_input_vars, :set_field_vars

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -489,9 +489,9 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to create two schema fields with identical name" do
-      field = {:aetype   => "attribute",
-               :datatype => "string",
-               :name     => "name01"}
+      field = {"aetype"   => "attribute",
+               "datatype" => "string",
+               "name"     => "name01"}
       session[:edit][:new][:fields] = [field, field]
       controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
       controller.send(:update_fields)
@@ -499,10 +499,10 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to add two parameters with identical name to a method" do
-      field = {:default_value => nil,
-               :datatype      => nil,
-               :name          => "name01",
-               :method_id     => @method.id}
+      field = {"default_value" => nil,
+               "datatype"      => nil,
+               "name"          => "name01",
+               "method_id"     => @method.id}
       session[:edit] = {
         :key         => "aemethod_edit__#{@method.id}",
         :ae_class_id => @cls.id,
@@ -518,10 +518,10 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to add two parameters with identical name to a newly created method" do
-      field = {:default_value => nil,
-               :datatype      => nil,
-               :name          => "name01",
-               :method_id     => nil}
+      field = {"default_value" => nil,
+               "datatype"      => nil,
+               "name"          => "name01",
+               "method_id"     => nil}
       session[:edit] = {
         :key         => "aemethod_edit__new",
         :ae_class_id => @cls.id,
@@ -559,10 +559,10 @@ describe MiqAeClassController do
     end
 
     it "update a method with inputs" do
-      field = {:default_value => nil,
-               :datatype      => nil,
-               :name          => "name01",
-               :method_id     => @method.id}
+      field = {"default_value" => nil,
+               "datatype"      => nil,
+               "name"          => "name01",
+               "method_id"     => @method.id}
       session[:edit] = {
         :key              => "aemethod_edit__#{@method.id}",
         :fields_to_delete => [],
@@ -583,9 +583,9 @@ describe MiqAeClassController do
     end
 
     it "update a class with fields" do
-      field = {:aetype   => "attribute",
-               :datatype => "string",
-               :name     => "name01"}
+      field = {"aetype"   => "attribute",
+               "datatype" => "string",
+               "name"     => "name01"}
       session[:edit] = {
         :key              => "aefields_edit__#{@cls.id}",
         :ae_class_id      => @cls.id,
@@ -603,9 +603,9 @@ describe MiqAeClassController do
     end
 
     it "update a default value of existing class field" do
-      field = {:aetype        => "attribute",
-               :default_value => "Wilma",
-               :name          => "name01"}
+      field = {"aetype"        => "attribute",
+               "default_value" => "Wilma",
+               "name"          => "name01"}
       session[:field_data] = field
       session[:edit] = {
         :key              => "aefields_edit__#{@cls.id}",
@@ -706,20 +706,20 @@ describe MiqAeClassController do
       ns = FactoryGirl.create(:miq_ae_namespace)
       cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
       field1 = FactoryGirl.create(:miq_ae_field,
-                                  :aetype   => "attribute",
-                                  :datatype => "string",
-                                  :name     => "name01",
-                                  :class_id => cls.id,
-                                  :priority => 1)
+                                  "aetype"   => "attribute",
+                                  "datatype" => "string",
+                                  "name"     => "name01",
+                                  "class_id" => cls.id,
+                                  "priority" => 1)
       field2 = FactoryGirl.create(:miq_ae_field,
-                                  :aetype   => "attribute",
-                                  :datatype => "string",
-                                  :name     => "name02",
-                                  :class_id => cls.id,
-                                  :priority => 2)
-      field3 = {:aetype   => "attribute",
-                :datatype => "string",
-                :name     => "name03"}
+                                  "aetype"   => "attribute",
+                                  "datatype" => "string",
+                                  "name"     => "name02",
+                                  "class_id" => cls.id,
+                                  "priority" => 2)
+      field3 = {"aetype"   => "attribute",
+                "datatype" => "string",
+                "name"     => "name03"}
       edit = {:fields_to_delete => [], :new => {:fields => [field2, field3, field1]}}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@ae_class, cls)


### PR DESCRIPTION
This issue was introduced in https://github.com/ManageIQ/manageiq/pull/12322, some of the code is common between class schema editor and method editor that caused method editor to break.
Fixed any affected spec tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1403026

@mkanoor @gmcculloug please review/merge