### PR TITLE
[WIP] Add methods to reduce the size of provision workflow object.

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -43,6 +43,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       show_dialog(:requester, :hide, "disabled")
       show_dialog(:purpose,   :hide, "disabled")
     end
+
+    create_values_methods
   end
 
   def dialog_name_from_automate(message = 'get_dialog_name', extra_attrs = {})

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -109,12 +109,13 @@ class MiqRequestWorkflow
           val = field_values[:default]
         end
 
-        if field_values[:values]
-          if field_values[:values].kind_of?(Hash)
+        possible_values = field_values.key?(:values_from) ? send("#{dialog_name}_#{field_name}_values") : field_values[:values]
+        if possible_values
+          if possible_values.kind_of?(Hash)
             # Save [value, description], skip for timezones array
-            init_values[field_name] = [val, field_values[:values][val]]
+            init_values[field_name] = [val, possible_values[val]]
           else
-            field_values[:values].each do |tz|
+            possible_values.each do |tz|
               if tz[1].to_i_with_method == val.to_i_with_method
                 # Save [value, description] for timezones array
                 init_values[field_name] = [val, tz[0]]
@@ -297,17 +298,17 @@ class MiqRequestWorkflow
     if field.key?(:values_from) && refresh_values
       options = field[:values_from][:options] || {}
       options[:prov_field_name] = field_name
-      field[:values] = send(field[:values_from][:method], options)
 
-      # Reset then currently selected item if it no longer appears in the available values
-      if field[:values].kind_of?(Hash)
-        if field[:values].length == 1
+      field_values = send("#{dialog_name}_#{field_name}_values", options)
+
+      if field_values.kind_of?(Hash)
+        if field_values.length == 1
           unless field[:auto_select_single] == false
-            @values[field_name] = field[:values].to_a.first
+            @values[field_name] = field_values.to_a.first
           end
         else
           currently_selected = get_value(@values[field_name])
-          unless currently_selected.nil? || field[:values].key?(currently_selected)
+          unless currently_selected.nil? || field_values.key?(currently_selected)
             @values[field_name] = [nil, nil]
           end
         end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -9,6 +9,7 @@ describe MiqProvisionWorkflow do
       before do
         server
         dialog
+        Rails.cache.clear
       end
       context "Without a Valid Template," do
         it "should not create an MiqRequest when calling from_ws" do

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -77,6 +77,8 @@ describe MiqRequestWorkflow do
     before do
       values = {:values_from => {:method => :allowed_clusters}}
       dialog.store_path(:dialogs, :environment, :fields, :placement_cluster_name, values)
+      workflow.create_values_methods
+      Rails.cache.clear
     end
 
     it "refreshes value by default" do
@@ -169,6 +171,7 @@ describe MiqRequestWorkflow do
           it "auto-selects single value when true" do
             values[:auto_select_single] = true
             dialogs.store_path(:dialogs, :environment, :fields, :cluster_filter, values)
+            workflow.create_values_methods
             workflow.init_from_dialog(init_values)
 
             expect(init_values).to include(:cluster_filter => [122, 'name not empty'])
@@ -177,6 +180,7 @@ describe MiqRequestWorkflow do
           it "should not auto-select single value when false" do
             values[:auto_select_single] = false
             dialogs.store_path(:dialogs, :environment, :fields, :cluster_filter, values)
+            workflow.create_values_methods
             workflow.init_from_dialog(init_values)
 
             expect(init_values).to include(:cluster_filter => [nil, nil])

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -41,6 +41,7 @@ describe "Provision Requests API" do
         "status"         => "Ok"
       }
     end
+    before { Rails.cache.clear }
 
     it "filters the list of provision requests by requester" do
       other_user = FactoryGirl.create(:user)


### PR DESCRIPTION
The allowed values for the dialog fields are saved as an instance variable in the provision workflow. 
The session size gets bigger when the size of the workflow object increases in a big environment.

This PR removes the allowed field values from the instance variable and put them into methods that get all the possible values for the fields and use Rails cache to store the values.   

The UI change is in https://github.com/ManageIQ/manageiq-ui-classic/pull/52.

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1364135