### PR TITLE
Fix post_refresh_ems by only reclassifying VMs if they were changed directly

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1150,24 +1150,38 @@ class VmOrTemplate < ApplicationRecord
       assign_ems_created_on_queue(added_vm_ids) if ::Settings.ems_refresh.capture_vm_created_on_date
     end
 
+    post_refresh_ems_folder_updates(ems, update_start_time, added_vms)
+  end
+
+  def self.post_refresh_ems_folder_updates(ems, update_start_time, added_vms)
     # Collect the updated folder relationships to determine which vms need updated path information
     ems_folders = ems.ems_folders
     MiqPreloader.preload(ems_folders, :all_relationships)
 
-    updated_folders = ems_folders.select do |f|
-      f.created_on >= update_start_time || f.updated_on >= update_start_time || # Has the folder itself changed (e.g. renamed)?
-      f.relationships.any? do |r|                                                  # Or has its relationship rows changed?
-        r.created_at >= update_start_time || r.updated_at >= update_start_time || #   Has the direct relationship changed (e.g. this folder moved under another folder)?
-        r.children.any? do |child_r|                                             #   Or have any of the child relationship rows changed (e.g. vm moved under this folder)?
-          child_r.created_at >= update_start_time || child_r.updated_at >= update_start_time
+    # Find any VMs that were created or moved into a new folder
+    updated_vm_rels = ems_folders.collect do |f|
+      f.relationships.collect do |r|
+        r.children.select do |child_r|
+          child_r.resource_type == "VmOrTemplate" &&
+            (child_r.created_at >= update_start_time || child_r.updated_at >= update_start_time)
         end
       end
+    end.flatten
+
+    # Now find any Folders that were renamed or moved into a new parent folder
+    updated_folders = ems_folders.select do |f|
+      f.created_on >= update_start_time || f.updated_on >= update_start_time ||  # Has the folder itself changed (e.g. renamed)?
+        f.relationships.any? do |r|
+          r.created_at >= update_start_time || r.updated_at >= update_start_time # Has the relationship changed (e.g. this folder moved under another folder)?
+        end
     end
-    unless updated_folders.empty?
-      updated_vms = updated_folders.collect(&:all_vms_and_templates).flatten.uniq - added_vms
-      updated_vms.each(&:classify_with_parent_folder_path_queue)
-    end
+
+    updated_vms  = VmOrTemplate.where(:id => updated_vm_rels.collect(&:resource_id))
+    updated_vms += updated_folders.flat_map(&:all_vms_and_templates)
+    updated_vms  = updated_vms.uniq - added_vms
+    updated_vms.each(&:classify_with_parent_folder_path_queue)
   end
+  private_class_method :post_refresh_ems_folder_updates
 
   def self.assign_ems_created_on_queue(vm_ids)
     MiqQueue.put(

--- a/spec/factories/ems_folder.rb
+++ b/spec/factories/ems_folder.rb
@@ -14,4 +14,83 @@ FactoryGirl.define do
   factory :inventory_root_group,
           :class  => "ManageIQ::Providers::ConfigurationManager::InventoryRootGroup",
           :parent => :ems_folder
+
+  #
+  # VMware specific folders
+  #
+
+  factory :vmware_folder, :parent => :ems_folder do
+    sequence(:ems_ref) { |n| "group-d#{n}" }
+  end
+
+  factory :vmware_folder_vm, :parent => :ems_folder do
+    sequence(:ems_ref) { |n| "group-v#{n}" }
+  end
+
+  factory :vmware_folder_host, :parent => :ems_folder do
+    sequence(:ems_ref) { |n| "group-h#{n}" }
+  end
+
+  factory :vmware_folder_datastore, :parent => :ems_folder do
+    sequence(:ems_ref) { |n| "group-s#{n}" }
+  end
+
+  factory :vmware_folder_network, :parent => :ems_folder do
+    sequence(:ems_ref) { |n| "group-n#{n}" }
+  end
+
+  factory :vmware_folder_root, :parent => :vmware_folder do
+    name   "Datacenters"
+    hidden true
+  end
+
+  factory :vmware_folder_vm_root, :parent => :vmware_folder_vm do
+    name   "vm"
+    hidden true
+  end
+
+  factory :vmware_folder_host_root, :parent => :vmware_folder_host do
+    name   "host"
+    hidden true
+  end
+
+  factory :vmware_folder_datastore_root, :parent => :vmware_folder_datastore do
+    name   "datastore"
+    hidden true
+  end
+
+  factory :vmware_folder_network_root, :parent => :vmware_folder_network do
+    name   "network"
+    hidden true
+  end
+
+  factory :vmware_datacenter, :parent => :vmware_folder, :class => "Datacenter" do
+    sequence(:name) { |n| "Test Datacenter #{seq_padded_for_sorting(n)}" }
+  end
+end
+
+def build_vmware_folder_structure!(ems)
+  ems.add_child(
+    FactoryGirl.create(:vmware_folder_root, :ems_id => ems.id).tap do |root|
+      root.add_child(
+        FactoryGirl.create(:vmware_folder, :name => "yellow1", :ems_id => ems.id).tap do |f|
+          f.add_child(
+            FactoryGirl.create(:vmware_datacenter, :ems_id => ems.id).tap do |dc|
+              dc.add_children(
+                FactoryGirl.create(:vmware_folder_vm_root, :ems_id => ems.id) do |vm|
+                  vm.add_children(
+                    FactoryGirl.create(:vmware_folder_vm, :name => "blue1", :ems_id => ems.id),
+                    FactoryGirl.create(:vmware_folder_vm, :name => "blue2", :ems_id => ems.id)
+                  )
+                end,
+                FactoryGirl.create(:vmware_folder_host_root, :ems_id => ems.id),
+                FactoryGirl.create(:vmware_folder_datastore_root, :ems_id => ems.id),
+                FactoryGirl.create(:vmware_folder_network_root, :ems_id => ems.id)
+              )
+            end
+          )
+        end
+      )
+    end
+  )
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -866,4 +866,155 @@ describe VmOrTemplate do
       expect(VmOrTemplate.not_archived_nor_orphaned).to eq([vm])
     end
   end
+
+  describe ".post_refresh_ems" do
+    let(:folder_blue1)   { EmsFolder.find_by(:name => "blue1") }
+    let(:folder_blue2)   { EmsFolder.find_by(:name => "blue2") }
+    let(:folder_vm_root) { EmsFolder.find_by(:name => "vm") }
+    let(:vm_blue1)       { VmOrTemplate.find_by(:name => "vm_blue1") }
+    let(:vm_blue2)       { VmOrTemplate.find_by(:name => "vm_blue2") }
+
+    let!(:ems) do
+      _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
+      FactoryGirl.create(:ems_vmware, :zone => zone).tap do |ems|
+        build_vmware_folder_structure!(ems)
+        folder_blue1.add_child(FactoryGirl.create(:vm_vmware, :name => "vm_blue1", :ems_id => ems.id))
+        folder_blue2.add_child(FactoryGirl.create(:vm_vmware, :name => "vm_blue2", :ems_id => ems.id))
+      end
+    end
+
+    let!(:start_time) { Time.now.utc }
+
+    it "when a folder is created under a folder" do
+      new_folder = FactoryGirl.create(:vmware_folder_vm, :ems_id => ems.id)
+      new_folder.parent = folder_blue1
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(0)
+    end
+
+    it "when a folder is renamed" do
+      folder_blue1.update_attributes(:name => "new blue1")
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a folder is moved" do
+      folder_blue1.parent = folder_blue2
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a VM is created under a folder" do
+      new_vm = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
+      new_vm.with_relationship_type("ems_metadata") { |v| v.parent = folder_blue1 }
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => new_vm.class.name,
+        :instance_id => new_vm.id,
+        :method_name => "post_create_actions"
+      )
+    end
+
+    it "when a VM is moved to another folder" do
+      vm_blue1.with_relationship_type("ems_metadata") { |v| v.parent = folder_blue2 }
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a folder is created and a folder is moved under it simultaneously" do
+      new_folder = FactoryGirl.create(:vmware_folder_vm, :ems_id => ems.id)
+      new_folder.parent = folder_vm_root
+      folder_blue1.parent = new_folder
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a folder is renamed and a folder is moved under it simultaneously" do
+      folder_blue1.update_attributes(:name => "new blue1")
+      folder_blue2.parent = folder_blue1
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      queue_items = MiqQueue.order(:instance_id)
+      expect(queue_items.count).to eq(2)
+      expect(queue_items[0]).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+      expect(queue_items[1]).to have_attributes(
+        :class_name  => vm_blue2.class.name,
+        :instance_id => vm_blue2.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a folder is created and a VM is moved under it simultaneously" do
+      new_folder = FactoryGirl.create(:vmware_folder_vm, :ems_id => ems.id)
+      new_folder.parent = folder_vm_root
+      vm_blue1.with_relationship_type("ems_metadata") { |v| v.parent = new_folder }
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+
+    it "when a folder is renamed and a VM is moved under it simultaneously" do
+      folder_blue2.update_attributes(:name => "new blue2")
+      vm_blue1.with_relationship_type("ems_metadata") { |v| v.parent = folder_blue2 }
+
+      described_class.post_refresh_ems(ems.id, start_time)
+
+      queue_items = MiqQueue.order(:instance_id)
+      expect(queue_items.count).to eq(2)
+      expect(queue_items[0]).to have_attributes(
+        :class_name  => vm_blue1.class.name,
+        :instance_id => vm_blue1.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+      expect(queue_items[1]).to have_attributes(
+        :class_name  => vm_blue2.class.name,
+        :instance_id => vm_blue2.id,
+        :method_name => "classify_with_parent_folder_path"
+      )
+    end
+  end
 end


### PR DESCRIPTION
After refreshing an EMS, the method `VmOrTemplate.post_refresh_ems` should call `classify_with_parent_folder_path_queue` for

- every vm that has moved to a different folder
- every vm under a folder that was renamed
- every vm under a folder that was moved

However, it was found that if any object (whether a VM or another folder) was moved under a folder, it would update *every* VM under that folder, instead of just the object.  This leads to a burst of taggings changes on the record that aren't necessary, and can be detrimental in large environments.

This PR fixes that and add specs to verify the various combinations.  Paired with @agrare on this one.
@gtanzillo, @jrafanie Please review.  In particular I had to create a helper method in the factory file, and I don't like it, but I don't know where it should live...thoughts?

https://bugzilla.redhat.com/show_bug.cgi?id=1404028
