### PR TITLE
Removed unnecessary call of building miq_action_cat_tree

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -712,7 +712,6 @@ class MiqPolicyController < ApplicationController
     elsif @assign
       @changed = (@assign[:new] != @assign[:current])
     end
-    get_tags_tree if @action_type_changed || @snmp_trap_refresh
     render :update do |page|
       page << javascript_prologue
       if @edit


### PR DESCRIPTION
The tree was called in every action (when action drop down list changed) and also when
some category was selected. But it was not displayed and it seems that data inside the tree was not used.

@mig_bot add_label ui