### PR TITLE
[WIP] Containers Dashboard: Support hourly and realtime trends

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -124,12 +124,34 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
           $scope.nodeMemoryUsage.loadingDone = true;
 
           // Network metrics
-          $scope.networkUtilizationDailyConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
+          if (data.daily_network_metrics != undefined && data.daily_network_metrics.xData.length > 1) {
+            $scope.networkUtilizationConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
+            $scope.networkUtilization =
+              chartsMixin.processUtilizationData(data.daily_network_metrics,
+                                                 "dates",
+                                                 $scope.networkUtilizationConfig.units);
+          } else if (data.hourly_network_metrics != undefined && data.hourly_network_metrics.xData.length > 1) {
+            data.hourly_network_metrics.xData = data.hourly_network_metrics.xData.map(function (date) {
+              return dashboardUtilsFactory.parseDate(date)
+            });
 
-          $scope.dailyNetworkUtilization =
-            chartsMixin.processUtilizationData(data.daily_network_metrics,
-                                               "dates",
-                                               $scope.networkUtilizationDailyConfig.units);
+            $scope.networkUtilizationConfig = chartsMixin.chartConfig.hourlyNetworkUsageConfig;
+            $scope.networkUtilization =
+              chartsMixin.processUtilizationData(data.hourly_network_metrics,
+                                                 "dates",
+                                                  $scope.networkUtilizationConfig.units);
+          } else {
+            if (data.realtime_network_metrics != undefined) {
+              data.realtime_network_metrics.xData = data.realtime_network_metrics.xData.map(function (date) {
+                return dashboardUtilsFactory.parseDate(date)
+              });
+            }
+            $scope.networkUtilizationConfig = chartsMixin.chartConfig.realtimeNetworkUsageConfig;
+            $scope.networkUtilization =
+              chartsMixin.processUtilizationData(data.realtime_network_metrics,
+                    "dates",
+                    $scope.networkUtilizationConfig.units);
+          }
 
           // Pod metrics
           $scope.podEntityTrendDailyConfig = chartsMixin.chartConfig.dailyPodUsageConfig;

--- a/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
+++ b/app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js
@@ -9,6 +9,14 @@ angular.module('miq.util').factory('chartsMixin', ['pfUtils', function(pfUtils) 
     });
   };
 
+  var hourlyTimeTooltip = function (data) {
+    var theMoment = moment(data[0].x);
+    return _.template('<div class="tooltip-inner"><%- col1 %>: <%- col2 %></div>')({
+      col1: theMoment.format('h:mm A'),
+      col2: data[0].value + ' ' + data[0].name
+    });
+  };
+
   var dailyPodTimeTooltip = function (data) {
     var theMoment = moment(data[0].x);
     return _.template('<div class="tooltip-inner"><%- col1 %></br>  <%- col2 %></div>')({
@@ -65,6 +73,22 @@ angular.module('miq.util').factory('chartsMixin', ['pfUtils', function(pfUtils) 
       units    : __('KBps'),
       dataName : __('KBps'),
       tooltipFn  : dailyTimeTooltip
+    },
+    hourlyNetworkUsageConfig: {
+      chartId  : 'networkUsageHourlyChart',
+      headTitle: __('Network Utilization Trend'),
+      timeFrame: __('Last 24 Hours'),
+      units    : __('KBps'),
+      dataName : __('KBps'),
+      tooltipFn  : hourlyTimeTooltip
+    },
+    realtimeNetworkUsageConfig: {
+      chartId  : 'networkUsageHourlyChart',
+      headTitle: __('Network Utilization Trend'),
+      timeFrame: __('Last 60 minutes'),
+      units    : __('KBps'),
+      dataName : __('KBps'),
+      tooltipFn  : hourlyTimeTooltip
     },
     dailyPodUsageConfig: {
       chartId     : 'podUsageDailyChart',

--- a/app/views/shared/views/_show_containers_dashboard.html.haml
+++ b/app/views/shared/views/_show_containers_dashboard.html.haml
@@ -93,13 +93,13 @@
     .col-xs-12.col-sm-6.col-md-5
       .row.row-tile-pf
         .col-xs-12.col-sm-12.col-md-12
-          %div{"head-title" => "{{networkUtilizationDailyConfig.headTitle}}",
+          %div{"head-title" => "{{networkUtilizationConfig.headTitle}}",
                "pf-card" => ""}
 
             .spinner.spinner-lg.loading{"ng-if" => "!loadingDone"}
-            %div{"chart-data" => "dailyNetworkUtilization",
+            %div{"chart-data" => "networkUtilization",
                  "chart-height" => "chartHeight",
-                 :config => "networkUtilizationDailyConfig",
+                 :config => "networkUtilizationConfig",
                  "ng-if" => "loadingDone",
                  "pf-trends-chart" => ""}
 


### PR DESCRIPTION
In case that there are no daily trends yet, we would like to display hourly trends instead. 
Currently added support only in the Network Utilization card, still need to add support in the rest of the dashboard cards. 

![dashboard](https://cloud.githubusercontent.com/assets/11769555/21102784/4a18df50-c088-11e6-89e8-4acf6511682a.png)

![dashmin](https://cloud.githubusercontent.com/assets/11769555/21148918/773a09de-c162-11e6-8394-6a0fa8cf8297.png)


