### PR TITLE
Fetch the user from the workspace object.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -17,7 +17,7 @@ module MiqAeMethodService
     private
 
     def ae_user_identity
-      @ae_user = DRb.front.workspace.ae_user
+      @ae_user = MiqAeEngine::DrbRemoteInvoker.workspace.ae_user
       ar_method { @object.ae_user_identity(@ae_user, @ae_user.current_group, @ae_user.current_tenant) }
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -1,7 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceVm < MiqAeServiceVmOrTemplate
     def remote_console_url=(url)
-      object_send(:remote_console_url=, url, DRb.front.workspace.ae_user.id)
+      object_send(:remote_console_url=, url, MiqAeEngine::DrbRemoteInvoker.workspace.ae_user.id)
     end
 
     def add_to_service(service)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
@@ -12,9 +12,7 @@ module MiqAeServiceGenericObjectSpec
         :generic_object_definition,
         :name       => "test_definition",
         :properties => {
-          :attributes   => {},
-          :associations => {},
-          :methods      => [method_name]
+          :methods => [method_name]
         }
       )
     end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
@@ -36,14 +36,14 @@ module MiqAeServiceGenericObjectSpec
     end
 
     let(:options) do
-     { :object_type   => "GenericObject",
-       :object_id     => go.id,
-       :instance_name => "GenericObject",
-       :user_id       => user.id,
-       :miq_group_id  => user.current_group.id,
-       :tenant_id     => user.current_tenant.id,
-       :attrs         => {:method_name => method_name}
-     }
+      { :object_type   => "GenericObject",
+        :object_id     => go.id,
+        :instance_name => "GenericObject",
+        :user_id       => user.id,
+        :miq_group_id  => user.current_group.id,
+        :tenant_id     => user.current_tenant.id,
+        :attrs         => {:method_name => method_name}
+      }
     end
 
     describe "call method on generic object" do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
@@ -33,23 +33,20 @@ module MiqAeServiceGenericObjectSpec
                    :root               => {})
     end
 
-    let(:options) do
-      { :object_type   => "GenericObject",
-        :object_id     => go.id,
-        :instance_name => "GenericObject",
-        :user_id       => user.id,
-        :miq_group_id  => user.current_group.id,
-        :tenant_id     => user.current_tenant.id,
-        :attrs         => {:method_name => method_name}
-      }
-    end
-
     describe "call method on generic object" do
       before do
         allow(MiqAeEngine::DrbRemoteInvoker).to receive('workspace').and_return(workspace)
       end
 
       it "calls into automate" do
+        options = { :object_type   => "GenericObject",
+                    :object_id     => go.id,
+                    :instance_name => "GenericObject",
+                    :user_id       => user.id,
+                    :miq_group_id  => user.current_group.id,
+                    :tenant_id     => user.current_tenant.id,
+                    :attrs         => {:method_name => method_name}
+                  }
         svc_obj = MiqAeMethodService::MiqAeServiceGenericObject.find(go.id)
         expect(MiqAeEngine).to receive('deliver').with(options).and_return(workspace)
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_generic_object_spec.rb
@@ -6,6 +6,58 @@ module MiqAeServiceGenericObjectSpec
     let(:service_service)  { MiqAeMethodService::MiqAeServiceService.find(service.id) }
     let(:service2)         { FactoryGirl.create(:service) }
     let(:service_service2) { MiqAeMethodService::MiqAeServiceService.find(service2.id) }
+    let(:method_name)      { 'fred' }
+    let(:definition) do
+      FactoryGirl.create(
+        :generic_object_definition,
+        :name       => "test_definition",
+        :properties => {
+          :attributes   => {},
+          :associations => {},
+          :methods      => [method_name]
+        }
+      )
+    end
+
+    let(:go) do
+      FactoryGirl.create(
+        :generic_object,
+        :generic_object_definition => definition,
+        :name                      => 'test'
+      )
+    end
+
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:workspace) do
+      double('ws', :persist_state_hash => {},
+                   :ae_user            => user,
+                   :rbac_enabled?      => false,
+                   :root               => {})
+    end
+
+    let(:options) do
+     { :object_type   => "GenericObject",
+       :object_id     => go.id,
+       :instance_name => "GenericObject",
+       :user_id       => user.id,
+       :miq_group_id  => user.current_group.id,
+       :tenant_id     => user.current_tenant.id,
+       :attrs         => {:method_name => method_name}
+     }
+    end
+
+    describe "call method on generic object" do
+      before do
+        allow(MiqAeEngine::DrbRemoteInvoker).to receive('workspace').and_return(workspace)
+      end
+
+      it "calls into automate" do
+        svc_obj = MiqAeMethodService::MiqAeServiceGenericObject.find(go.id)
+        expect(MiqAeEngine).to receive('deliver').with(options).and_return(workspace)
+
+        svc_obj.send(method_name)
+      end
+    end
 
     describe "#add_to_service" do
       it "adds a generic object to service_resources of a valid service" do
@@ -54,7 +106,6 @@ module MiqAeServiceGenericObjectSpec
     end
 
     describe '#convert_params_to_ar_model' do
-      let(:user) { FactoryGirl.create(:user_with_group) }
       subject    { service_go.send(:convert_params_to_ar_model, @args) }
 
       before do


### PR DESCRIPTION
Since DRb client runs in different threads we need to pick the
correct user for submitting Automate Requests for Generic Methods.
The DRb Front object is stored by DRb in a thread local variable. We store the user in the workspace object and the workspace object is stored in the Front. Previously we were using the DRb.front module which is not thread safe, instead of using the DRb front from the thread local storage.

Links
-----
* https://github.com/ManageIQ/manageiq/pull/12369

