### PR TITLE
This isn't referenced by any ManageIQ code or default automate domains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,10 +90,6 @@ gem "ruport",                         "=1.7.0",                       :git => "h
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 
-group :automate do
-  gem "savon",                        "~>2.2.0",   :require => false  # Automate uses this for simple SOAP Integration
-end
-
 group :ui_dependencies do # Added to Bundler.require in config/application.rb
   # Unmodified gems
   gem "angular-ui-bootstrap-rails",   "~>0.13.0"


### PR DESCRIPTION
At one point this was an automate dependency for communicating with some external services.  None of the current automate model code and none of the internal code reference this gem.  I think it should be removed and users that need it should maintain their dependencies.