### PR TITLE
Missing DELETE /api/actions/:id

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -697,6 +697,9 @@
           :identifier: action_edit
         - :name: delete
           :identifier: action_delete
+        :delete:
+        - :name: delete
+          :identifier: action_delete
   :policies:
     :description: Policies
     :identifier: policy

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -73,6 +73,15 @@ describe "Actions API" do
       expect(response.parsed_body["results"].count).to eq(2)
     end
 
+    it "deletes action via DELETE" do
+      api_basic_authorize collection_action_identifier(:actions, :delete)
+
+      run_delete(actions_url(action.id))
+
+      expect(response).to have_http_status(:no_content)
+      expect(MiqAction.exists?(action.id)).to be_falsey
+    end
+
     it "edits new action" do
       api_basic_authorize collection_action_identifier(:actions, :edit)
       run_post(action_url, gen_request(:edit, "description" => "change"))


### PR DESCRIPTION

The Actions delete was implemented via POST "delete"
on both resources and collection for bulks delete, but we
were missing support for HTTP DELETE /api/actions/:id