### PR TITLE
[DARGA] Make a link from User/Group/Role screens text in Access Control

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -42,7 +42,7 @@
             - else
               - params = {}
             %i.product.product-role{params}
-            = h(@group.miq_user_role.name)
+            = link_to(@group.miq_user_role.name, "#", params)
         - else
           = select_tag('group_role',
               options_for_select(@edit[:roles].sort, @edit[:new][:role]),

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -53,7 +53,7 @@
                   - else
                     - params = {}
                   %i.product.product-group{params}
-                  = h(g.description)
+                  = link_to(g.description, "#", params)
 
 
     .col-md-12.col-lg-6

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -99,7 +99,7 @@
             - if role_allows(:feature => "rbac_group_show")
               - params = {:class => "pointer", :onclick => "miqDynatreeActivateNode('rbac_tree', 'g-#{to_cid(@user.current_group.id)}');", :title => _("View this Group")}
             %i.product.product-group{params}
-            = h(@user.current_group.description)
+            = link_to(@user.current_group.description, "#", params)
         - else
           - if disabled
             %p.form-control-static
@@ -123,7 +123,7 @@
             - else
               - params = {}
             %i.product.product-role{params}
-            = h(@user.miq_user_role_name)
+            = link_to(@user.miq_user_role_name, "#", params)
           - else
             %p.form-control-static
               = h(@user.miq_user_role_name)


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1402903

Make a link from User/Group/Role summary screens text to respective
screens in Settings -> Configuration -> Access Control similar to icons.

Before:
![access_c2](https://cloud.githubusercontent.com/assets/13417815/21188729/98c00922-c21c-11e6-9491-b28ef1c01f82.png)

After:
![access_c1](https://cloud.githubusercontent.com/assets/13417815/21188730/9a3359a8-c21c-11e6-9067-dee24cc69c4e.png)