### PR TITLE
Fix supports_shutdown_guest bug and added specs

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -9,10 +9,12 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
 
     supports :shutdown_guest do
       unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports_control?
-      unless tools_status && tools_status == 'toolsNotInstalled'
-        if current_state != "on"
-          unsupported_reason_add(:shutdown_guest, _("The VM is not powered on"))
+      if current_state == "on"
+        if tools_status == 'toolsNotInstalled'
+          unsupported_reason_add(:shutdown_guest, _("The VM tools is not installed"))
         end
+      else
+        unsupported_reason_add(:shutdown_guest, _("The VM is not powered on"))
       end
     end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -1,11 +1,11 @@
 describe ManageIQ::Providers::Vmware::InfraManager::Vm do
-  context "#is_available?" do
-    let(:ems)  { FactoryGirl.create(:ems_vmware) }
-    let(:host) { FactoryGirl.create(:host_vmware_esx, :ext_management_system => ems) }
-    let(:vm)   { FactoryGirl.create(:vm_vmware, :ext_management_system => ems, :host => host) }
-    let(:power_state_on)        { "poweredOn" }
-    let(:power_state_suspended) { "poweredOff" }
+  let(:ems)  { FactoryGirl.create(:ems_vmware) }
+  let(:host) { FactoryGirl.create(:host_vmware_esx, :ext_management_system => ems) }
+  let(:vm)   { FactoryGirl.create(:vm_vmware, :ext_management_system => ems, :host => host) }
+  let(:power_state_on)        { "poweredOn" }
+  let(:power_state_suspended) { "poweredOff" }
 
+  context "#is_available?" do
     context("with :start") do
       let(:state) { :start }
       include_examples "Vm operation is available when not powered on"
@@ -18,11 +18,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
 
     context("with :suspend") do
       let(:state) { :suspend }
-      include_examples "Vm operation is available when powered on"
-    end
-
-    context("with :shutdown_guest") do
-      let(:state) { :shutdown_guest }
       include_examples "Vm operation is available when powered on"
     end
 
@@ -43,11 +38,46 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
   end
 
   context "supports_clone?" do
-    let(:ems)  { FactoryGirl.create(:ems_vmware) }
-    let(:vm)   { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
-
     it "returns true" do
       expect(vm.supports?(:clone)).to eq(true)
+    end
+  end
+
+  context "supports_shutdown_guest?" do
+    let(:op) { 'shutdown_guest' }
+
+    context "when powered off" do
+      let(:vm_status) { {:raw_power_state => power_state_suspended} }
+
+      it 'is not available if tools is not installed' do
+        vm_status[:tools_status] = 'toolsNotInstalled'
+        vm.update_attributes(vm_status)
+        expect(vm.public_send("supports_#{op}?")).to be false
+        expect(vm.unsupported_reason(op)).to include("power")
+      end
+
+      it 'is not available even if tools is installed' do
+        vm_status[:tools_status] = nil
+        vm.update_attributes(vm_status)
+        expect(vm.public_send("supports_#{op}?")).to be false
+        expect(vm.unsupported_reason(op)).to include("power")
+      end
+    end
+
+    context "when powered on" do
+      let(:vm_status) { {:raw_power_state => power_state_on} }
+
+      it 'is not available if tools not installed' do
+        vm_status[:tools_status] = 'toolsNotInstalled'
+        vm.update_attributes(vm_status)
+        expect(vm.public_send("supports_#{op}?")).to be false
+        expect(vm.unsupported_reason(op)).to include("tools")
+      end
+
+      it 'is available if tools installed' do
+        vm_status[:tools_status] = nil
+        expect(vm.public_send("supports_#{op}?")).to be true
+      end
     end
   end
 


### PR DESCRIPTION
When a VMware VM's `tools_status` is not installed, even when the VM is powered off, toolbar menu on VM summary page still shows the shutdown guest option.

https://bugzilla.redhat.com/show_bug.cgi?id=1393530

