### PR TITLE
Fix wrong EmsCluster image in Compare table

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1461,7 +1461,7 @@ module ApplicationController::Compare
                       <img src=\"#{img}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\" />
                     </a>"
     else
-      img = ActionController::Base.helpers.image_path("svg/vendor-#{h[:compare_db].downcase}.svg")
+      img = ActionController::Base.helpers.image_path("100/#{@sb[:compare_db].underscore}.png")
       html_text <<
         "<a href=\"/ems_cluster/show/#{h[:id]}\">
           <img src=\"#{img}\" align=\"middle\" border=\"0\" width=\"20\" height=\"20\"/>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1400413

My Settings -> Default Views -> Compare -> Set to Compressed View
Compute -> Infrastructure -> Clusters / Deployment Roles -> choose two or more -> Configuration -> Compare Selected Items 

Before:
`undefined method 'downcase' for nil:NilClass [ems_cluster/compare_miq]`
After:
![screen shot 2016-12-12 at 4 56 21 pm](https://cloud.githubusercontent.com/assets/9210860/21105825/f43b0b36-c08b-11e6-9fd2-9c331d29e9b4.png)


@miq-bot add_label ui, bug, euwe/yes 