### PR TITLE
Remove the api authentication values from advanced settings

### DIFF
--- a/db/migrate/20161213140739_remove_remote_api_settings.rb
+++ b/db/migrate/20161213140739_remove_remote_api_settings.rb
@@ -1,0 +1,13 @@
+class RemoveRemoteApiSettings < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  API_AUTH_KEY = "/webservices/remote_miq_api%".freeze
+
+  def up
+    say_with_time("Removing configured API authentication") do
+      SettingsChange.where("key LIKE ?", API_AUTH_KEY).delete_all
+    end
+  end
+end

--- a/spec/migrations/20161213140739_remove_remote_api_settings_spec.rb
+++ b/spec/migrations/20161213140739_remove_remote_api_settings_spec.rb
@@ -1,0 +1,37 @@
+require_migration
+
+describe RemoveRemoteApiSettings do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it "removes the remote api authentication settings" do
+      settings_change_stub.create!(
+        :resource_type => "MiqServer",
+        :key           => "/webservices/remote_miq_api/user",
+        :value         => "admin"
+      )
+
+      settings_change_stub.create!(
+        :resource_type => "MiqServer",
+        :key           => "/webservices/remote_miq_api/password",
+        :value         => "thepassword"
+      )
+
+      settings_change_stub.create!(
+        :resource_type => "MiqServer",
+        :key           => "/api/token_ttl",
+        :value         => "5.minutes"
+      )
+
+      migrate
+
+      expect(settings_change_stub.where("key LIKE ?", described_class::API_AUTH_KEY).count).to eq 0
+      expect(settings_change_stub.count).to eq 1
+
+      kept_change = settings_change_stub.first
+      expect(kept_change.resource_type).to eq("MiqServer")
+      expect(kept_change.key).to eq("/api/token_ttl")
+      expect(kept_change.value).to eq("5.minutes")
+    end
+  end
+end


### PR DESCRIPTION
These settings were added in #13129 in order to add back the ability to kick off VM power ops from the global region, which was lost when the SOAP api was removed.

This PR removes those settings in favor of using the new central admin feature, which uses a more robust authentication mechanism.

@Fryguy please review