### PR TITLE
Toolbar refactoring  ems network

### DIFF
--- a/app/helpers/application_helper/button/ems_network.rb
+++ b/app/helpers/application_helper/button/ems_network.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsNetwork < ApplicationHelper::Button::Basic
+  def visible?
+    ::Settings.product.nuage
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -22,7 +22,8 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
           :ems_network_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Network Provider'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::EmsNetwork),
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -21,7 +21,8 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a New Network Provider'),
           t,
-          :url => "/new"),
+          :url   => "/new",
+          :klass => ApplicationHelper::Button::EmsNetwork),
         button(
           :ems_network_edit,
           'pficon pficon-edit fa-lg',
@@ -29,7 +30,8 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
           N_('Edit Selected Network Provider'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass     => ApplicationHelper::Button::EmsNetwork),
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -550,8 +550,6 @@ class ApplicationHelper::ToolbarBuilder
 
     return false if id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report"
 
-    return true if %w(ems_network_new ems_network_edit).include?(id) && ::Settings.product.nuage != true
-
     # don't check for feature RBAC if id is miq_request_approve/deny
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) && !["miq_request_approve", "miq_request_deny"].include?(id) &&

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -329,20 +329,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with ems_network_new" do
-      it "with product nuage not set to true" do
-        @id = 'ems_network_new'
-        expect(subject).to be_truthy
-      end
-    end
-
-    context "when with ems_network_edit" do
-      it "with product nuage not set to true" do
-        @id = 'ems_network_edit'
-        expect(subject).to be_truthy
-      end
-    end
-
     context "when with miq_task_canceljob" do
       before do
         @id = 'miq_task_canceljob'


### PR DESCRIPTION
Refactored `ems_network` buttons. Spec file has not been created because stubbing the visibility condition has been found difficult.

| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| ems_network_new, ems_network_edit | EmsNetwork < Basic |

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135693047