### PR TITLE
[DARGA] Backports PR 11003 to darga: Hide VMs in tree

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -331,7 +331,7 @@ module RelationshipMixin
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true)
     return {} if rel.nil?  # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
-    Relationship.filter_arranged_rels_by_resource_type(rel.descendants.arrange, options)
+    Relationship.filter_by_resource_type(rel.descendants, options).arrange
   end
 
   # Returns the descendant class/id pairs arranged in a tree
@@ -374,7 +374,7 @@ module RelationshipMixin
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true)
     return {} if rel.nil?  # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
-    Relationship.filter_arranged_rels_by_resource_type(rel.subtree.arrange, options)
+    Relationship.filter_by_resource_type(rel.subtree, options).arrange
   end
 
   # Returns the subtree class/id pairs arranged in a tree
@@ -485,7 +485,7 @@ module RelationshipMixin
     return {} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
     root_id = relationship.root_id
     rels = Relationship.subtree_of(root_id).arrange
-    Relationship.filter_arranged_rels_by_resource_type(rels, options)
+    Relationship.filter_by_resource_type(Relationship.subtree_of(root_id), options).arrange
   end
 
   # Returns the class/id pairs in the tree from the root arranged in a tree

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -96,6 +96,8 @@ class Relationship < ApplicationRecord
     end
   end
 
+  # This prunes a tree already in memory
+  # may be faster to prune the tree before creating the tree
   def self.filter_arranged_rels_by_resource_type(relationships, options)
     of_type = options[:of_type].to_miq_a
     except_type = options[:except_type].to_miq_a

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -8,18 +8,22 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
 
   def relationship_tree
     # TODO: Do more to pre-prune the tree.
-    # - Use :of_type to limit the types of objects
     # - Perhaps only get the folders, then prune those based on RBAC and let
     #   the UI still do the lazy loading of individual folders.  This can be
     #   possibly done by querying the relationship tree only, and then only
     #   converting the folders to real objects.  For the VMs we only need ids,
     #   so taking them from the relationship records can cut down on the huge
     #   VM query.
-    tree = root.subtree_arranged
+
+    # TODO: Zita: please change next 2 lines
+    display_vms = User.current_user.settings.fetch_path(:display, :display_vms)
+    display_vms = true if display_vms.nil?
+
+    tree = root.subtree_arranged(display_vms ? {} : {:except_type => VmOrTemplate})
 
     prune_non_vandt_folders(tree)
     reparent_hidden_folders(tree)
-    prune_rbac(tree)
+    prune_rbac(tree, display_vms)
     sort_tree(tree)
 
     tree
@@ -50,13 +54,19 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     end
   end
 
-  def prune_rbac(tree)
-    vms = extract_vms(tree).uniq
-
-    allowed_vm_ids = Set.new(Rbac.filtered(vms).map(&:id)) # results_format == :ids
-
-    prune_filtered_vms(tree, allowed_vm_ids)
-    prune_empty_folders(tree)
+  def prune_rbac(tree, display_vms)
+    if display_vms
+      allowed_vm_ids = Set.new(Rbac.filtered(@root_ems.vms).pluck(:id))
+      prune_folders_via_vms(tree, allowed_vm_ids)
+    else
+      allowed_vms = Rbac.filtered(@root_ems.vms) # this is a sub-query
+      vm_relations = Relationship.where(:resource     => allowed_vms,
+                                        :relationship => "ems_metadata")
+                                 .select(:ancestry).distinct # bigger sub-query
+                                 .map(&:parent_id)
+      allowed_folder_ids = Relationship.where(:id => vm_relations).pluck(:resource_id)
+      prune_folders_via_folders(tree, allowed_folder_ids)
+    end
   end
 
   def extract_vms(tree)
@@ -67,18 +77,28 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     end.flatten
   end
 
-  def prune_filtered_vms(tree, allowed_vm_ids)
+  def prune_folders_via_vms(tree, allowed_vm_ids)
     tree.reject! do |object, children|
-      prune_filtered_vms(children, allowed_vm_ids)
-      object.kind_of?(VmOrTemplate) && !allowed_vm_ids.include?(object.id)
+      prune_folders_via_vms(children, allowed_vm_ids)
+      if object.kind_of?(VmOrTemplate)
+        !allowed_vm_ids.include?(object.id)
+      elsif object.kind_of?(EmsFolder)
+        children.empty?
+      end
     end
   end
 
-  def prune_empty_folders(tree)
-    tree.reject! do |object, children|
-      prune_empty_folders(children)
-      object.kind_of?(EmsFolder) && children.empty?
+  def prune_folders_via_folders(tree, allowed_folder_ids)
+    has_sub_folders = false
+    tree.select! do |object, children|
+      has_sub_sub_folders = prune_folders_via_folders(children, allowed_folder_ids)
+
+      next(true) unless object.kind_of?(EmsFolder)
+      keep_folder = has_sub_sub_folders || allowed_folder_ids.include?(object.id)
+      has_sub_folders = true if keep_folder
+      keep_folder
     end
+    has_sub_folders
   end
 
   # Datacenters will sort before normal folders via the sort_tree method

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -1,22 +1,69 @@
 describe TreeBuilderVmsAndTemplates do
-  before do
-    ems     = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone))
-    folder  = FactoryGirl.create(:ems_folder, :ext_management_system => ems)
-    subfolder1 = FactoryGirl.create(:ems_folder)
+  let(:ems) { FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone)) }
+  let(:folder) { FactoryGirl.create(:ems_folder, :ext_management_system => ems) }
+  let(:subfolder1) { FactoryGirl.create(:ems_folder) }
+
+  let(:tree) do
     subfolder2 = FactoryGirl.create(:ems_folder)
     subfolder3 = FactoryGirl.create(:datacenter)
 
+    ems.with_relationship_type("ems_metadata") { ems.add_child(folder) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder1) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder2) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder3) }
 
-    @vandt_tree = TreeBuilderVmsAndTemplates.new(ems, {})
-    @tree = {ems => {folder => {subfolder1 => {}, subfolder2 => {}, subfolder3 => {}}}}
+    {ems => {folder => {subfolder1 => {}, subfolder2 => {}, subfolder3 => {}}}}
   end
 
-  context "#sort_tree" do
+  describe "#sort_tree" do
     it "making sure sort_tree was successful for mixed ems_folder types" do
-      expect { @vandt_tree.send(:sort_tree, @tree) }.not_to raise_error
+      builder = TreeBuilderVmsAndTemplates.new(ems)
+      expect { builder.send(:sort_tree, tree) }.not_to raise_error
+    end
+  end
+
+  describe "#tree" do
+    it "returns vms with display_vms=true" do
+      EvmSpecHelper.local_miq_server
+      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => true}})
+      tree
+      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
+
+      tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
+      expect(tree_v[:title]).to eq(ems.name)
+      expect(tree_v[:children].size).to eq(1)
+
+      folders_v = tree_v[:children].first
+      expect(folders_v[:title]).to match folder.name
+      expect(folders_v[:children].size).to eq(1)
+
+      subfolders_v = folders_v[:children].detect { |f| f[:title] == subfolder1.name }
+      expect(subfolders_v).to be_present
+      expect(subfolders_v[:children].size).to eq(2)
+
+      ems_vs = subfolders_v[:children]
+      expect(ems_vs.map { |e| e[:title] }).to match_array(vms.map(&:name))
+    end
+
+    it "returns no vms with display_vms=false" do
+      EvmSpecHelper.local_miq_server
+      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => false}})
+      tree
+      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
+
+      tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
+      expect(tree_v[:title]).to eq(ems.name)
+      expect(tree_v[:children].size).to eq(1)
+
+      folders_v = tree_v[:children].first
+      expect(folders_v[:title]).to match folder.name
+      expect(folders_v[:children].size).to eq(1) # would be 3 if we did not prune
+
+      subfolders_v = folders_v[:children].detect { |f| f[:title] == subfolder1.name }
+      expect(subfolders_v).to be_present
+      expect(subfolders_v[:children]).to be_blank # no vms in the tree
     end
   end
 end


### PR DESCRIPTION
Overview
--------

This squashes and backports the following two commits to the darga
branch:

    40c88201d2dc76d755ae559445e60ab70b2891b5
    8352bfac405a33a3ea3e8fc08420d35f6a1b02c0


**40c88201d2dc76d755ae559445e60ab70b2891b5**

_Original Commit Message_

```
Tree views - skip bringing back vms in tree
```

_Summary_

Given the user setting is enabled to do so (currently no UI provided to do so), this will allow for hiding VMs (leaf nodes) in trees, preventing a lot of records from being displayed.  If the VMs are needed, the parent folder can be selected, and the specific VM can be selected from a paginated list from there.

**8352bfac405a33a3ea3e8fc08420d35f6a1b02c0**

_Original Commit Message_

```
Filter relationship rels before fetching them

Works well for tree nodes, not so good for middle nodes
```

_Summary_

Adds some (smaller) performance benefits to trees regardless if VMs are hidden or not.


Metrics
-------

A big thing to be aware of is that there are some savings (with little risk) when just applying the changes from the second commit:

**Darga Base**

```
/vm_infra/explorer
|      ms | queries | query (ms) |     rows |
|    ---: |    ---: |       ---: |     ---: |
|   28632 |     310 |       1897 |   166470 |
|   14952 |     294 |       1866 |    84368 |
|   15652 |     294 |       1879 |    84368 |
```


_Note:  https://github.com/ManageIQ/manageiq/pull/13163 is also applied with these next two sets of numbers_

**Without Hiding VMs**

```
/vm_infra/explorer
|      ms | queries | query (ms) |     rows |
|    ---: |    ---: |       ---: |     ---: |
|   20234 |     368 |       4029 |   106002 |
|   12911 |     287 |       2867 |    54166 |
|   10965 |     266 |       2179 |    54139 |
```

But when you change the line:

```ruby
display_vms = true if display_vms.nil?
```

to:

```ruby
display_vms = false if display_vms.nil?
```

You see "master-like" improvements.


**With Hiding VMs**

```
/vm_infra/explorer
|     ms | queries | query (ms) |    rows |
|   ---: |    ---: |       ---: |    ---: |
|   4650 |     379 |       1578 |   19552 |
|   2246 |     266 |        284 |   10909 |
|   2028 |     266 |        226 |   10909 |
```


Pros/Cons and other notes
-------------------------

* #11003 is a prerequisite to https://github.com/ManageIQ/manageiq/pull/11387
* https://github.com/ManageIQ/manageiq/pull/11387 was built on top of this PR, and does far more sweeping changes to the trees in general and adds a UI for setting the User setting for hiding VMs.  This also defaults that setting to "hide VMs", which wasn't the case in #11003, which is originally why we didn't see as big of an improvement.
* https://github.com/ManageIQ/manageiq/pull/11387 also is built on top of https://github.com/ManageIQ/manageiq/pull/10767 , which ripped out dynatree for the patternfly equivalent.  There is a lot in 11387 that isn't relevant for darga.
* There are some bugs when #11387 is applied that didn't present themselves when enabling hiding VMs by default in this #11003, and some differences/regressions with #11003 as well
  - #11387 Refreshing a VM show page after navigating to it will actually show the contents for the parent folder.  This would be confusing for a end user, but this is because #11387 attempts to expand the `/vm_infra/explorer` tree for the user for context, and only can go down to the parent folder (again, because we are hiding VMs)
  - #11003 in contrast (when VMs are hidden) will not expand the tree at all.  Also, I (@NickLaMuro) personally don't know how doing that would be accomplished in dynatree, and attempting to do so when attempting to backporting #11387 was tricky.
* Both #11387 and #11003 (with the vms hidden) change default behaviour of the tree, and if the user is not expecting it, could be confusing.  But the performance gains are significant, so that might outweigh confusion.


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1405452