### PR TITLE
Chargeback spec cleanup

### DIFF
--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -111,7 +111,6 @@ describe ChargebackContainerImage do
                                                                 :image_tag_names => "environment/prod")
         time += 12.hours
       end
-      @metric_size = @container.metric_rollups.size
     end
 
     subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
@@ -166,7 +165,6 @@ describe ChargebackContainerImage do
                                                                 :image_tag_names => "")
         time += 12.hours
       end
-      @metric_size = @container.metric_rollups.size
     end
 
     subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,5 +1,12 @@
 describe ChargebackContainerImage do
   let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:hourly_rate)       { 0.01 }
+  let(:cpu_usage_rate)    { 50.0 }
+  let(:cpu_count)         { 1.0 }
+  let(:memory_available)  { 1000.0 }
+  let(:memory_used)       { 100.0 }
+  let(:net_usage_rate)    { 25.0 }
+
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -23,14 +30,6 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    @hourly_rate       = 0.01
-    @count_hourly_rate = 1.00
-    @cpu_usage_rate    = 50.0
-    @cpu_count         = 1.0
-    @memory_available  = 1000.0
-    @memory_used       = 100.0
-    @net_usage_rate    = 25.0
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -47,11 +46,11 @@ describe ChargebackContainerImage do
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => t,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -70,7 +69,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -80,7 +79,7 @@ describe ChargebackContainerImage do
                          :chargeback_tiers   => [cbt])
     }
     it "fixed_compute" do
-      expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * hours_in_day)
+      expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
     end
   end
 
@@ -98,11 +97,11 @@ describe ChargebackContainerImage do
       while time < end_time
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -122,7 +121,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -133,7 +132,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
     end
   end
 
@@ -153,11 +152,11 @@ describe ChargebackContainerImage do
       while time < end_time
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -177,7 +176,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -188,7 +187,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
     end
   end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -7,6 +7,8 @@ describe ChargebackContainerImage do
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
 
   before do
     MiqRegion.seed
@@ -87,13 +89,9 @@ describe ChargebackContainerImage do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
-
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
                                                         :cpu_usage_rate_average   => cpu_usage_rate,
@@ -108,7 +106,6 @@ describe ChargebackContainerImage do
         @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
                                                                 :timestamp => time,
                                                                 :image_tag_names => "environment/prod")
-        time += 12.hours
       end
     end
 
@@ -140,12 +137,9 @@ describe ChargebackContainerImage do
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_end.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
                                                         :cpu_usage_rate_average   => cpu_usage_rate,
@@ -160,7 +154,6 @@ describe ChargebackContainerImage do
         @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
                                                                 :timestamp => time,
                                                                 :image_tag_names => "")
-        time += 12.hours
       end
     end
 

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -6,6 +6,7 @@ describe ChargebackContainerImage do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -87,8 +88,6 @@ describe ChargebackContainerImage do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -141,8 +140,6 @@ describe ChargebackContainerImage do
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackContainerImage do
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -30,11 +31,6 @@ describe ChargebackContainerImage do
     @memory_used       = 100.0
     @net_usage_rate    = 25.0
 
-    @options = {:interval_size       => 1,
-                :end_interval_offset => 0,
-                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-    }
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -44,11 +40,9 @@ describe ChargebackContainerImage do
 
   context "Daily" do
     let(:hours_in_day) { 24 }
+    let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
 
     before do
-      @options[:interval] = "daily"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
 
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
@@ -69,7 +63,7 @@ describe ChargebackContainerImage do
       end
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,
@@ -91,12 +85,10 @@ describe ChargebackContainerImage do
   end
 
   context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
 
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -123,7 +115,7 @@ describe ChargebackContainerImage do
       @metric_size = @container.metric_rollups.size
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,
@@ -146,14 +138,12 @@ describe ChargebackContainerImage do
   end
 
   context "Label" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -180,7 +170,7 @@ describe ChargebackContainerImage do
       @metric_size = @container.metric_rollups.size
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -10,19 +10,18 @@ describe ChargebackContainerImage do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryGirl.create(:ems_openshift) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_openshift)
-
     @node = FactoryGirl.create(:container_node, :name => "node")
-    @image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+    @image = FactoryGirl.create(:container_image, :ext_management_system => ems)
     @label = FactoryGirl.build(:custom_attribute, :name => "version_label-1", :value => "1.0.0-rc_2", :section => 'docker_labels')
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
-    @group = FactoryGirl.create(:container_group, :ext_management_system => @ems, :container_project => @project,
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
+    @group = FactoryGirl.create(:container_group, :ext_management_system => ems, :container_project => @project,
                                 :container_node => @node)
     @container = FactoryGirl.create(:kubernetes_container, :container_group => @group, :container_image => @image)
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
@@ -55,7 +54,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)
@@ -98,7 +97,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)
@@ -144,7 +143,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackContainerProject do
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -25,11 +26,6 @@ describe ChargebackContainerProject do
     @memory_used       = 100.0
     @net_usage_rate    = 25.0
 
-    @options = {:interval_size       => 1,
-                :end_interval_offset => 0,
-                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-    }
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -43,12 +39,9 @@ describe ChargebackContainerProject do
 
   context "Daily" do
     let(:hours_in_day) { 24 }
+    let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
 
     before do
-      @options[:interval] = "daily"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => t,
@@ -65,7 +58,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -141,12 +134,9 @@ describe ChargebackContainerProject do
   end
 
   context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -171,7 +161,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -248,12 +238,9 @@ describe ChargebackContainerProject do
   end
 
   context "tagged project" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = nil
-      @options[:tag] = "/managed/environment/prod"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -275,7 +262,7 @@ describe ChargebackContainerProject do
       end
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -297,13 +284,9 @@ describe ChargebackContainerProject do
   end
 
   context "group results by tag" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = nil
-      @options[:provider_id] = "all"
-      @options[:groupby_tag] = "environment"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -326,7 +309,7 @@ describe ChargebackContainerProject do
       end
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -349,12 +332,9 @@ describe ChargebackContainerProject do
   end
 
   context "ignore empty metrics in fixed_compute" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -390,7 +370,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
                                    :start                     => 0,

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -10,18 +10,17 @@ describe ChargebackContainerProject do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) {FactoryGirl.create(:ems_openshift) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_openshift)
-
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
-    temp = {:cb_rate => @cbr, :object => @ems}
+    temp = {:cb_rate => @cbr, :object => ems}
     ChargebackRate.set_assignments(:compute, [temp])
 
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
@@ -53,7 +52,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -147,7 +146,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -242,7 +241,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -280,7 +279,7 @@ describe ChargebackContainerProject do
                                                       :derived_memory_available => memory_available,
                                                       :derived_memory_used      => memory_used,
                                                       :net_usage_rate_average   => net_usage_rate,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "environment/prod",
                                                       :resource_name            => @project.name)
       end
@@ -319,7 +318,7 @@ describe ChargebackContainerProject do
                                                       :derived_memory_available => memory_available,
                                                       :derived_memory_used      => memory_used,
                                                       :net_usage_rate_average   => net_usage_rate,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
         # Empty metric for fixed compute
@@ -327,7 +326,7 @@ describe ChargebackContainerProject do
                                                       :timestamp                => time + 12.hours,
                                                       :cpu_usage_rate_average   => 0.0,
                                                       :derived_memory_used      => 0.0,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
       end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -7,6 +7,8 @@ describe ChargebackContainerProject do
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
 
   before do
     MiqRegion.seed
@@ -136,12 +138,9 @@ describe ChargebackContainerProject do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
                                                          :cpu_usage_rate_average   => cpu_usage_rate,
@@ -152,8 +151,6 @@ describe ChargebackContainerProject do
                                                          :parent_ems_id            => @ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
-
-        time += 12.hours
       end
 
       @metric_size = @project.metric_rollups.size
@@ -238,12 +235,9 @@ describe ChargebackContainerProject do
   context "tagged project" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
                                                          :cpu_usage_rate_average   => cpu_usage_rate,
@@ -254,7 +248,6 @@ describe ChargebackContainerProject do
                                                          :parent_ems_id            => @ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
-        time += 12.hours
       end
     end
 
@@ -282,12 +275,9 @@ describe ChargebackContainerProject do
   context "group results by tag" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
                                                       :cpu_usage_rate_average   => cpu_usage_rate,
@@ -298,8 +288,6 @@ describe ChargebackContainerProject do
                                                       :parent_ems_id            => @ems.id,
                                                       :tag_names                => "environment/prod",
                                                       :resource_name            => @project.name)
-
-        time += 12.hours
       end
     end
 
@@ -328,12 +316,9 @@ describe ChargebackContainerProject do
   context "ignore empty metrics in fixed_compute" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(24.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
                                                       :cpu_usage_rate_average   => cpu_usage_rate,
@@ -344,19 +329,14 @@ describe ChargebackContainerProject do
                                                       :parent_ems_id            => @ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
-
-        time += 12.hours
-
         # Empty metric for fixed compute
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
-                                                      :timestamp                => time,
+                                                      :timestamp                => time + 12.hours,
                                                       :cpu_usage_rate_average   => 0.0,
                                                       :derived_memory_used      => 0.0,
                                                       :parent_ems_id            => @ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
-
-        time += 12.hours
       end
 
       @metric_size = @project.metric_rollups.size

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -6,6 +6,7 @@ describe ChargebackContainerProject do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -135,8 +136,6 @@ describe ChargebackContainerProject do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -239,8 +238,6 @@ describe ChargebackContainerProject do
   context "tagged project" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -285,8 +282,6 @@ describe ChargebackContainerProject do
   context "group results by tag" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -333,8 +328,6 @@ describe ChargebackContainerProject do
   context "ignore empty metrics in fixed_compute" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -349,7 +349,7 @@ describe ChargebackContainerProject do
 
         # Empty metric for fixed compute
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
-                                                      :timestamp                => "2012-08-31T07:00:00Z",
+                                                      :timestamp                => time,
                                                       :cpu_usage_rate_average   => 0.0,
                                                       :derived_memory_used      => 0.0,
                                                       :parent_ems_id            => @ems.id,

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackVm do
+  let(:admin) { FactoryGirl.create(:user_admin) }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -9,9 +10,7 @@ describe ChargebackVm do
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
 
-    @admin = FactoryGirl.create(:user_admin)
-
-    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => @admin, :ems_ref => "ems_ref")
+    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref")
     @vm1.tag_with(@tag.name, :ns => '*')
 
     @host1   = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -40,7 +39,7 @@ describe ChargebackVm do
                 :end_interval_offset => 0,
                 :tag                 => "/managed/environment/prod",
                 :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-                :userid              => @admin.userid
+                :userid              => admin.userid
                 }
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
@@ -70,7 +69,7 @@ describe ChargebackVm do
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
-      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => @admin)
+      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => admin)
 
       while time < end_time
         [@vm1, @vm2].each do |vm|
@@ -835,7 +834,7 @@ describe ChargebackVm do
 
     it 'sets extra fields' do
       extra_fields = ChargebackVm.new(report_options, metric_rollup).attributes
-      expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => @ems.name,
+      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => @ems.name,
                          "provider_uid" => @ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
                          "vm_id" => @vm1.id}
 
@@ -851,7 +850,7 @@ describe ChargebackVm do
 
     it 'sets extra fields when parent ems is missing' do
       extra_fields = ChargebackVm.new(report_options, metric_rollup_without_ems).attributes
-      expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => nil,
+      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => nil,
                          "provider_uid" => nil, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
                          "vm_id" => @vm1.id}
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -21,13 +21,13 @@ describe ChargebackVm do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_vmware)
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
@@ -39,7 +39,7 @@ describe ChargebackVm do
     @storage = FactoryGirl.create(:storage_target_vmware)
     @host1.storages << @storage
 
-    @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => @ems)
+    @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => ems)
     @ems_cluster.hosts << @host1
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
@@ -88,7 +88,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -153,7 +153,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -446,7 +446,7 @@ describe ChargebackVm do
                              :tag_names                         => "environment/prod",
                              :parent_host_id                    => @host1.id,
                              :parent_ems_cluster_id             => @ems_cluster.id,
-                             :parent_ems_id                     => @ems.id,
+                             :parent_ems_id                     => ems.id,
                              :parent_storage_id                 => @storage.id,
                              :resource_name                     => @vm_tenant.name,
                             )
@@ -482,7 +482,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -761,7 +761,7 @@ describe ChargebackVm do
     let(:metric_rollup) do
       FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z", :tag_names => "environment/prod",
                                                :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                                               :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                                               :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                                                :resource => @vm1)
     end
 
@@ -796,7 +796,7 @@ describe ChargebackVm do
     let(:metric_rollup) do
       FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
                         :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                        :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                        :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                         :resource => @vm1, :resource_name => @vm1.name)
     end
 
@@ -806,8 +806,8 @@ describe ChargebackVm do
 
     it 'sets extra fields' do
       extra_fields = ChargebackVm.new(report_options, metric_rollup).attributes
-      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => @ems.name,
-                         "provider_uid" => @ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
+      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => ems.name,
+                         "provider_uid" => ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
                          "vm_id" => @vm1.id}
 
       expect(extra_fields).to include(expected_fields)
@@ -845,7 +845,7 @@ describe ChargebackVm do
     let(:metric_rollup) do
       FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z",
                          :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                         :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                         :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                          :resource => @vm1)
     end
 
@@ -880,7 +880,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
         )

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -7,6 +7,16 @@ describe ChargebackVm do
      :ext_options         => {:tz => 'Pacific Time (US & Canada)'},
      :userid              => admin.userid}
   end
+  let(:hourly_rate)               { 0.01 }
+  let(:count_hourly_rate)         { 1.00 }
+  let(:cpu_usagemhz_rate)         { 50.0 }
+  let(:cpu_count)                 { 1.0 }
+  let(:memory_available)          { 1000.0 }
+  let(:memory_used)               { 100.0 }
+  let(:disk_usage_rate)           { 100.0 }
+  let(:net_usage_rate)            { 25.0 }
+  let(:vm_used_disk_storage)      { 1.0 }
+  let(:vm_allocated_disk_storage) { 4.0 }
 
   before do
     MiqRegion.seed
@@ -31,17 +41,6 @@ describe ChargebackVm do
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
     temp = {:cb_rate => @cbr, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
-
-    @hourly_rate               = 0.01
-    @count_hourly_rate         = 1.00
-    @cpu_usagemhz_rate         = 50.0
-    @cpu_count                 = 1.0
-    @memory_available          = 1000.0
-    @memory_used               = 100.0
-    @disk_usage_rate           = 100.0
-    @net_usage_rate            = 25.0
-    @vm_used_disk_storage      = 1.0
-    @vm_allocated_disk_storage = 4.0
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
@@ -79,14 +78,14 @@ describe ChargebackVm do
         [@vm1, @vm2].each do |vm|
           vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -108,7 +107,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -121,7 +120,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -146,14 +145,14 @@ describe ChargebackVm do
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => t,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -176,7 +175,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -189,17 +188,17 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
-      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * hours_in_day)
-      expect(subject.cpu_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+      expect(subject.cpu_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
@@ -217,7 +216,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -230,7 +229,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -243,16 +242,16 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 1.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
-      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * hours_in_day)
-      expect(subject.cpu_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+      expect(subject.cpu_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
@@ -266,7 +265,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -279,18 +278,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_allocated_metric).to eq(@memory_available)
+      expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, hours_in_day)
       expect(subject.memory_used_metric).to eq(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      expect(subject.memory_allocated_cost).to eq(@memory_available * @hourly_rate * hours_in_day)
-      expect(subject.memory_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.memory_allocated_cost).to eq(memory_available * hourly_rate * hours_in_day)
+      expect(subject.memory_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
@@ -304,14 +303,14 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       used_metric = used_average_for(:disk_usage_rate_average, hours_in_day)
       expect(subject.disk_io_used_metric).to eq(used_metric)
-      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_day)
     end
 
     it "net io" do
@@ -324,14 +323,14 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       used_metric = used_average_for(:net_usage_rate_average, hours_in_day)
       expect(subject.net_io_used_metric).to eq(used_metric)
-      expect(subject.net_io_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.net_io_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
     end
 
     it "storage" do
@@ -348,7 +347,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -364,17 +363,17 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
       expect(subject.storage_used_metric).to eq(used_metric)
-      expect(subject.storage_used_cost).to eq(used_metric / 1.gigabyte * @count_hourly_rate * hours_in_day)
+      expect(subject.storage_used_cost).to eq(used_metric / 1.gigabyte * count_hourly_rate * hours_in_day)
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
-      storage_allocated_cost = @vm_allocated_disk_storage * @count_hourly_rate * hours_in_day
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
+      storage_allocated_cost = vm_allocated_disk_storage * count_hourly_rate * hours_in_day
       expect(subject.storage_allocated_cost).to eq(storage_allocated_cost)
 
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
@@ -414,7 +413,7 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
 
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
       expect(subject.storage_used_metric).to eq(used_metric)
@@ -439,14 +438,14 @@ describe ChargebackVm do
         @vm_tenant.metric_rollups <<
           FactoryGirl.create(:metric_rollup_vm_hr,
                              :timestamp                         => t,
-                             :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                             :derived_vm_numvcpus               => @cpu_count,
-                             :derived_memory_available          => @memory_available,
-                             :derived_memory_used               => @memory_used,
-                             :disk_usage_rate_average           => @disk_usage_rate,
-                             :net_usage_rate_average            => @net_usage_rate,
-                             :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                             :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                             :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                             :derived_vm_numvcpus               => cpu_count,
+                             :derived_memory_available          => memory_available,
+                             :derived_memory_used               => memory_used,
+                             :disk_usage_rate_average           => disk_usage_rate,
+                             :net_usage_rate_average            => net_usage_rate,
+                             :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                             :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                              :tag_names                         => "environment/prod",
                              :parent_host_id                    => @host1.id,
                              :parent_ems_cluster_id             => @ems_cluster.id,
@@ -482,14 +481,14 @@ describe ChargebackVm do
       while time < end_time
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -513,7 +512,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -526,16 +525,16 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
-      expect(subject.cpu_allocated_cost).to be_within(0.01).of(@cpu_count * @count_hourly_rate * @hours_in_month)
+      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
+      expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * @hours_in_month)
     end
 
     let(:fixed_rate) { 10.0 }
@@ -550,7 +549,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => fixed_rate,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
 
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -564,21 +563,21 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => fixed_rate,
-                               :variable_rate             => @count_hourly_rate.to_s)
+                               :variable_rate             => count_hourly_rate.to_s)
 
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
 
       fixed = fixed_rate * @hours_in_month
-      variable = @cpu_count * @count_hourly_rate * @hours_in_month
+      variable = cpu_count * count_hourly_rate * @hours_in_month
       expect(subject.cpu_allocated_cost).to be_within(0.01).of(fixed + variable)
 
       fixed = fixed_rate * @hours_in_month
-      variable = used_metric * @hourly_rate * @hours_in_month
+      variable = used_metric * hourly_rate * @hours_in_month
       expect(subject.cpu_used_cost).to be_within(0.01).of(fixed + variable)
     end
 
@@ -592,7 +591,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -605,18 +604,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.memory_allocated_metric).to eq(@memory_available)
+      expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, @hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      memory_allocated_cost = @memory_available * @hourly_rate * @hours_in_month
+      memory_allocated_cost = memory_available * hourly_rate * @hours_in_month
       expect(subject.memory_allocated_cost).to be_within(0.01).of(memory_allocated_cost)
-      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
       expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
@@ -630,7 +629,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -638,7 +637,7 @@ describe ChargebackVm do
       used_metric = used_average_for(:disk_usage_rate_average, @hours_in_month)
       expect(subject.disk_io_used_metric).to be_within(0.01).of(used_metric)
 
-      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
     end
 
     it "net io" do
@@ -651,13 +650,13 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
       used_metric = used_average_for(:net_usage_rate_average, @hours_in_month)
       expect(subject.net_io_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
     end
 
     let(:hourly_fixed_rate) { 10 }
@@ -693,7 +692,7 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
@@ -718,7 +717,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -732,18 +731,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expected_value = @vm_allocated_disk_storage * @count_hourly_rate * @hours_in_month
+      expected_value = vm_allocated_disk_storage * count_hourly_rate * @hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
-      expected_value = used_metric / 1.gigabytes * @count_hourly_rate * @hours_in_month
+      expected_value = used_metric / 1.gigabytes * count_hourly_rate * @hours_in_month
       expect(subject.storage_used_cost).to be_within(0.01).of(expected_value)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
@@ -888,14 +887,14 @@ describe ChargebackVm do
       while time < end_time
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -919,7 +918,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
       )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -932,12 +931,12 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
       )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.tag_name).to eq('Production')

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -761,23 +761,23 @@ describe ChargebackVm do
     end
 
     context "by owner" do
+      let(:user) { FactoryGirl.create(:user, :name => 'Test VM Owner', :userid => 'test_user') }
       before do
-        @user = FactoryGirl.create(:user, :name => 'Test VM Owner', :userid => 'test_user')
-        @vm1.update_attribute(:evm_owner, @user)
+        @vm1.update_attribute(:evm_owner, user)
 
         @options = {:interval_size => 4,
-                    :owner         => @user.userid,
+                    :owner         => user.userid,
                     :ext_options   => {:tz => "Eastern Time (US & Canada)"},
                    }
       end
 
       it "valid" do
-        expect(subject.owner_name).to eq(@user.name)
+        expect(subject.owner_name).to eq(user.name)
       end
 
       it "not exist" do
-        @user.delete
-        expect { subject }.to raise_error(MiqException::Error, "Unable to find user '#{@user.userid}'")
+        user.delete
+        expect { subject }.to raise_error(MiqException::Error, "Unable to find user '#{user.userid}'")
       end
     end
   end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -17,6 +17,7 @@ describe ChargebackVm do
   let(:net_usage_rate)            { 25.0 }
   let(:vm_used_disk_storage)      { 1.0 }
   let(:vm_allocated_disk_storage) { 4.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -67,8 +68,6 @@ describe ChargebackVm do
       @service << @vm1
       @service.save
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -471,8 +470,6 @@ describe ChargebackVm do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly') }
     before  do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -877,8 +874,6 @@ describe ChargebackVm do
   context "Group by tags" do
     let(:options) { base_options.merge(:interval => 'monthly', :groupby_tag => 'environment') }
     before  do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 


### PR DESCRIPTION
Need to do some house cleaning in the specs of `Chargeback.descendants`.

There is a problem with the way we handle time. We set timezone to Pacific, but all the inputs are in the UTC. Also we move time back and forth, which has side effects. Need to do some clean-up to have better understanding of the problem.

@miq-bot add_label refactoring, chargeback, euwe/no
@miq-bot assign @gtanzillo 