### PR TITLE
Display IPv6Address on VM summary page

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -29,7 +29,7 @@ class Hardware < ApplicationRecord
   virtual_attribute :ram_size_in_bytes, :integer, :arel => ->(t) { t.grouping(t[:memory_mb] * 1.megabyte) }
 
   def ipaddresses
-    @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq
+    @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq + networks.collect(&:ipv6address).compact.uniq
   end
 
   def hostnames


### PR DESCRIPTION
Currently only IPv4 addresses are displayed on VM summary page. This PR is to have IPv6 displayed as well.

Basically, `vm.ipaddresses` will now include IPv6 addresses as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1375737