### PR TITLE
Fix ram_size_in_bytes for hardware#memory_mb = nil

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -41,7 +41,7 @@ class Hardware < ApplicationRecord
   end
 
   def ram_size_in_bytes
-    memory_mb * 1.megabyte
+    memory_mb.to_i * 1.megabyte
   end
 
   @@dh = {"type" => "device_name", "devicetype" => "device_type", "id" => "location", "present" => "present",

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -179,4 +179,24 @@ describe Hardware do
       end
     end
   end
+
+  describe ".ram_size_in_bytes" do
+    it "handles nil" do
+      hardware = FactoryGirl.build(:hardware)
+
+      expect(hardware.ram_size_in_bytes).to eq(0)
+    end
+
+    it "works in ruby" do
+      hardware = FactoryGirl.build(:hardware, :memory_mb => 5)
+
+      expect(hardware.ram_size_in_bytes).to eq(5.megabytes)
+    end
+
+    it "works in sql" do
+      hardware = FactoryGirl.create(:hardware, :memory_mb => 5)
+
+      expect(virtual_column_sql_value(Hardware, "ram_size_in_bytes")).to eq(5.megabytes)
+    end
+  end
 end


### PR DESCRIPTION
fixes `ram_size_in_bytes` for nil `memory_mb`
Fixes #13115 
The bug was introduced in #12938


before #12938
---

`hardware#ram_size_in_bytes` returns 0 when `memory_mb` is nil

now
---

`hardware#ram_size_in_bytes` blows up when `memory_mb` is nil

after this pr
-----

`hardware#ram_size_in_bytes` returns 0 when `memory_mb` is nil

/cc @vecerek

