### PR TITLE
Update Blueprint ui_properties with service template ids on publish

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -93,6 +93,8 @@ class Blueprint < ApplicationRecord
         new_bundle.service_template_catalog = parse_service_catalog
 
         new_dialog = parse_service_dialog.deep_copy(:name => random_dialog_name(name), :blueprint => self).tap(&:save!)
+        # Update ui_properties to reflect the new dialog
+        ui_properties['service_dialog']['id'] = new_dialog.id
         add_entry_points(new_bundle, parse_entry_points, new_dialog, 'composite')
 
         new_bundle.display = true # visible for ordering service

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -131,6 +131,8 @@ class Blueprint < ApplicationRecord
       if node["tags"]
         parse_tags(node["tags"]).each { |tag| Classification.classify_by_tag(new_template, tag) }
       end
+      # Update node to include ID of copied or new ServiceTemplate
+      node['id'] = new_template.id
       new_template
     end
   end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -306,6 +306,9 @@ describe Blueprint do
 
       ui_property_ids = subject.ui_properties.fetch_path('chart_data_model', 'nodes').pluck('id')
       expect(ui_property_ids).to match_array(bundle.descendants.pluck(:id))
+
+      dialog_id = subject.ui_properties.fetch_path('service_dialog', 'id')
+      expect(dialog_id).to eq(bundle.resource_actions.first.dialog.id)
     end
   end
 end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -303,6 +303,9 @@ describe Blueprint do
       reconfig = bundle.resource_actions.find_by(:action => 'Reconfigure')
       expect(reconfig.ae_uri).to eq('/x/y/z')
       expect(reconfig.dialog).to eq(prov.dialog)
+
+      ui_property_ids = subject.ui_properties.fetch_path('chart_data_model', 'nodes').pluck('id')
+      expect(ui_property_ids).to match_array(bundle.descendants.pluck(:id))
     end
   end
 end


### PR DESCRIPTION
When a Blueprint is published, it should update the IDs of the nodes in `ui_properties` so that the UI can reflect those changes, as well as that of the copied service_dialog.

* [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/136054345)

@miq-bot assign @bzwei 
@miq-bot add_label enhancement, euwe/no 

cc: @dtaylor113 

