### PR TITLE
Remove "attempt" from ssh parameters when checking OSP host auth

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -301,7 +301,7 @@ module AuthenticationMixin
     save            = options.fetch(:save, true)
     auth            = authentication_best_fit(args.first)
     type            = args.first || auth.try(:authtype)
-    status, details = authentication_check_no_validation(type, options)
+    status, details = authentication_check_no_validation(type, options.except(:attempt))
 
     if auth && save
       status == :valid ? auth.validation_successful : auth.validation_failed(status, details)


### PR DESCRIPTION
Fixes a situation where "attempt" would accidentally get passed as an SSH parameter to Openstack hosts during scheduled authentication checks, resulting in a cryptic authentication status in the UI.

```
INFO -- : MIQ(ManageIQ::Providers::Openstack::InfraManager::Host#connect_ssh) SSH connection established to [192.0.2.14]
ERROR -- : MIQ(ManageIQ::Providers::Openstack::InfraManager::Host#connect_ssh) SSH connection failed for [192.0.2.14] with [ArgumentError: invalid option(s): attempt]
```

https://bugzilla.redhat.com/show_bug.cgi?id=1392460