### PR TITLE
Missing DELETE /api/conditions/:id

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -327,7 +327,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: Condition
     :collection_actions:
       :get:
@@ -349,6 +349,9 @@
       :post:
       - :name: edit
         :identifier: condition_edit
+      - :name: delete
+        :identifier: condition_delete
+      :delete:
       - :name: delete
         :identifier: condition_delete
   :data_stores:

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -108,6 +108,15 @@ describe "Conditions API" do
       expect(response.parsed_body["results"].count).to eq(2)
     end
 
+    it "deletes condition via DELETE" do
+      api_basic_authorize collection_action_identifier(:conditions, :delete)
+
+      run_delete(conditions_url(condition.id))
+
+      expect(response).to have_http_status(:no_content)
+      expect(Condition.exists?(condition.id)).to be_falsey
+    end
+
     it "edits condition" do
       api_basic_authorize collection_action_identifier(:conditions, :edit)
       run_post(conditions_url(condition.id), gen_request(:edit, "description" => "change"))


### PR DESCRIPTION

The Conditions delete was implemented via POST "delete"
on both resources and collection for bulks delete, but we
were missing support for HTTP DELETE /api/conditions/:id