### PR TITLE
Use live metrics in reports

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -33,6 +33,14 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       end
     end
 
+    def total_memory
+      @node_memory
+    end
+
+    def total_cpu_time
+      @node_cores
+    end
+
     def ts_values
       # Filtering out entries that are not containing all the metrics.
       # This generally happens because metrics are collected at slightly

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -439,6 +439,107 @@ module VimPerformanceAnalysis
                   .select(options[:select])
   end
 
+  def self.collect_metrics(obj, start_time, end_time, interval)
+    client = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::CaptureContext.new(
+      obj, start_time, end_time, interval
+    )
+
+    client.collect_metrics
+    total_memory = client.total_memory
+    total_cpu_time = client.total_cpu_time
+
+    results = {}
+    client.ts_values.each do |k, v|
+      values = v.symbolize_keys
+
+      # Add missing fields
+      values[:timestamp] = k
+      values[:max_mem_usage_absolute_average] = values[:mem_usage_absolute_average]
+      values[:max_cpu_usage_rate_average] = values[:cpu_usage_rate_average]
+      values[:total_memory] = total_memory
+      values[:total_cpu_time] = total_cpu_time
+
+      unless values[:mem_usage_absolute_average].nil?
+        values[:derived_memory_used] = total_memory * values[:mem_usage_absolute_average] / 100
+      end
+      unless values[:cpu_usage_rate_average].nil?
+        values[:cpu_usagemhz_rate_average] = total_cpu_time * values[:cpu_usage_rate_average] / 100
+      end
+
+      results[k] = values
+    end
+
+    results
+  end
+
+  def self.reduce_metrics(value, new_value)
+    return new_value if value.nil?
+
+    {
+      :cpu_usagemhz_rate_average      => value[:cpu_usagemhz_rate_average] + new_value[:cpu_usagemhz_rate_average],
+      :derived_memory_used            => value[:derived_memory_used] + new_value[:derived_memory_used],
+      :net_usage_rate_average         => value[:net_usage_rate_average] + new_value[:net_usage_rate_average],
+      :max_mem_usage_absolute_average => [
+        value[:max_mem_usage_absolute_average],
+        new_value[:max_mem_usage_absolute_average]
+      ].max,
+      :max_cpu_usage_rate_average     => [
+        value[:max_cpu_usage_rate_average],
+        new_value[:max_cpu_usage_rate_average]
+      ].max,
+      :total_memory                   => value[:total_memory] + new_value[:total_memory],
+      :total_cpu_time                 => value[:total_cpu_time] + new_value[:total_cpu_time]
+    }
+  end
+
+  def self.avg_metrics(values)
+    results = []
+    values.each do |k, v|
+      v.symbolize_keys!
+      v[:timestamp] = k
+      v[:mem_usage_absolute_average] = 100.0 * v[:derived_memory_used] / v[:total_memory]
+      v[:cpu_usage_rate_average] = 100.0 * v[:cpu_usagemhz_rate_average] / v[:total_cpu_time]
+      results << v
+    end
+    results
+  end
+
+  def self.live_perf_for_time_period(obj, interval_name, options = {})
+    # Options
+    #   :days        => Number of days back from end_date. Used only if start_date not passed
+    #   :start_date  => Starting date
+    #   :end_date    => Ending date
+    #   :conditions  => ActiveRecord find conditions
+    ems = ExtManagementSystem.find(obj.ems_id) if obj.try(:ems_id)
+    return unless ems || obj.class.name == "ManageIQ::Providers::Openshift::ContainerManager"
+
+    time_range = Metric::Helper.time_range_from_hash(options)
+    start_time = time_range.first
+    end_time = time_range.last
+    interval = {
+      :hourly => 60 * 60,
+      :daily  => 24 * 60 * 60
+    }[interval_name.to_sym]
+
+    objs_list = if obj.class.name == "ContainerProject"
+                  obj.container_groups
+                elsif obj.class.name == "ManageIQ::Providers::Openshift::ContainerManager"
+                  obj.container_nodes
+                else
+                  [obj]
+                end
+
+    values = {}
+    objs_list.each do |o|
+      v = collect_metrics(o, start_time, end_time, interval)
+      v.keys.each do |k|
+        values[k] = reduce_metrics(values[k], v[k])
+      end
+    end
+
+    avg_metrics(values)
+  end
+
   # @param obj base object
   # @param interval_name
   # @option options :days        [Numeric] Number of days back from end_date. Used to derive start_date (if not passed)

--- a/db/fixtures/classifications.yml
+++ b/db/fixtures/classifications.yml
@@ -943,4 +943,20 @@
   :parent_id: 0
   :default: true
   :single_value: "1"
-
+- :description: LiveReports
+  :entries:
+  - :description: Use Hawkular as Live data source for Reports
+    :read_only: "0"
+    :syntax: string
+    :name: use_hawkular
+    :example_text:
+    :default: true
+    :single_value: "1"
+  :read_only: "0"
+  :syntax: string
+  :show: true
+  :name: live_reports
+  :example_text: LiveReports Options
+  :parent_id: 0
+  :default: true
+  :single_value: "1"

--- a/spec/models/metric/long_term_averages_spec.rb
+++ b/spec/models/metric/long_term_averages_spec.rb
@@ -1,0 +1,29 @@
+describe Metric::LongTermAverages do
+  context ".get_averages_over_time_period" do
+    let(:ems_openshift) do
+      FactoryGirl.create(:ems_openshift, :hostname => 't', :port => 8443, :name => 't',
+                         :zone => Zone.first)
+    end
+    let(:c1) { FactoryGirl.create(:container_group) }
+    let(:c2) { FactoryGirl.create(:container_image) }
+
+    it "it does not collect live metrics unless object is valid and ems is taged" do
+      ems_openshift.container_groups << [c1]
+      ems_openshift.container_images << [c2]
+
+      expect(Metric::LongTermAverages.live_report?(ems_openshift)).to eq(false)
+      expect(Metric::LongTermAverages.live_report?(c1)).to eq(false)
+      expect(Metric::LongTermAverages.live_report?(c2)).to eq(false)
+    end
+
+    it "it will collect live metrics if object is valid and ems is taged" do
+      ems_openshift.container_groups << [c1]
+      ems_openshift.container_images << [c2]
+      ems_openshift.tag_with("/live_reports/use_hawkular", :ns => "/managed")
+
+      expect(Metric::LongTermAverages.live_report?(ems_openshift)).to eq(true)
+      expect(Metric::LongTermAverages.live_report?(c1)).to eq(true)
+      expect(Metric::LongTermAverages.live_report?(c2)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
**Description**
for a concept approach for using live metrics in reports.

- [x] All Methods used in metrics reports (cpu, memeory)
- [x] Use a tag on ems to specify using live reports. 
- [x] All Objects used in metrics reports (done pods, nodes, containers, project and providers)
- [x] Specs, check only taged ems will use live reports

**Screenshot**
A pre set report
![screenshot-2017-01-10-16-32-13](https://cloud.githubusercontent.com/assets/2181522/21810007/c64573be-d752-11e6-9854-04f55371e952.png)

A custom report
![screenshot-localhost 3000-2017-01-10-20-40-40](https://cloud.githubusercontent.com/assets/2181522/21819635/2b5ddd14-d775-11e6-930b-a4d78f980a98.png)

Using custom tag, to specify using live reports
![screenshot-localhost 3000-2017-01-24-14-09-02](https://cloud.githubusercontent.com/assets/2181522/22246727/dc6fa870-e23e-11e6-8d90-5ec1811a5d78.png)
