### PR TITLE
Make created filters in Datastores visible and fix commiting filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -307,7 +307,7 @@ module ApplicationController::Filter
             {:model => ui_lookup(:model => @edit[@expkey][:exp_model]),
              :name => @edit[:new_search_name]})
           @edit[@expkey].select_filter(s)
-          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description]
+          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description] unless @edit[@expkey][:exp_model] == "Storage"
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -311,7 +311,7 @@ module ApplicationController::Filter
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])
-          @efit[@expkey].history.reset(@edit[@expkey][:expression])
+          @edit[@expkey].history.reset(@edit[@expkey][:expression])
           # Clear the current selected token
           @edit[@expkey][:exp_token] = nil
         else

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -24,8 +24,13 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    return count_only ? 0 : [] if object[:id] != "global"
-    objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
+    objects = MiqSearch.where(:db => options[:leaf])
+    objects = case object[:id]
+              when "global" # Global filters
+                objects.visible_to_all
+              when "my"     # My filters
+                objects.where(:search_type => "user", :search_key => User.current_user.userid)
+              end
     count_only_or_objects(count_only, objects, "description")
   end
 end

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -23,25 +23,24 @@
     %fieldset
       .toolbar-pf-actions
         .form-group
-          %button
-            - t = _('Commit expression element changes')
-            = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
-              {:action => 'exp_button', :pressed => 'commit'},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-          %button
-            - t = _("Discard expression element changes")
-            = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
-              {:action => 'exp_button', :pressed  => 'discard'},
-              "data-miq_sparkle_on"  => true,
-              "data-miq_sparkle_off" => true,
-              :remote                => true,
-              "data-method"          => :post,
-              :title                 => t)
-
+          - t = _('Commit expression element changes')
+          = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
+            {:action => 'exp_button', :pressed => 'commit'},
+            "data-miq_sparkle_on"  => true,
+            "data-miq_sparkle_off" => true,
+            :remote                => true,
+            "data-method"          => :post,
+            :title                 => t,
+            :class                 => "btn btn-default")
+          - t = _("Discard expression element changes")
+          = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
+            {:action => 'exp_button', :pressed  => 'discard'},
+            "data-miq_sparkle_on"  => true,
+            "data-miq_sparkle_off" => true,
+            :remote                => true,
+            "data-method"          => :post,
+            :title                 => t,
+            :class                 => "btn btn-default")
       - if @edit[@expkey][:exp_key] == "NOT"
         %font{:color => "black"}
           = _('NOT')


### PR DESCRIPTION
fixing
https://bugzilla.redhat.com/show_bug.cgi?id=1398748
https://bugzilla.redhat.com/show_bug.cgi?id=1382768

Make created filters (not global) in Compute -> Infrastructure -> Datastores
visible under My Filters in accordion, no need to refresh the page
after creating a new filter.
Fix commiting a new filter which is related to its creating and saving.

Commiting filters was broken by
https://github.com/ManageIQ/manageiq/pull/12998

Before:
![datastores2](https://cloud.githubusercontent.com/assets/13417815/21146658/bec2af64-c152-11e6-94d7-a2886b7e854f.png)
![datastores4](https://cloud.githubusercontent.com/assets/13417815/21147606/e176f2ec-c155-11e6-8824-48e6adfd46fd.png)

After:
![datastores1](https://cloud.githubusercontent.com/assets/13417815/21146664/c231250e-c152-11e6-990a-6432d6fbd12d.png)
![datastores3](https://cloud.githubusercontent.com/assets/13417815/21147594/d667a2c0-c155-11e6-9bec-fb2ef72a316d.png)

No need to refresh the page after creating a new filter:
![datastores5](https://cloud.githubusercontent.com/assets/13417815/21147707/30b08990-c156-11e6-9428-60b8e096056e.png)


