### PR TITLE
Remove 'cache_with_timeout' for settings in 'infra_manager' and 'vm_or_template'

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -24,23 +24,13 @@ module ManageIQ::Providers
     #     :service
     #        :read_timeout: 1.hour
     #
-    cache_with_timeout(:ems_config, 2.minutes) { ::Settings.ems }
-
     def self.ems_timeouts(type, service = nil)
-      read_timeout = open_timeout = nil
-      if ems_config[type]
-        if service
-          if ems_config[type][service.downcase.to_sym]
-            config       = ems_config[type][service.downcase.to_sym]
-            read_timeout = config[:read_timeout] if config[:read_timeout]
-            open_timeout = config[:open_timeout] if config[:open_timeout]
-          end
-        end
-        read_timeout = ems_config[type][:read_timeout] if read_timeout.nil?
-        open_timeout = ems_config[type][:open_timeout] if open_timeout.nil?
-      end
-      read_timeout = read_timeout.to_i_with_method if read_timeout
-      open_timeout = open_timeout.to_i_with_method if open_timeout
+      ems_settings = ::Settings.ems[type]
+      return [nil, nil] unless ems_settings
+
+      service = service.try(:downcase)
+      read_timeout = ems_settings.fetch_path([service, :read_timeout].compact).try(:to_i_with_method)
+      open_timeout = ems_settings.fetch_path([service, :open_timeout].compact).try(:to_i_with_method)
       [read_timeout, open_timeout]
     end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -863,12 +863,8 @@ class VmOrTemplate < ApplicationRecord
     self.class.proxy_host_for_repository_scans
   end
 
-  cache_with_timeout(:scan_via_host?, 30.seconds) do
-    ::Settings.coresident_miqproxy.scan_via_host
-  end
-
   def self.scan_via_ems?
-    !self.scan_via_host?
+    !::Settings.coresident_miqproxy.scan_via_host
   end
 
   delegate :scan_via_ems?, :to => :class

--- a/spec/models/manageiq/providers/ems_infra_spec.rb
+++ b/spec/models/manageiq/providers/ems_infra_spec.rb
@@ -1,0 +1,25 @@
+describe EmsInfra do
+  it ".types" do
+    expected_types = [ManageIQ::Providers::Vmware::InfraManager,
+                      ManageIQ::Providers::Redhat::InfraManager,
+                      ManageIQ::Providers::Microsoft::InfraManager,
+                      ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
+    expect(described_class.types).to match_array(expected_types)
+  end
+
+  it ".supported_subclasses" do
+    expected_subclasses = [ManageIQ::Providers::Vmware::InfraManager,
+                           ManageIQ::Providers::Microsoft::InfraManager,
+                           ManageIQ::Providers::Redhat::InfraManager,
+                           ManageIQ::Providers::Openstack::InfraManager]
+    expect(described_class.supported_subclasses).to match_array(expected_subclasses)
+  end
+
+  it ".supported_types" do
+    expected_types = [ManageIQ::Providers::Vmware::InfraManager,
+                      ManageIQ::Providers::Microsoft::InfraManager,
+                      ManageIQ::Providers::Redhat::InfraManager,
+                      ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
+    expect(described_class.supported_types).to match_array(expected_types)
+  end
+end

--- a/spec/models/manageiq/providers/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager_spec.rb
@@ -2,14 +2,14 @@ describe ManageIQ::Providers::InfraManager do
   describe ".ems_timeouts" do
     before do
       stub_settings(:ems => {:ems_amazon => {},
-                             :ems_redhat => {:inventory => {:read_timeout => 5.hours}}})
+                             :ems_redhat => {:inventory => {:read_timeout => "5.hours"}}})
     end
 
     it "returns [nil,nil] if provider not present in settings.yml under :ems:" do
       expect(described_class.ems_timeouts(:hello_world)).to eq [nil, nil]
     end
 
-    it "returns [nil, nil] if provider entry exists in settings.yml but no timeout specifyied" do
+    it "returns [nil, nil] if provider entry exists in settings.yml but no timeout specified" do
       expect(described_class.ems_timeouts(:ems_amazon)).to eq [nil, nil]
     end
 
@@ -18,11 +18,11 @@ describe ManageIQ::Providers::InfraManager do
     end
 
     it "returns timeouts if there are specified and service passed to the method" do
-      expect(described_class.ems_timeouts(:ems_redhat, :inventory)).to eq [5 * 60 * 60, nil]
+      expect(described_class.ems_timeouts(:ems_redhat, :inventory)).to eq [5.hours, nil]
     end
 
     it "supports case insensitivity for keys in settings.yml" do
-      expect(described_class.ems_timeouts(:ems_redhat, :InVentory)).to eq [5 * 60 * 60, nil]
+      expect(described_class.ems_timeouts(:ems_redhat, :InVentory)).to eq [5.hours, nil]
     end
   end
 end

--- a/spec/models/manageiq/providers/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager_spec.rb
@@ -1,16 +1,28 @@
-describe EmsInfra do
-  it ".types" do
-    expected_types = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
-    expect(described_class.types).to match_array(expected_types)
-  end
+describe ManageIQ::Providers::InfraManager do
+  describe ".ems_timeouts" do
+    before do
+      stub_settings(:ems => {:ems_amazon => {},
+                             :ems_redhat => {:inventory => {:read_timeout => 5.hours}}})
+    end
 
-  it ".supported_subclasses" do
-    expected_subclasses = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Openstack::InfraManager]
-    expect(described_class.supported_subclasses).to match_array(expected_subclasses)
-  end
+    it "returns [nil,nil] if provider not present in settings.yml under :ems:" do
+      expect(described_class.ems_timeouts(:hello_world)).to eq [nil, nil]
+    end
 
-  it ".supported_types" do
-    expected_types = [ManageIQ::Providers::Vmware::InfraManager, ManageIQ::Providers::Microsoft::InfraManager, ManageIQ::Providers::Redhat::InfraManager, ManageIQ::Providers::Openstack::InfraManager].collect(&:ems_type)
-    expect(described_class.supported_types).to match_array(expected_types)
+    it "returns [nil, nil] if provider entry exists in settings.yml but no timeout specifyied" do
+      expect(described_class.ems_timeouts(:ems_amazon)).to eq [nil, nil]
+    end
+
+    it "returns [nil, nil] if timeout settings for provider exist but no service passed to the method" do
+      expect(described_class.ems_timeouts(:ems_redhat)).to eq [nil, nil]
+    end
+
+    it "returns timeouts if there are specified and service passed to the method" do
+      expect(described_class.ems_timeouts(:ems_redhat, :inventory)).to eq [5 * 60 * 60, nil]
+    end
+
+    it "supports case insensitivity for keys in settings.yml" do
+      expect(described_class.ems_timeouts(:ems_redhat, :InVentory)).to eq [5 * 60 * 60, nil]
+    end
   end
 end


### PR DESCRIPTION
Instead of caching configuration parameter call ::Settings directly since there are already in memory.

@miq-bot add-label wip, core, performance, technical debt