### PR TITLE
create blueprint in_use? virtual attribute

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -4,6 +4,7 @@ class Blueprint < ApplicationRecord
 
   virtual_has_one :bundle
   virtual_has_one :content, :class_name => "Hash"
+  virtual_column :in_use?, :type => :boolean
 
   acts_as_miq_taggable
 
@@ -14,6 +15,11 @@ class Blueprint < ApplicationRecord
 
   def published?
     status == 'published'
+  end
+
+  def in_use?
+    return false unless published?
+    bundle.request_class.exists?(:source_id => bundle.id)
   end
 
   def readonly?

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -305,6 +305,28 @@ describe Blueprint do
       expect(reconfig.dialog).to eq(prov.dialog)
     end
   end
+
+  describe '#in_use?' do
+    it 'returns false if not published' do
+      expect(subject).not_to be_in_use
+    end
+
+    it 'returns false if it is published and has not been ordered' do
+      subject.ui_properties = ui_properties
+      subject.publish
+
+      expect(subject).not_to be_in_use
+    end
+
+    it 'returns true if it is published and has been ordered' do
+      subject.ui_properties = ui_properties
+      subject.publish
+      user = FactoryGirl.create(:user)
+      FactoryGirl.create(:service_template_provision_request, :requester => user, :source => subject.bundle)
+
+      expect(subject).to be_in_use
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
Need a way to determine if a blueprint is "in use" and has been ordered. This adds a virtual attribute that returns `false` if it has not been published, and only returns `true` if the blueprint bundle has been ordered.

cc: @dtaylor113 

@bzwei feedback appreciated 😄 
@miq-bot add_label enhancement, euwe/no 
