### PR TITLE
Add :disabled_regions setting for ems_azure

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -103,6 +103,8 @@
   :ems_amazon:
     :disabled_regions: []
     :additional_regions: {}
+  :ems_azure:
+    :disabled_regions: []
 :ems_events:
   :history:
     :keep_ems_events: 6.months


### PR DESCRIPTION
This PR adds a ```:disabled_regions``` setting to the setting.yml file for the Azure EMS, this will allow specific regions to be enabled for support exceptions only.

Related PR https://github.com/ManageIQ/manageiq-providers-azure/pull/19 is dependent on this.

https://bugzilla.redhat.com/show_bug.cgi?id=1403366