### PR TITLE
Allow cpu_usagemhz_rate_average_max_over_time_period and derived_memory_used_max_over_time_period to be used in reports as SQL

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -273,7 +273,7 @@ module MiqReport::Generator
           :filter           => conditions,
           :include_for_find => includes,
           :where_clause     => where_clause,
-          :skip_count       => true,
+          :skip_counts      => true,
         )
       )
       results = Metric::Helper.remove_duplicate_timestamps(results)

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -266,16 +266,20 @@ module MiqReport::Generator
       # TODO: add once only_cols is fixed
       # targets = targets.select(only_cols)
       where_clause = MiqExpression.merge_where_clauses(self.where_clause, options[:where_clause])
-
-      results, attrs = Rbac.search(
-        options.merge(
-          :targets          => targets,
-          :filter           => conditions,
-          :include_for_find => includes,
-          :where_clause     => where_clause,
-          :skip_counts      => true,
-        )
+      va_sql_cols = cols.select do |col|
+        db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
+      end
+      rbac_opts = options.merge(
+        :targets          => targets,
+        :filter           => conditions,
+        :include_for_find => includes,
+        :where_clause     => where_clause,
+        :skip_counts      => true,
       )
+
+      rbac_opts[:extra_cols] = va_sql_cols unless va_sql_cols.nil? || va_sql_cols.empty?
+
+      results, attrs = Rbac.search(rbac_opts)
       results = Metric::Helper.remove_duplicate_timestamps(results)
       results = BottleneckEvent.remove_duplicate_find_results(results) if db == "BottleneckEvent"
       @user_categories = attrs[:user_filters]["managed"]

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -163,21 +163,29 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    opts = {
-      :end_date => Time.now.utc,
-      :days     => Metric::LongTermAverages::AVG_DAYS
-    }
-    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                          .maximum(:cpu_usagemhz_rate_average)
+    if has_attribute?("cpu_usagemhz_rate_average_max_over_time_period")
+      self["cpu_usagemhz_rate_average_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:cpu_usagemhz_rate_average)
+    end
   end
 
   def derived_memory_used_max_over_time_period
-    opts = {
-      :end_date => Time.now.utc,
-      :days     => Metric::LongTermAverages::AVG_DAYS
-    }
-    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                          .maximum(:derived_memory_used)
+    if has_attribute?("derived_memory_used_max_over_time_period")
+      self["derived_memory_used_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:derived_memory_used)
+    end
   end
 
   private

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -31,11 +31,39 @@ module VmOrTemplate::RightSizing
 
     virtual_column :max_cpu_usage_rate_average_max_over_time_period,     :type => :float
     virtual_column :max_mem_usage_absolute_average_max_over_time_period, :type => :float
-    virtual_column :cpu_usagemhz_rate_average_max_over_time_period,      :type => :float
-    virtual_column :derived_memory_used_max_over_time_period,            :type => :float
+
+    virtual_attribute :cpu_usagemhz_rate_average_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:cpu_usagemhz_rate_average)
+    virtual_attribute :derived_memory_used_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:derived_memory_used)
   end
 
   module ClassMethods
+    def metric_rollup_vattr_arel(col)
+      lambda do |t|
+        metric_rollup_table = MetricRollup.arel_table
+        select_clause = metric_rollup_table[col].maximum
+
+        now       = Time.now.utc
+        timestamp = (now - 30.days).utc..now
+        tp_ids    = TimeProfile.default_time_profile(nil)
+                               .profile_for_each_region
+                               .pluck(:id)
+
+        where_clause =
+          metric_rollup_table[:time_profile_id].in(tp_ids)
+            .and(metric_rollup_table[:capture_interval_name].eq("daily"))
+            .and(metric_rollup_table[:timestamp].between(timestamp))
+            .and(metric_rollup_table[:resource_type].eq("VmOrTemplate"))
+            .and(metric_rollup_table[:resource_id].eq(t[:id]))
+
+        t.grouping(
+          metric_rollup_table.project(select_clause)
+                             .where(where_clause)
+        )
+      end
+    end
+
     def cpu_recommendation_minimum
       ::Settings.recommendations.cpu_minimum
     end

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -135,13 +135,21 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:cpu_usagemhz_rate_average).compact.max
+    opts = {
+      :end_date => Time.now.utc,
+      :days     => Metric::LongTermAverages::AVG_DAYS
+    }
+    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                          .maximum(:cpu_usagemhz_rate_average)
   end
 
   def derived_memory_used_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:derived_memory_used).compact.max
+    opts = {
+      :end_date => Time.now.utc,
+      :days     => Metric::LongTermAverages::AVG_DAYS
+    }
+    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                          .maximum(:derived_memory_used)
   end
 
   private

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -597,6 +597,94 @@ module ActiveRecord
         end
       }
     end
+
+    # FIXME: Hopefully we can get this into Rails core so this is no longer
+    # required in our codebase, but the rule that are broken here are mostly
+    # due to the style of the Rails codebase conflicting with our own.
+    # Ignoring them to avoid noise in RuboCop, but allow us to keep the same
+    # syntax from the original codebase.
+    #
+    # rubocop:disable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+    # rubocop:disable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    class JoinDependency
+      def instantiate(result_set, aliases)
+        primary_key = aliases.column_alias(join_root, join_root.primary_key)
+
+        seen = Hash.new { |i, object_id|
+          i[object_id] = Hash.new { |j, child_class|
+            j[child_class] = {}
+          }
+        }
+
+        model_cache = Hash.new { |h,klass| h[klass] = {} }
+        parents = model_cache[join_root]
+        column_aliases = aliases.column_aliases join_root
+
+        # New Code
+        #
+        # This monkey patches the ActiveRecord::Associations::JoinDependency to
+        # include columns into the main record that might have been added
+        # through a `select` clause.
+        #
+        # This can be seen with the following:
+        #
+        #   Vm.select(Vm.arel_table[Arel.star]).select(:some_vm_virtual_col)
+        #     .includes(:tags => {}).references(:tags => {})
+        #
+        # Which will produce a SQL SELECT statement kind of like this:
+        #
+        #   SELECT "vms".*,
+        #          (<virtual_attribute_arel>) AS some_vm_virtual_col,
+        #          "vms"."id"      AS t0_r0
+        #          "vms"."vendor"  AS t0_r1
+        #          "vms"."format"  AS t0_r1
+        #          "vms"."version" AS t0_r1
+        #          ...
+        #          "tags"."id"     AS t1_r0
+        #          "tags"."name"   AS t1_r1
+        #
+        # This is because rails is trying to reduce the number of queries
+        # needed to fetch all of the records in the include, so it grabs the
+        # columns for both of the tables together to do it.  Unfortuantely (or
+        # fortunately... depending on how you look at it), it does not remove
+        # any `.select` columns from the query that is run in the process, so
+        # that is brought along for the ride, but never used when this method
+        # instanciates the objects.
+        #
+        # The "New Code" here simply also instanciates any extra rows that
+        # might have been included in the select (virtual_columns) as well and
+        # brought back with the result set.
+        unless result_set.empty?
+          join_dep_keys         = aliases.columns.map(&:right)
+          join_root_aliases     = column_aliases.map(&:first)
+          additional_attributes = result_set.first.keys
+                                            .reject { |k| join_dep_keys.include?(k) }
+                                            .reject { |k| join_root_aliases.include?(k) }
+                                            .map    { |k| [k, k] }
+          column_aliases += additional_attributes
+        end
+        # End of New Code
+
+        message_bus = ActiveSupport::Notifications.instrumenter
+
+        payload = {
+          record_count: result_set.length,
+          class_name: join_root.base_klass.name
+        }
+
+        message_bus.instrument('instantiation.active_record', payload) do
+          result_set.each { |row_hash|
+            parent_key = primary_key ? row_hash[primary_key] : row_hash
+            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
+            construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
+          }
+        end
+
+        parents.values
+      end
+      # rubocop:enable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+      # rubocop:enable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    end
   end
 
   class Relation

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -179,6 +179,7 @@ module Rbac
 
       if targets.nil?
         scope = apply_scope(klass, scope)
+        scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
       elsif targets.kind_of?(Array)
         if targets.first.kind_of?(Numeric)
           target_ids = targets
@@ -188,6 +189,7 @@ module Rbac
           klass            = targets.first.class.base_class unless klass.respond_to?(:find)
         end
         scope = apply_scope(klass, scope)
+        scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
 
         ids_clause = ["#{klass.table_name}.id IN (?)", target_ids] if klass.respond_to?(:table_name)
       else # targets is a class_name, scope, class, or acts_as_ar_model class (VimPerformanceDaily in particular)
@@ -200,6 +202,7 @@ module Rbac
           # working around MiqAeDomain not being in rbac_class
           klass = klass.base_class if klass.respond_to?(:base_class) && rbac_class(klass).nil? && rbac_class(klass.base_class)
         end
+        scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
       end
 
       user_filters['match_via_descendants'] = to_class(options[:match_via_descendants])
@@ -513,6 +516,10 @@ module Rbac
       else
         klass.send(*scope)
       end
+    end
+
+    def apply_select(klass, scope, extra_cols)
+      scope.select(scope.select_values.blank? ? klass.arel_table[Arel.star] : nil).select(extra_cols)
     end
 
     def get_belongsto_matches(blist, klass)

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -688,6 +688,17 @@ describe VirtualFields do
         TestClass.create(:id => 2, :col1 => 20)
         expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
+
+      it "supports #includes with #references" do
+        vm           = FactoryGirl.create :vm_vmware
+        table        = Vm.arel_table
+        dash         = Arel::Nodes::SqlLiteral.new("'-'")
+        name_dash_id = Arel::Nodes::NamedFunction.new("CONCAT", [table[:name], dash, table[:id]])
+                                                 .as("name_dash_id")
+        result       = Vm.select(name_dash_id).includes(:tags => {}).references(:tags => {})
+
+        expect(result.first.attributes["name_dash_id"]).to eq("#{vm.name}-#{vm.id}")
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -74,6 +74,12 @@ describe Rbac::Filterer do
         expect(results).to match_array [owned_vm]
       end
 
+      it "with :extra_cols finds Service" do
+        FactoryGirl.create :service, :evm_owner => owner_user
+        results = described_class.search(:class => "Service", :extra_cols => [:owned_by_current_user]).first
+        expect(results.first.attributes["owned_by_current_user"]).to be false
+      end
+
       it "leaving tenant doesnt find Vm" do
         owner_user.update_attributes(:miq_groups => [other_user.current_group])
         User.with_user(owner_user) do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -637,6 +637,78 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".cpu_usagemhz_rate_average_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 10.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 100.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.cpu_usagemhz_rate_average_max_over_time_period).to eq(100.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "cpu_usagemhz_rate_average_max_over_time_period"
+        )
+      ).to eq(100.0)
+    end
+  end
+
+  describe ".derived_memory_used_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 10.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 1000.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.derived_memory_used_max_over_time_period).to eq(1000.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "derived_memory_used_max_over_time_period"
+        )
+      ).to eq(1000.0)
+    end
+  end
+
   describe ".host_name" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }


### PR DESCRIPTION
Overview
--------

Speeds up reports that use `cpu_usagemhz_rate_average_max_over_time_period` and `derived_memory_used_max_over_time_period` columns in reports by allowing them to:

* Be queried via SQL by updating the `virtual_column` definitions
* Updating Rbac to allow `.selects` on the main object
* Updating `MiqReport::Generator#_generate_table` to take advantage of the Rbac feature
* Updating a portion of ActiveRecord's codebase to support these extra columns when using a `.include`


Metrics
-------

**Note: This metrics are currently a bit skewed as they are reporting duplicate query and rows, so those are probably double from the correct values.  These will be updated once I am able to correct the flaw in the capture and given the time to re-run the tests**

|                          |         ms |   queries |  query (ms) |       rows |
|                     ---: |       ---: |      ---: |        ---: |       ---: |
|                   master |  3,362,848 |   760,540 |     819,652 |  5,235,802 |
|          PRs 12737+12972 |    458,369 |   120,774 |     266,825 |  1,697,414 |
|  PRs 12737+12972 and max |    414,806 |   120,630 |     314,313 |    763,662 |
|     PRs 12737+12972+this |    215,525 |    39,628 |      50,851 |    763,724 |
| | 94% | 95% | 94% | 85% |


Now, besides the incorrect data collection, the master one is probably slightly skewed as well just based on how much more objects needed to be instantiated to run it.  That said, it was still slow and the improvements from the cumulative changes are fairly substantial.

"PRs 12737+12972 and max" and "PRs 12737+12972+this" are probably of the most interest, and require some minor explanation.

"PRs 12737+12972 and max" essentially takes PRs #12737 and #12972 together, and adds another minor patch on top of it to change the `cpu_usagemhz_rate_average_max_over_time_period` and `derived_memory_used_max_over_time_period` basically to add the `.maximum` change from the `.collect(:col).max` change that is part of this PR.  When this patch is used, it significantly reduces the number of rows returned by the DB, taking off time that Ruby needs to instantiate those rows into ActiveRecord objects, but also just data returned from the DB, reducing memory usage.  That said, the query time ended up going up, even though the total time for the report was reduced.  This is because the `MAX` queries in SQL take more time (about 4x) than a normal query in the DB, but again, this is offset by the aforementioned savings, but still could be improved.

"PRs 12737+12972+this" removes that `N+1` that then existed (and did exist prior, but was just optimized in "PRs 12737+12972 and max") so that all of the `MAX` calls are done upfront.  This data is then included as part of the original query against the `vms` table, and significantly reduces the queries required for the report.  It should be noted that this query isn't cheap, and takes about 12 seconds alone for 25k-ish Vm records, but that is much better than 3ms per record * 2 (two different virtual_columns per VM record), which adds up to much more time overall.


Explanation of the monkey patch
--------------------------------
This basically allows virtual_columns to also be queried when an `.includes` exists as part of the query as well, which for the report being tested against, is present.

For a smaller example, this effects can be seen with the following:

```
Vm.select(Vm.arel_table[Arel.star]).select(:cpu_usagemhz_rate_average_max_over_time_period)
  .includes(:tags => {}).references(:tags => {})
```

In which rails will produce a SQL SELECT statement kind of like this:

```
SELECT "vms".*,
       (<virtual_attribute_arel>) AS cpu_usagemhz_rate_average_max_over_time_period,
       "vms"."id"      AS t0_r0
       "vms"."vendor"  AS t0_r1
       "vms"."format"  AS t0_r1
       "vms"."version" AS t0_r1
       ...
       "tags"."id"     AS t1_r0
       "tags"."name"   AS t1_r1
```

This is because rails is trying to reduce the number of queries needed to fetch all of the records in the include, so it grabs the columns for both of the tables together to do it.  Unfortunately (or fortunately... depending on how you look at it), it does not remove any `.select` statements from the relation that is run in the process, so they are brought along for the ride, but never used when this method instantiates the objects in it's original form.

The additions to this method added via the monkey patch simply also instantiates `ActiveRecord` objects with attributes to include any extra columns that were part of the result set in the select (virtual_columns), striping out any duplicates as well.  Now, the monkey patch done here is far from ideal, but doing it that way was very much preferable to appending to the existing method (as was done in other places in `ar_virtual.rb`).


Considerations
--------------
* The long initial query could end up causing issues and with write locks and such, so it is something we might want to look at replacing eventually
* Alternatives to the `ActiveRecord` monkey patch would be preferable, but I am not sure how else we could handle it.
* This PR is probably better suited for 2 or 3 smaller PRs, but was left as a single one to start to allow the reviewer to see the proposed changes as a whole.  I expect to split this up if we wish to move forward with all of the changes.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/12972 [WIP] [POC] Remove on-the-fly creating of VimPerformanceOperatingRanges
* https://github.com/ManageIQ/manageiq/pull/12737 [WIP] Cache TimeProfiles when building reports (kinda a hack...)
* https://bugzilla.redhat.com/show_bug.cgi?id=1395743