### PR TITLE
[DARGA] Reimplement VM power operations from the global region over REST

### DIFF
--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -27,7 +27,7 @@ module ProcessTasksMixin
 
       # TODO: invoke_tasks_remote currently is only implemented by VmOrTemplate.
       # it can be refactored to be generalized like invoke_tasks_local
-      invoke_tasks_remote(options.merge(:ids => remote)) if remote.present? && respond_to?("invoke_tasks_remote")
+      invoke_tasks_remote_queue(options.merge(:ids => remote)) if remote.present? && respond_to?("invoke_tasks_remote_queue")
     end
 
     def invoke_tasks_local(options)

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -22,7 +22,7 @@ module ProcessTasksMixin
 
     # Performs tasks received from the UI via the queue
     def invoke_tasks(options)
-      local, remote = partition_ids_by_remote_region(options[:ids])
+      local, remote = partition_ids_by_remote_region(options[:ids].map(&:to_i))
       invoke_tasks_local(options.merge(:ids => local)) unless local.empty?
 
       # TODO: invoke_tasks_remote currently is only implemented by VmOrTemplate.

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -474,7 +474,6 @@ class VmOrTemplate < ApplicationRecord
 
   def self.invoke_tasks_remote_queue(options, deliver_on = nil)
     queue_opts = {
-      :role        => "user_interface",
       :class_name  => base_class.name,
       :method_name => 'invoke_tasks_remote',
       :args        => [options]

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -490,6 +490,7 @@ class VmOrTemplate < ApplicationRecord
     api_user     = Settings.webservices.remote_miq_api.user
     api_password = Settings.webservices.remote_miq_api.password
 
+    raise "No API username provided for remote #{action}" if api_user.blank?
     raise "No API password provided for user #{api_user} for remote #{action}" if api_password.blank?
 
     uri = URI::HTTPS.build(

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -494,7 +494,7 @@ class VmOrTemplate < ApplicationRecord
 
     uri = URI::HTTPS.build(
       :host     => hostname,
-      :userinfo => "#{api_user}:#{api_password}",
+      :userinfo => "#{CGI.escape(api_user)}:#{CGI.escape(api_password)}",
       :path     => "/api/vms"
     )
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1081,6 +1081,10 @@
   :timeout: 120
   :use_vim_broker: true
   :authentication_timeout: 30.seconds
+  :remote_miq_api:
+    :user: admin
+    :password:
+    :request_timeout: 600
 :workers:
   :worker_base:
     :defaults:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1082,7 +1082,7 @@
   :use_vim_broker: true
   :authentication_timeout: 30.seconds
   :remote_miq_api:
-    :user: admin
+    :user:
     :password:
     :request_timeout: 600
 :workers:


### PR DESCRIPTION
This feature was lost when we removed the old SOAP API in favor of REST.

This change will bridge the gap between the old SOAP based feature and the new, fully featured Central Administration feature in the Euwe release.

The bulk of this change is adding VmOrTemplate.invoke_api_task which uses the REST API to invoke a particular task on a group of VMs.

New configuration keys for specifying the remote API user and password were also necessary. This user and password must exist in the target regions for API authentication.

These settings must be specified in the advanced settings page of the server(s) with the User Interface role in the global region. These appliances will be used to route the requests to the appliance in the remote region with the webservices role active.

The password can be encrypted using the global region's v2_key


This is being opened mostly for review purposes, I'm not sure it actually needs to get merged.