### PR TITLE
[DARGA] Move rubyrep to the newest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 
 # Vendored but not required
 gem "net-ldap",                       "~>0.14.0",  :require => false
-gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-9"
+gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-10"
 gem "simple-rss",                     "~>1.3.1",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"
 


### PR DESCRIPTION
This version includes a fix which ensures the special trigger row variables, NEW and OLD are not quoted in trigger functions.

This was breaking replication for the reserves table.

https://bugzilla.redhat.com/show_bug.cgi?id=1403529