### PR TITLE
Fix the CSS path for Prince XML PDF reports and use fit to page width option

### DIFF
--- a/app/assets/stylesheets/pdf_report.css
+++ b/app/assets/stylesheets/pdf_report.css
@@ -22,3 +22,4 @@ table tbody tr td.miq_rpt_gray_bg, table.adminlist tbody tr td.miq_rpt_gray_bg, 
 .miq_rpt_purple_text {color: #925bad; font-weight: bold}
 .miq_rpt_maroon_text {color: #76badf; font-weight: bold}
 .miq_rpt_gray_text {color: gray; font-weight: bold}
+@page { prince-shrink-to-fit: auto }

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -149,7 +149,7 @@ class MiqReportResult < ApplicationRecord
 
     html_string << report_build_html_table(report_results, html_rows.join)  # Build the html report table using all html rows
 
-    PdfGenerator.pdf_from_string(html_string, 'pdf_report')
+    PdfGenerator.pdf_from_string(html_string, "pdf_report.css")
   end
 
   # Generate the header html section for pdfs

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -162,7 +162,6 @@ class MiqReportResult < ApplicationRecord
     hdr << "@page{size: #{page_size} landscape}"
     hdr << "@page{margin: 40pt 30pt 40pt 30pt}"
     hdr << "@page{@top{content: '#{title}';color:blue}}"
-    hdr << "@page{@bottom-left{content: url('#{ActionController::Base.helpers.image_path('layout/reportbanner_small1.png')}')}}"
     hdr << "@page{@bottom-center{font-size: 75%;content: '" + _("Report date: %{report_date}") % {:report_date => run_date} + "'}}"
     hdr << "@page{@bottom-right{font-size: 75%;content: '" + _("Page %{page_number} of %{total_pages}") % {:page_number => " ' counter(page) '", :total_pages => " ' counter(pages)}}"}
     hdr << "</style></head>"

--- a/lib/pdf_generator.rb
+++ b/lib/pdf_generator.rb
@@ -43,9 +43,9 @@ class PdfGenerator
   private_class_method :sanitize_html
 
   def self.stylesheet_file_path(stylesheet)
-    # Determine path relative to Rails.public_path
-    "/../app/assets/stylesheets/#{stylesheet}.css"
+    Rails.root.join(*%W(app assets stylesheets #{stylesheet})).to_s
   end
+
   private_class_method :stylesheet_file_path
 end
 

--- a/lib/pdf_generator/prince_pdf_generator.rb
+++ b/lib/pdf_generator/prince_pdf_generator.rb
@@ -18,7 +18,6 @@ class PrincePdfGenerator < PdfGenerator
       :params  => {
         :input    => "html",
         :style    => stylesheet,
-        :fileroot => Rails.public_path,
         :log      => Rails.root.join("log/prince.log"),
         :output   => "-", # Write to stdout
         "-"       => nil  # Read from stdin


### PR DESCRIPTION
Before fix:
[Chargeback - Production VMs Summary for this week_20161212_160004.pdf](https://github.com/ManageIQ/manageiq/files/646575/Chargeback.-.Production.VMs.Summary.for.this.week_20161212_160004.pdf)

After fix:
[Chargeback - Production VMs Summary for this week_20161212_172526.pdf](https://github.com/ManageIQ/manageiq/files/646577/Chargeback.-.Production.VMs.Summary.for.this.week_20161212_172526.pdf)


https://bugzilla.redhat.com/show_bug.cgi?id=1396133