### PR TITLE
[WIP] Force disconnect ActionCable connection when unauthorized

### DIFF
--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -1,6 +1,10 @@
 class NotificationChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "notifications_#{current_user.id}" if current_user
+    if current_user
+      stream_from("notifications_#{current_user.id}")
+    else
+      @connection.close
+    end
   end
 
   def unsubscribed


### PR DESCRIPTION
This is a fix for our friends at QE to limit the number of active WebSocket connections.
Testing is done by @psav and he will also provide a bugzilla.