### PR TITLE
Stop nils from appearing in list of hosts to test OSP ssh keys against

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -115,9 +115,11 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   end
 
   def verify_ssh_keypair_credentials(_options)
+    # Select one powered-on host in each cluster to verify
+    # ssh credentials against
     hosts.sort_by(&:ems_cluster_id)
          .slice_when { |i, j| i.ems_cluster_id != j.ems_cluster_id }
-         .map { |c| c.find { |h| h.power_state == 'on' } }
+         .map { |c| c.find { |h| h.power_state == 'on' } }.compact
          .all? { |h| h.verify_credentials('ssh_keypair') }
   end
   private :verify_ssh_keypair_credentials

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -14,6 +14,29 @@ describe ManageIQ::Providers::Openstack::InfraManager do
     end
   end
 
+  context "verifying SSH keypair credentials" do
+    it "verifies Openstack SSH credentials successfully when all hosts report that the credentials are valid" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(true)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
+    end
+
+    it "fails to verify Openstack SSH credentials when any hosts report that the credentials are invalid" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_falsey
+    end
+
+    it "disregards powered off hosts when verifying Openstack SSH credentials" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "off")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
+    end
+  end
+
   context "validation" do
     before :each do
       @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)


### PR DESCRIPTION
This fixes a scenario when validating a new SSH key where Openstack Infra hosts that were powered off would cause validation to throw an exception. The enumeration used to collection hosts was returning `nil` for powered off hosts instead of excluding them from the list, resulting in an attempt to call `verify_credentials` against `nil`. 

This fixes the issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1376605

@petrblaho
@tzumainn