### PR TITLE
[WIP] Use nested routes for sub-lists

### DIFF
--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -78,13 +78,13 @@ module Mixins
       nested_list("template_cloud", ManageIQ::Providers::CloudManager::Template)
     end
 
-    def nested_list(table_name, model)
+    def nested_list(table_name, model, parent_table = self.class.table_name, parent_record = @record)
       title = ui_lookup(:tables => table_name)
-      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record.name},
-                      :url  => "/#{self.class.table_name}/show/#{@record.id}")
-      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @record.name, :title => title},
-                      :url  => "/#{self.class.table_name}/show/#{@record.id}?display=#{@display}")
-      @view, @pages = get_view(model, :parent => @record) # Get the records (into a view) and the paginator
+      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => parent_record.name},
+                      :url  => "/#{parent_table}/show/#{parent_record.id}")
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => parent_record.name, :title => title},
+                      :url  => "/#{parent_table}/show/#{parent_record.id}?display=#{@display}")
+      @view, @pages = get_view(model, :parent => parent_record) # Get the records (into a view) and the paginator
       @showtype     = @display
     end
   end

--- a/app/controllers/mixins/nested_list_mixin.rb
+++ b/app/controllers/mixins/nested_list_mixin.rb
@@ -1,0 +1,11 @@
+module Mixins
+  module NestedListMixin
+    def show_nested
+      render :json => {
+        :parent_collection => params[:parent_collection],
+        :parent_id => from_cid(params[:parent_id]),
+      }
+    end
+
+  end
+end

--- a/app/controllers/mixins/nested_list_mixin.rb
+++ b/app/controllers/mixins/nested_list_mixin.rb
@@ -1,10 +1,26 @@
 module Mixins
   module NestedListMixin
     def show_nested
-      render :json => {
-        :parent_collection => params[:parent_collection],
-        :parent_id => from_cid(params[:parent_id]),
-      }
+      parent_table = params[:parent_collection]
+      parent_id = from_cid(params[:parent_id])
+
+      parent_controller = "#{parent_table}_controller".camelcase.constantize
+      parent_model = controller_to_model(parent_controller)
+      parent_record = identify_record(parent_id, parent_model)
+
+      return render :json => {
+        :parent_table => parent_table,
+        :parent_id => parent_id,
+        :my_table => self.class.table_name,
+        :my_model => controller_to_model.name,
+        :parent_record => parent_record,
+        :parent_model => parent_model.name,
+      } if params[:debug]
+
+      @display = 'main'
+      nested_list(self.class.table_name, controller_to_model, parent_table, parent_record)
+      #show_list
+      render :action => 'show_list' unless performed?
     end
 
   end

--- a/app/controllers/network_port_controller.rb
+++ b/app/controllers/network_port_controller.rb
@@ -8,6 +8,7 @@ class NetworkPortController < ApplicationController
   include Mixins::GenericListMixin
   include Mixins::GenericSessionMixin
   include Mixins::GenericShowMixin
+  include Mixins::NestedListMixin
 
   def self.display_methods
     %w(cloud_subnets floating_ips)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,12 +148,12 @@ module ApplicationHelper
     record.class.base_model.name.underscore
   end
 
-  def controller_to_model
-    case self.class.model.to_s
+  def controller_to_model(klass = self.class)
+    case klass.model.to_s
     when "ManageIQ::Providers::CloudManager::Template", "ManageIQ::Providers::CloudManager::Vm", "ManageIQ::Providers::InfraManager::Template", "ManageIQ::Providers::InfraManager::Vm"
       VmOrTemplate
     else
-      self.class.model
+      klass.model
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3226,6 +3226,22 @@ Vmdb::Application.routes.draw do
     end
   end
 
+  nested_routes = {
+    # TODO: controller_name.to_sym => self.display_methods
+    :security_group => %i(instances network_ports),
+  }
+  nested_routes.each do |collection, display_methods|
+    display_methods.each do |plural|
+      singular = plural.to_s.singularize.to_sym
+      get "#{collection}/:parent_id/#{plural}",
+        :controller => singular,
+        :action => 'show_nested',
+        :parent_collection => collection,
+        :constraints => { :parent_id => /(\d+r)?\d+/ }
+    end
+  end
+
+
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false
 


### PR DESCRIPTION
Parent issue: https://github.com/ManageIQ/manageiq/issues/13050
(Related to toolbar actions refactoring.)

Right now, if we want to display (for example) a list of network ports under a specific security group, the route is `/security_group/show/10000000000009?display=network_ports`, and displaying the list is handled in `SecurityGroupController`.

However, `NetworkPortController` is the controller that can do actions on network ports, knows how to render them, etc. etc. So right now, we're duplicating that functionality in any controller that needs to show network ports.

The new plan is to use routes like `/security_group/10000000000009/network_ports`, which would be routed to the `NetworkPortController` (right now, `#show_nested`, with `parent_collection` (= `:security_group`) and `parent_id` (= `10000000000009`) in params).

---

WIP for now, only that specific route mentioned actually does something, doesn't support non-generic things, should probably offload the `get_view` call to `process_show_list`, just preparing @parent_record for it.