### PR TITLE
Server group deployments

### DIFF
--- a/app/models/ems_refresh/save_inventory_middleware.rb
+++ b/app/models/ems_refresh/save_inventory_middleware.rb
@@ -89,6 +89,8 @@ module EmsRefresh::SaveInventoryMiddleware
 
     hashes.each do |h|
       h[:server_id] = h.fetch_path(:middleware_server, :id)
+      server_group_id = h.fetch_path(:middleware_server, :server_group_id)
+      h[:server_group_id] = server_group_id unless server_group_id.nil?
     end
 
     save_inventory_multi(ems.middleware_deployments, hashes, deletes, [:ems_ref], nil,

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -262,6 +262,14 @@ module ManageIQ::Providers
           :binary_content        => hash[:file]["file"].read,
           :resource_path         => ems_ref.to_s
         }
+        unless hash[:file]['server_groups'].nil?
+          # in case of deploying into server group the resource path should point to the domain controller
+          deployment_data[:server_groups] = hash[:file]['server_groups']
+          server_group_path_hash = ::Hawkular::Inventory::CanonicalPath.parse(deployment_data[:resource_path]).to_h
+          server_group_path_hash[:resource_ids].slice!(1..-1)
+          host_controller_path = ::Hawkular::Inventory::CanonicalPath.new(server_group_path_hash)
+          deployment_data[:resource_path] = host_controller_path.to_s
+        end
 
         connection.operations(true).add_deployment(deployment_data) do |on|
           on.success do |data|

--- a/app/models/middleware_deployment.rb
+++ b/app/models/middleware_deployment.rb
@@ -1,5 +1,6 @@
 class MiddlewareDeployment < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :middleware_server, :foreign_key => "server_id"
+  belongs_to :middleware_server_group, :foreign_key => "server_group_id", :optional => true
   acts_as_miq_taggable
 end

--- a/app/models/middleware_server_group.rb
+++ b/app/models/middleware_server_group.rb
@@ -1,6 +1,9 @@
 class MiddlewareServerGroup < ApplicationRecord
   belongs_to :middleware_domain, :foreign_key => "domain_id"
   has_many :middleware_servers, :foreign_key => "server_group_id", :dependent => :destroy
+  has_many :middleware_deployments, :foreign_key => "server_group_id", :dependent => :destroy
   serialize :properties
   acts_as_miq_taggable
+
+  delegate :ext_management_system, :to => :middleware_domain, :allow_nil => true
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4031,6 +4031,10 @@
       :description: Edit Tags of Middleware Server Groups
       :feature_type: control
       :identifier: middleware_server_group_tag
+    - :name: Add middleware deployment
+      :description: Add middleware deployment
+      :feature_type: admin
+      :identifier: middleware_group_deployment_add
 
 # Middleware Messaging
 - :name: Middleware Messaging

--- a/db/migrate/20161213112148_add_server_group_id_to_middleware_deployments.rb
+++ b/db/migrate/20161213112148_add_server_group_id_to_middleware_deployments.rb
@@ -1,0 +1,5 @@
+class AddServerGroupIdToMiddlewareDeployments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :middleware_deployments, :server_group_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4633,6 +4633,7 @@ middleware_deployments:
 - status
 - feed
 - properties
+- server_group_id
 middleware_domains:
 - id
 - name

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -23,18 +23,18 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
 
     @ems_hawkular.reload
 
-    expect(@ems_hawkular.middleware_domains.count).to be > 0
+    expect(@ems_hawkular.middleware_domains).not_to be_empty
     domain = @ems_hawkular.middleware_domains.first
-    expect(domain.middleware_server_groups.count).to be > 0
-    expect(@ems_hawkular.middleware_servers.count).to be > 0
+    expect(domain.middleware_server_groups).not_to be_empty
+    expect(@ems_hawkular.middleware_servers).not_to be_empty
 
     # check whether the server was associated with the vm
     server = @ems_hawkular.middleware_servers.first
     expect(server.lives_on_id).to eql(@vm.id)
     expect(server.lives_on_type).to eql(@vm.type)
-    expect(@ems_hawkular.middleware_deployments.count).to be > 0
-    expect(@ems_hawkular.middleware_datasources.count).to be > 0
-    expect(@ems_hawkular.middleware_messagings.count).to be > 0
+    expect(@ems_hawkular.middleware_deployments).not_to be_empty
+    expect(@ems_hawkular.middleware_datasources).not_to be_empty
+    expect(@ems_hawkular.middleware_messagings).not_to be_empty
     expect(@ems_hawkular.middleware_deployments.first).to have_attributes(:status => 'Enabled')
     assert_specific_datasource(@ems_hawkular, 'Local~/subsystem=datasources/data-source=ExampleDS')
     assert_specific_datasource(@ems_hawkular,
@@ -80,6 +80,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
       :profile  => 'full',
     )
     expect(server_group.properties).not_to be_nil
+    expect(server_group.middleware_deployments).to be_empty
+    expect(server_group.ext_management_system).to eq(@ems_hawkular)
   end
 
   def assert_specific_domain_server
@@ -103,13 +105,13 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
 
     @ems_hawkular2.reload
     expect(@ems_hawkular2.middleware_domains).to be_empty
-    expect(@ems_hawkular2.middleware_servers.count).to be > 0
+    expect(@ems_hawkular2.middleware_servers).not_to be_empty
     server = @ems_hawkular2.middleware_servers.first
     expect(server.lives_on_id).to be_nil
     expect(server.lives_on_type).to be_nil
-    expect(@ems_hawkular2.middleware_deployments.count).to be > 0
-    expect(@ems_hawkular2.middleware_datasources.count).to be > 0
-    expect(@ems_hawkular2.middleware_messagings.count).to be > 0
+    expect(@ems_hawkular2.middleware_deployments).not_to be_empty
+    expect(@ems_hawkular2.middleware_datasources).not_to be_empty
+    expect(@ems_hawkular2.middleware_messagings).not_to be_empty
     assert_specific_datasource(@ems_hawkular2, 'Local~/subsystem=datasources/data-source=ExampleDS')
   end
 end


### PR DESCRIPTION
This PR adds the ability for the server_group to own the deployments. In the domain mode the deploy operation is invoked against the server group. The WildFly then delivers the app to the underlying servers in that group, but the ownership is still on that group.

todo: 
- [x] split (the PR to UI is here - https://github.com/ManageIQ/manageiq-ui-classic/pull/23)
- [x] add this PR description
- [x] specs

@miq-bot add_labels wip, providers/hawkular, enhancement, euwe/no
