### PR TITLE
Removed MiqScheduleWorker#worker_setting_or_default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1365,6 +1365,8 @@
         :queue_timeout: 120.minutes
     :schedule_worker:
       :authentication_check_interval: 1.hour
+      :chargeback_generation_interval: 1.day
+      :chargeback_generation_time_utc: 01:00:00
       :db_diagnostics_interval: 30.minutes
       :drift_state_purge_interval: 1.day
       :ems_events_purge_interval: 1.day
@@ -1374,12 +1376,12 @@
       :job_proxy_dispatcher_stale_message_check_interval: 60.seconds
       :job_proxy_dispatcher_stale_message_timeout: 2.minutes
       :job_timeout_interval: 60.seconds
+      :load_balancer_retired_interval: 10.minutes
       :log_active_configuration_interval: 1.days
       :log_database_statistics_interval: 1.days
       :memory_threshold: 500.megabytes
       :nice_delta: 3
       :orchestration_stack_retired_interval: 10.minutes
-      :load_balancer_retired_interval: 10.minutes
       :performance_collection_interval: 3.minutes
       :performance_collection_start_delay: 5.minutes
       :performance_realtime_purging_interval: 15.minutes
@@ -1388,6 +1390,7 @@
       :performance_rollup_purging_start_delay: 5.minutes
       :policy_events_purge_interval: 1.day
       :poll: 15.seconds
+      :resync_rhn_mirror: 12.hours
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds
       :service_retired_interval: 10.minutes
@@ -1395,8 +1398,7 @@
       :storage_file_collection_interval: 1.days
       :storage_file_collection_time_utc: 21600
       :vm_retired_interval: 10.minutes
-      :chargeback_generation_time_utc: 01:00:00
-      :chargeback_generation_interval: 1.day
+      :yum_update_check: 12.hours
     :smis_refresh_worker:
       :memory_threshold: 1.gigabytes
       :nice_delta: 3

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -447,7 +447,8 @@ describe MiqScheduleWorker::Runner do
           before(:each) do
             allow(@schedule_worker).to receive(:heartbeat)
             @schedule_worker.instance_variable_set(:@active_roles, ["event"])
-            allow(@schedule_worker).to receive(:worker_settings).and_return(:ems_events_purge_interval => 1.day)
+            allow(@schedule_worker).to receive(:worker_settings).and_return(:ems_events_purge_interval    => 1.day,
+                                                                            :policy_events_purge_interval => 1.day)
             allow_any_instance_of(Zone).to receive(:role_active?).with("event").and_return(true)
           end
 
@@ -479,7 +480,7 @@ describe MiqScheduleWorker::Runner do
           before do
             allow(@schedule_worker).to receive(:heartbeat)
             @schedule_worker.instance_variable_set(:@active_roles, ["scheduler"])
-            allow(@schedule_worker).to receive(:worker_settings).and_return(:ems_events_purge_interval => 1.day)
+            allow(@schedule_worker).to receive(:worker_settings).and_return(:chargeback_generation_interval => 1.day)
             @schedule_worker.instance_variable_set(:@schedules, :scheduler => [])
           end
 


### PR DESCRIPTION
Since all default settings must be present in ```settings.yml``` we do not need method to set default value for settings.

Removed ```MiqScheduleWorker#worker_setting_or_default``` and moved 'hidden' constants related to ```MiqScheduleWorker``` from code to ```settings.yml```

@miq-bot add-label wip, core