### PR TITLE
gitignore /plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .tags
 /data/
 /productization
-/providers
+/plugins
 /vmdb/
 BUILD
 ca/root


### PR DESCRIPTION
ignore /plugins instead of /providers

TBD: change the docs to be more comprehensive in ManageIQ plugin development setup

https://github.com/ManageIQ/manageiq/pull/9856
https://github.com/ManageIQ/guides/pull/136