### PR TITLE
[WIP] Adding Physical infra pages

### DIFF
--- a/app/controllers/ems_physical_infra_controller.rb
+++ b/app/controllers/ems_physical_infra_controller.rb
@@ -1,0 +1,165 @@
+class EmsPhysicalInfraController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
+  include EmsCommon        # common methods for EmsInfra/Cloud controllers
+  include Mixins::EmsCommonAngular
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.model
+    ManageIQ::Providers::PhysicalInfraManager
+  end
+
+  def self.table_name
+    @table_name ||= "ems_physical_infra"
+  end
+
+  def ems_path(*args)
+    ems_physical_infra_path(*args)
+  end
+
+  def new_ems_path
+    new_ems_physical_infra_path
+  end
+
+  def index
+    redirect_to :action => 'show_list'
+  end
+
+  def register_nodes
+    assert_privileges("host_register_nodes")
+    redirect_to ems_physical_infra_path(params[:id], :display => "hosts") if params[:cancel]
+
+    # Hiding the toolbars
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Register Nodes"), :url => "/ems_physical_infra/register_nodes")
+
+    @infra = ManageIQ::Providers::Openstack::InfraManager.find(params[:id])
+
+    if params[:register]
+      if params[:nodes_json].nil? || params[:nodes_json][:file].nil?
+        log_and_flash_message(_("Please select a JSON file containing the nodes you would like to register."))
+        return
+      end
+
+      begin
+        uploaded_file = params[:nodes_json][:file]
+        nodes_json = parse_json(uploaded_file)
+        if nodes_json.nil?
+          log_and_flash_message(_("JSON file format is incorrect, missing 'nodes'."))
+        end
+      rescue => ex
+        log_and_flash_message(_("Cannot parse JSON file: %{message}") %
+                                  {:message => ex})
+      end
+
+      if nodes_json
+        begin
+          @infra.workflow_service
+        rescue => ex
+          log_and_flash_message(_("Cannot connect to workflow service: %{message}") %
+                                    {:message => ex})
+          return
+        end
+        begin
+          state, response = @infra.register_and_configure_nodes(nodes_json)
+        rescue => ex
+          log_and_flash_message(_("Error executing register and configure workflows: %{message}") %
+                                    {:message => ex})
+          return
+        end
+        if state == "SUCCESS"
+          redirect_to ems_infra_path(params[:id],
+                                     :display   => "hosts",
+                                     :flash_msg => _("Nodes were added successfully. Refresh queued."))
+        else
+          log_and_flash_message(_("Unable to add nodes: %{error}") % {:error => response})
+        end
+      end
+    end
+  end
+
+  def ems_physical_infra_form_fields
+    ems_form_fields
+  end
+
+  private
+
+  ############################
+  # Special EmsCloud link builder for restful routes
+  def show_link(ems, options = {})
+    ems_path(ems.id, options)
+  end
+
+  def log_and_flash_message(message)
+    add_flash(message, :error)
+    $log.error(message)
+  end
+
+  def update_stack(stack, stack_parameters, provider_id, return_message, operation, additional_args = {})
+    begin
+      # Check if stack is ready to be updated
+      update_ready = stack.update_ready?
+    rescue => ex
+      log_and_flash_message(_("Unable to update stack, obtaining of status failed: %{message}") %
+                            {:message => ex})
+      return
+    end
+
+    if !update_ready
+      add_flash(_("Provider stack is not ready to be updated, another operation is in progress."), :error)
+    elsif !stack_parameters.empty?
+      # A value was changed
+      begin
+        stack.raw_update_stack(nil, stack_parameters)
+        if operation == 'scaledown'
+          @stack.queue_post_scaledown_task(additional_args[:services])
+        end
+        redirect_to ems_infra_path(provider_id, :flash_msg => return_message)
+      rescue => ex
+        log_and_flash_message(_("Unable to initiate scaling: %{message}") % {:message => ex})
+      end
+    else
+      # No values were changed
+      add_flash(_("A value must be changed or provider stack will not be updated."), :error)
+    end
+  end
+
+  def verify_hosts_for_scaledown(hosts)
+    has_invalid_nodes = false
+    error_return_message = _("Not all hosts can be removed from the deployment.")
+
+    hosts.each do |host|
+      unless host.maintenance
+        has_invalid_nodes = true
+        error_return_message += _(" %{host_uid_ems} needs to be in maintenance mode before it can be removed ") %
+                                {:host_uid_ems => host.uid_ems}
+      end
+      if host.number_of(:vms) > 0
+        has_invalid_nodes = true
+        error_return_message += _(" %{host_uid_ems} needs to be evacuated before it can be removed ") %
+                                {:host_uid_ems => host.uid_ems}
+      end
+      unless host.name.include?('Compute')
+        has_invalid_nodes = true
+        error_return_message += _(" %{host_uid_ems} is not a compute node ") % {:host_uid_ems => host.uid_ems}
+      end
+    end
+
+    return has_invalid_nodes, error_return_message
+  end
+
+  def restful?
+    true
+  end
+  public :restful?
+
+  def parse_json(uploaded_file)
+    JSON.parse(uploaded_file.read)["nodes"]
+  end
+
+  menu_section :inf
+end

--- a/app/controllers/ems_physical_infra_dashboard_controller.rb
+++ b/app/controllers/ems_physical_infra_dashboard_controller.rb
@@ -1,0 +1,32 @@
+class EmsPhysicalInfraDashboardController < ApplicationController
+  extend ActiveSupport::Concern
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def show
+    if params[:id].nil?
+      @breadcrumbs.clear
+    end
+  end
+
+  def data
+    render :json => {:data => collect_data(params[:id])}
+  end
+
+  private
+
+  def collect_data(ems_id)
+    EmsInfraDashboardService.new(ems_id, self).all_data
+  end
+
+  def get_session_data
+    @layout = "ems_infra_dashboard"
+  end
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -5,7 +5,8 @@ module Menu
         Menu::Section.new(:compute, N_("Compute"), 'fa product-memory fa-2x', [
           clouds_menu_section,
           infrastructure_menu_section,
-          container_menu_section
+          container_menu_section,
+          physical_menu_section
         ])
       end
 
@@ -108,6 +109,13 @@ module Menu
           Menu::Item.new('container_image',          N_('Container Images'),                                    'container_image',          {:feature => 'container_image_show_list'},                 '/container_image'),
           Menu::Item.new('container_template',       N_('Container Templates'),                                 'container_template',       {:feature => 'container_template_show_list'},              '/container_template'),
           Menu::Item.new('container_topology',       N_('Topology'),                                            'container_topology',       {:feature => 'container_topology', :any => true},          '/container_topology')
+        ])
+      end
+
+      def physical_menu_section
+        Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
+          Menu::Item.new('ems_physical',    N_('Providers'), 'ems_physical',    {:feature => 'ems_physical_show_list'},    '/ems_physical'),
+          Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
         ])
       end
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -6,7 +6,7 @@ module Menu
           clouds_menu_section,
           infrastructure_menu_section,
           container_menu_section,
-          physical_menu_section
+          physical_infrastructure_menu_section
         ])
       end
 
@@ -112,9 +112,9 @@ module Menu
         ])
       end
 
-      def physical_menu_section
+      def physical_infrastructure_menu_section
         Menu::Section.new(:phy, N_("Physical Infrastructure"), 'fa fa-plus fa-2x', [
-          Menu::Item.new('ems_physical',    N_('Providers'), 'ems_physical',    {:feature => 'ems_physical_show_list'},    '/ems_physical'),
+          Menu::Item.new('ems_physical_infra',    N_('Providers'), 'ems_physical_infra',    {:feature => 'ems_physical_infra_show_list'},    '/ems_physical_infra'),
           Menu::Item.new('physical_server', N_('Servers'),   'physical_server', {:feature => 'physical_server_show_list'}, '/physical_server'),
         ])
       end

--- a/app/views/ems_physical_infra/_form.html.haml
+++ b/app/views/ems_physical_infra/_form.html.haml
@@ -1,0 +1,123 @@
+- @angular_form = true
+
+.form-horizontal{:id => "start_form_div", :style => "display:none"}
+  = render :partial => "layouts/flash_msg"
+  %div
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_name"}
+        = _('Name')
+      .col-md-4
+        %input.form-control{"type"           => "text",
+                            "id"             => "ems_name",
+                            "name"           => "name",
+                            "ng-model"       => "emsCommonModel.name",
+                            "maxlength"      => "#{MAX_NAME_LEN}",
+                            "required"       => "",
+                            "checkchange"    => "",
+                            "auto-focus"     => "",
+                            "start-form-div" => "start_form_div"}
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.emstype.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_type"}
+        = _('Type')
+      .col-md-8
+        = select_tag('emstype',
+                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
+                     "ng-if"                       => "newRecord",
+                     "ng-model"                    => "emsCommonModel.emstype",
+                     "ng-change"                   => "providerTypeChanged()",
+                     "required"                    => "",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+        %div{"ng-if" => "!newRecord"}
+          %label.form-control{"type"        => "text",
+                              "id"          => "ems_type",
+                              "name"        => "emstype",
+                              "ng-if"       => "!newRecord",
+                              "readonly"    => true,
+                              "style"       => "color: black; font-weight: normal;"}
+            = @emstype_display
+
+    .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack_infra'"}
+      %label.col-md-2.control-label{"for" => "ems_api_version"}
+        = _("API Version")
+      .col-md-8
+        = select_tag('api_version',
+                     options_for_select(@openstack_api_versions),
+                     "ng-model"                    => "emsCommonModel.api_version",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_zone"}
+        = _("Zone")
+      .col-md-4
+        - if @server_zones.length <= 1
+          %input.form-control{"type"        => "text",
+                              "id"          => "ems_zone",
+                              "name"        => "zone",
+                              "ng-model"    => "emsCommonModel.zone",
+                              "maxlength"   => 15,
+                              "required"    => "",
+                              "checkchange" => "",
+                              "readonly"    => true,
+                              "style"       => "color: black;"}
+        - else
+          = select_tag('zone',
+                       options_for_select(@server_zones.sort_by { |name, _name| name }),
+                       "ng-model"                    => "emsCommonModel.zone",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_start.$invalid}", "ng-if" => "formId != 'new' && emsCommonModel.emstype == 'vmwarews'"}
+      %label.col-md-2.control-label{"for" => "ems_vnc_start_port"}
+        = _('Host Default VNC Start Port')
+      .col-md-8
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_vnc_start_port",
+                            "name"        => "host_default_vnc_port_start",
+                            "ng-model"    => "emsCommonModel.host_default_vnc_port_start",
+                            "maxlength"   => 6,
+                            "checkchange" => ""}
+
+    .form-group{"ng-class" => "{'has-error': angularForm.host_default_vnc_port_end.$invalid}", "ng-if" => "formId != 'new' && emsCommonModel.emstype == 'vmwarews'"}
+      %label.col-md-2.control-label{"for" => "ems_vnc_end_port"}
+        = _('Host Default VNC End Port')
+      .col-md-8
+        %input.form-control{"type"        => "text",
+                            "id"          => "ems_vnc_end_port",
+                            "name"        => "host_default_vnc_port_end",
+                            "ng-model"    => "emsCommonModel.host_default_vnc_port_end",
+                            "maxlength"   => 6,
+                            "checkchange" => ""}
+
+  %hr
+    - if controller_name == "ems_container"
+      = render :partial => "/layouts/container_auth", :locals  => {:record => @ems}
+    - else
+      %div{"ng-show" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
+        %h3
+          = _("Credentials")
+        = render :partial => "/layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                 :locals  => {:record                 => @ems,
+                              :ng_model               => "emsCommonModel",
+                              :ng_reqd_password       => "emsCommonModel.default_userid != ''",
+                              :ng_reqd_verify         => "emsCommonModel.default_userid != ''",
+                              :prefix                 => "default",
+                              :validate_url           => @ems.id ? "update" : "create",
+                              :id                     => @ems.id || "new",
+                              :basic_info_needed      => true,
+                              :userid_label           => _("Client ID"),
+                              :password_label         => _("Client Key"),
+                              :verify_label           => _("Confirm Client Key"),
+                              :passwd_mismatch        => _("Client Keys do not match"),
+                              :change_stored_password => _("Change stored client key"),
+                              :cancel_password_change => _("Cancel client key change"),
+                              :verify_title_off       => _("Tenant ID, Client ID and matching Client Key fields are needed to perform verification of credentials")}
+      %div{"ng-show" => "emsCommonModel.emstype != 'azure'"}
+        = render :partial => "/layouts/angular/multi_auth_credentials", :locals  => {:record => @ems, :ng_model => "emsCommonModel"}
+
+    = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/ems_physical_infra/_form_fields.html.haml
+++ b/app/views/ems_physical_infra/_form_fields.html.haml
@@ -1,0 +1,34 @@
+- unless @edit[:new][:emstype].blank?
+  .form-group
+    %label.control-label.col-md-2
+      = _('Hostname or IP address')
+    .col-md-4
+      = text_field_tag("hostname",
+        @edit[:new][:hostname],
+        :maxlength => MAX_HOSTNAME_LEN,
+        "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+        :class => "form-control",
+        :title => _("Hostname or IPv4/IPv6 address"))
+  - if @edit[:new][:emstype] == "scvmm" || @edit[:new][:emstype] == "openstack" || @edit[:new][:emstype] == "openstack_infra"
+    .form-group
+      %label.control-label.col-md-2
+        = _('Security Protocol')
+      .col-md-8
+        = select_tag("security_protocol",
+                     options_for_select(@edit[:protocols],
+                     @edit[:new][:default_security_protocol]),
+                     :class => "selectpicker")
+        :javascript
+          miqInitSelectPicker();
+          miqSelectPickerEvent("security_protocol", "#{url}");
+    - if @edit[:new][:default_security_protocol] == "kerberos"
+      .form-group
+        %label.control-label.col-md-2
+          = _('Realm')
+        .col-md-6
+          = text_field_tag("realm",
+                           @edit[:new][:realm],
+                           :maxlength => MAX_NAME_LEN,
+                           :class             => "form-control",
+                           "data-miq_observe" => {:interval => ".5",
+                                                  :url => url}.to_json)

--- a/app/views/ems_physical_infra/_main.html.haml
+++ b/app/views/ems_physical_infra/_main.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "shared/views/ems_common/main"

--- a/app/views/ems_physical_infra/_show_dashboard.html.haml
+++ b/app/views/ems_physical_infra/_show_dashboard.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "shared/views/show_ems_infra_dashboard"

--- a/app/views/ems_physical_infra/discover.html.haml
+++ b/app/views/ems_physical_infra/discover.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "layouts/discover"

--- a/app/views/ems_physical_infra/edit.html.haml
+++ b/app/views/ems_physical_infra/edit.html.haml
@@ -1,0 +1,17 @@
+= form_for(@ems,
+           :url    => ems_infra_path(@ems),
+           :method => :patch,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "update-url"      => "#{ems_infra_path(@ems)}",
+                       "form-fields-url" => "/#{controller_name}/ems_infra_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "save"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/ems_physical_infra/new.html.haml
+++ b/app/views/ems_physical_infra/new.html.haml
@@ -1,0 +1,19 @@
+- url = @ems.persisted? ? ems_infras_path(@ems) : ems_infras_path
+= form_for(@ems,
+           :url    => url,
+           :method => :post,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "create-url"      => "#{url}",
+                       "form-fields-url" => "/#{controller_name}/ems_infra_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "add"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/ems_physical_infra/register_nodes.html.haml
+++ b/app/views/ems_physical_infra/register_nodes.html.haml
@@ -1,0 +1,18 @@
+= render :partial => "layouts/flash_msg"
+= form_tag('/ems_infra/register_nodes',
+           :class     => "form-horizontal",
+           :multipart => true,
+           :method    => :post) do
+  = hidden_field_tag('id', @infra.id)
+  .form-group
+    .col-md-4
+      = render :partial => "shared/file_chooser", :locals => {:object_name => "nodes_json", :method => "file"}
+
+    .col-md-6
+      = submit_tag(_("Register"),
+                  :name  => "register",
+                  :class => "btn btn-primary")
+      = submit_tag(_("Cancel"),
+                  :name  => "cancel",
+                  :class => "btn btn-default")
+

--- a/app/views/ems_physical_infra/scaledown.html.haml
+++ b/app/views/ems_physical_infra/scaledown.html.haml
@@ -1,0 +1,51 @@
+= render :partial => "layouts/flash_msg"
+= form_tag('/ems_infra/scaledown', :method => :post)
+= hidden_field_tag('id', @infra.id)
+- unless @stack.nil?
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Orchestration Stack')
+      .col-md-8
+        = @stack.name
+    .form-group
+      %label.col-md-2.control-label
+        = _('Number of Compute Hosts')
+      .col-md-8
+        = @compute_hosts.count
+    %table.table.table-bordered.table-striped
+      %thead
+        %tr
+          %th
+          %th= _('Node')
+          %th= _('VMs')
+          %th= _('Maintenance')
+      %tbody
+        - @compute_hosts.each do |host|
+          %tr
+            %td
+              - if host.number_of(:vms) == 0 && host.maintenance
+                %input{:type => 'checkbox', :name => 'host_ids[]', :value => host.id}
+            %td
+              = host.uid_ems
+            %td
+              = host.number_of(:vms)
+            %td
+              = host.maintenance
+
+  %table{:width => "100%"}
+    %tr
+      %td{:align => "right"}
+        #buttons_on
+          = button_tag(_("Scale Down"),
+                       :name => "scaledown",
+                       :class => "btn btn-primary",
+                       :alt => t = _("Scale Infrastructure Provider Down"),
+                       :title => t,
+                       :type => "submit")
+          = button_tag(_("Cancel"),
+                       :name => "cancel",
+                       :class => "btn btn-default",
+                       :alt => t = _("Cancel"),
+                       :title => t,
+                       :type => "submit")

--- a/app/views/ems_physical_infra/scaling.html.haml
+++ b/app/views/ems_physical_infra/scaling.html.haml
@@ -1,0 +1,37 @@
+= render :partial => "layouts/flash_msg"
+= form_tag('/ems_infra/scaling', :method => :post)
+= hidden_field_tag('id', @infra.id)
+- unless @stack.nil?
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Orchestration Stack')
+      .col-md-8
+        = @stack.name
+    .form-group
+      %label.col-md-2.control-label
+        = _('Number of Hosts')
+      .col-md-8
+        = @infra.hosts.count
+    - @count_parameters.each do |parameter|
+      .form-group
+        %label.col-md-2.control-label
+          = parameter.name
+        .col-md-8
+          = text_field_tag(parameter.name, parameter.value, :maxlength => 5)
+  %table{:width => "100%"}
+    %tr
+      %td{:align => "right"}
+        #buttons_on
+          = button_tag(_("Scale"),
+                       :name  => "scale",
+                       :class => "btn btn-primary",
+                       :alt   => t = _("Scale Infrastructure Provider"),
+                       :title => t,
+                       :type  => "submit")
+          = button_tag(_("Cancel"),
+                       :name  => "cancel",
+                       :class => "btn btn-default",
+                       :alt   => t = _("Cancel"),
+                       :title => t,
+                       :type  => "submit")

--- a/app/views/ems_physical_infra/show.html.haml
+++ b/app/views/ems_physical_infra/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_physical_infra/show_list.html.haml
+++ b/app/views/ems_physical_infra/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/ems_physical_infra/show_policy_timeline.html.haml
+++ b/app/views/ems_physical_infra/show_policy_timeline.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => "layouts/tl_show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1134,6 +1134,59 @@ Vmdb::Application.routes.draw do
       )
     },
 
+    :ems_physical_infra                => {
+      :get  => %w(
+        dialog_load
+        discover
+        download_data
+        ems_physical_infra_form_fields
+        register_nodes
+        introspect_nodes
+        protect
+        show_list
+        tagging_edit
+        scaling
+        scaledown
+      ) +
+               compare_get,
+      :post => %w(
+        button
+        create
+        form_field_changed
+        register_nodes
+        introspect_nodes
+        listnav_search_selected
+        protect
+        quick_search
+        sections_field_changed
+        show
+        show_list
+        tag_edit_form_field_changed
+        tagging_edit
+        tl_chooser
+        tree_autoload
+        update
+        wait_for_task
+        scaling
+        scaledown
+        x_show
+        squash_toggle
+      ) +
+               adv_search_post +
+               compare_post +
+               dialog_runner_post +
+               discover_get_post +
+               exp_post +
+               save_post
+    },
+
+    :ems_physical_infra_dashboard      => {
+      :get => %w(
+        show
+        data
+      )
+    },
+
     :ems_container            => {
       :get  => %w(
         download_data
@@ -3194,7 +3247,7 @@ Vmdb::Application.routes.draw do
   controller_routes.each do |controller_name, controller_actions|
     # Default route with no action to controller's index action
     unless [
-      :ems_cloud, :ems_infra, :ems_container, :ems_middleware, :ems_datawarehouse, :ems_network
+      :ems_cloud, :ems_infra, :ems_physical_infra, :ems_container, :ems_middleware, :ems_datawarehouse, :ems_network
     ].include?(controller_name)
       match controller_name.to_s, :controller => controller_name, :action => :index, :via => :get
     end
@@ -3225,12 +3278,13 @@ Vmdb::Application.routes.draw do
   # ping response for load balancing
   get '/ping' => 'ping#index'
 
-  resources :ems_cloud, :as => :ems_clouds
-  resources :ems_infra, :as => :ems_infras
-  resources :ems_container, :as => :ems_containers
-  resources :ems_middleware, :as => :ems_middlewares
-  resources :ems_datawarehouse, :as => :ems_datawarehouses
-  resources :ems_network, :as => :ems_networks
+  resources :ems_cloud,          :as => :ems_clouds
+  resources :ems_infra,          :as => :ems_infras
+  resources :ems_physical_infra, :as => :ems_physical_infras
+  resources :ems_container,      :as => :ems_containers
+  resources :ems_middleware,     :as => :ems_middlewares
+  resources :ems_datawarehouse,  :as => :ems_datawarehouses
+  resources :ems_network,        :as => :ems_networks
 
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6051,3 +6051,60 @@
       :description: Display Timelines for Object Storage Managers
       :feature_type: view
       :identifier: ems_object_storage_timeline
+
+# EmsPhysical
+- :name: Physical Providers
+  :description: Everything under Physical Providers
+  :feature_type: node
+  :identifier: ems_physical
+  :children:
+  - :name: View
+    :description: View Physical Providers
+    :feature_type: view
+    :identifier: ems_physical_view
+    :children:
+    - :name: List
+      :description: Display Lists of Containers Providers
+      :feature_type: view
+      :identifier: ems_physical_show_list
+    - :name: Show
+      :description: Display Individual Containers Providers
+      :feature_type: view
+      :identifier: ems_physical_show
+  - :name: Modify
+    :description: Modify Physical Providers
+    :feature_type: admin
+    :identifier: ems_physical_admin
+    :children:
+    - :name: Remove
+      :description: Remove Physical Provider
+      :feature_type: admin
+      :identifier: ems_physical_delete
+    - :name: Edit
+      :description: Edit a Physical Provider
+      :feature_type: admin
+      :identifier: ems_physical_edit
+    - :name: Add
+      :description: Add a Physical Provider
+      :feature_type: admin
+      :identifier: ems_physical_new
+
+# Physical Servers
+- :name: Physical Servers
+  :description: Everything under Physical Servers
+  :feature_type: node
+  :identifier: physical_server
+  :children:
+  - :name: View
+    :description: View Physical Server
+    :feature_type: view
+    :identifier: physical_server_view
+    :children:
+    - :name: List
+      :description: Display Lists of Physical Servers
+      :feature_type: view
+      :identifier: shosical_server_show_list
+    - :name: Show
+      :description: Display Individual Physical Server
+      :feature_type: view
+      :identifier: physical_server_show

--- a/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
+++ b/product/views/ManageIQ_Providers_PhysicalInfraManager.yaml
@@ -1,0 +1,98 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Physical Infrastructure Providers
+
+# Menu name
+name: EmsPhysicalInfra
+
+# Main DB table report is based on
+db: EmsPhysicalInfra
+
+# Columns to fetch from the main table
+cols:
+- name
+- hostname
+- ipaddress
+- emstype_description
+- port
+- total_hosts
+- total_storages
+- total_vms
+- total_miq_templates
+- region_description
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+  :zone: {}
+  :tags: {}
+
+# Order of columns (from all tables)
+col_order:
+- name
+- hostname
+- ipaddress
+- emstype_description
+- zone.name
+- total_hosts
+- total_storages
+- total_vms
+- total_miq_templates
+- region_description
+
+# Column titles, in order
+headers:
+- Name
+- Hostname
+- Discovered IP Address
+- Type
+- EVM Zone
+- Hosts
+- Datastores
+- VMs
+- Templates
+- Region
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:


### PR DESCRIPTION
Adding Physical Infrastructure pages.

The goal of this PR is to be able to graphical add, edit physical infra providers
and display summary information on said provider.

This PR is based of of Martin's https://github.com/martinpovolny/manageiq/tree/psy_ui_menu albeit with one change. Changed `Physical` to `Physical_Infra` to be more consistent with `Infra` - which will eventually change to `Virtual_Infra`