### PR TITLE
[Ad hoc metrics for OPS] Add option to show counters data

### DIFF
--- a/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller.js
@@ -4,6 +4,7 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
   .controller('containerLiveDashboardController', ['$scope', 'pfViewUtils', '$http', '$interval', '$timeout', '$window',
   function ($scope, pfViewUtils, $http, $interval, $timeout, $window) {
     $scope.tenant = '_ops';
+    $scope.metricsType = 'gauges';
 
     // get the pathname and remove trailing / if exist
     var pathname = $window.location.pathname.replace(/\/$/, '');
@@ -29,7 +30,8 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
       $scope.toolbarConfig.filterConfig = $scope.filterConfig;
       $scope.toolbarConfig.actionsConfig = $scope.actionsConfig;
 
-      $scope.url = '/container_dashboard/data' + id + '/?live=true&tenant=' + $scope.tenant;
+      $scope.url = '/container_dashboard/data' + id + 
+        '/?live=true&type=' + $scope.metricsType + '&tenant=' + $scope.tenant;
     }
 
     var filterChange = function (filters) {
@@ -73,6 +75,13 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
 
       initialization();
       filterChange();
+      getMetricTags();
+    };
+
+    var doRefreshCounters = function (action) {
+      $scope.metricsType = action.type;
+
+      initialization();
       getMetricTags();
     };
 
@@ -273,6 +282,18 @@ miqHttpInject(angular.module('containerLiveDashboard', ['ui.bootstrap', 'pattern
           tenant: '_ops',
           title: __("Use the Ops Tenant Metrics"),
           actionFn: doRefreshTenant
+        },
+        {
+          name: 'Gauges',
+          type: 'gauges',
+          title: __("Gauges Metrics"),
+          actionFn: doRefreshCounters
+        },
+        {
+          name: 'Counters',
+          type: 'counters',
+          title: __("Counters Metrics"),
+          actionFn: doRefreshCounters
         }
       ]
     };

--- a/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/container_live_dashboard/container_live_dashboard_controller_spec.js
@@ -18,10 +18,10 @@ describe('containerLiveDashboardController', function() {
     pfViewUtils = _pfViewUtils_;
     $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_tags').respond(mock_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
-    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_tags').respond(mock_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=metric_definitions&tags={}').respond(mock_metrics_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello1&limit=5&order=DESC').respond(mock_data1_data);
+    $httpBackend.when('GET','/container_dashboard/data/42/?live=true&type=gauges&tenant=_ops&query=get_data&metric_id=hello2&limit=5&order=DESC').respond(mock_data2_data);
     $controller = _$controller_('containerLiveDashboardController', {
         $scope: $scope,
         pfViewUtils: pfViewUtils


### PR DESCRIPTION
**Description**
Refactor https://github.com/ManageIQ/manageiq/pull/12165 

- [x] Add option to show counter metrics (currently only gauges visible)
- [x] Add option to get counter metrics (currently we only get gauges)

**Screenshot**
![screenshot-2016-12-12-13-42-28](https://cloud.githubusercontent.com/assets/2181522/21098247/f8657392-c070-11e6-8a62-bc90f6ec5c0f.png)
