### PR TITLE
Set Retirement Entrypoint on Blueprint Publish

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -228,12 +228,12 @@ class Blueprint < ApplicationRecord
   end
 
   def add_entry_points(new_bundle, entry_points, dialog, service_type)
-    entry_points ||= {
-      'Provision'  => ServiceTemplate.default_provisioning_entry_point(service_type),
-      'Retirement' => ServiceTemplate.default_retirement_entry_point
-    }
+    entry_points ||= {}
+    entry_points['Provision'] ||= ServiceTemplate.default_provisioning_entry_point(service_type)
+    entry_points['Retirement'] ||= ServiceTemplate.default_retirement_entry_point
 
     entry_points.each do |key, value|
+      next if value.blank?
       new_bundle.resource_actions.build(:action => key, :fqname => value, :dialog => dialog)
     end
   end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -201,6 +201,10 @@ describe Blueprint do
             "ae_namespace" => "x",
             "ae_class"     => "y",
             "ae_instance"  => "z"
+          ),
+          a_hash_including(
+            "action"      => "Retirement",
+            "ae_instance" => "Default"
           )
         )
       }
@@ -299,6 +303,9 @@ describe Blueprint do
 
       prov = bundle.resource_actions.find_by(:action => 'Provision')
       expect(prov.ae_uri).to eq('/a/b/c')
+
+      retirement = bundle.resource_actions.find_by(:action => 'Retirement')
+      expect(retirement.ae_uri).to eq(ServiceTemplate.default_retirement_entry_point)
 
       reconfig = bundle.resource_actions.find_by(:action => 'Reconfigure')
       expect(reconfig.ae_uri).to eq('/x/y/z')


### PR DESCRIPTION
This fixes an issue when publishing a Blueprint where retirement was not getting set when the automate entrypoints in `ui_properties` were:
```
{
"Provision" => "/a/b/c",
"Retirement" => nil
}
```

This fixes that by ensuring both the Provision and Retirement get set separately. 

It also fixes an error when
```
'Reconfigure' => nil
```
raises an `undefined method `split' for nil:NilClass` from `miq_ae_path.rb` by not building the resource action.

Links
----------------
* [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/135872349)

cc: @bzwei, @dtaylor113 
@miq-bot add_label bug, euwe/yes 

