### PR TITLE
Show detailed events checkbox should only toggle detailed events.

### DIFF
--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -39,7 +39,9 @@ module ApplicationController::Timelines
       if params[:tl_categories]
         params[:tl_categories].each do |category|
           categories[events[category]] = {:display_name => category}
-          categories[events[category]][:event_groups] = event_groups[events[category]][level]
+          categories[events[category]][:event_groups] = level == :critical ?
+            event_groups[events[category]][level] :
+            event_groups[events[category]][level] + event_groups[events[category]][:critical]
         end
       end
     end

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -1,17 +1,20 @@
 describe ApplicationController, "#Timelines" do
   describe EmsInfraController do
     context "#tl_chooser" do
-      it "resets timeline options correctly when apply button is pressed" do
-        ems = FactoryGirl.create(:ems_openstack_infra)
+      before do
+        @ems = FactoryGirl.create(:ems_openstack_infra)
         controller.instance_variable_set(:@tl_options,
                                          ApplicationController::Timelines::Options.new)
+      end
+
+      it "resets timeline options correctly when apply button is pressed" do
         options            = assigns(:tl_options)
         dt                 = Time.zone.now
         options.date       = ApplicationController::Timelines::DateOptions.new
         options.date.end   = dt
         options.date.start = dt
 
-        controller.instance_variable_set(:@_params, :id => ems.id, :tl_show => "policy_timeline")
+        controller.instance_variable_set(:@_params, :id => @ems.id, :tl_show => "policy_timeline")
         expect(controller).to receive(:render)
 
         expect(options.date[:start]).to eq(dt)
@@ -25,18 +28,40 @@ describe ApplicationController, "#Timelines" do
       end
 
       it "sets categories for policy timelines correctly" do
-        ems = FactoryGirl.create(:ems_openstack_infra)
-        controller.instance_variable_set(:@tl_options,
-                                         ApplicationController::Timelines::Options.new)
-
         controller.instance_variable_set(:@_params,
-                                         :id            => ems.id,
+                                         :id            => @ems.id,
                                          :tl_show       => "policy_timeline",
                                          :tl_categories => ["VM Operation"])
         expect(controller).to receive(:render)
         controller.send(:tl_chooser)
         options = assigns(:tl_options)
         expect(options.policy[:categories]).to include('VM Operation')
+      end
+
+      it "unchecking Detailed events checkbox of Timelines options should remove them from list of events" do
+        controller.instance_variable_set(:@_params,
+                                         :id            => @ems.id,
+                                         :tl_show       => "timeline",
+                                         :tl_fl_typ     => "critical",
+                                         :tl_categories => ["Power Activity"])
+        expect(controller).to receive(:render)
+        controller.send(:tl_chooser)
+        options = assigns(:tl_options)
+        expect(options.management[:categories][:power][:event_groups]).to include('AUTO_FAILED_SUSPEND_VM')
+        expect(options.management[:categories][:power][:event_groups]).to_not include('PowerOffVM_Task')
+      end
+
+      it "checking Detailed events checkbox of Timelines options should append them to list of events" do
+        controller.instance_variable_set(:@_params,
+                                         :id            => @ems.id,
+                                         :tl_show       => "timeline",
+                                         :tl_fl_typ     => "detail",
+                                         :tl_categories => ["Power Activity"])
+        expect(controller).to receive(:render)
+        controller.send(:tl_chooser)
+        options = assigns(:tl_options)
+        expect(options.management[:categories][:power][:event_groups]).to include('PowerOffVM_Task')
+        expect(options.management[:categories][:power][:event_groups]).to include('AUTO_FAILED_SUSPEND_VM')
       end
     end
   end


### PR DESCRIPTION
"Show detailed events" checkbox of Timelines view should not remove critical events from timeline. Critical events should always show on timeline, checkbox should only toggle display of details evenrts on timeline.

https://bugzilla.redhat.com/show_bug.cgi?id=1402487

@dclarizio please review, after fix screenshots show the correct total counts of events when Detailed events checkbox is checked.

before:
![before1](https://cloud.githubusercontent.com/assets/3450808/21150149/fa28cc9a-c12b-11e6-92a7-d16ebba548b7.png)
![before2](https://cloud.githubusercontent.com/assets/3450808/21150153/fd570c7e-c12b-11e6-86ff-1e7ea4d86e13.png)

after:
![after1](https://cloud.githubusercontent.com/assets/3450808/21150156/0090760a-c12c-11e6-8cff-cba74486bca9.png)
![after2](https://cloud.githubusercontent.com/assets/3450808/21150158/02b33be8-c12c-11e6-9f45-d35fc156e569.png)
