### PR TITLE
[WIP] Toolbar refactoring: Simple buttons without Rbac check

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -51,7 +51,7 @@ class ApplicationHelper::Button::Basic < Hash
   # are not `nil`
   def all_instance_variables_set
     self.class.instance_variables_required.to_a.all? do |instance_variable|
-      instance_variable_get("#{instance_variable}").present?
+      instance_variable_get(instance_variable.to_s).present?
     end
   end
   private :all_instance_variables_set
@@ -59,7 +59,7 @@ class ApplicationHelper::Button::Basic < Hash
   def skipped?
     return true unless role_allows_feature?
     return true unless all_instance_variables_set
-    return !visible?
+    !visible?
   end
 
   # Tells whether the button should displayed in the toolbar or not

--- a/app/helpers/application_helper/button/dialog.rb
+++ b/app/helpers/application_helper/button/dialog.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::Dialog < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::Dialog < ApplicationHelper::Button::ButtonWithoutRbacCheck
   needs :@edit
 
   def visible?

--- a/app/helpers/application_helper/button/dialog_action.rb
+++ b/app/helpers/application_helper/button/dialog_action.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::DialogAction < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::DialogAction < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def visible?
     !@edit || !@edit[:current]
   end

--- a/app/helpers/application_helper/button/miq_capacity.rb
+++ b/app/helpers/application_helper/button/miq_capacity.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqCapacity < ApplicationHelper::Button::Basic
+  def visible?
+    @view_context.sandbox[:active_tab] == 'report'
+  end
+end

--- a/app/helpers/application_helper/button/miq_request_reload.rb
+++ b/app/helpers/application_helper/button/miq_request_reload.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqRequestReload < ApplicationHelper::Button::Basic
+  def visible?
+    @lastaction == 'show_list' || @showtype == 'miq_provisions'
+  end
+end

--- a/app/helpers/application_helper/button/miq_task_canceljob.rb
+++ b/app/helpers/application_helper/button/miq_task_canceljob.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::MiqTaskCanceljob < ApplicationHelper::Button::ButtonWithoutRbacCheck
+  def visible?
+    !%w(all_tasks all_ui_tasks).include?(@layout)
+  end
+end

--- a/app/helpers/application_helper/toolbar/compare_view.rb
+++ b/app/helpers/application_helper/toolbar/compare_view.rb
@@ -27,13 +27,15 @@ class ApplicationHelper::Toolbar::CompareView < ApplicationHelper::Toolbar::Basi
           'fa fa-file-text-o fa-lg',
           N_('Download comparison report in text format'),
           N_('Download as Text'),
-          :url => "/compare_to_txt"),
+          :url   => "/compare_to_txt",
+          :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :compare_download_csv,
           'fa fa-file-text-o fa-lg',
           N_('Download comparison report in CSV format'),
           N_('Download as CSV'),
-          :url => "/compare_to_csv"),
+          :url   => "/compare_to_csv",
+          :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :compare_download_pdf,
           'fa fa-file-pdf-o fa-lg',

--- a/app/helpers/application_helper/toolbar/drift_view.rb
+++ b/app/helpers/application_helper/toolbar/drift_view.rb
@@ -11,7 +11,8 @@ class ApplicationHelper::Toolbar::DriftView < ApplicationHelper::Toolbar::Basic
       'fa fa-bars fa-rotate-90 fa-lg',
       N_('Compressed View'),
       nil,
-      :url => "drift_compress"),
+      :url   => "drift_compress",
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
   ])
   button_group('drift_downloading', [
     select(
@@ -25,13 +26,15 @@ class ApplicationHelper::Toolbar::DriftView < ApplicationHelper::Toolbar::Basic
           'fa fa-file-text-o fa-lg',
           N_('Download comparison report in text format'),
           N_('Download as Text'),
-          :url => "/drift_to_txt"),
+          :url   => "/drift_to_txt",
+          :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :drift_download_csv,
           'fa fa-file-text-o fa-lg',
           N_('Download comparison report in CSV format'),
           N_('Download as CSV'),
-          :url => "/drift_to_csv"),
+          :url   => "/drift_to_csv",
+          :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :drift_download_pdf,
           'fa fa-file-pdf-o fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb
@@ -6,6 +6,7 @@ class ApplicationHelper::Toolbar::MiqAeToolsSimulateCenter < ApplicationHelper::
       N_('Copy object details for use in a Button'),
       N_('Copy'),
       :url       => "resolve",
-      :url_parms => "?button=copy"),
+      :url_parms => "?button=copy",
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
   ])
 end

--- a/app/helpers/application_helper/toolbar/miq_capacity_view.rb
+++ b/app/helpers/application_helper/toolbar/miq_capacity_view.rb
@@ -13,14 +13,16 @@ class ApplicationHelper::Toolbar::MiqCapacityView < ApplicationHelper::Toolbar::
           N_('Download this report in text format'),
           N_('Download as Text'),
           :url       => "/\#{x_active_tree == :utilization_tree ? \"util_report\" : \"planning_report\"}_download",
-          :url_parms => "?typ=txt"),
+          :url_parms => "?typ=txt",
+          :klass     => ApplicationHelper::Button::MiqCapacity),
         button(
           :miq_capacity_download_csv,
           'fa fa-file-text-o fa-lg',
           N_('Download this report in CSV format'),
           N_('Download as CSV'),
           :url       => "/\#{x_active_tree == :utilization_tree ? \"util_report\" : \"planning_report\"}_download",
-          :url_parms => "?typ=csv"),
+          :url_parms => "?typ=csv",
+          :klass     => ApplicationHelper::Button::MiqCapacity),
         button(
           :miq_capacity_download_pdf,
           'fa fa-file-pdf-o fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_request_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_request_center.rb
@@ -26,7 +26,8 @@ class ApplicationHelper::Toolbar::MiqRequestCenter < ApplicationHelper::Toolbar:
       'fa fa-repeat fa-lg',
       N_('Reload the current display'),
       N_('Reload'),
-      :url_parms => "&display=miq_provisions"),
+      :url_parms => "&display=miq_provisions",
+      :klass     => ApplicationHelper::Button::MiqRequestReload),
   ])
   button_group('miq_request_approve', [
     button(

--- a/app/helpers/application_helper/toolbar/miq_requests_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_requests_center.rb
@@ -5,6 +5,7 @@ class ApplicationHelper::Toolbar::MiqRequestsCenter < ApplicationHelper::Toolbar
       'fa fa-repeat fa-lg',
       N_('Reload the current display'),
       N_('Reload'),
-      :url_parms => "main_div"),
+      :url_parms => "main_div",
+      :klass     => ApplicationHelper::Button::MiqRequestReload),
   ])
 end

--- a/app/helpers/application_helper/toolbar/tasks_center.rb
+++ b/app/helpers/application_helper/toolbar/tasks_center.rb
@@ -5,7 +5,8 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
       'fa fa-repeat fa-lg',
       N_('Reload the current display'),
       N_('Reload'),
-      :url_parms => "main_div"),
+      :url_parms => "main_div",
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
   ])
   button_group('miq_task_delete', [
     select(
@@ -23,7 +24,8 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected tasks will be permanently removed from the database!"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :miq_task_deleteolder,
           'pficon pficon-delete fa-lg',
@@ -32,7 +34,8 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           :url_parms => "main_div",
           :confirm   => N_("Warning: Tasks that are older than selected task will be permanently removed from the database!"),
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
         button(
           :miq_task_deleteall,
           'pficon pficon-delete fa-lg',
@@ -40,7 +43,8 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete All'),
           :url_parms => "main_div",
           :confirm   => N_("Warning: Finished tasks will be permanently removed from the database!"),
-          :enabled   => true),
+          :enabled   => true,
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck),
       ]
     ),
   ])
@@ -53,6 +57,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
       :url_parms => "main_div",
       :confirm   => N_("Warning: The selected task will be cancelled. Are you sure you want to cancel the task?"),
       :enabled   => false,
-      :onwhen    => "1"),
+      :onwhen    => "1",
+      :klass     => ApplicationHelper::Button::MiqTaskCanceljob),
   ])
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -430,9 +430,6 @@ class ApplicationHelper::ToolbarBuilder
     return true if id.ends_with?("_new", "_discover") &&
                    @lastaction == "show" && !["main", "vms"].include?(@display)
 
-    # user can see the buttons if they can get to Policy RSOP/Automate Simulate screen
-    return false if ["miq_ae_tools"].include?(@layout)
-
     return false if id == "miq_request_reload" && # Show the request reload button
                     (@lastaction == "show_list" || @showtype == "miq_provisions")
 
@@ -449,7 +446,7 @@ class ApplicationHelper::ToolbarBuilder
                      id !~ /^history_\d*/ &&
                      !(id == "show_summary" && !@explorer) && id != "summary_reload"
                      !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",
-                                      "custom_")
+                                      "custom_") && @layout != 'miq_ae_tools'
     end
 
     # Check buttons with other restriction logic

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -433,12 +433,6 @@ class ApplicationHelper::ToolbarBuilder
     # user can see the buttons if they can get to Policy RSOP/Automate Simulate screen
     return false if ["miq_ae_tools"].include?(@layout)
 
-    # buttons on compare/drift screen are allowed if user has access to compare/drift
-    return false if id.starts_with?("compare_", "drift_", "comparemode_", "driftmode_")
-
-    # Allow custom buttons on CI show screen, user can see custom button if they can get to show screen
-    return false if id.starts_with?("custom_")
-
     return false if id == "miq_request_reload" && # Show the request reload button
                     (@lastaction == "show_list" || @showtype == "miq_provisions")
 
@@ -453,8 +447,9 @@ class ApplicationHelper::ToolbarBuilder
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) && !["miq_request_approve", "miq_request_deny"].include?(id) &&
                      id !~ /^history_\d*/ &&
-                     !id.starts_with?("dialog_") && !id.starts_with?("miq_task_") &&
                      !(id == "show_summary" && !@explorer) && id != "summary_reload"
+                     !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",
+                                      "custom_")
     end
 
     # Check buttons with other restriction logic

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -435,20 +435,8 @@ class ApplicationHelper::ToolbarBuilder
       return res
     end
 
-    # don't check for feature RBAC if id is miq_request_approve/deny
-    unless %w(miq_policy catalogs).include?(@layout)
-      return true if !role_allows?(:feature => id) &&
-                     !["miq_request_approve", "miq_request_deny", "miq_request_reload"].include?(id) &&
-                     !(id == "show_summary" && !@explorer) && id != "summary_reload"
-                     !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",
-                                      "custom_") && @layout != 'miq_ae_tools' &&
-                     !(id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report")
-    end
-
     # Check buttons with other restriction logic
     case id
-    when "miq_task_canceljob"
-      return true unless ["all_tasks", "all_ui_tasks"].include?(@layout)
     when "vm_console"
       type = ::Settings.server.remote_console_type
       return type != 'MKS' || !@record.console_supported?(type)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -439,7 +439,6 @@ class ApplicationHelper::ToolbarBuilder
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) &&
                      !["miq_request_approve", "miq_request_deny", "miq_request_reload"].include?(id) &&
-                     id !~ /^history_\d*/ &&
                      !(id == "show_summary" && !@explorer) && id != "summary_reload"
                      !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",
                                       "custom_") && @layout != 'miq_ae_tools' &&

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -435,8 +435,6 @@ class ApplicationHelper::ToolbarBuilder
       return res
     end
 
-    return false if id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report"
-
     # don't check for feature RBAC if id is miq_request_approve/deny
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) &&
@@ -444,7 +442,8 @@ class ApplicationHelper::ToolbarBuilder
                      id !~ /^history_\d*/ &&
                      !(id == "show_summary" && !@explorer) && id != "summary_reload"
                      !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",
-                                      "custom_") && @layout != 'miq_ae_tools'
+                                      "custom_") && @layout != 'miq_ae_tools' &&
+                     !(id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report")
     end
 
     # Check buttons with other restriction logic

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -430,9 +430,6 @@ class ApplicationHelper::ToolbarBuilder
     return true if id.ends_with?("_new", "_discover") &&
                    @lastaction == "show" && !["main", "vms"].include?(@display)
 
-    return false if id == "miq_request_reload" && # Show the request reload button
-                    (@lastaction == "show_list" || @showtype == "miq_provisions")
-
     if @layout == "ops"
       res = hide_button_ops(id)
       return res
@@ -442,7 +439,8 @@ class ApplicationHelper::ToolbarBuilder
 
     # don't check for feature RBAC if id is miq_request_approve/deny
     unless %w(miq_policy catalogs).include?(@layout)
-      return true if !role_allows?(:feature => id) && !["miq_request_approve", "miq_request_deny"].include?(id) &&
+      return true if !role_allows?(:feature => id) &&
+                     !["miq_request_approve", "miq_request_deny", "miq_request_reload"].include?(id) &&
                      id !~ /^history_\d*/ &&
                      !(id == "show_summary" && !@explorer) && id != "summary_reload"
                      !id.starts_with?("dialog_", "miq_task_", "compare_", "drift_", "comparemode_", "driftmode_",

--- a/spec/helpers/application_helper/buttons/miq_capacity_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_capacity_spec.rb
@@ -1,0 +1,16 @@
+describe ApplicationHelper::Button::MiqCapacity do
+  let(:view_context) { setup_view_context_with_sandbox(:active_tab => tab) }
+  let(:button) { described_class.new(view_context, {}, {}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+    context 'when active_tab == report' do
+      let(:tab) { 'report' }
+      it { is_expected.to be_truthy }
+    end
+    context 'when active_tab != report' do
+      let(:tab) { 'not_report' }
+      it { is_expected.to be_falsey }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/miq_request_reload_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_reload_spec.rb
@@ -1,0 +1,29 @@
+describe ApplicationHelper::Button::MiqRequestReload do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:action) { 'not_show_list' }
+  let(:type) { 'not_miq_provisions' }
+  let(:button) { described_class.new(view_context, {}, {'lastaction' => action, 'showtype' => type}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+    context 'when lastaction != show_list' do
+      context 'showtype != miq_provisions' do
+        it { is_expected.to be_falsey }
+      end
+      context 'and showtype == miq_provisions' do
+        let(:type) { 'miq_provisions' }
+        it { is_expected.to be_truthy }
+      end
+    end
+    context 'when lastaction == show_list' do
+      let(:action) { 'show_list' }
+      context 'and showtype != miq_provisions' do
+        it { is_expected.to be_truthy }
+      end
+      context 'and showtype == miq_provisions' do
+        let(:type) { 'miq_provisions' }
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_task_canceljob_spec.rb
@@ -1,0 +1,17 @@
+describe ApplicationHelper::Button::MiqTaskCanceljob do
+  let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'layout' => layout}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+    %w(all_tasks all_ui_tasks).each do |layout|
+      context "when layout == #{layout}" do
+        let(:layout) { layout }
+        it { is_expected.to be_falsey }
+      end
+    end
+    context 'when !layout.in(%w(all_tasks all_ui_tasks))' do
+      let(:layout) { 'something' }
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -183,49 +183,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       }
     end
 
-    it "when id likes old_dialogs_*" do
-      @id = "old_dialogs_some_thing"
-      expect(subject).to be_truthy
-    end
-
-    it "when id likes ab_*" do
-      @id = "ab_some_thing"
-      expect(subject).to be_truthy
-    end
-
-    ["miq_task_", "compare_", "drift_", "comparemode_", "driftmode_", "custom_"].each do |i|
-      it "when id likes #{i}*" do
-        @id = "#{i}some_thing"
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "when with miq_request_reload" do
-      before { @id = "miq_request_reload" }
-      it "and lastaction is show_list" do
-        @lastaction = "show_list"
-        expect(subject).to be_falsey
-      end
-
-      it "and lastaction is not show_list" do
-        @lastaction = "log"
-        expect(subject).to be_truthy
-      end
-    end
-
-    context "when with miq_request_reload" do
-      before { @id = "miq_request_reload" }
-      it "and showtype is miq_provisions" do
-        @showtype = "miq_provisions"
-        expect(subject).to be_falsey
-      end
-
-      it "and showtype is not miq_provisions" do
-        @showtype = "compare"
-        expect(subject).to be_truthy
-      end
-    end
-
     it "when id likes dialog_*" do
       @id = "dialog_some_thing"
       expect(subject).to be_falsey
@@ -243,11 +200,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       # when the role allows the feature
       stub_user(:features => :all)
       expect(subject).to be_falsey
-    end
-
-    it "when not with miq_request_approve or miq_request_deny and not allowed by the role" do
-      @id = "miq_request_edit"
-      expect(subject).to be_truthy
     end
 
     ["ems_cluster_protect", "ext_management_system_protect",
@@ -273,33 +225,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       it "when with #{id}" do
         @id = id
         stub_user(:features => :all)
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "when with miq_task_canceljob" do
-      before do
-        @id = 'miq_task_canceljob'
-        stub_user(:features => :all)
-      end
-
-      it "and @layout != all_tasks" do
-        @layout = "x_tasks"
-        expect(subject).to be_truthy
-      end
-
-      it "and @layout != all_ui_tasks" do
-        @layout = "x_ui_tasks"
-        expect(subject).to be_truthy
-      end
-
-      it "and @layout = all_tasks" do
-        @layout = "all_tasks"
-        expect(subject).to be_falsey
-      end
-
-      it "and @layout = all_ui_tasks" do
-        @layout = "all_ui_tasks"
         expect(subject).to be_falsey
       end
     end
@@ -424,20 +349,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
       end
     end
 
-    context "CustomButtonSet" do
-      before do
-        @record = CustomButtonSet.new
-        @sb = {:active_tree => :sandt_tree}
-      end
-
-      %w(ab_button_new ab_group_edit ab_group_delete).each do |id|
-        it "hides #{id} action from toolbar when user has view permission only" do
-          @id = id
-          expect(subject).to be_truthy
-        end
-      end
-    end
-
     context "when with Host" do
       before do
         @record = Host.new
@@ -452,35 +363,6 @@ describe ApplicationHelper, "::ToolbarBuilder" do
 
         it "and lastaction = drift_history" do
           expect(subject).to be_falsey
-        end
-      end
-    end
-
-    context "ServiceTemplate" do
-      before do
-        @record = ServiceTemplate.new
-        @sb = {:active_tree => :sandt_tree}
-      end
-
-      %w(ab_button_new ab_group_new catalogitem_edit catalogitem_delete).each do |id|
-        it "hides #{id} action from toolbar when user has view permission only" do
-          @id = id
-          expect(subject).to be_truthy
-        end
-      end
-    end
-
-    context "when record class = ExtManagementSystem" do
-      before do
-        @record = FactoryGirl.create(:ems_amazon)
-      end
-
-      context "and id = ems_cloud_timeline" do
-        before { @id = "ems_cloud_timeline" }
-
-        it "hide timelines button for EC2 provider" do
-          allow(@record).to receive(:has_events?).and_return(false)
-          expect(subject).to be_truthy
         end
       end
     end


### PR DESCRIPTION
| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| miq_task_canceljob | MiqTaskCancelJob < ButtonWithoutRbacCheck |

TODO: Remove spec examples

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135859475