### PR TITLE
Adds the :additional_regions hash for ems_azure.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,6 +105,7 @@
     :additional_regions: {}
   :ems_azure:
     :disabled_regions: []
+    :additional_regions: {}
 :ems_events:
   :history:
     :keep_ems_events: 6.months


### PR DESCRIPTION
This PR modifies the config/settings.yml file to add a new hash for ```:ems_azure``` called ```:additional_regions```.

In a separate PR, the Azure regions.rb file will be updated to read this hash and include the additional regions in the list of supported Azure regions.

