### PR TITLE
Added missing target information and links on Policy Event bubbles.

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -103,12 +103,10 @@ module ReportFormatter
           e_title = rec[:name]
           e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vendor.downcase}.png")
           e_image = ActionController::Base.helpers.image_path("100/os-#{rec.os_image_name.downcase}.png")
-          e_text = "&lt;a href=/vm/show/#{rec.id}&gt;#{e_title}&lt;/a&gt;"
         when "Host"
           e_title = rec[:name]
           e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vmm_vendor_display.downcase}.png")
           e_image = ActionController::Base.helpers.image_path("100/os-#{rec.os_image_name.downcase}.png")
-          e_text = "&lt;a href=/host/show/#{rec.id}&gt;#{e_title}&lt;/a&gt;"
         when "EventStream"
           ems_cloud = false
           if rec[:ems_id] && ExtManagementSystem.exists?(rec[:ems_id])
@@ -149,43 +147,9 @@ module ReportFormatter
           if rec[:vm_or_template_id] && Vm.exists?(rec[:vm_or_template_id])
             e_image = ActionController::Base.helpers.image_path("100/os-#{Vm.find(rec[:vm_or_template_id]).os_image_name.downcase}.png")
           end
-          e_text = e_title
-        when "PolicyEvent"
-          if rec[:target_name]              # Create the title using Policy description
-            e_title = rec[:target_name]
-          elsif rec[:miq_policy_id] && MiqPolicy.exists?(rec[:miq_policy_id])   #   or Policy name
-            e_title = MiqPolicy.find(rec[:miq_policy_id]).name
-          else
-            e_title = "Policy no longer exists"
-          end
-          e_title ||= "No Policy"
-          e_icon = ActionController::Base.helpers.image_path("100/event-#{rec.event_type.downcase}.png")
-          # e_icon = "/images/100/vendor-ec2.png"
-          e_text = e_title
-          unless rec.target_id.nil?
-            e_text += "<br/>&lt;a href=/#{Dictionary.gettext(rec.target_class, :type => :model, :notfound => :titleize).downcase}/show/#{to_cid(rec.target_id)}&gt;<b> #{Dictionary.gettext(rec.target_class, :type => :model, :notfound => :titleize)}:</b> #{rec.target_name}&lt;/a&gt;"
-          end
-
-          assigned_profiles = {}
-          profile_sets = rec.miq_policy_sets
-
-          profile_sets.each do |profile|
-            assigned_profiles[profile.id] = profile.description unless profile.description.nil?
-          end
-
-          unless rec.event_type.nil?
-            e_text += "<br/><b>Assigned Profiles:</b> "
-            assigned_profiles.each_with_index do |p, i|
-              e_text += "&lt;a href=/miq_policy/explorer?profile=#{p[0]}&gt;<b> #{p[1]}&lt;/a&gt;"
-              if assigned_profiles.length > 1 && i < assigned_profiles.length
-                e_text += ", "
-              end
-            end
-          end
         else
           e_title = rec[:name] ? rec[:name] : row[mri.col_order.first].to_s
           e_icon = image = nil
-          e_text = e_title
         end
       end
 

--- a/product/timelines/miq_reports/tl_policy_events_daily.yaml
+++ b/product/timelines/miq_reports/tl_policy_events_daily.yaml
@@ -24,6 +24,9 @@ cols:
 - miq_event_description
 - miq_policy_description
 - result
+- target_name
+- target_id
+- target_class
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -35,6 +38,7 @@ col_order:
 - miq_event_description
 - miq_policy_description
 - result
+- target_name
 
 # Column titles, in order
 headers:
@@ -43,6 +47,7 @@ headers:
 - Miq Event Description
 - Miq Policy Description
 - Result
+- Tagret
 
 # Condition(s) string for the SQL query
 conditions:

--- a/product/timelines/miq_reports/tl_policy_events_hourly.yaml
+++ b/product/timelines/miq_reports/tl_policy_events_hourly.yaml
@@ -24,6 +24,9 @@ cols:
 - miq_event_description
 - miq_policy_description
 - result
+- target_name
+- target_id
+- target_class
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -35,6 +38,7 @@ col_order:
 - miq_event_description
 - miq_policy_description
 - result
+- target_name
 
 # Column titles, in order
 headers:
@@ -43,6 +47,7 @@ headers:
 - Miq Event Description
 - Miq Policy Description
 - Result
+- Target
 
 # Condition(s) string for the SQL query
 conditions:

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -106,6 +106,29 @@ describe ReportFormatter::TimelineMessage do
     end
   end
 
+  describe '#message_html on policy event' do
+    row = {}
+    let(:vm) { FactoryGirl.create(:vm_redhat, :id => 42, :name => 'Test VM') }
+    let(:event) do
+      FactoryGirl.create(:policy_event,
+                         :event_type   => 'vm_poweroff',
+                         :target_id    => 42,
+                         :target_name  => vm.name,
+                         :target_class => 'VmOrTemplate')
+    end
+
+    tests = {'event_type'  => 'vm_poweroff',
+             'target_name' => 'Test VM<br><b>VM or Template:</b>&nbsp;<a href=/vm_or_template/show/42>Test VM</a><br/><b>Assigned Profiles:</b>&nbsp;'}
+
+    tests.each do |column, href|
+      it "Evaluate column #{column} content" do
+        row[column] = 'vm_poweroff'
+        val = ReportFormatter::TimelineMessage.new(row, event, {}, 'PolicyEvent').message_html(column)
+        expect(val).to eq(href)
+      end
+    end
+  end
+
   describe '#events count for different categories' do
     def stub_ems_event(event_type)
       ems = FactoryGirl.create(:ems_redhat)


### PR DESCRIPTION
changes in 4f650a999c893b7519d9e7648acea92b027f59ff introduced the issue variable e_text was initialized to '' ignoring the fact that it was being set in several places above in the code. Fixed code to use TimelineMessage class to set links and other target related information for PolicyEvent timelines event bubble.

https://bugzilla.redhat.com/show_bug.cgi?id=1402786

before:
![before](https://cloud.githubusercontent.com/assets/3450808/21161929/d9da634a-c158-11e6-89e5-3a85451ab4ce.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/21161934/dcc871b4-c158-11e6-994d-f5948cdf7a82.png)

This issues was introduced with changes in https://github.com/ManageIQ/manageiq/pull/8346