### PR TITLE
Scope the zone to the server's region

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -34,7 +34,7 @@ module MiqServer::ConfigurationManagement
     end
 
     unless data.zone.nil?
-      self.zone = Zone.find_by(:name => data.zone)
+      self.zone = Zone.in_my_region.find_by(:name => data.zone)
       save
     end
     update_capabilities

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -83,5 +83,24 @@ describe MiqServer, "::ConfigurationManagement" do
         expect(message.method_name).to eq("reload_settings")
       end
     end
+
+    describe "#config_activated" do
+      let(:zone) { FactoryGirl.create(:zone, :name => "My Zone") }
+      let(:zone_other_region) do
+        other_region_id = ApplicationRecord.id_in_region(1, MiqRegion.my_region_number + 1)
+        FactoryGirl.create(:zone, :id => other_region_id).tap do |z|
+          z.update_column(:name, "My Zone") # Bypass validation for test purposes
+        end
+      end
+
+      it "saves settings with the zone in the correct region" do
+        miq_server = EvmSpecHelper.local_miq_server(:zone => zone)
+        zone_other_region
+
+        miq_server.config_activated(OpenStruct.new(:zone => "My Zone"))
+
+        expect(miq_server.reload.zone).to eq(zone)
+      end
+    end
   end
 end


### PR DESCRIPTION
Ensure the zone is in the server's region when looking up and saving zone during config activation. In multi region environments, it's typical to have a zone in the global region that is named the same as one in a lower region. This change fixes a bug where a zone from a different region is saved as the server zone during config activation.

https://bugzilla.redhat.com/show_bug.cgi?id=1396330