### PR TITLE
Allow dialog drop-downs to be 'searchable' again

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -83,6 +83,7 @@ module ApplicationHelper::Dialogs
     extra_options = {
       "data-miq_sparkle_on"  => true,
       "data-miq_sparkle_off" => true,
+      "data-live-search"     => true
       # data-miq_observe functionality is handled by dialogFieldRefresh.initializeDialogSelectPicker here
     }
 

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -278,7 +278,8 @@ describe ApplicationHelper::Dialogs do
           expect(helper.drop_down_options(dialog_field, "url")).to eq(
             :class                 => "dynamic-drop-down-100 selectpicker",
             "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true
+            "data-miq_sparkle_off" => true,
+            "data-live-search"     => true
           )
         end
       end
@@ -290,7 +291,8 @@ describe ApplicationHelper::Dialogs do
           expect(helper.drop_down_options(dialog_field, "url")).to eq(
             :class                 => "dynamic-drop-down-100 selectpicker",
             "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true
+            "data-miq_sparkle_off" => true,
+            "data-live-search"     => true
           )
         end
       end


### PR DESCRIPTION
Previously, the old drop-down style inherently would wait a second or so while typing so if you typed (in this case) "turbo", if something matched "turbo" it would be selected. Now, though, with the new selectpicker style, when you type, it immediately goes to the next letter, so if you have something that starts with 'tu' and something else that starts with just a 'u', it would pick the one that starts with the 'u' instead of the 'tu'.

This PR just adds in the live data search functionality provided by the selectpicker bootstrap js as a baseline for all dialog drop-downs. If people are relying on the typing "search" functionality anywhere else that has been converted from drop-downs to the selectpicker style, it will need this live data attribute as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1403525

/cc @gmcculloug 