### PR TITLE
Make more_core_extensions direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "mime-types",                     "~>2.6.1",       :require => "mime/types/columnar"
+gem "more_core_extensions",           "~>3.1"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false


### PR DESCRIPTION
Since the gem's `RE_EMAIL` constant is used in app/models/user.rb, the
gem should be a direct dependency.

To precede https://github.com/ManageIQ/manageiq/pull/12901 so that, once a new release of the gem is cut, the version specified here can be bumped to coordinate the moving of test code from app to gem.

@Fryguy hope I am understanding this process correctly :grin: 

@miq-bot assign @Fryguy 