### PR TITLE
Updates to work with Ruby 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,9 +76,9 @@ gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"
 gem "responders",                     "~>2.0"
+gem "ripper_ruby_parser",                              :require => false
 gem "ruby-dbus" # For external auth
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
-gem "ruby_parser",                    "~>3.8",         :require => false
 gem "rufus-scheduler",                "~>3.1.3",       :require => false
 gem "rugged",                         "=0.25.0b10",    :require => false
 gem "secure_headers",                 "~>3.0.0"

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -68,10 +68,10 @@ class DescendantLoader
   # and the name of its superclass), given a path to a ruby script file.
   module Parser
     def classes_in(filename)
-      require 'ruby_parser'
+      require 'ripper_ruby_parser'
 
       content = File.read(filename)
-      parsed = RubyParser.for_current_ruby.parse(content)
+      parsed = RipperRubyParser::Parser.new.parse(content)
 
       classes = collect_classes(parsed)
 
@@ -94,7 +94,7 @@ class DescendantLoader
         [search_combos, define_combos, flatten_name(name), flatten_name(sklass)]
       end.compact
 
-    rescue Racc::ParseError
+    rescue RipperRubyParser::SyntaxError
       puts "\nSyntax error in #{filename}\n\n"
       raise
     end

--- a/spec/models/custom_attribute_spec.rb
+++ b/spec/models/custom_attribute_spec.rb
@@ -12,6 +12,9 @@ describe CustomAttribute do
   end
 
   it "returns the value type of Fixnum custom attributes" do
-    expect(int_custom_attribute.value_type).to eq(:fixnum)
+    # TODO: Ruby 2.4 unifies fixnum and bignum into integer, we shouldn't be
+    # returnings ruby types like this.
+    expected = RUBY_VERSION >= "2.4.0" ? :integer : :fixnum
+    expect(int_custom_attribute.value_type).to eq(expected)
   end
 end

--- a/spec/models/miq_server/rhn_mirror_spec.rb
+++ b/spec/models/miq_server/rhn_mirror_spec.rb
@@ -34,7 +34,7 @@ describe "MiqServer" do
 
       expect(FileUtils).to receive(:mkdir_p).with("/repo/mirror")
       expect(MiqApache::Conf).to receive(:create_conf_file).once.and_return(true)
-      expect(FileUtils).to receive(:rm).with("/etc/httpd/conf.d/manageiq-https-mirror.conf", :force => true)
+      expect(FileUtils).to receive(:rm).with("/etc/httpd/conf.d/manageiq-https-mirror.conf", hash_including(:force => true))
       expect(MiqApache::Control).to receive(:restart).once
       expect(LinuxAdmin::Yum).to receive(:download_packages).once.with("/repo/mirror", "cfme-appliance")
       expect(Dir).to receive(:glob).with("/repo/mirror/**/*.rpm").and_return(rpm_file_list)

--- a/spec/support/webmock_ruby24_bridge.rb
+++ b/spec/support/webmock_ruby24_bridge.rb
@@ -1,0 +1,15 @@
+# Ruby 2.4.0 removed the closed? check in the conditional in: s.close if !s.closed?
+# Webmock was changed to add close to StubSocket along with another change.
+# https://github.com/ruby/ruby/commit/f845a9ef76c0195254ded79c85c24332534f4057
+# https://github.com/bblimke/webmock/commit/8f2176a1fa75374df55b87d782e08ded673a75b4
+# WebMock 2.3.1+ fixed this.
+# We should upgrade webmock but that requires some re-recording of cassettes (I think)
+# and maybe other things.
+if WebMock::VERSION < "2.3.1"
+  class StubSocket
+    def close
+    end
+  end
+else
+  warn "Remove me: #{__FILE__}:#{__LINE__}. WebMock 2.3.1+ fixed the issue with ruby 2.4.0 by adding StubSocket#close."
+end


### PR DESCRIPTION
This is one step to ruby 2.4, here is an outline of the steps: https://github.com/ManageIQ/manageiq/issues/14446

Known issues:
- RubyParser didn't support Ruby 2.4 immediately, and now does in [3.9.0](https://github.com/seattlerb/ruby_parser/commit/10cde047856b8e10924d1ba90362b4bb2aab9650) and [here](https://github.com/seattlerb/ruby_parser/commit/1814c37c2e6d8014c50b098e5be5aa2005ca089f), with changelog [here](https://github.com/seattlerb/ruby_parser/commit/4a16566d12aa444b5eb512106e1a57ec07d1d884).  RubyParser tends to lag, so instead I found [RipperRubyParser](https://github.com/mvz/ripper_ruby_parser) which is a "drop-in replacement for RubyParser using Ripper".  Since Ripper comes with Ruby it will always be up-to-date.
- ~~Expand symbol to proc in a factory due to a ruby 2.4.0 bug  …
https://bugs.ruby-lang.org/issues/13074
via
thoughtbot/factory_girl#980~~
   *  ~~"When executing instance_exec with symbol.to_proc, it ignores first
argument"~~ 
   * Fixed in ruby 2.4.1

- Ruby 2.4 unifies Fixnum and Bignum into Integer, the former classes are deprecated
- Monkey patch webmock for now, will need to re-record cassettes with new webmock supporting ruby 2.4: Added https://github.com/ManageIQ/manageiq/issues/14270 to upgrade webmock and remove this temporary monkey patch.

NOTE:  We are not changing the required ruby version in the `Gemfile` nor the one tested by travis in the `.travis.yml` in this PR.  These changes will work with ruby 2.4 and 2.3 and probably even 2.2.


cc @jrafanie 
