### PR TITLE
Custom button submit redirected to request list

### DIFF
--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -47,9 +47,13 @@ module ApplicationController::DialogRunner
             @in_a_form = false
             if session[:edit][:explorer]
               add_flash(flash)
-              javascript_redirect :controller => 'miq_request',
-                                  :action     => 'show_list',
-                                  :flash_msg  => flash
+              if result[:request].nil?
+                replace_right_cell
+              else
+                javascript_redirect :controller => 'miq_request',
+                                    :action     => 'show_list',
+                                    :flash_msg  => flash
+              end
             else
               javascript_redirect redirect_url(flash)
             end


### PR DESCRIPTION
When a custom dialog is submitted, there should be a redirect to the list of requests only if a request was actually created

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1403604

DARGA PR: https://github.com/ManageIQ/manageiq/pull/13188

Steps for Testing/QA 
-------------------------------

1. Add a custom button/dialog for services. When the submit is pressed for the button, the page should stay on the service
2. for an orchestration template service - when 'order' is pressed - there should be a redirect to the list of requests
