### PR TITLE
VCpus and Memory for Cloud Providers visual

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -138,6 +138,9 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
 
+  virtual_aggregate :total_cloud_vcpus, :vms, :sum, :cpu_total_cores
+  virtual_aggregate :total_cloud_memory, :vms, :sum, :ram_size
+
   alias_method :clusters, :ems_clusters # Used by web-services to return clusters as the property name
   alias_attribute :to_s, :name
 

--- a/product/views/ManageIQ_Providers_CloudManager.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager.yaml
@@ -23,6 +23,8 @@ cols:
 - emstype_description
 - port
 - total_vms
+- total_cloud_vcpus
+- total_cloud_memory
 - total_miq_templates
 - region_description
 
@@ -43,8 +45,18 @@ col_order:
 - emstype_description
 - zone.name
 - total_vms
+- total_cloud_vcpus
+- total_cloud_memory
 - total_miq_templates
 - region_description
+
+col_formats:
+-
+-
+-
+-
+-
+- :megabytes_human
 
 # Column titles, in order
 headers:
@@ -52,6 +64,8 @@ headers:
 - Type
 - EVM Zone
 - Instances
+- VCpus
+- Memory
 - Images
 - Region
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -258,7 +258,21 @@ describe ExtManagementSystem do
   context "with virtual totals" do
     before(:each) do
       @ems = FactoryGirl.create(:ems_vmware)
-      (1..2).each { |i| FactoryGirl.create(:vm_vmware, :ext_management_system => @ems, :name => "vm_#{i}") }
+      2.times do
+        FactoryGirl.create(:vm_vmware,
+                           :ext_management_system => @ems,
+                           :hardware              => FactoryGirl.create(:hardware,
+                                                                        :cpu1x2,
+                                                                        :ram1GB))
+      end
+    end
+
+    it "#total_cloud_vcpus" do
+      expect(@ems.total_cloud_vcpus).to eq(4)
+    end
+
+    it "#total_cloud_memory" do
+      expect(@ems.total_cloud_memory).to eq(2048)
     end
 
     it "#total_vms_on" do


### PR DESCRIPTION
This is a simple change in the visual of Cloud list View of providers, now we can see Total Cores and Total Memory of each Provider of Instances(VMs).

@sergio-ocon, @kbrock is the same than #12758 but in cloud provider list view.

![captura de pantalla de 2016-12-12 19-39-01](https://cloud.githubusercontent.com/assets/3019213/21111634/b66868a0-c0a2-11e6-8638-4f23e0d7bd5a.png)
