### PR TITLE
Toolbar refactoring:  EmsInfraScale buttons

### DIFF
--- a/app/helpers/application_helper/button/ems_infra_scale.rb
+++ b/app/helpers/application_helper/button/ems_infra_scale.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::EmsInfraScale < ApplicationHelper::Button::Basic
+  def role_allows_feature?
+    super && role_allows?(:feature => "ems_infra_scale")
+  end
+
+  def visible?
+    @record.class == ManageIQ::Providers::Openstack::InfraManager && @record.orchestration_stacks.count != 0
+  end
+end

--- a/app/helpers/application_helper/button/ems_infra_scale.rb
+++ b/app/helpers/application_helper/button/ems_infra_scale.rb
@@ -1,8 +1,4 @@
 class ApplicationHelper::Button::EmsInfraScale < ApplicationHelper::Button::Basic
-  def role_allows_feature?
-    super && role_allows?(:feature => "ems_infra_scale")
-  end
-
   def visible?
     @record.class == ManageIQ::Providers::Openstack::InfraManager && @record.orchestration_stacks.count != 0
   end

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -34,13 +34,15 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-edit fa-lg',
           t = N_('Scale this Infrastructure Provider'),
           t,
-          :url => "/scaling"),
+          :url   => "/scaling",
+          :klass => ApplicationHelper::Button::EmsInfraScale),
         button(
           :ems_infra_scaledown,
           'pficon pficon-edit fa-lg',
           t = N_('Scale this Infrastructure Provider down'),
           t,
-          :url => "/scaledown"),
+          :url   => "/scaledown",
+          :klass => ApplicationHelper::Button::EmsInfraScale),
         button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -594,12 +594,6 @@ class ApplicationHelper::ToolbarBuilder
                      @record.hardware.provision_state == "manageable"
     end
 
-    # Scale is only supported by OpenStack Infrastructure Provider
-    return true if (id == "ems_infra_scale" || id == "ems_infra_scaledown") &&
-                   (@record.class != ManageIQ::Providers::Openstack::InfraManager ||
-                    !role_allows?(:feature => "ems_infra_scale") ||
-                   (@record.class == ManageIQ::Providers::Openstack::InfraManager && @record.orchestration_stacks.count == 0))
-
     false  # No reason to hide, allow the button to show
   end
 

--- a/spec/helpers/application_helper/buttons/ems_infra_scale_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_infra_scale_spec.rb
@@ -1,0 +1,22 @@
+describe ApplicationHelper::Button::EmsInfraScale do
+  let(:record) { FactoryGirl.create(:ems_openstack_infra) }
+  let(:button) { described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record}, {}) }
+
+  describe '#visible?' do
+    subject { button.visible? }
+
+    context 'when record is OpenStack Provider' do
+      context 'and orchestration stack is empty' do
+        it { expect(subject).to be_falsey }
+      end
+      context 'and orchestration stack is not empty' do
+        let(:record) { FactoryGirl.create(:ems_openstack_infra_with_stack) }
+        it { expect(subject).to be_truthy }
+      end
+    end
+    context 'when record is not an OpenStack provider' do
+      let(:record) { :ems_redhat }
+      it { expect(subject).to be_falsey }
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -559,50 +559,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when id = ems_infra_scale" do
-      before do
-        @id = "ems_infra_scale"
-      end
-
-      context "when @record = EmsOpenstackInfra" do
-        before do
-          @record = FactoryGirl.create(:ems_openstack_infra_with_stack)
-        end
-
-        it "user allowed" do
-          stub_user(:features => :all)
-          expect(subject).to be_falsey
-        end
-
-        it "user not allowed" do
-          stub_user(:features => :none)
-          expect(subject).to be_truthy
-        end
-
-        it "button hidden if provider has no stacks" do
-          @record = FactoryGirl.create(:ems_openstack_infra)
-          stub_user(:features => :all)
-          expect(subject).to be_truthy
-        end
-      end
-
-      context "when @record != EmsOpenstackInfra" do
-        before do
-          @record = ManageIQ::Providers::Vmware::InfraManager.new
-        end
-
-        it "user allowed but hide button because wrong provider" do
-          stub_user(:features => :all)
-          expect(subject).to be_truthy
-        end
-
-        it "user not allowed" do
-          stub_user(:features => :all)
-          expect(subject).to be_truthy
-        end
-      end
-    end
-
     context "when record class = ExtManagementSystem" do
       before do
         @record = FactoryGirl.create(:ems_amazon)


### PR DESCRIPTION
Refactored `ems_infra_scale` buttons and the related spec examples in `#hide_button?`.

| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| ems_infra_scale, ems_infra_scaledown | EmsInfraScale < Basic |

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/135544827