### PR TITLE
[DARGA] Fix infra breadcrumb from showing on about page

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -19,6 +19,7 @@ class SupportController < ApplicationController
   def about
     #   @tabs ||= [ ["1", ""] ]
     #   @tabs.push( ["1", "Help"] )
+    @breadcrumbs = []
     @vmdb = {:version => Vmdb::Appliance.VERSION, :build => Vmdb::Appliance.BUILD}
     @user_role = User.current_user.miq_user_role_name
     @pdf_documents = pdf_documents


### PR DESCRIPTION
Clear breadcrumbs before displaying about page.

**Before**

![screen shot 2016-12-12 at 8 30 11 pm](https://cloud.githubusercontent.com/assets/39493/21127693/d8bfb8de-c0a9-11e6-90e5-5ac526252e66.png)

**After**

![screen shot 2016-12-12 at 8 25 19 pm](https://cloud.githubusercontent.com/assets/39493/21127699/df0b2084-c0a9-11e6-8864-962d03201964.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1245133