### PR TITLE
Textual summaries - make it possible to use fonticons, decorators

### DIFF
--- a/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
+++ b/app/helpers/auth_key_pair_cloud_helper/textual_summary.rb
@@ -22,7 +22,7 @@ module AuthKeyPairCloudHelper::TextualSummary
   def textual_vms
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/availability_zone_helper/textual_summary.rb
+++ b/app/helpers/availability_zone_helper/textual_summary.rb
@@ -20,7 +20,7 @@ module AvailabilityZoneHelper::TextualSummary
   def textual_cloud_volumes
     label = ui_lookup(:tables => "cloud_volume")
     num   = @record.number_of(:cloud_volumes)
-    h     = {:label => label, :image => "cloud_volume", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:link]  = url_for(:action => 'show', :id => @availability_zone, :display => 'cloud_volumes')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -31,7 +31,7 @@ module AvailabilityZoneHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @availability_zone, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/catalog_helper/textual_summary.rb
+++ b/app/helpers/catalog_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module CatalogHelper::TextualSummary
         p[:value].push(value)
       else
         name = Classification.find_by(:id => Classification.find_by(:tag_id => tag.id).parent_id).description
-        tags.push(:image => "smarttag", :label => name, :value => [value])
+        tags.push(:image => "100/smarttag.png", :label => name, :value => [value])
       end
     end
     tags

--- a/app/helpers/catalog_helper/textual_summary.rb
+++ b/app/helpers/catalog_helper/textual_summary.rb
@@ -19,7 +19,7 @@ module CatalogHelper::TextualSummary
     label = _("%{name} Tags") % {:name => session[:customer_name]}
     tags = {:label => label}
     if @record.tags.blank?
-      tags[:image] = "smarttag"
+      tags[:image] = "100/smarttag.png"
       tags[:value] = _("No %{label} have been assigned") % {:label => label}
     else
       tags[:value] = tags_from_record

--- a/app/helpers/cloud_network_helper/textual_summary.rb
+++ b/app/helpers/cloud_network_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module CloudNetworkHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/cloud_object_store_container_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_container_helper/textual_summary.rb
@@ -29,7 +29,7 @@ module CloudObjectStoreContainerHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenant")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Cloud Object Store's parent %{parent}") % {:parent => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
@@ -40,7 +40,7 @@ module CloudObjectStoreContainerHelper::TextualSummary
   def textual_cloud_object_store_objects
     label = ui_lookup(:tables => "cloud_object_store_object")
     num = @record.number_of(:cloud_object_store_objects)
-    h = {:label => label, :image => "cloud_object_store_object", :value => num}
+    h = {:label => label, :image => "100/cloud_object_store_object.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_object_store_object_show_list")
       h[:title] = _("Show this Cloud Object Store's child %{children}") % {:children => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_object_store_objects')

--- a/app/helpers/cloud_object_store_object_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_object_helper/textual_summary.rb
@@ -36,7 +36,7 @@ module CloudObjectStoreObjectHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenant")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.nil? ? "None" : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Cloud Object's parent %{parent}") % {:parent => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
@@ -49,7 +49,7 @@ module CloudObjectStoreObjectHelper::TextualSummary
     label = ui_lookup(:table => "cloud_object_store_container")
     h = {
       :label => label,
-      :image => "cloud_object_store_container",
+      :image => "100/cloud_object_store_container.png",
       :value => (object_store_container.nil? ? "None" : object_store_container.key)
     }
     if object_store_container && role_allows?(:feature => "cloud_object_store_container_show")

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -56,7 +56,7 @@ module CloudSubnetHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -83,7 +83,7 @@ module CloudSubnetHelper::TextualSummary
   def textual_managed_subnets
     label = _("Managed Subnets")
     num   = @record.number_of(:cloud_subnets)
-    h     = {:label => label, :image => "cloud_subnet", :value => num}
+    h     = {:label => label, :image => "100/cloud_subnet.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_subnet_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_subnets')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/cloud_tenant_helper/textual_summary.rb
+++ b/app/helpers/cloud_tenant_helper/textual_summary.rb
@@ -20,7 +20,7 @@ module CloudTenantHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -31,7 +31,7 @@ module CloudTenantHelper::TextualSummary
   def textual_images
     label = ui_lookup(:tables => "template_cloud")
     num   = @record.number_of(:miq_templates)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'images')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -54,7 +54,7 @@ module CloudTenantHelper::TextualSummary
   def textual_cloud_volumes
     label = _('Volumes')
     num   = @record.number_of(:cloud_volumes)
-    h     = {:label => label, :image => "cloud_volume", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => "cloud_volumes")
@@ -65,7 +65,7 @@ module CloudTenantHelper::TextualSummary
   def textual_cloud_volume_snapshots
     label = _('Volume Snapshots')
     num   = @record.number_of(:cloud_volume_snapshots)
-    h     = {:label => label, :image => "cloud_volume_snapshot", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume_snapshot.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_snapshot_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => "cloud_volume_snapshots")
@@ -76,7 +76,7 @@ module CloudTenantHelper::TextualSummary
   def textual_cloud_object_store_containers
     label = ui_lookup(:tables => "cloud_object_store_container")
     num   = @record.number_of(:cloud_object_store_containers)
-    h     = {:label => label, :image => "cloud_object_store_container", :value => num}
+    h     = {:label => label, :image => "100/cloud_object_store_container.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_object_store_container_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_object_store_containers')
       h[:title] = _("Show all %{models}") % {:models => label}

--- a/app/helpers/cloud_volume_backup_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_backup_helper/textual_summary.rb
@@ -34,7 +34,7 @@ module CloudVolumeBackupHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.try(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenants")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.try(:name) || _("None"))}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.try(:name) || _("None"))}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Backup's %{parent}") % {:parent => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -33,7 +33,7 @@ module CloudVolumeHelper::TextualSummary
     label = ui_lookup(:table => "availability_zone")
     h = {
       :label => label,
-      :image => "availability_zone",
+      :image => "100/availability_zone.png",
       :value => (availability_zone.nil? ? _("None") : availability_zone.name)
     }
     if availability_zone && role_allows?(:feature => "availability_zone_show")
@@ -48,7 +48,7 @@ module CloudVolumeHelper::TextualSummary
     label = ui_lookup(:table => "base_snapshot")
     h = {
       :label => label,
-      :image => "cloud_volume_snapshot",
+      :image => "100/cloud_volume_snapshot.png",
       :value => (base_snapshot.nil? ? _("None") : base_snapshot.name)
     }
     if base_snapshot && role_allows?(:feature => "cloud_volume_snapshot_show")
@@ -61,7 +61,7 @@ module CloudVolumeHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenants")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Volume's %{cloud_tenant}") % {:cloud_tenant => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
@@ -72,7 +72,7 @@ module CloudVolumeHelper::TextualSummary
   def textual_cloud_volume_snapshots
     label = ui_lookup(:tables => "cloud_volume_snapshots")
     num   = @record.number_of(:cloud_volume_snapshots)
-    h     = {:label => label, :image => "cloud_volume_snapshot", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume_snapshot.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_snapshot_show_list")
       label = ui_lookup(:tables => "cloud_volume_snapshots")
       h[:title] = _("Show all %{models}") % {:models => label}
@@ -84,7 +84,7 @@ module CloudVolumeHelper::TextualSummary
   def textual_cloud_volume_backups
     label = ui_lookup(:tables => "cloud_volume_backup")
     num   = @record.number_of(:cloud_volume_backups)
-    h     = {:label => label, :image => "cloud_volume_backup", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume_backup.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_backup_show_list")
       label = ui_lookup(:tables => "cloud_volume_backups")
       h[:title] = _("Show all %{models}") % {:models => label}
@@ -96,7 +96,7 @@ module CloudVolumeHelper::TextualSummary
   def textual_attachments
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:attachments)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all attached %{models}") % {:models => label}
       h[:link]  = url_for(:action => 'show', :id => @volume, :display => 'instances')

--- a/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
@@ -18,7 +18,7 @@ module CloudVolumeSnapshotHelper::TextualSummary
   def textual_based_volumes
     label = ui_lookup(:table => "based_volumes")
     num   = @record.total_based_volumes
-    h     = {:label => label, :image => "cloud_volume", :value => num}
+    h     = {:label => label, :image => "100/cloud_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       label = ui_lookup(:table => "cloud_volumes")
       h[:title] = _("Show all %{volumes} based on this Snapshot.") % {:volumes => label}
@@ -42,7 +42,7 @@ module CloudVolumeSnapshotHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenants")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this Snapshot's %{parent}") % {:parent => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)

--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -35,7 +35,7 @@ module ComplianceSummaryHelper
     if @record.number_of(:compliances) == 0
       h[:value] = _("Not Available")
     else
-      h[:image] = "compliance"
+      h[:image] = "100/compliance.png"
       h[:value] = _("Available")
       h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") %
                   {:model => ui_lookup(:model => controller.class.model.name)}

--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -10,7 +10,7 @@ module ComplianceSummaryHelper
     else
       compliant = @record.last_compliance_status
       date      = @record.last_compliance_timestamp
-      h[:image] = compliant ? "check" : "x"
+      h[:image] = "100/#{compliant ? "check" : "x"}.png"
       h[:value] = if !compliant
                     _("Non-Compliant as of %{time} Ago") %
                     {:time => time_ago_in_words(date.in_time_zone(Time.zone)).titleize}

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -30,7 +30,7 @@ module ConfigurationJobHelper::TextualSummary
   end
 
   def textual_service
-    h = {:label => _("Service"), :image => "service"}
+    h = {:label => _("Service"), :image => "100/service.png"}
     service = @record.service
     if service.nil?
       h[:value] = _("None")
@@ -43,7 +43,7 @@ module ConfigurationJobHelper::TextualSummary
   end
 
   def textual_provider
-    h = {:label => _("Provider"), :image => "vendor-ansible_tower_configuration"}
+    h = {:label => _("Provider"), :image => "100/vendor-ansible_tower_configuration.png"}
     provider = @record.ext_management_system
     if provider.nil?
       h[:value] = _("None")
@@ -57,7 +57,7 @@ module ConfigurationJobHelper::TextualSummary
 
   def textual_parameters
     num   = @record.number_of(:parameters)
-    h     = {:label => _("Parameters"), :image => "parameter", :value => num}
+    h     = {:label => _("Parameters"), :image => "100/parameter.png", :value => num}
     if num > 0
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
       h[:title] = _("Show all parameters")

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -101,7 +101,7 @@ module ContainerGroupHelper::TextualSummary
     lives_on_entity_name = lives_on_ems.kind_of?(EmsCloud) ? _("Instance") : _("Virtual Machine")
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
-      :image => "vendor-#{lives_on_ems.image_name}",
+      :image => "100/vendor-#{lives_on_ems.image_name}.png",
       :value => @record.container_node.lives_on.name.to_s,
       :link  => url_for(
         :action     => 'show',

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -78,7 +78,7 @@ module ContainerNodeHelper::TextualSummary
     lives_on_entity_name = lives_on_ems.kind_of?(EmsCloud) ? _("Instance") : _("Virtual Machine")
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
-      :image => "vendor-#{lives_on_ems.image_name}",
+      :image => "100/vendor-#{lives_on_ems.image_name}.png",
       :value => @record.lives_on.name.to_s,
       :link  => url_for(
         :action     => 'show',

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -150,7 +150,7 @@ module ContainerSummaryHelper
     if object.nil? && @record.respond_to?(:display_registry)
       {
         :label => ui_lookup(:model => ContainerImageRegistry.name),
-        :image => "container_image_registry_unknown",
+        :image => "100/container_image_registry_unknown.png",
         :value => @record.display_registry
       }
     else
@@ -181,13 +181,13 @@ module ContainerSummaryHelper
     if tags.present?
       h[:value] = tags.sort_by { |category, _assigned| category.downcase }.collect do |category, assigned|
         {
-          :image => "smarttag",
+          :image => "100/smarttag.png",
           :label => category,
           :value => assigned
         }
       end
     else
-      h[:image] = "smarttag"
+      h[:image] = "100/smarttag.png"
       h[:value] = _("No %{label} have been assigned") % {:label => label}
     end
 

--- a/app/helpers/ems_cinder_helper/textual_summary.rb
+++ b/app/helpers/ems_cinder_helper/textual_summary.rb
@@ -69,6 +69,6 @@ module EmsCinderHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.try(:name)}
   end
 end

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -75,7 +75,7 @@ module EmsCloudHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @ems.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = ems_cloud_path(@ems.id, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -86,7 +86,7 @@ module EmsCloudHelper::TextualSummary
   def textual_images
     label = ui_lookup(:tables => "template_cloud")
     num = @ems.number_of(:miq_templates)
-    h = {:label => label, :image => "vm", :value => num}
+    h = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
       h[:link] = ems_cloud_path(@ems.id, :display => 'images')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -105,7 +105,7 @@ module EmsCloudHelper::TextualSummary
   def textual_storage_managers
     label = _("Storage Managers")
     num   = @ems.try(:storage_managers) ?  @ems.number_of(:storage_managers) : 0
-    h     = {:label => label, :image => "storage_manager", :value => num}
+    h     = {:label => label, :image => "100/storage_manager.png", :value => num}
     if num > 0 && role_allows?(:feature => "ems_storage_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link] = ems_cloud_path(@ems.id, :display => 'storage_managers')
@@ -136,7 +136,7 @@ module EmsCloudHelper::TextualSummary
   def textual_security_groups
     label = ui_lookup(:tables => "security_group")
     num = @ems.number_of(:security_groups)
-    h = {:label => label, :image => "security_group", :value => num}
+    h = {:label => label, :image => "100/security_group.png", :value => num}
     if num > 0 && role_allows?(:feature => "security_group_show_list")
       h[:link] = ems_cloud_path(@ems.id, :display => 'security_groups')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -146,7 +146,7 @@ module EmsCloudHelper::TextualSummary
 
   def textual_arbitration_profiles
     num = @record.number_of(:arbitration_profiles)
-    h = {:label => _("Arbitration Profiles"), :image => "arbitration_profile", :value => num}
+    h = {:label => _("Arbitration Profiles"), :image => "100/arbitration_profile.png", :value => num}
     if num > 0
       h[:title] = n_("Show Arbitration Profiles for this Provider",
                      "Show Arbitration Profiles for this Provider", num)
@@ -159,7 +159,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.name}
   end
 
   def textual_topology

--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -164,7 +164,7 @@ module EmsCloudHelper::TextualSummary
 
   def textual_topology
     {:label => _('Topology'),
-     :image => 'topology',
+     :image => '100/topology.png',
      :link  => url_for(:controller => 'cloud_topology', :action => 'show', :id => @ems.id),
      :title => _("Show topology")}
   end

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -121,12 +121,12 @@ module EmsClusterHelper::TextualSummary
   end
 
   def textual_parent_datacenter
-    {:label => _("Datacenter"), :image => "datacenter", :value => @record.v_parent_datacenter || _("None")}
+    {:label => _("Datacenter"), :image => "100/datacenter.png", :value => @record.v_parent_datacenter || _("None")}
   end
 
   def textual_total_hosts
     num = @record.total_hosts
-    h = {:label => title_for_hosts, :image => "host", :value => num}
+    h = {:label => title_for_hosts, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{title}") % {:title => title_for_hosts}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'hosts')
@@ -136,7 +136,7 @@ module EmsClusterHelper::TextualSummary
 
   def textual_total_direct_vms
     num = @record.total_direct_vms
-    h = {:label => _("Direct VMs"), :image => "vm", :value => num}
+    h = {:label => _("Direct VMs"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show VMs in this %{title}, but not in Resource Pools below") % {:title => cluster_title}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'vms')
@@ -146,7 +146,7 @@ module EmsClusterHelper::TextualSummary
 
   def textual_allvms_size
     num = @record.total_vms
-    h = {:label => _("All VMs"), :image => "vm", :value => num}
+    h = {:label => _("All VMs"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all VMs in this %{title}") % {:title => cluster_title}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'all_vms')
@@ -158,7 +158,7 @@ module EmsClusterHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::EmsCluster)
 
     num = @record.total_miq_templates
-    h = {:label => _("All Templates"), :image => "vm", :value => num}
+    h = {:label => _("All Templates"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
       h[:title] = _("Show all Templates in this %{title}") % {:title => cluster_title}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'miq_templates')
@@ -168,7 +168,7 @@ module EmsClusterHelper::TextualSummary
 
   def textual_total_vms
     num = @record.total_vms
-    h = {:label => _("All VMs (Tree View)"), :image => "vm", :value => num}
+    h = {:label => _("All VMs (Tree View)"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show tree of all VMs by Resource Pool in this %{title}") % {:title => cluster_title}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'descendant_vms')
@@ -187,7 +187,7 @@ module EmsClusterHelper::TextualSummary
   def textual_states_size
     return nil unless role_allows?(:feature => "ems_cluster_drift")
     num = @record.number_of(:drift_states)
-    h = {:label => _("Drift History"), :image => "drift", :value => (num == 0 ? _("None") : num)}
+    h = {:label => _("Drift History"), :image => "100/drift.png", :value => (num == 0 ? _("None") : num)}
     if num > 0
       h[:title] = _("Show %{title} drift history") % {:title => cluster_title}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'drift_history', :id => @record)
@@ -198,7 +198,7 @@ module EmsClusterHelper::TextualSummary
   def textual_ss_size
     num = @record.storage_systems.count
     label = ui_lookup(:tables => "ontap_storage_system")
-    h = {:label => label, :image => "ontap_storage_system", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_system.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_system_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'storage_systems')
@@ -209,7 +209,7 @@ module EmsClusterHelper::TextualSummary
   def textual_sv_size
     num = @record.storage_systems.count
     label = ui_lookup(:tables => "ontap_storage_volume")
-    h = {:label => label, :image => "ontap_storage_volume", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_system_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'ontap_storage_volumes')
@@ -220,7 +220,7 @@ module EmsClusterHelper::TextualSummary
   def textual_fs_size
     num = @record.file_shares.count
     label = ui_lookup(:tables => "ontap_file_share")
-    h = {:label => label, :image => "ontap_file_share", :value => num}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_file_share_show_list")
       h[:title] = label
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'ontap_file_shares')
@@ -231,7 +231,7 @@ module EmsClusterHelper::TextualSummary
   def textual_se_size
     num = @record.base_storage_extents.count
     label = ui_lookup(:tables => "cim_base_storage_extent")
-    h = {:label => label, :image => "cim_base_storage_extent", :value => num}
+    h = {:label => label, :image => "100/cim_base_storage_extent.png", :value => num}
     if num > 0 && role_allows?(:feature => "cim_base_storage_extent_show_list")
       h[:title] = label
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => @record, :display => 'storage_extents')

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -45,7 +45,7 @@ module EmsClusterHelper::TextualSummary
 
       running = {:title => _("Show list of hosts with running %{name}") % {:name => x.name},
                  :value => _("Running (%{number})") % {:number => running_count},
-                 :image => failed_count == 0 && running_count > 0 ? 'status_complete' : nil,
+                 :image => failed_count == 0 && running_count > 0 ? '100/status_complete.png' : nil,
                  :link  => if running_count > 0
                              url_for(:controller              => controller.controller_name,
                                      :action                  => 'show',
@@ -57,7 +57,7 @@ module EmsClusterHelper::TextualSummary
 
       failed = {:title => _("Show list of hosts with failed %{name}") % {:name => x.name},
                 :value => _("Failed (%{number})") % {:number => failed_count},
-                :image => failed_count > 0 ? 'status_error' : nil,
+                :image => failed_count > 0 ? '100/status_error.png' : nil,
                 :link  => if failed_count > 0
                             url_for(:controller              => controller.controller_name,
                                     :action                  => 'show',

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -69,7 +69,7 @@ module EmsClusterHelper::TextualSummary
 
       all = {:title => _("Show list of hosts with %{name}") % {:name => x.name},
              :value => _("All (%{number})") % {:number => all_count},
-             :image => 'host',
+             :image => '100/host.png',
              :link  => if all_count > 0
                          url_for(:controller              => controller.controller_name,
                                  :action                  => 'show',

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -77,7 +77,7 @@ module EmsContainerHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.name}
   end
 
   def textual_topology
@@ -90,7 +90,7 @@ module EmsContainerHelper::TextualSummary
   def textual_volumes
     count_of_volumes = @ems.number_of(:persistent_volumes)
     label = ui_lookup(:tables => "volume")
-    h     = {:label => label, :image => "container_volume", :value => count_of_volumes}
+    h     = {:label => label, :image => "100/container_volume.png", :value => count_of_volumes}
     if count_of_volumes > 0 && role_allows?(:feature => "persistent_volume_show_list")
       h[:link]  = ems_container_path(@ems.id, :display => 'persistent_volumes')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -82,7 +82,7 @@ module EmsContainerHelper::TextualSummary
 
   def textual_topology
     {:label => _('Topology'),
-     :image => 'topology',
+     :image => '100/topology.png',
      :link  => polymorphic_path(@ems, :display => 'topology'),
      :title => _("Show topology")}
   end

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module EmsInfraHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
     label     = "#{title_for_hosts} & #{title_for_clusters}"
     available = @ems.number_of(:ems_folders) > 0 && @ems.ems_folder_root
-    h         = {:label => label, :image => "hosts_and_clusters", :value => available ? _("Available") : _("N/A")}
+    h         = {:label => label, :image => "100/hosts_and_clusters.png", :value => available ? _("Available") : _("N/A")}
     if available
       h[:link]  = ems_infra_path(@ems.id, :display => 'ems_folders')
       h[:title] = _("Show %{label}") % {:label => label}
@@ -83,7 +83,7 @@ module EmsInfraHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
     label     = _("VMs & Templates")
     available = @ems.number_of(:ems_folders) > 0 && @ems.ems_folder_root
-    h         = {:label => label, :image => "vms_and_templates", :value => available ? _("Available") : _("N/A")}
+    h         = {:label => label, :image => "100/vms_and_templates.png", :value => available ? _("Available") : _("N/A")}
     if available
       h[:link]  = ems_infra_path(@ems.id, :display => 'ems_folders', :vat => true)
       h[:title] = _("Show Virtual Machines & Templates")
@@ -94,7 +94,7 @@ module EmsInfraHelper::TextualSummary
   def textual_clusters
     label = title_for_clusters
     num   = @ems.number_of(:ems_clusters)
-    h     = {:label => label, :image => "cluster", :value => num}
+    h     = {:label => label, :image => "100/cluster.png", :value => num}
     if num > 0 && role_allows?(:feature => "ems_cluster_show_list")
       h[:link] = ems_infra_path(@ems.id, :display => 'ems_clusters', :vat => true)
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -105,7 +105,7 @@ module EmsInfraHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @ems.number_of(:hosts)
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:link]  = ems_infra_path(@ems.id, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -169,7 +169,7 @@ module EmsInfraHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.name}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.name}
   end
 
   def textual_host_default_vnc_port_range

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -180,7 +180,7 @@ module EmsInfraHelper::TextualSummary
 
   def textual_topology
     {:label => _('Topology'),
-     :image => 'topology',
+     :image => '100/topology.png',
      :link  => url_for(:controller => '/infra_topology', :action => 'show', :id => @ems.id),
      :title => _("Show topology")}
   end

--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -50,7 +50,7 @@ module EmsMiddlewareHelper::TextualSummary
 
   def textual_topology
     {:label => _('Topology'),
-     :image => 'topology',
+     :image => '100/topology.png',
      :link  => url_for(:controller => 'middleware_topology', :action => 'show', :id => @ems.id),
      :title => _('Show topology')}
   end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -94,6 +94,6 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.try(:name)}
   end
 end

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -88,7 +88,7 @@ module EmsNetworkHelper::TextualSummary
 
   def textual_topology
     {:label => _('Topology'),
-     :image => 'topology',
+     :image => '100/topology.png',
      :link  => url_for(:controller => 'network_topology', :action => 'show', :id => @ems.id),
      :title => _("Show topology")}
   end

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -57,7 +57,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.try(:name)}
   end
 
   def textual_cloud_volumes

--- a/app/helpers/ems_swift_helper/textual_summary.rb
+++ b/app/helpers/ems_swift_helper/textual_summary.rb
@@ -65,6 +65,6 @@ module EmsSwiftHelper::TextualSummary
   end
 
   def textual_zone
-    {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.try(:name)}
+    {:label => _("Managed by Zone"), :image => "100/zone.png", :value => @ems.zone.try(:name)}
   end
 end

--- a/app/helpers/flavor_helper/textual_summary.rb
+++ b/app/helpers/flavor_helper/textual_summary.rb
@@ -71,7 +71,7 @@ module FlavorHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/floating_ip_helper/textual_summary.rb
+++ b/app/helpers/floating_ip_helper/textual_summary.rb
@@ -40,7 +40,7 @@ module FloatingIpHelper::TextualSummary
   def textual_instance
     label    = ui_lookup(:table => "vm_cloud")
     instance = @record.vm
-    h        = {:label => label, :image => "vm"}
+    h        = {:label => label, :image => "100/vm.png"}
     if instance && role_allows?(:feature => "vm_show")
       h[:value] = instance.name
       h[:link]  = url_for(:controller => 'vm_cloud', :action => 'show', :id => instance.id)

--- a/app/helpers/host_aggregate_helper/textual_summary.rb
+++ b/app/helpers/host_aggregate_helper/textual_summary.rb
@@ -16,7 +16,7 @@ module HostAggregateHelper::TextualSummary
   def textual_hosts
     label = ui_lookup(:tables => "host")
     num   = @record.number_of(:hosts)
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:link]  = url_for(:action => 'show', :id => @host_aggregate, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -27,7 +27,7 @@ module HostAggregateHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @host_aggregate, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -186,7 +186,7 @@ module HostHelper::TextualSummary
   def textual_power_state
     state = @record.state.to_s.downcase
     state = "unknown" if state.blank?
-    {:label => _("Power State"), :image => "currentstate-#{state}", :value => state}
+    {:label => _("Power State"), :image => "100/currentstate-#{state}.png", :value => state}
   end
 
   def textual_lockdown_mode
@@ -200,7 +200,7 @@ module HostHelper::TextualSummary
   def textual_storage_adapters
     return nil if @record.openstack_host?
     num = @record.hardware.nil? ? 0 : @record.hardware.number_of(:storage_adapters)
-    h = {:label => _("Storage Adapters"), :image => "sa", :value => num}
+    h = {:label => _("Storage Adapters"), :image => "100/sa.png", :value => num}
     if num > 0
       h[:title] = _("Show %{title} Storage Adapters") % {:title => host_title}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'storage_adapters')
@@ -211,7 +211,7 @@ module HostHelper::TextualSummary
   def textual_network
     return nil if @record.openstack_host?
     num = @record.number_of(:switches)
-    h = {:label => _("Network"), :image => "network", :value => (num == 0 ? _("N/A") : _("Available"))}
+    h = {:label => _("Network"), :image => "100/network.png", :value => (num == 0 ? _("N/A") : _("Available"))}
     if num > 0
       h[:title] = _("Show %{title} Network") % {:title => host_title}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'network')
@@ -221,7 +221,7 @@ module HostHelper::TextualSummary
 
   def textual_devices
     h = {:label => _("Devices"),
-         :image => "devices",
+         :image => "100/devices.png",
          :value => (@devices.nil? || @devices.empty? ? _("None") : @devices.length)}
     if @devices.length > 0
       h[:title] = _("Show %{title} devices") % {:title => host_title}
@@ -262,7 +262,7 @@ module HostHelper::TextualSummary
 
   def textual_cluster
     cluster = @record.ems_cluster
-    h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? _("None") : cluster.name)}
+    h = {:label => title_for_cluster, :image => "100/ems_cluster.png", :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show this %{host_title}'s %{cluster_title}") %
                   {:host_title => host_title, :cluster_title => title_for_cluster}
@@ -287,7 +287,7 @@ module HostHelper::TextualSummary
     return nil unless role_allows?(:feature => "host_drift")
     label = _("Drift History")
     num   = @record.number_of(:drift_states)
-    h     = {:label => label, :image => "drift", :value => num}
+    h     = {:label => label, :image => "100/drift.png", :value => num}
     if num > 0
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'drift_history', :id => @record)
@@ -300,7 +300,7 @@ module HostHelper::TextualSummary
     availability_zone = @record.availability_zone
     label = ui_lookup(:table => "availability_zone")
     h = {:label => label,
-         :image => "availability_zone",
+         :image => "100/availability_zone.png",
          :value => (availability_zone.nil? ? _("None") : availability_zone.name)}
     if availability_zone && role_allows?(:feature => "availability_zone_show")
       h[:title] = _("Show this %{title}'s %{label}") % {:title => host_title, :label => label}
@@ -319,7 +319,7 @@ module HostHelper::TextualSummary
   def textual_vms
     label = _("VMs")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'vms')
@@ -335,7 +335,7 @@ module HostHelper::TextualSummary
   def textual_storage_systems
     num = @record.storage_systems_size
     label = ui_lookup(:tables => "ontap_storage_system")
-    h = {:label => label, :image => "ontap_storage_system", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_system.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_system_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_storage_systems")
@@ -346,7 +346,7 @@ module HostHelper::TextualSummary
   def textual_storage_volumes
     num = @record.storage_volumes_size
     label = ui_lookup(:tables => "ontap_storage_volume")
-    h = {:label => label, :image => "ontap_storage_volume", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_volume_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_storage_volumes")
@@ -357,7 +357,7 @@ module HostHelper::TextualSummary
   def textual_file_shares
     num = @record.file_shares_size
     label = ui_lookup(:tables => "ontap_file_share")
-    h = {:label => label, :image => "ontap_file_share", :value => num}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_file_share_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_file_shares")
@@ -368,7 +368,7 @@ module HostHelper::TextualSummary
   def textual_logical_disks
     num = @record.logical_disks_size
     label = ui_lookup(:tables => "ontap_logical_disk")
-    h = {:label => label, :image => "ontap_logical_disk", :value => num}
+    h = {:label => label, :image => "100/ontap_logical_disk.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_logical_disk_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_logical_disks")
@@ -383,7 +383,7 @@ module HostHelper::TextualSummary
   def textual_users
     return nil if @record.is_vmware_esxi?
     num = @record.number_of(:users)
-    h = {:label => _("Users"), :image => "user", :value => num}
+    h = {:label => _("Users"), :image => "100/user.png", :value => num}
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
       h[:link]  = url_for(:action => 'users', :id => @record, :db => controller.controller_name)
@@ -394,7 +394,7 @@ module HostHelper::TextualSummary
   def textual_groups
     return nil if @record.is_vmware_esxi?
     num = @record.number_of(:groups)
-    h = {:label => _("Groups"), :image => "group", :value => num}
+    h = {:label => _("Groups"), :image => "100/group.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Group defined on this %{title}", "Show the Groups defined on this %{title}", num) %
         {:title => host_title}
@@ -406,7 +406,7 @@ module HostHelper::TextualSummary
   def textual_firewall_rules
     return nil if @record.is_vmware_esxi?
     num = @record.number_of(:firewall_rules)
-    h = {:label => _("Firewall Rules"), :image => "firewallrule", :value => num}
+    h = {:label => _("Firewall Rules"), :image => "100/firewallrule.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Firewall Rule defined on this %{title}",
                     "Show the Firewall Rules defined on this %{title}", num) % {:title => host_title}
@@ -423,7 +423,7 @@ module HostHelper::TextualSummary
   def textual_patches
     return nil if @record.is_vmware_esxi?
     num = @record.number_of(:patches)
-    h = {:label => _("Patches"), :image => "patch", :value => num}
+    h = {:label => _("Patches"), :image => "100/patch.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Patch defined on this %{title}", "Show the Patches defined on this %{title}", num) %
         {:title => host_title}
@@ -434,7 +434,7 @@ module HostHelper::TextualSummary
 
   def textual_guest_applications
     num = @record.number_of(:guest_applications)
-    h = {:label => _("Packages"), :image => "guest_application", :value => num}
+    h = {:label => _("Packages"), :image => "100/guest_application.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Package installed on this %{title}",
                      "Show the Packages installed on this %{title}", num) % {:title => host_title}
@@ -445,7 +445,7 @@ module HostHelper::TextualSummary
 
   def textual_host_services
     num = @record.number_of(:host_services)
-    h = {:label => _("Services"), :image => "service", :value => num}
+    h = {:label => _("Services"), :image => "100/service.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Service installed on this %{title}",
                      "Show the Services installed on this %{title}", num) % {:title => host_title}
@@ -456,7 +456,7 @@ module HostHelper::TextualSummary
 
   def textual_filesystems
     num = @record.number_of(:filesystems)
-    h = {:label => _("Files"), :image => "filesystems", :value => num}
+    h = {:label => _("Files"), :image => "100/filesystems.png", :value => num}
     if num > 0
       h[:title] = n_("Show the File installed on this %{title}", "Show the Files installed on this %{title}", num) %
         {:title => host_title}
@@ -467,7 +467,7 @@ module HostHelper::TextualSummary
 
   def textual_advanced_settings
     num = @record.number_of(:advanced_settings)
-    h = {:label => _("Advanced Settings"), :image => "advancedsetting", :value => num}
+    h = {:label => _("Advanced Settings"), :image => "100/advancedsetting.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Advanced Setting installed on this %{title}",
                      "Show the Advanced Settings installed on this %{title}", num) % {:title => host_title}
@@ -478,7 +478,7 @@ module HostHelper::TextualSummary
 
   def textual_esx_logs
     num = @record.operating_system.nil? ? 0 : @record.operating_system.number_of(:event_logs)
-    h = {:label => _("ESX Logs"), :image => "logs", :value => (num == 0 ? _("Not Available") : _("Available"))}
+    h = {:label => _("ESX Logs"), :image => "100/logs.png", :value => (num == 0 ? _("Not Available") : _("Available"))}
     if num > 0
       h[:title] = _("Show %{title} Network") % {:title => host_title}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'event_logs')

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -92,13 +92,13 @@ module HostHelper::TextualSummary
 
       all = {:title => _("Show list of all %{name}") % {:name => x.name},
              :value => _("All (%{number})") % {:number => all_count},
-             :image => 'service',
+             :image => '100/service.png',
              :link => all_count > 0 ? url_for(:controller => controller.controller_name, :action => 'host_services',
                                               :id => @record, :db => controller.controller_name,
                                               :host_service_group => x.id, :status => :all) : nil}
 
       configuration = {:title => _("Show list of configuration files of %{name}") % {:name => x.name},
-                       :image => 'filesystems',
+                       :image => '100/filesystems.png',
                        :value => _("Configuration (%{number})") % {:number => configuration_count},
                        :link  => configuration_count > 0 ? url_for(:controller => controller.controller_name,
                                                                   :action => 'filesystems', :id => @record,

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -134,9 +134,9 @@ module HostHelper::TextualSummary
     h = {:label => _("VMM Information")}
     if @vmminfo.nil? || @vmminfo.empty?
       h[:value] = _("None")
-      h[:image] = "unknown"
+      h[:image] = "100/unknown.png"
     else
-      h[:image] = "vendor-#{@vmminfo[0][:description].downcase}"
+      h[:image] = "100/vendor-#{@vmminfo[0][:description].downcase}.png"
       h[:value] = @vmminfo[0][:description]
       h[:title] = _("Show VMM container information")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')
@@ -166,9 +166,9 @@ module HostHelper::TextualSummary
     h = {:label => _("Operating System")}
     if @osinfo.nil? || @osinfo.empty?
       h[:value] = _("Unknown")
-      h[:image] = "os-unknown"
+      h[:image] = "100/os-unknown.png"
     else
-      h[:image] = "os-#{@record.os_image_name.downcase}"
+      h[:image] = "100/os-#{@record.os_image_name.downcase}.png"
       h[:value] = @osinfo[0][:description]
       unless @record.operating_system.version.blank?
         h[:value] << " #{@record.operating_system.version}"

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -76,7 +76,7 @@ module HostHelper::TextualSummary
 
       running = {:title => _("Show list of running %{name}") % {:name => x.name},
                  :value => _("Running (%{number})") % {:number => running_count},
-                 :image => failed_count == 0 && running_count > 0 ? 'status_complete' : nil,
+                 :image => failed_count == 0 && running_count > 0 ? '100/status_complete.png' : nil,
                  :link => running_count > 0 ? url_for(:controller => controller.controller_name,
                                                       :action => 'host_services', :id => @record,
                                                       :db => controller.controller_name, :host_service_group => x.id,
@@ -84,7 +84,7 @@ module HostHelper::TextualSummary
 
       failed = {:title => _("Show list of failed %{name}") % {:name => x.name},
                 :value => _("Failed (%{number})") % {:number => failed_count},
-                :image => failed_count > 0 ? 'status_error' : nil,
+                :image => failed_count > 0 ? '100/status_error.png' : nil,
                 :link => failed_count > 0 ? url_for(:controller => controller.controller_name,
                                                     :action => 'host_services', :id => @record,
                                                     :db => controller.controller_name, :host_service_group => x.id,

--- a/app/helpers/infra_networking_helper/textual_summary.rb
+++ b/app/helpers/infra_networking_helper/textual_summary.rb
@@ -20,9 +20,9 @@ module InfraNetworkingHelper::TextualSummary
   #
   def textual_hosts
     num = @record.number_of(:hosts)
-    h = {:label => title_for_hosts, :image => "host", :value => num}
+    h = {:label => title_for_hosts, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
-      h = {:label => title_for_hosts, :image => "host", :value => num}
+      h = {:label => title_for_hosts, :image => "100/host.png", :value => num}
       h[:explorer] = true
       h[:link] = url_for(:action => 'hosts', :id => @record, :db => 'switch')
     end

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -52,7 +52,7 @@ module LoadBalancerHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -60,7 +60,7 @@ module MiddlewareServerHelper::TextualSummary
     lives_on_entity_name = _("Virtual Machine")
      {
          :label      => "Underlying #{lives_on_entity_name}",
-         :image      => "vendor-#{lives_on_ems.image_name}",
+         :image      => "100/vendor-#{lives_on_ems.image_name}.png",
          :value      => @record.lives_on.name.to_s,
          :link       => url_for(
            :action     => 'show',

--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -46,7 +46,7 @@ module NetworkPortHelper::TextualSummary
     instance = @record.device
     h        = nil
     if instance && role_allows?(:feature => "vm_show")
-      h = {:label => label, :image => "vm"}
+      h = {:label => label, :image => "100/vm.png"}
       h[:value] = instance.name
       h[:link]  = url_for(:controller => 'vm_cloud', :action => 'show', :id => instance.id)
       h[:title] = _("Show %{label}") % {:label => label}
@@ -68,7 +68,7 @@ module NetworkPortHelper::TextualSummary
 
   def textual_host
     return nil unless @record.device_type == "Host"
-    {:image => "host", :value => @record.device, :link => url_for(:controller => "host",
+    {:image => "100/host.png", :value => @record.device, :link => url_for(:controller => "host",
                                                                   :action     => "show",
                                                                   :id         => @record.device.id)}
   end

--- a/app/helpers/network_router_helper/textual_summary.rb
+++ b/app/helpers/network_router_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module NetworkRouterHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/ontap_file_share_helper/textual_summary.rb
+++ b/app/helpers/ontap_file_share_helper/textual_summary.rb
@@ -58,7 +58,7 @@ module OntapFileShareHelper::TextualSummary
   def textual_storage_system
     label = ui_lookup(:table => "ontap_storage_system")
     ss    = @record.storage_system
-    h     = {:label => label, :image => "ontap_storage_system", :value => (ss.blank? ? _("None") : ss.evm_display_name)}
+    h     = {:label => label, :image => "100/ontap_storage_system.png", :value => (ss.blank? ? _("None") : ss.evm_display_name)}
     if !ss.blank? && role_allows?(:feature => "ontap_storage_system_show")
       h[:title] = _("Show %{label} '%{name}'") % {:label => label, :name => ss.evm_display_name}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => ss.id)
@@ -70,7 +70,7 @@ module OntapFileShareHelper::TextualSummary
     label = ui_lookup(:table => "snia_local_file_system")
     lfs   = @record.file_system
     h     = {:label => label,
-             :image => "snia_local_file_system",
+             :image => "100/snia_local_file_system.png",
              :value => (lfs.blank? ? _("None") : lfs.evm_display_name)}
     if !lfs.blank? && role_allows?(:feature => "snia_local_file_system_show")
       h[:title] = _("Show %{label} '%{name}'") % {:label => label, :name => lfs.evm_display_name}
@@ -83,7 +83,7 @@ module OntapFileShareHelper::TextualSummary
   def textual_logical_disk
     label = ui_lookup(:table => "ontap_logical_disk")
     ld    = @record.logical_disk
-    h     = {:label => label, :image => "ontap_logical_disk", :value => (ld.blank? ? _("None") : ld.evm_display_name)}
+    h     = {:label => label, :image => "100/ontap_logical_disk.png", :value => (ld.blank? ? _("None") : ld.evm_display_name)}
     if !ld.blank? && role_allows?(:feature => "ontap_logical_disk_show")
       h[:title] = _("Show %{label} '%{name}'") % {:label => label, :name => ld.evm_display_name}
       h[:link]  = url_for(:controller => 'ontap_logical_disk', :action => 'show', :id => ld.id)
@@ -94,7 +94,7 @@ module OntapFileShareHelper::TextualSummary
   def textual_base_storage_extents
     label = ui_lookup(:tables => "cim_base_storage_extent")
     num   = @record.base_storage_extents_size
-    h     = {:label => label, :image => "cim_base_storage_extent", :value => num}
+    h     = {:label => label, :image => "100/cim_base_storage_extent.png", :value => num}
     if num > 0 && role_allows?(:feature => "cim_base_storage_extent_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'cim_base_storage_extents', :id => @record, :db => controller.controller_name)
@@ -105,7 +105,7 @@ module OntapFileShareHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @record.hosts_size
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')

--- a/app/helpers/ontap_logical_disk_helper/textual_summary.rb
+++ b/app/helpers/ontap_logical_disk_helper/textual_summary.rb
@@ -186,7 +186,7 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_storage_system
     label = ui_lookup(:table => "ontap_storage_system")
     ss    = @record.storage_system
-    h     = {:label => label, :image => "ontap_storage_system", :value => (ss.blank? ? _("None") : ss.evm_display_name)}
+    h     = {:label => label, :image => "100/ontap_storage_system.png", :value => (ss.blank? ? _("None") : ss.evm_display_name)}
     if !ss.blank? && role_allows?(:feature => "ontap_storage_system_show")
       h[:title] = _("Show %{label} '%{name}'") % {:label => label, :name => ss.evm_display_name}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => ss.id)
@@ -197,7 +197,7 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_file_shares
     label = ui_lookup(:tables => "ontap_file_share")
     num   = @record.file_shares_size
-    h = {:label => label, :image => "ontap_file_share", :value => num}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_file_share_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_logical_disk', :action => 'show', :id => @record, :display => 'ontap_file_share')
@@ -208,7 +208,7 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_file_system
     label = ui_lookup(:table => "snia_local_file_system")
     lfs   = @record.file_system
-    h = {:label => label, :image => "snia_local_file_system", :value => (lfs.blank? ? _("None") : lfs.evm_display_name)}
+    h = {:label => label, :image => "100/snia_local_file_system.png", :value => (lfs.blank? ? _("None") : lfs.evm_display_name)}
     if !lfs.blank? && role_allows?(:feature => "snia_local_file_system_show")
       h[:title] = _("Show %{label} '%{name}'") % {:label => label, :name => lfs.evm_display_name}
       h[:link]  = url_for(:db => controller.controller_name, :action => 'snia_local_file_systems', :id => @record, :show => lfs.id)
@@ -219,7 +219,7 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_base_storage_extents
     label = ui_lookup(:tables => "cim_base_storage_extent")
     num   = @record.base_storage_extents_size
-    h     = {:label => label, :image => "cim_base_storage_extent", :value => num}
+    h     = {:label => label, :image => "100/cim_base_storage_extent.png", :value => num}
     if num > 0 && role_allows?(:feature => "cim_base_storage_extent_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_logical_disk', :action => 'show', :id => @record, :display => 'cim_base_storage_extents')
@@ -230,7 +230,7 @@ module OntapLogicalDiskHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @record.hosts_size
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')

--- a/app/helpers/ontap_storage_system_helper/textual_summary.rb
+++ b/app/helpers/ontap_storage_system_helper/textual_summary.rb
@@ -62,7 +62,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_storage_volumes
     label = ui_lookup(:tables => "ontap_storage_volume")
     num   = @record.storage_volumes_size
-    h     = {:label => label, :image => "ontap_storage_volume", :value => num}
+    h     = {:label => label, :image => "100/ontap_storage_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_volume_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => @record, :display => 'ontap_storage_volume')
@@ -73,7 +73,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_hosted_file_shares
     label = ui_lookup(:tables => "ontap_file_share")
     num   = @record.hosted_file_shares_size
-    h = {:label => label, :image => "ontap_file_share", :value => num}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_file_share_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => @record, :display => 'ontap_file_share')
@@ -84,7 +84,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_local_file_systems
     label = ui_lookup(:tables => "snia_local_file_system")
     num   = @record.local_file_systems_size
-    h = {:label => label, :image => "snia_local_file_system", :value => num}
+    h = {:label => label, :image => "100/snia_local_file_system.png", :value => num}
     if num > 0 && role_allows?(:feature => "snia_local_file_system_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'snia_local_file_systems', :id => @record, :db => controller.controller_name)
@@ -95,7 +95,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_logical_disks
     label = ui_lookup(:tables => "ontap_logical_disk")
     num   = @record.logical_disks_size
-    h = {:label => label, :image => "ontap_logical_disk", :value => num}
+    h = {:label => label, :image => "100/ontap_logical_disk.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_logical_disk_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => @record, :display => 'ontap_logical_disks')
@@ -106,7 +106,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_base_storage_extents
     label = ui_lookup(:tables => "cim_base_storage_extent")
     num   = @record.base_storage_extents_size
-    h     = {:label => label, :image => "cim_base_storage_extent", :value => num}
+    h     = {:label => label, :image => "100/cim_base_storage_extent.png", :value => num}
     if num > 0 && role_allows?(:feature => "cim_base_storage_extent_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'cim_base_storage_extents', :id => @record, :db => controller.controller_name)
@@ -117,7 +117,7 @@ module OntapStorageSystemHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @record.hosts_size
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')

--- a/app/helpers/ontap_storage_volume_helper/textual_summary.rb
+++ b/app/helpers/ontap_storage_volume_helper/textual_summary.rb
@@ -110,7 +110,7 @@ module OntapStorageVolumeHelper::TextualSummary
   def textual_storage_system
     label = ui_lookup(:table => "ontap_storage_system")
     ss   = @record.storage_system
-    h     = {:label => label, :image => "ontap_storage_system", :value => ss.evm_display_name}
+    h     = {:label => label, :image => "100/ontap_storage_system.png", :value => ss.evm_display_name}
     if role_allows?(:feature => "ontap_storage_system_show")
       h[:title] = _("Show all %{label} '%{name}'") % {:label => label, :name => ss.evm_display_name}
       h[:link]  = url_for(:controller => 'ontap_storage_system', :action => 'show', :id => ss.id)
@@ -121,7 +121,7 @@ module OntapStorageVolumeHelper::TextualSummary
   def textual_base_storage_extents
     label = ui_lookup(:tables => "cim_base_storage_extent")
     num   = @record.base_storage_extents_size
-    h     = {:label => label, :image => "cim_base_storage_extent", :value => num}
+    h     = {:label => label, :image => "100/cim_base_storage_extent.png", :value => num}
     if num > 0 && role_allows?(:feature => "cim_base_storage_extent_show")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'cim_base_storage_extents', :id => @record, :db => controller.controller_name)
@@ -132,7 +132,7 @@ module OntapStorageVolumeHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @record.hosts_size
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -36,12 +36,12 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_retirement_date
     {:label => _("Retirement Date"),
-     :image => "retirement",
+     :image => "100/retirement.png",
      :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
   def textual_service
-    h = {:label => _("Service"), :image => "service"}
+    h = {:label => _("Service"), :image => "100/service.png"}
     service = @record.service || @record.try(:root).try(:service)
     if service.nil?
       h[:value] = _("None")
@@ -63,7 +63,7 @@ module OrchestrationStackHelper::TextualSummary
       @record.children.first
     elsif num > 1 && role_allows(:feature => "orchestration_stack_show_list")
       label     = _("Child Orchestration Stacks")
-      h         = {:label => label, :image => "orchestration_stack", :value => num}
+      h         = {:label => label, :image => "100/orchestration_stack.png", :value => num}
       h[:link]  = url_for(:action => 'show', :id => @record.id, :display => 'children')
       h[:title] = _("Show all %{label}") % {:label => label}
       h
@@ -74,7 +74,7 @@ module OrchestrationStackHelper::TextualSummary
     template = @record.try(:orchestration_template)
     return nil if template.nil?
     label = ui_lookup(:table => "orchestration_template")
-    h = {:label => label, :image => "orchestration_template", :value => template.name}
+    h = {:label => label, :image => "100/orchestration_template.png", :value => template.name}
     if role_allows?(:feature => "orchestration_templates_view")
       h[:title] = _("Show this Orchestration Template")
       h[:link] = url_for(:action => 'show', :id => @orchestration_stack, :display => 'stack_orchestration_template')
@@ -85,7 +85,7 @@ module OrchestrationStackHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @orchestration_stack, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -100,12 +100,12 @@ module OrchestrationStackHelper::TextualSummary
   def textual_cloud_networks
     num = @record.number_of(:cloud_networks)
     return nil if num <= 0
-    {:label => ui_lookup(:tables => "cloud_network"), :image => "cloud_network", :value => num}
+    {:label => ui_lookup(:tables => "cloud_network"), :image => "100/cloud_network.png", :value => num}
   end
 
   def textual_parameters
     num   = @record.number_of(:parameters)
-    h     = {:label => _("Parameters"), :image => "parameter", :value => num}
+    h     = {:label => _("Parameters"), :image => "100/parameter.png", :value => num}
     if num > 0
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
       h[:title] = _("Show all parameters")
@@ -115,7 +115,7 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_outputs
     num   = @record.number_of(:outputs)
-    h     = {:label => _("Outputs"), :image => "output", :value => num}
+    h     = {:label => _("Outputs"), :image => "100/output.png", :value => num}
     if num > 0
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'outputs', :id => @record)
       h[:title] = _("Show all outputs")
@@ -125,7 +125,7 @@ module OrchestrationStackHelper::TextualSummary
 
   def textual_resources
     num   = @record.number_of(:resources)
-    h     = {:label => _("Resources"), :image => "resource", :value => num}
+    h     = {:label => _("Resources"), :image => "100/resource.png", :value => num}
     if num > 0
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'resources', :id => @record)
       h[:title] = _("Show all resources")

--- a/app/helpers/provider_configuration_manager_helper.rb
+++ b/app/helpers/provider_configuration_manager_helper.rb
@@ -12,7 +12,7 @@ module ProviderConfigurationManagerHelper
 
   def textual_hostname
     {:label => _("Hostname"),
-     :image => "configured_system",
+     :image => "100/configured_system.png",
      :value => @record.hostname,
     }
   end
@@ -31,7 +31,7 @@ module ProviderConfigurationManagerHelper
 
   def textual_provider_name
     {:label    => _("Provider"),
-     :image    => "vendor-#{@record.configuration_manager.image_name}",
+     :image    => "100/vendor-#{@record.configuration_manager.image_name}.png",
      :value    => @record.configuration_manager.try(:name),
      :explorer => true
     }

--- a/app/helpers/provider_foreman_helper.rb
+++ b/app/helpers/provider_foreman_helper.rb
@@ -13,7 +13,7 @@ module ProviderForemanHelper
 
   def textual_hostname
     {:label => _("Hostname"),
-     :image => "configured_system",
+     :image => "100/configured_system.png",
      :value => @record.hostname,
     }
   end
@@ -36,13 +36,13 @@ module ProviderForemanHelper
       :value    => @record.configuration_profile.try(:description),
       :explorer => true
     }
-    h[:image] = "configuration_profile" if @record.configuration_profile
+    h[:image] = "100/configuration_profile.png" if @record.configuration_profile
     h
   end
 
   def textual_provider_name
     {:label    => _("Provider"),
-     :image    => "vendor-#{@record.configuration_manager.image_name}",
+     :image    => "100/vendor-#{@record.configuration_manager.image_name}.png",
      :value    => @record.configuration_manager.try(:name),
      :explorer => true
     }

--- a/app/helpers/resource_pool_helper/textual_summary.rb
+++ b/app/helpers/resource_pool_helper/textual_summary.rb
@@ -57,13 +57,13 @@ module ResourcePoolHelper::TextualSummary
   end
 
   def textual_parent_datacenter
-    {:label => _("Parent Datacenter"), :image => "datacenter", :value => @record.v_parent_datacenter || _("None")}
+    {:label => _("Parent Datacenter"), :image => "100/datacenter.png", :value => @record.v_parent_datacenter || _("None")}
   end
 
   def textual_parent_cluster
     cluster = @record.parent_cluster
     h = {:label => _("Parent '%{title}'") % {:title => title_for_cluster},
-         :image => "ems_cluster",
+         :image => "100/ems_cluster.png",
          :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show Parent %{title} %{name}") % {:title => title_for_cluster, :name => cluster.name}
@@ -75,7 +75,7 @@ module ResourcePoolHelper::TextualSummary
   def textual_parent_host
     host = @record.parent_host
     h = {:label => _("Parent %{title}") % {:title => title_for_host},
-         :image => "host",
+         :image => "100/host.png",
          :value => (host.nil? ? _("None") : host.name)}
     if host && role_allows?(:feature => "host_show")
       h[:title] = _("Show Parent %{title} '%{name}'") % {:title => title_for_host, :name => host.name}
@@ -86,7 +86,7 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_direct_vms
     num = @record.v_direct_vms
-    h = {:label => _("Direct VMs"), :image => "vm", :value => num}
+    h = {:label => _("Direct VMs"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show VMs in this Resource Pool, but not in Resource Pools below")
       h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'vms')
@@ -96,7 +96,7 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_allvms_size
     num = @record.total_vms
-    h = {:label => _("All VMs"), :image => "vm", :value => num}
+    h = {:label => _("All VMs"), :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:title] = _("Show all VMs in this Resource Pool")
       h[:link]  = url_for(:controller => 'resource_pool', :action => 'show', :id => @record, :display => 'all_vms')
@@ -106,7 +106,7 @@ module ResourcePoolHelper::TextualSummary
 
   def textual_total_vms
     num = @record.v_total_vms
-    h = {:label => _("All VMs (Tree View)"), :image => "vm", :value => num}
+    h = {:label => _("All VMs (Tree View)"), :image => "100/vm.png", :value => num}
     # TODO: Why is this role_allows? resource_pool_show_list but the previous 2 methods are for vm_show_list
     if num > 0 && role_allows?(:feature => "resource_pool_show_list")
       h[:title] = _("Show tree of all VMs in this Resource Pool")

--- a/app/helpers/security_group_helper/textual_summary.rb
+++ b/app/helpers/security_group_helper/textual_summary.rb
@@ -42,7 +42,7 @@ module SecurityGroupHelper::TextualSummary
   def textual_instances
     label = ui_lookup(:tables => "vm_cloud")
     num   = @record.number_of(:vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'instances')
       h[:title] = _("Show all %{label}") % {:label => label}

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -64,7 +64,7 @@ module ServiceHelper::TextualSummary
 
   def textual_retirement_date
     {:label => _("Retirement Date"),
-     :image => "retirement",
+     :image => "100/retirement.png",
      :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
@@ -74,7 +74,7 @@ module ServiceHelper::TextualSummary
 
   def textual_catalog_item
     st = @record.service_template
-    s = {:label => _("Parent Catalog Item"), :image => "service_template", :value => (st.nil? ? _("None") : st.name)}
+    s = {:label => _("Parent Catalog Item"), :image => "100/service_template.png", :value => (st.nil? ? _("None") : st.name)}
     if st && role_allows?(:feature => "catalog_items_accord")
       s[:title] = _("Show this Service's Parent Service Catalog")
       s[:link]  = url_for(:controller => 'catalog', :action => 'show', :id => st)
@@ -101,7 +101,7 @@ module ServiceHelper::TextualSummary
     job = @record.try(:job)
     {
       :label => _("Job"),
-      :image => "orchestration_stack",
+      :image => "100/orchestration_stack.png",
       :value => job.name,
       :title => _("Show this Service's Job"),
       :link  => url_for(:controller => 'configuration_job', :action => 'show', :id => job.id)

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -86,7 +86,7 @@ module ServiceHelper::TextualSummary
     parent = @record.parent_service
     {
       :label => _("Parent Service"),
-      :image => parent.picture ? "/pictures/#{parent.picture.basename}" : 'service',
+      :image => parent.picture ? "/pictures/#{parent.picture.basename}" : '100/service.png',
       :value => parent.name,
       :title => _("Show this Service's Parent Service"),
       :link  => url_for(:controller => 'service', :action => 'show', :id => parent)

--- a/app/helpers/storage_helper/textual_summary.rb
+++ b/app/helpers/storage_helper/textual_summary.rb
@@ -74,7 +74,7 @@ module StorageHelper::TextualSummary
   def textual_hosts
     label = title_for_hosts
     num   = @record.number_of(:hosts)
-    h     = {:label => label, :image => "host", :value => num}
+    h     = {:label => label, :image => "100/host.png", :value => num}
     if num > 0 && role_allows?(:feature => "host_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hosts')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -85,7 +85,7 @@ module StorageHelper::TextualSummary
   def textual_managed_vms
     label = _("Managed VMs")
     num   = @record.number_of(:all_vms)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "vm_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'all_vms')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -96,7 +96,7 @@ module StorageHelper::TextualSummary
   def textual_managed_miq_templates
     label = _("Managed %{tables}") % {:tables => ui_lookup(:tables => "miq_template")}
     num   = @record.number_of(:all_miq_templates)
-    h     = {:label => label, :image => "vm", :value => num}
+    h     = {:label => label, :image => "100/vm.png", :value => num}
     if num > 0 && role_allows?(:feature => "miq_template_show_list")
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'all_miq_templates')
       h[:title] = _("Show all %{label}") % {:label => label}
@@ -105,21 +105,21 @@ module StorageHelper::TextualSummary
   end
 
   def textual_registered_vms
-    {:label => _("Managed/Registered VMs"), :image => "vm", :value => @record.total_managed_registered_vms}
+    {:label => _("Managed/Registered VMs"), :image => "100/vm.png", :value => @record.total_managed_registered_vms}
   end
 
   def textual_unregistered_vms
-    {:label => _("Managed/Unregistered VMs"), :image => "vm", :value => @record.total_managed_unregistered_vms}
+    {:label => _("Managed/Unregistered VMs"), :image => "100/vm.png", :value => @record.total_managed_unregistered_vms}
   end
 
   def textual_unmanaged_vms
-    {:label => _("Unmanaged VMs"), :image => "vm", :value => @record.total_unmanaged_vms}
+    {:label => _("Unmanaged VMs"), :image => "100/vm.png", :value => @record.total_unmanaged_vms}
   end
 
   def textual_storage_systems
     num   = @record.storage_systems_size
     label = ui_lookup(:tables => "ontap_storage_system")
-    h     = {:label => label, :image => "ontap_storage_system", :value => num}
+    h     = {:label => label, :image => "100/ontap_storage_system.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_system_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_storage_systems")
@@ -130,7 +130,7 @@ module StorageHelper::TextualSummary
   def textual_storage_volumes
     num   = @record.storage_volumes_size
     label = ui_lookup(:tables => "ontap_storage_volume")
-    h     = {:label => label, :image => "ontap_storage_volume", :value => num}
+    h     = {:label => label, :image => "100/ontap_storage_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_volume_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'show', :id => @record, :display => "ontap_storage_volumes")
@@ -141,7 +141,7 @@ module StorageHelper::TextualSummary
   def textual_logical_disk
     ld = @record.logical_disk
     label = ui_lookup(:table => "ontap_logical_disk")
-    h = {:label => label, :image => "ontap_logical_disk", :value => (ld.blank? ? _("None") : ld.evm_display_name)}
+    h = {:label => label, :image => "100/ontap_logical_disk.png", :value => (ld.blank? ? _("None") : ld.evm_display_name)}
     if !ld.blank? && role_allows?(:feature => "ontap_logical_disk_show")
       h[:title] = _("Show this Datastore's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_logical_disk', :action => 'show', :id => ld)
@@ -152,7 +152,7 @@ module StorageHelper::TextualSummary
   def textual_file_share
     fs = @record.file_share
     label = ui_lookup(:table => "ontap_file_share")
-    h = {:label => label, :image => "ontap_file_share", :value => (fs.blank? ? _("None") : fs.evm_display_name)}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => (fs.blank? ? _("None") : fs.evm_display_name)}
     if !fs.blank? && role_allows?(:feature => "ontap_file_share_show")
       h[:title] = _("Show this Datastore's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'ontap_file_share', :action => 'show', :id => fs)
@@ -162,7 +162,7 @@ module StorageHelper::TextualSummary
 
   def textual_files
     num   = @record.number_of(:files)
-    h     = {:label => _("All Files"), :image => "storage_files", :value => num}
+    h     = {:label => _("All Files"), :image => "100/storage_files.png", :value => num}
     if num > 0
       h[:title] = _("Show all files installed on this %{table}") % {:table => ui_lookup(:table => "storages")}
       h[:link]  = url_for(:action => 'files', :id => @record)
@@ -180,7 +180,7 @@ module StorageHelper::TextualSummary
                         :percentage => @record.v_disk_percent_of_used.to_s + "%",
                         :amount     => @record.number_of(:disk_files)}
 
-    h     = {:label => _("VM Provisioned Disk Files"), :image => "storage_disk_files", :value => value}
+    h     = {:label => _("VM Provisioned Disk Files"), :image => "100/storage_disk_files.png", :value => value}
     if num > 0
       h[:title] = _("Show VM Provisioned Disk Files installed on this %{table}") %
                   {:table => ui_lookup(:table => "storages")}
@@ -198,7 +198,7 @@ module StorageHelper::TextualSummary
                     {:number     => number_to_human_size(@record.v_total_snapshot_size, :precision => 2),
                      :percentage => @record.v_snapshot_percent_of_used.to_s + "%",
                      :amount     => @record.number_of(:snapshot_files)}
-    h     = {:label => _("VM Snapshot Files"), :image => "storage_snapshot_files", :value => value}
+    h     = {:label => _("VM Snapshot Files"), :image => "100/storage_snapshot_files.png", :value => value}
     if num > 0
       h[:title] = _("Show VM Snapshot Files installed on this %{storage}") %
                   {:storage => ui_lookup(:table => "storages")}
@@ -216,7 +216,7 @@ module StorageHelper::TextualSummary
                     {:number     => number_to_human_size(@record.v_total_memory_size, :precision => 2),
                      :percentage => @record.v_memory_percent_of_used.to_s + "%",
                      :amount     => @record.number_of(:vm_ram_files)}
-    h     = {:label => _("VM Memory Files"), :image => "storage_memory_files", :value => value}
+    h     = {:label => _("VM Memory Files"), :image => "100/storage_memory_files.png", :value => value}
     if num > 0
       h[:title] = _("Show VM Memory Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
       h[:link]  = url_for(:action => 'vm_ram_files', :id => @record)
@@ -233,7 +233,7 @@ module StorageHelper::TextualSummary
                     {:number     => number_to_human_size(@record.v_total_vm_misc_size, :precision => 2),
                      :percentage => @record.v_vm_misc_percent_of_used.to_s + "%",
                      :amount     => @record.number_of(:vm_misc_files)}
-    h     = {:label => _("Other VM Files"), :image => "storage_other_vm_files", :value => value}
+    h     = {:label => _("Other VM Files"), :image => "100/storage_other_vm_files.png", :value => value}
     if num > 0
       h[:title] = _("Show Other VM Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
       h[:link]  = url_for(:action => 'vm_misc_files', :id => @record)
@@ -250,7 +250,7 @@ module StorageHelper::TextualSummary
                     {:number     => number_to_human_size(@record.v_total_debris_size, :precision => 2),
                      :percentage => @record.v_debris_percent_of_used.to_s + "%",
                      :amount     => @record.number_of(:debris_files)}
-    h     = {:label => _("Non-VM Files"), :image => "storage_non_vm_files", :value => value}
+    h     = {:label => _("Non-VM Files"), :image => "100/storage_non_vm_files.png", :value => value}
     if num > 0
       h[:title] = _("Show Non-VM Files installed on this %{storage}") % {:storage => ui_lookup(:table => "storages")}
       h[:link]  = url_for(:action => 'debris_files', :id => @record)

--- a/app/helpers/textual_mixins/textual_advanced_settings.rb
+++ b/app/helpers/textual_mixins/textual_advanced_settings.rb
@@ -1,7 +1,7 @@
 module TextualMixins::TextualAdvancedSettings
   def textual_advanced_settings
     num = @record.number_of(:advanced_settings)
-    h = {:label => _("Advanced Settings"), :image => "advancedsetting", :value => num}
+    h = {:label => _("Advanced Settings"), :image => "100/advancedsetting.png", :value => num}
     if num > 0
       h[:title] = _("Show the advanced settings on this VM")
       h[:explorer] = true

--- a/app/helpers/textual_mixins/textual_drift.rb
+++ b/app/helpers/textual_mixins/textual_drift.rb
@@ -1,7 +1,7 @@
 module TextualMixins::TextualDrift
   def textual_drift
     return nil unless role_allows?(:feature => "vm_drift")
-    h = {:label => _("Drift History"), :image => "drift"}
+    h = {:label => _("Drift History"), :image => "100/drift.png"}
     num = @record.number_of(:drift_states)
     if num == 0
       h[:value] = _("None")

--- a/app/helpers/textual_mixins/textual_filesystems.rb
+++ b/app/helpers/textual_mixins/textual_filesystems.rb
@@ -1,7 +1,7 @@
 module TextualMixins::TextualFilesystems
   def textual_filesystems
     num = @record.number_of(:filesystems)
-    h = {:label => _("Files"), :image => "filesystems", :value => num}
+    h = {:label => _("Files"), :image => "100/filesystems.png", :value => num}
     if num > 0
       h[:title] = n_("Show the File installed on this VM", "Show the Files installed on this VM", num)
       h[:explorer] = true

--- a/app/helpers/textual_mixins/textual_init_processes.rb
+++ b/app/helpers/textual_mixins/textual_init_processes.rb
@@ -4,7 +4,7 @@ module TextualMixins::TextualInitProcesses
     return nil unless os =~ /linux/
     num = @record.number_of(:linux_initprocesses)
     # TODO: Why is this image different than graphical?
-    h = {:label => _("Init Processes"), :image => "gears", :value => num}
+    h = {:label => _("Init Processes"), :image => "100/gears.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Init Process installed on this VM", "Show the Init Processes installed on this VM", num)
       h[:explorer] = true

--- a/app/helpers/textual_mixins/textual_os_info.rb
+++ b/app/helpers/textual_mixins/textual_os_info.rb
@@ -7,11 +7,11 @@ module TextualMixins::TextualOsInfo
       if os_image_name.blank?
         h[:value] = _("Unknown")
       else
-        h[:image] = "os-#{os_image_name.downcase}"
+        h[:image] = "100/os-#{os_image_name.downcase}.png"
         h[:value] = os_image_name
       end
     else
-      h[:image] = "os-#{@record.os_image_name.downcase}"
+      h[:image] = "100/os-#{@record.os_image_name.downcase}.png"
       h[:value] = product_name
       h[:title] = _("Show OS container information")
       h[:explorer] = true

--- a/app/helpers/textual_mixins/textual_patches.rb
+++ b/app/helpers/textual_mixins/textual_patches.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualPatches
     os = @record.os_image_name.downcase
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:patches)
-    h = {:label => _("Patches"), :image => "patch", :value => num}
+    h = {:label => _("Patches"), :image => "100/patch.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Patch defined on this VM", "Show the Patches defined on this VM", num)
       h[:explorer] = true

--- a/app/helpers/textual_mixins/textual_power_state.rb
+++ b/app/helpers/textual_mixins/textual_power_state.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualPowerState
     state = @record.current_state.downcase
     state = "unknown" if state.blank?
     h = {:label => _("Power State"), :value => state}
-    h[:image] = "currentstate-#{@record.template? ? (@record.host ? "template" : "template-no-host") : state}"
+    h[:image] = "100/currentstate-#{@record.template? ? (@record.host ? "template" : "template-no-host") : state}.png"
     h
   end
 end

--- a/app/helpers/textual_mixins/textual_scan_history.rb
+++ b/app/helpers/textual_mixins/textual_scan_history.rb
@@ -1,6 +1,6 @@
 module TextualMixins::TextualScanHistory
   def textual_scan_history
-    h = {:label => _("Analysis History"), :image => "scan"}
+    h = {:label => _("Analysis History"), :image => "100/scan.png"}
     num = @record.number_of(:scan_histories)
     if num == 0
       h[:value] = _("None")

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -139,7 +139,7 @@ module TextualSummaryHelper
   def textual_object_icon(object, klass)
     case object
     when ExtManagementSystem
-      "vendor-#{object.image_name}"
+      "100/vendor-#{object.image_name}.png"
     else
       textual_class_icon(klass)
     end
@@ -151,11 +151,11 @@ module TextualSummaryHelper
 
   def textual_class_icon(klass)
     if klass <= AdvancedSetting
-      "advancedsetting"
+      "100/advancedsetting.png"
     elsif klass <= MiqTemplate
-      "vm"
+      "100/vm.png"
     else
-      klass.name.underscore
+      "100/#{klass.name.underscore}.png"
     end
   end
 

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -49,7 +49,7 @@ module TextualSummaryHelper
     else
       h[:value] = tags.sort_by { |category, _assigned| category.downcase }
                   .collect do |category, assigned|
-                    {:image => "smarttag",
+                    {:image => "100/smarttag.png",
                      :label => category,
                      :value => assigned}
                   end

--- a/app/helpers/textual_summary_helper.rb
+++ b/app/helpers/textual_summary_helper.rb
@@ -44,7 +44,7 @@ module TextualSummaryHelper
     h = {:label => label}
     tags = session[:assigned_filters]
     if tags.blank?
-      h[:image] = "smarttag"
+      h[:image] = "100/smarttag.png"
       h[:value] = _("No %{label} have been assigned") % {:label => label}
     else
       h[:value] = tags.sort_by { |category, _assigned| category.downcase }

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -97,7 +97,7 @@ module VmCloudHelper::TextualSummary
 
   def textual_snapshots
     num = @record.number_of(:snapshots)
-    h = {:label => _("Snapshots"), :image => "snapshot", :value => (num == 0 ? _("None") : num)}
+    h = {:label => _("Snapshots"), :image => "100/snapshot.png", :value => (num == 0 ? _("None") : num)}
     if role_allows?(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:title] = _("Show the snapshot info for this VM")
       h[:explorer] = true
@@ -118,7 +118,7 @@ module VmCloudHelper::TextualSummary
 
   def textual_users
     num = @record.number_of(:users)
-    h = {:label => _("Users"), :image => "user", :value => num}
+    h = {:label => _("Users"), :image => "100/user.png", :value => num}
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
       h[:explorer] = true
@@ -129,7 +129,7 @@ module VmCloudHelper::TextualSummary
 
   def textual_groups
     num = @record.number_of(:groups)
-    h = {:label => _("Groups"), :image => "group", :value => num}
+    h = {:label => _("Groups"), :image => "100/group.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Group defined on this VM", "Show the Groups defined on this VM", num)
       h[:explorer] = true
@@ -151,7 +151,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown"
     num = @record.number_of(:guest_applications)
     label = (os =~ /linux/) ? n_("Package", "Packages", num) : n_("Application", "Applications", num)
-    h = {:label => label, :image => "guest_application", :value => num}
+    h = {:label => label, :image => "100/guest_application.png", :value => num}
     if num > 0
       h[:title] = ("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true
@@ -164,7 +164,7 @@ module VmCloudHelper::TextualSummary
     os = @record.os_image_name.downcase
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:win32_services)
-    h = {:label => _("Win32 Services"), :image => "win32service", :value => num}
+    h = {:label => _("Win32 Services"), :image => "100/win32service.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Win32 Service installed on this VM",
                      "Show the Win32 Services installed on this VM", num)
@@ -179,7 +179,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:kernel_drivers)
     # TODO: Why is this image different than graphical?
-    h = {:label => _("Kernel Drivers"), :image => "gears", :value => num}
+    h = {:label => _("Kernel Drivers"), :image => "100/gears.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Kernel Driver installed on this VM",
                      "Show the Kernel Drivers installed on this VM", num)
@@ -194,7 +194,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:filesystem_drivers)
     # TODO: Why is this image different than graphical?
-    h = {:label => _("File System Drivers"), :image => "gears", :value => num}
+    h = {:label => _("File System Drivers"), :image => "100/gears.png", :value => num}
     if num > 0
       h[:title] = n_("Show the File System Driver installed on this VM" ,
                     "Show the File System Drivers installed on this VM", num)
@@ -209,7 +209,7 @@ module VmCloudHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:registry_items)
     # TODO: Why is this label different from the link title text?
-    h = {:label => _("Registry Entries"), :image => "registry_item", :value => num}
+    h = {:label => _("Registry Entries"), :image => "100/registry_item.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Registry Item installed on this VM", "Show the Registry Items installed on this VM", num)
       h[:explorer] = true
@@ -220,7 +220,7 @@ module VmCloudHelper::TextualSummary
 
   def textual_processes
     return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
-    h = {:label => _("Running Processes"), :image => "processes"}
+    h = {:label => _("Running Processes"), :image => "100/processes.png"}
     date = last_date(:processes)
     if date.nil?
       h[:value] = _("Not Available")
@@ -237,7 +237,7 @@ module VmCloudHelper::TextualSummary
   def textual_event_logs
     return nil if @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
     num = @record.operating_system.nil? ? 0 : @record.operating_system.number_of(:event_logs)
-    h = {:label => _("Event Logs"), :image => "event_logs", :value => (num == 0 ? _("Not Available") : _("Available"))}
+    h = {:label => _("Event Logs"), :image => "100/event_logs.png", :value => (num == 0 ? _("Not Available") : _("Available"))}
     if num > 0
       h[:title] = n_("Show Event Log on this VM", "Show Event Logs on this VM", num)
       h[:explorer] = true

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -239,7 +239,7 @@ module VmHelper::TextualSummary
 
   def textual_resource_pool
     rp = @record.parent_resource_pool
-    image = (rp && rp.vapp?) ? "vapp" : "resource_pool"
+    image = (rp && rp.vapp?) ? "100/vapp.png" : "100/resource_pool.png"
     h = {:label => _("Resource Pool"), :image => image, :value => (rp.nil? ? _("None") : rp.name)}
     if rp && role_allows?(:feature => "resource_pool_show")
       h[:title] = _("Show this VM's Resource Pool")

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -157,7 +157,7 @@ module VmHelper::TextualSummary
 
   def textual_snapshots
     num = @record.number_of(:snapshots)
-    h = {:label => _("Snapshots"), :image => "snapshot", :value => (num == 0 ? _("None") : num)}
+    h = {:label => _("Snapshots"), :image => "100/snapshot.png", :value => (num == 0 ? _("None") : num)}
     if role_allows?(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
       h[:title] = _("Show the snapshot info for this VM")
       h[:explorer] = true
@@ -181,19 +181,19 @@ module VmHelper::TextualSummary
   end
 
   def textual_discovered
-    {:label => _("Discovered"), :image => "discover", :value => format_timezone(@record.created_on)}
+    {:label => _("Discovered"), :image => "100/discover.png", :value => format_timezone(@record.created_on)}
   end
 
   def textual_analyzed
     {:label => _("Last Analyzed"),
-     :image => "scan",
+     :image => "100/scan.png",
      :value => (@record.last_sync_on.nil? ? _("Never") : format_timezone(@record.last_sync_on))}
   end
 
   def textual_retirement_date
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
     {:label => _("Retirement Date"),
-     :image => "retirement",
+     :image => "100/retirement.png",
      :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
@@ -218,7 +218,7 @@ module VmHelper::TextualSummary
   def textual_cluster
     cluster = @record.try(:ems_cluster)
     return nil if cluster.nil?
-    h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? _("None") : cluster.name)}
+    h = {:label => title_for_cluster, :image => "100/ems_cluster.png", :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")
       h[:title] = _("Show this VM's %{title}") % {:title => title_for_cluster}
       h[:link]  = url_for(:controller => 'ems_cluster', :action => 'show', :id => cluster)
@@ -229,7 +229,7 @@ module VmHelper::TextualSummary
   def textual_host
     host = @record.host
     return nil if host.nil?
-    h = {:label => title_for_host, :image => "host", :value => (host.nil? ? _("None") : host.name)}
+    h = {:label => title_for_host, :image => "100/host.png", :value => (host.nil? ? _("None") : host.name)}
     if host && role_allows?(:feature => "host_show")
       h[:title] = _("Show this VM's %{title}") % {:title => title_for_host}
       h[:link]  = url_for(:controller => 'host', :action => 'show', :id => host)
@@ -251,7 +251,7 @@ module VmHelper::TextualSummary
   def textual_storage
     storages = @record.storages
     label = ui_lookup(:table => "storages")
-    h = {:label => label, :image => "storage"}
+    h = {:label => label, :image => "100/storage.png"}
     if storages.empty?
       h[:value] = _("None")
     elsif storages.length == 1
@@ -263,7 +263,7 @@ module VmHelper::TextualSummary
       h.delete(:image) # Image will be part of each line item, instead
       main = @record.storage
       h[:value] = storages.sort_by { |s| s.name.downcase }.collect do |s|
-        {:image => "storage",
+        {:image => "100/storage.png",
          :value => "#{s.name}#{" (main)" if s == main}",
          :title => _("Show this VM's %{label}") % {:label => label},
          :link => url_for(:controller => 'storage', :action => 'show', :id => s)}
@@ -284,7 +284,7 @@ module VmHelper::TextualSummary
     availability_zone = @record.availability_zone
     label = ui_lookup(:table => "availability_zone")
     h = {:label => label,
-         :image => "availability_zone",
+         :image => "100/availability_zone.png",
          :value => (availability_zone.nil? ? _("None") : availability_zone.name)}
     if availability_zone && role_allows?(:feature => "availability_zone_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
@@ -296,7 +296,7 @@ module VmHelper::TextualSummary
   def textual_flavor
     flavor = @record.flavor
     label = ui_lookup(:table => "flavor")
-    h = {:label => label, :image => "flavor", :value => (flavor.nil? ? _("None") : flavor.name)}
+    h = {:label => label, :image => "100/flavor.png", :value => (flavor.nil? ? _("None") : flavor.name)}
     if flavor && role_allows?(:feature => "flavor_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'flavor', :action => 'show', :id => flavor)
@@ -307,7 +307,7 @@ module VmHelper::TextualSummary
   def textual_vm_template
     vm_template = @record.genealogy_parent
     label = ui_lookup(:table => "miq_template")
-    h = {:label => label, :image => "template", :value => (vm_template.nil? ? _("None") : vm_template.name)}
+    h = {:label => label, :image => "100/template.png", :value => (vm_template.nil? ? _("None") : vm_template.name)}
     if vm_template && role_allows?(:feature => "miq_template_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'miq_template', :action => 'show', :id => vm_template)
@@ -317,7 +317,7 @@ module VmHelper::TextualSummary
 
   def textual_parent_vm
     return nil unless @record.template?
-    h = {:label => _("Parent VM"), :image => "vm"}
+    h = {:label => _("Parent VM"), :image => "100/vm.png"}
     parent_vm = @record.with_relationship_type("genealogy", &:parent)
     if parent_vm.nil?
       h[:value] = _("None")
@@ -334,7 +334,7 @@ module VmHelper::TextualSummary
   def textual_orchestration_stack
     stack = @record.orchestration_stack
     label = ui_lookup(:table => "orchestration_stack")
-    h = {:label => label, :image => "orchestration_stack", :value => (stack.nil? ? _("None") : stack.name)}
+    h = {:label => label, :image => "100/orchestration_stack.png", :value => (stack.nil? ? _("None") : stack.name)}
     if stack && role_allows?(:feature => "orchestration_stack_show")
       h[:title] = _("Show this VM's %{label} '%{name}'") % {:label => label, :name => stack.name}
       h[:link]  = url_for(:controller => 'orchestration_stack', :action => 'show', :id => stack)
@@ -343,7 +343,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_service
-    h = {:label => _("Service"), :image => "service"}
+    h = {:label => _("Service"), :image => "100/service.png"}
     service = @record.service
     if service.nil?
       h[:value] = _("None")
@@ -358,7 +358,7 @@ module VmHelper::TextualSummary
   def textual_security_groups
     label = ui_lookup(:tables => "security_group")
     num   = @record.number_of(:security_groups)
-    h     = {:label => label, :image => "security_group", :value => num}
+    h     = {:label => label, :image => "100/security_group.png", :value => num}
     if num > 0 && role_allows?(:feature => "security_group_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -370,7 +370,7 @@ module VmHelper::TextualSummary
   def textual_floating_ips
     label = ui_lookup(:tables => "floating_ip")
     num   = @record.number_of(:floating_ips)
-    h     = {:label => label, :image => "floating_ip", :value => num}
+    h     = {:label => label, :image => "100/floating_ip.png", :value => num}
     if num > 0 && role_allows?(:feature => "floating_ip_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -382,7 +382,7 @@ module VmHelper::TextualSummary
   def textual_network_routers
     label = ui_lookup(:tables => "network_router")
     num   = @record.number_of(:network_routers)
-    h     = {:label => label, :image => "network_router", :value => num}
+    h     = {:label => label, :image => "100/network_router.png", :value => num}
     if num > 0 && role_allows?(:feature => "network_router_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -394,7 +394,7 @@ module VmHelper::TextualSummary
   def textual_cloud_subnets
     label = ui_lookup(:tables => "cloud_subnet")
     num   = @record.number_of(:cloud_subnets)
-    h     = {:label => label, :image => "cloud_subnet", :value => num}
+    h     = {:label => label, :image => "100/cloud_subnet.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_subnet_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -406,7 +406,7 @@ module VmHelper::TextualSummary
   def textual_network_ports
     label = ui_lookup(:tables => "network_port")
     num   = @record.number_of(:network_ports)
-    h     = {:label => label, :image => "network_port", :value => num}
+    h     = {:label => label, :image => "100/network_port.png", :value => num}
     if num > 0 && role_allows?(:feature => "network_port_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -420,7 +420,7 @@ module VmHelper::TextualSummary
 
     label = ui_lookup(:tables => "load_balancer")
     num   = @record.number_of(:load_balancers)
-    h     = {:label => label, :image => "load_balancer", :value => num}
+    h     = {:label => label, :image => "100/load_balancer.png", :value => num}
     if num > 0 && role_allows?(:feature => "load_balancer_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -432,7 +432,7 @@ module VmHelper::TextualSummary
   def textual_cloud_networks
     label = ui_lookup(:tables => "cloud_network")
     num   = @record.number_of(:cloud_networks)
-    h     = {:label => label, :image => "cloud_network", :value => num}
+    h     = {:label => label, :image => "100/cloud_network.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_network_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -444,7 +444,7 @@ module VmHelper::TextualSummary
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenants")
-    h = {:label => label, :image => "cloud_tenant", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
+    h = {:label => label, :image => "100/cloud_tenant.png", :value => (cloud_tenant.nil? ? _("None") : cloud_tenant.name)}
     if cloud_tenant && role_allows?(:feature => "cloud_tenant_show")
       h[:title] = _("Show this VM's %{label}") % {:label => label}
       h[:link]  = url_for(:controller => 'cloud_tenant', :action => 'show', :id => cloud_tenant)
@@ -455,7 +455,7 @@ module VmHelper::TextualSummary
   def textual_cloud_volumes
     label = ui_lookup(:tables => "cloud_volumes")
     num = @record.number_of(:cloud_volumes)
-    h = {:label => label, :image => "cloud_volume", :value => num}
+    h = {:label => label, :image => "100/cloud_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "cloud_volume_show_list")
       h[:title]    = _("Show all Cloud Volumes attached to this VM.")
       h[:explorer] = true
@@ -467,7 +467,7 @@ module VmHelper::TextualSummary
   def textual_genealogy
     {
       :label    => _("Genealogy"),
-      :image    => "genealogy",
+      :image    => "100/genealogy.png",
       :value    => _("Show parent and child VMs"),
       :title    => _("Show virtual machine genealogy"),
       :explorer => true,
@@ -483,7 +483,7 @@ module VmHelper::TextualSummary
 
   def textual_users
     num = @record.number_of(:users)
-    h = {:label => _("Users"), :image => "user", :value => num}
+    h = {:label => _("Users"), :image => "100/user.png", :value => num}
     if num > 0
       h[:title] = n_("Show the User defined on this VM", "Show the Users defined on this VM", num)
       h[:explorer] = true
@@ -494,7 +494,7 @@ module VmHelper::TextualSummary
 
   def textual_groups
     num = @record.number_of(:groups)
-    h = {:label => _("Groups"), :image => "group", :value => num}
+    h = {:label => _("Groups"), :image => "100/group.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Group defined on this VM", "Show the Groups defined on this VM", num)
       h[:explorer] = true
@@ -509,7 +509,7 @@ module VmHelper::TextualSummary
     num = @record.number_of(:guest_applications)
     label = (os =~ /linux/) ? n_("Package", "Packages", num) : n_("Application", "Applications", num)
 
-    h = {:label => label, :image => "guest_application", :value => num}
+    h = {:label => label, :image => "100/guest_application.png", :value => num}
     if num > 0
       h[:title] = _("Show the %{label} installed on this VM") % {:label => label}
       h[:explorer] = true
@@ -522,7 +522,7 @@ module VmHelper::TextualSummary
     os = @record.os_image_name.downcase
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:win32_services)
-    h = {:label => _("Win32 Services"), :image => "win32service", :value => num}
+    h = {:label => _("Win32 Services"), :image => "100/win32service.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Win32 Service installed on this VM", "Show the Win32 Services installed on this VM", num)
       h[:explorer] = true
@@ -536,7 +536,7 @@ module VmHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:kernel_drivers)
     # TODO: Why is this image different than graphical?
-    h = {:label => _("Kernel Drivers"), :image => "gears", :value => num}
+    h = {:label => _("Kernel Drivers"), :image => "100/gears.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Kernel Driver installed on this VM", "Show the Kernel Drivers installed on this VM", num)
       h[:explorer] = true
@@ -550,7 +550,7 @@ module VmHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:filesystem_drivers)
     # TODO: Why is this image different than graphical?
-    h = {:label => _("File System Drivers"), :image => "gears", :value => num}
+    h = {:label => _("File System Drivers"), :image => "100/gears.png", :value => num}
     if num > 0
       h[:title] = n_("Show the File System Driver installed on this VM",
                      "Show the File System Drivers installed on this VM", num)
@@ -565,7 +565,7 @@ module VmHelper::TextualSummary
     return nil if os == "unknown" || os =~ /linux/
     num = @record.number_of(:registry_items)
     # TODO: Why is this label different from the link title text?
-    h = {:label => _("Registry Entries"), :image => "registry_item", :value => num}
+    h = {:label => _("Registry Entries"), :image => "100/registry_item.png", :value => num}
     if num > 0
       h[:title] = n_("Show the Registry Item installed on this VM", "Show the Registry Items installed on this VM", num)
       h[:explorer] = true
@@ -576,7 +576,7 @@ module VmHelper::TextualSummary
 
   def textual_disks
     num = @record.hardware.nil? ? 0 : @record.hardware.number_of(:disks)
-    h = {:label => _("Number of Disks"), :image => "devices", :value => num}
+    h = {:label => _("Number of Disks"), :image => "100/devices.png", :value => num}
     if num > 0
       h[:title] = n_("Show disk on this VM", "Show disks on this VM", num)
       h[:explorer] = true
@@ -654,7 +654,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_processes
-    h = {:label => _("Running Processes"), :image => "processes"}
+    h = {:label => _("Running Processes"), :image => "100/processes.png"}
     date = last_date(:processes)
     if date.nil?
       h[:value] = _("Not Available")
@@ -670,7 +670,7 @@ module VmHelper::TextualSummary
 
   def textual_event_logs
     num = @record.operating_system.nil? ? 0 : @record.operating_system.number_of(:event_logs)
-    h = {:label => _("Event Logs"), :image => "event_logs", :value => (num == 0 ? _("Not Available") : _("Available"))}
+    h = {:label => _("Event Logs"), :image => "100/event_logs.png", :value => (num == 0 ? _("Not Available") : _("Available"))}
     if num > 0
       h[:title] = _("Show Event Logs on this VM")
       h[:explorer] = true
@@ -682,7 +682,7 @@ module VmHelper::TextualSummary
   def textual_storage_systems
     num = @record.storage_systems_size
     label = ui_lookup(:tables => "ontap_storage_system")
-    h = {:label => label, :image => "ontap_storage_system", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_system.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_system_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -694,7 +694,7 @@ module VmHelper::TextualSummary
   def textual_storage_volumes
     num = @record.storage_volumes_size
     label = ui_lookup(:tables => "ontap_storage_volume")
-    h = {:label => label, :image => "ontap_storage_volume", :value => num}
+    h = {:label => label, :image => "100/ontap_storage_volume.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_storage_volume_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -706,7 +706,7 @@ module VmHelper::TextualSummary
   def textual_file_shares
     num = @record.file_shares_size
     label = ui_lookup(:tables => "ontap_file_share")
-    h = {:label => label, :image => "ontap_file_share", :value => num}
+    h = {:label => label, :image => "100/ontap_file_share.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_file_share_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -718,7 +718,7 @@ module VmHelper::TextualSummary
   def textual_logical_disks
     num = @record.logical_disks_size
     label = ui_lookup(:tables => "ontap_logical_disk")
-    h = {:label => label, :image => "ontap_logical_disk", :value => num}
+    h = {:label => label, :image => "100/ontap_logical_disk.png", :value => num}
     if num > 0 && role_allows?(:feature => "ontap_logical_disk_show_list")
       h[:title] = _("Show all %{label}") % {:label => label}
       h[:explorer] = true
@@ -826,7 +826,7 @@ module VmHelper::TextualSummary
 
   def textual_devices
     h = {:label    => _("Devices"),
-         :image    => "devices",
+         :image    => "100/devices.png",
          :explorer => true,
          :value    => (@devices.nil? || @devices.empty? ? _("None") : @devices.length)}
     if @devices.length > 0

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -126,7 +126,7 @@ module VmHelper::TextualSummary
     if vendor.blank?
       h[:value] = _("None")
     else
-      h[:image] = "vendor-#{vendor}"
+      h[:image] = "100/vendor-#{vendor}.png"
       h[:title] = _("Show VMM container information")
       h[:explorer] = true
       h[:link]  = url_for(:action => 'show', :id => @record, :display => 'hv_info')

--- a/app/views/shared/summary/_icon_or_image.html.haml
+++ b/app/views/shared/summary/_icon_or_image.html.haml
@@ -1,0 +1,4 @@
+- if item[:icon]
+  %i{:class => item[:icon], :title => item[:title]}
+- elsif item[:image]
+  = image_tag(image_path(item[:image]), :alt => item[:title], :title => item[:title])

--- a/app/views/shared/summary/_textual.html.haml
+++ b/app/views/shared/summary/_textual.html.haml
@@ -20,6 +20,5 @@
         %td.label
           = item[:label]
         %td
-          - if item[:image]
-            %img{:src => image_path("100/#{item[:image]}#{File.extname(item[:image]).blank? ? '.png' : ''}")}
+          = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
           = !item[:value].kind_of?(Array) ? item[:value] : render(:partial => "shared/summary/textual_multivalue", :locals => {:items => item[:value]})

--- a/app/views/shared/summary/_textual_multilink.html.haml
+++ b/app/views/shared/summary/_textual_multilink.html.haml
@@ -8,14 +8,12 @@
       - items.each do |item|
         %tr{:class => 'no-hover'}
           %td{:class => 'hover'}
-            - if item[:image]
-              %img{:src => image_path("100/#{item[:image]}.png")}
+            = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
             = item[:value]
           - item[:sub_items].each do |sub_item|
             %td{:class => sub_item[:link] ? 'hover' : '',
                 :style => sub_item[:link] ? 'cursor: pointer; cursor: hand;' : '',
                 :title => sub_item[:title],
                 :onclick => sub_item[:link] ? "DoNav('#{sub_item[:link]}');" : ""}
-              - unless sub_item[:image].blank?
-                %img{:src => image_path("100/#{sub_item[:image]}.png")}
+              = render :partial => "shared/summary/icon_or_image", :locals => {:item => sub_item}
               = sub_item[:value]

--- a/app/views/shared/summary/_textual_multivalue.html.haml
+++ b/app/views/shared/summary/_textual_multivalue.html.haml
@@ -4,6 +4,5 @@
         :title => item[:title] ? item[:title] : "",
         :onclick => item[:link] ? "DoNav('#{item[:link]}');" : ""}
       %td{:style => "border: 0; margin: 0; padding: 0"}
-        - if item[:image]
-          %img{:src => image_path("100/#{item[:image]}.png")}
+        = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
         = item[:value]

--- a/app/views/shared/summary/_textual_tags.html.haml
+++ b/app/views/shared/summary/_textual_tags.html.haml
@@ -14,13 +14,12 @@
                 %td.label{:rowspan => item[:value].length}
                   = item[:label]
               %td
-                %img{:src => image_path("100/#{subitem[:image]}.png")}
+                = render :partial => "shared/summary/icon_or_image", :locals => {:item => subitem}
                 = "#{subitem[:label]}: #{subitem[:value].collect { |t| h(t) }.join("&nbsp;<b>|</b>&nbsp;")}".html_safe
         - else
           %tr
             %td.label
               = item[:label]
             %td
-              - if item[:image]
-                %img{:src => image_path("100/#{item[:image]}.png")}
-                = item[:value]
+              = render :partial => "shared/summary/icon_or_image", :locals => {:item => item}
+              = item[:value]

--- a/spec/helpers/catalog_helper/textual_summary_spec.rb
+++ b/spec/helpers/catalog_helper/textual_summary_spec.rb
@@ -7,7 +7,7 @@ describe CatalogHelper::TextualSummary do
     it 'returns Hash if no tags found' do
       tag = textual_tags
       expect(tag[:label]).to eq(_("%{name} Tags") % {:name => session[:customer_name]})
-      expect(tag[:image]).to eq("smarttag")
+      expect(tag[:image]).to eq("100/smarttag.png")
       expect(tag[:value]).to eq(_("No %{label} Tags have been assigned") % {:label => session[:customer_name]})
     end
   end
@@ -26,7 +26,7 @@ describe CatalogHelper::TextualSummary do
       tag = textual_tags
       expect(tag[:label]).to eq(_("%{name} Tags") % {:name => session[:customer_name]})
       expect(tag[:value]).to be_a_kind_of(Array)
-      expect(tag[:value].first).to eq(:image => "smarttag", :label => "Label", :value => ["Value"])
+      expect(tag[:value].first).to eq(:image => "100/smarttag.png", :label => "Label", :value => ["Value"])
     end
   end
 end

--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -18,7 +18,7 @@ describe ComplianceSummaryHelper do
       @record.compliances = [@compliance1]
       date = @compliance1.timestamp
       expect(helper.textual_compliance_status).to eq(:label    => "Status",
-                                                     :image    => "check",
+                                                     :image    => "100/check.png",
                                                      :value    => "Compliant as of #{time_ago_in_words(date.in_time_zone(Time.zone)).titleize} Ago",
                                                      :title    => "Show Details of Compliance Check on #{format_timezone(date)}",
                                                      :explorer => true,
@@ -28,7 +28,7 @@ describe ComplianceSummaryHelper do
     it "#textual_compliance_history" do
       @record.compliances = [@compliance1, @compliance2]
       expect(helper.textual_compliance_history).to eq(:label    => "History",
-                                                      :image    => "compliance",
+                                                      :image    => "100/compliance.png",
                                                       :value    => "Available",
                                                       :explorer => true,
                                                       :title    => "Show Compliance History of this VM or Template (Last 10 Checks)",
@@ -46,7 +46,7 @@ describe ComplianceSummaryHelper do
       @record.compliances = [@compliance1]
       date = @compliance1.timestamp
       expect(helper.textual_compliance_status).to eq(:label => "Status",
-                                                     :image => "check",
+                                                     :image => "100/check.png",
                                                      :value => "Compliant as of #{time_ago_in_words(date.in_time_zone(Time.zone)).titleize} Ago",
                                                      :title => "Show Details of Compliance Check on #{format_timezone(date)}",
                                                      :link  => "/host/show?count=1&display=compliance_history")
@@ -55,7 +55,7 @@ describe ComplianceSummaryHelper do
     it "#textual_compliance_history" do
       @record.compliances = [@compliance1, @compliance2]
       expect(helper.textual_compliance_history).to eq(:label => "History",
-                                                      :image => "compliance",
+                                                      :image => "100/compliance.png",
                                                       :value => "Available",
                                                       :title => "Show Compliance History of this Host / Node (Last 10 Checks)",
                                                       :link  => "/host/show?display=compliance_history")


### PR DESCRIPTION
Until now, textual summaries could return a hash with `{:image => "foo"}`, which would resolve to `100/foo.png` and get shown.

This changes the `:image` to be compatible with what `@record.decorate.listicon_image` returns - so now it must include the path and the extension, but makes it possible to simply offload that to the decorator.

Also, this unifies the code that actually shows that image to a common partial (`shared/summary/_icon_or_image`), which handles both images (`:image`) and fonticons (`:icon`), preferring fonticons if available.

https://www.pivotaltracker.com/n/projects/1613907/stories/123185371

(Also fixes a small bug introduced during haml conversion in #1301.)