### PR TITLE
run vmdb_plugins initializer before settings initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -146,6 +146,14 @@ module Vmdb
     # Note: If an initializer doesn't have an after, Rails will add one based
     # on the top to bottom order of initializer calls in the file.
     # Because this is easy to mess up, keep your initializers in order.
+    # register plugins even before loading settings, as plugins can bring their own settings
+    initializer :register_vmdb_plugins, :before => :load_vmdb_settings do
+      Rails.application.railties.each do |railtie|
+        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
+        Vmdb::Plugins.instance.register_vmdb_plugin(railtie)
+      end
+    end
+
     initializer :load_vmdb_settings, :before => :load_config_initializers do
       Vmdb::Settings.init
       Vmdb::Loggers.apply_config(::Settings.log)

--- a/config/initializers/register_vmdb_plugins.rb
+++ b/config/initializers/register_vmdb_plugins.rb
@@ -1,4 +1,0 @@
-Rails.application.railties.each do |railtie|
-  next unless (railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?))
-  Vmdb::Plugins.instance.register_vmdb_plugin(railtie)
-end


### PR DESCRIPTION
otherwise settings from vmdb plugins won't be picked up

see https://github.com/ManageIQ/manageiq/pull/10944/files

@miq-bot assign @Fryguy 
@miq-bot add_label enhancement, pluggable providers

cc @bdunne 