### PR TITLE
Improve UX for attaching Openstack cloud volumes to instances

### DIFF
--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -15,7 +15,7 @@ class VmCloudController < ApplicationController
     assert_privileges("instance_attach")
     @volume_choices = {}
     @record = @vm = find_by_id_filtered(VmCloud, params[:id])
-    @vm.cloud_tenant.cloud_volumes.each { |volume| @volume_choices[volume.name] = volume.id }
+    @vm.cloud_tenant.cloud_volumes.select { |v| v.status == 'available' }.each { |v| @volume_choices[v.name] = v.id }
 
     @in_a_form = true
     drop_breadcrumb(

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -15,7 +15,7 @@ class VmCloudController < ApplicationController
     assert_privileges("instance_attach")
     @volume_choices = {}
     @record = @vm = find_by_id_filtered(VmCloud, params[:id])
-    @vm.cloud_tenant.cloud_volumes.select { |v| v.status == 'available' }.each { |v| @volume_choices[v.name] = v.id }
+    @vm.cloud_tenant.cloud_volumes.where(:status => 'available').each { |v| @volume_choices[v.name] = v.id }
 
     @in_a_form = true
     drop_breadcrumb(

--- a/app/helpers/application_helper/button/instance_attach.rb
+++ b/app/helpers/application_helper/button/instance_attach.rb
@@ -1,10 +1,7 @@
 class ApplicationHelper::Button::InstanceAttach < ApplicationHelper::Button::Basic
   def disabled?
     if @record.cloud_tenant.cloud_volumes.where(:status => 'available').count.zero?
-      @error_message = _("There are no %{volumes} available to attach to this %{model}.") % {
-        :volumes => ui_lookup(:tables => 'cloud_volumes'),
-        :model   => ui_lookup(:table => 'vm_cloud')
-      }
+      @error_message = _("There are no Cloud Volumes available to attach to this Instance.")
     end
     @error_message.present?
   end

--- a/app/helpers/application_helper/button/instance_attach.rb
+++ b/app/helpers/application_helper/button/instance_attach.rb
@@ -1,0 +1,11 @@
+class ApplicationHelper::Button::InstanceAttach < ApplicationHelper::Button::Basic
+  def disabled?
+    if @record.cloud_tenant.cloud_volumes.where(:status => 'available').count.zero?
+      @error_message = _("There are no %{volumes} available to attach to this %{model}.") % {
+        :volumes => ui_lookup(:tables => 'cloud_volumes'),
+        :model   => ui_lookup(:table => 'vm_cloud')
+      }
+    end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/instance_detach.rb
+++ b/app/helpers/application_helper/button/instance_detach.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Basic
   def disabled?
-    if @record.number_of(:cloud_volumes) == 0
-      @error_message = _("%{model} \"%{name}\" has no attached %{volumes}") % {
+    if @record.number_of(:cloud_volumes).zero?
+      @error_message = _("This %{model} has no attached %{volumes}.") % {
         :model   => ui_lookup(:table => 'vm_cloud'),
         :name    => @record.name,
         :volumes => ui_lookup(:tables => 'cloud_volumes')

--- a/app/helpers/application_helper/button/instance_detach.rb
+++ b/app/helpers/application_helper/button/instance_detach.rb
@@ -1,11 +1,7 @@
 class ApplicationHelper::Button::InstanceDetach < ApplicationHelper::Button::Basic
   def disabled?
     if @record.number_of(:cloud_volumes).zero?
-      @error_message = _("This %{model} has no attached %{volumes}.") % {
-        :model   => ui_lookup(:table => 'vm_cloud'),
-        :name    => @record.name,
-        :volumes => ui_lookup(:tables => 'cloud_volumes')
-      }
+      @error_message = _("This Instance has no attached Cloud Volumes.")
     end
     @error_message.present?
   end

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -47,7 +47,8 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
           :instance_attach,
           'pficon pficon-volume fa-lg',
           t = N_('Attach a Cloud Volume to this Instance'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::InstanceAttach),
         button(
           :instance_detach,
           'pficon pficon-volume fa-lg',

--- a/spec/factories/vm_openstack.rb
+++ b/spec/factories/vm_openstack.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     vendor          "openstack"
     raw_power_state "ACTIVE"
     sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
+    cloud_tenant { FactoryGirl.create(:cloud_tenant_openstack) }
   end
 
   factory :vm_perf_openstack, :parent => :vm_openstack do

--- a/spec/helpers/application_helper/buttons/instance_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_attach_spec.rb
@@ -1,0 +1,47 @@
+describe ApplicationHelper::Button::InstanceAttach do
+  describe '#disabled?' do
+    it "when there are available volumes, then the button is enabled" do
+      view_context = setup_view_context_with_sandbox({})
+
+      tenant = FactoryGirl.create(:cloud_tenant_openstack)
+      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
+      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      button = described_class.new(view_context, {}, {"record" => record}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when there are no available volumes then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = FactoryGirl.create(:cloud_tenant_openstack)
+      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
+      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      button = described_class.new(view_context, {}, {"record" => record}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when there are no available volumes then the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = FactoryGirl.create(:cloud_tenant_openstack)
+      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'in-use')
+      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      button = described_class.new(view_context, {}, {"record" => record}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq(_("There are no %{volumes} available to attach to this %{model}.") % {
+        :model   => ui_lookup(:table => 'vm_cloud'),
+        :volumes => ui_lookup(:tables => 'cloud_volumes')
+      })
+    end
+
+    it "when there are available volumes, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      tenant = FactoryGirl.create(:cloud_tenant_openstack)
+      volume = FactoryGirl.create(:cloud_volume_openstack, :cloud_tenant => tenant, :status => 'available')
+      record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
+      button = described_class.new(view_context, {}, {"record" => record}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_attach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_attach_spec.rb
@@ -28,10 +28,7 @@ describe ApplicationHelper::Button::InstanceAttach do
       record = FactoryGirl.create(:vm_openstack, :cloud_tenant => tenant)
       button = described_class.new(view_context, {}, {"record" => record}, {})
       button.calculate_properties
-      expect(button[:title]).to eq(_("There are no %{volumes} available to attach to this %{model}.") % {
-        :model   => ui_lookup(:table => 'vm_cloud'),
-        :volumes => ui_lookup(:tables => 'cloud_volumes')
-      })
+      expect(button[:title]).to eq(_("There are no Cloud Volumes available to attach to this Instance."))
     end
 
     it "when there are available volumes, the button has no error in the title" do

--- a/spec/helpers/application_helper/buttons/instance_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_detach_spec.rb
@@ -26,7 +26,7 @@ describe ApplicationHelper::Button::InstanceDetach do
         )}, {}
       )
       button.calculate_properties
-      expect(button[:title]).to eq(_("%{model} \"TestVM\" has no attached %{volumes}") % {
+      expect(button[:title]).to eq(_("This %{model} has no attached %{volumes}.") % {
         :model   => ui_lookup(:table => 'vm_cloud'),
         :volumes => ui_lookup(:tables => 'cloud_volumes')
       })

--- a/spec/helpers/application_helper/buttons/instance_detach_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_detach_spec.rb
@@ -26,10 +26,7 @@ describe ApplicationHelper::Button::InstanceDetach do
         )}, {}
       )
       button.calculate_properties
-      expect(button[:title]).to eq(_("This %{model} has no attached %{volumes}.") % {
-        :model   => ui_lookup(:table => 'vm_cloud'),
-        :volumes => ui_lookup(:tables => 'cloud_volumes')
-      })
+      expect(button[:title]).to eq(_("This Instance has no attached Cloud Volumes."))
     end
 
     it "when there are volumes to detach, the button has no error in the title" do


### PR DESCRIPTION
This PR causes the Attach Volume to Instance form to only list volumes that are in an available state, and disables the Attach Volume to Instance button entirely when there are no volumes available to an instance. It also cleans up some tooltip wording for Detach to match other tooltips.

Links
-------
* https://bugzilla.redhat.com/show_bug.cgi?id=1389446