### PR TITLE
Extract class MiqReportFormats

### DIFF
--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -1,4 +1,4 @@
-class MiqReportFormats
+class MiqReport::Formats
   format_hash = YAML.load_file(ApplicationRecord::FIXTURE_DIR.join('miq_report_formats.yml')).freeze
   FORMATS                = format_hash[:formats].freeze
   DEFAULTS_AND_OVERRIDES = format_hash[:defaults_and_overrides].freeze
@@ -19,7 +19,7 @@ class MiqReportFormats
   def self.default_format_for(column, suffix, datatype)
     DEFAULTS_AND_OVERRIDES[:formats_by_suffix][suffix] ||
       DEFAULTS_AND_OVERRIDES[:formats_by_column][column] ||
-      DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][MiqReportFormats.sub_type(column)] ||
+      DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type(column)] ||
       DEFAULTS_AND_OVERRIDES[:formats_by_data_type][datatype]
   end
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -66,11 +66,7 @@ module MiqReport::Formatting
       dt = value.class.to_s.downcase.to_sym if dt.nil?
       dt = dt.to_sym unless dt.nil?
       sfx = col.to_s.split('__').last.try(:to_sym)
-      format = FORMATS[MiqReportFormats.default_format_for(col, sfx, dt)]
-      format = format.deep_clone if format # Make sure we don't taint the original
-      if format && MiqReportFormats::DEFAULTS_AND_OVERRIDES[:precision_by_column].key?(col.to_sym)
-        format[:precision] = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:precision_by_column][col.to_sym]
-      end
+      format = MiqReportFormats.default_format_details_for(col, sfx, dt)
     else
       format = format.deep_clone # Make sure we don't taint the original
     end

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -2,7 +2,6 @@
 
 module MiqReport::Formatting
   extend ActiveSupport::Concern
-  FORMATS = MiqReportFormats::FORMATS
 
   module ClassMethods
     def get_available_formats(path, dt)
@@ -22,7 +21,7 @@ module MiqReport::Formatting
     format_name ||= self.class.get_default_format(col, nil)
     return nil unless format_name && format_name != :_none_
 
-    format = FORMATS[format_name]
+    format = MiqReportFormats.details(format_name)
     function_name = format[:function][:name]
 
     options = format.merge(format[:function]).slice(
@@ -48,7 +47,7 @@ module MiqReport::Formatting
     return value.to_s if format == :_none_ # Raw value was requested, do not attempt to format
 
     # Format name passed in as a symbol or string
-    format = FORMATS[format.to_sym] if (format.kind_of?(Symbol) || format.kind_of?(String)) && format != :_default_
+    format = MiqReportFormats.details(format) if (format.kind_of?(Symbol) || format.kind_of?(String)) && format != :_default_
 
     # Look in this report object for column format
     self.col_formats ||= []
@@ -56,7 +55,7 @@ module MiqReport::Formatting
       idx = col.kind_of?(String) ? col_order.index(col) : col
       if idx
         col = col_order[idx]
-        format = FORMATS[self.col_formats[idx]]
+        format = MiqReportFormats.details(self.col_formats[idx])
       end
     end
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -62,11 +62,11 @@ module MiqReport::Formatting
 
     # Use default format for column stil nil
     if format.nil? || format == :_default_
-      expression_col = col_to_expression_col(col)
-      dt = self.class.get_col_type(expression_col)
+      dt = MiqExpression.get_col_type(col_to_expression_col(col))
       dt = value.class.to_s.downcase.to_sym if dt.nil?
       dt = dt.to_sym unless dt.nil?
-      format = FORMATS[self.class.get_default_format(expression_col, dt)]
+      sfx = col.to_s.split('__').last.try(:to_sym)
+      format = FORMATS[MiqReportFormats.default_format_for(col, sfx, dt)]
       format = format.deep_clone if format # Make sure we don't taint the original
       if format && MiqReportFormats::DEFAULTS_AND_OVERRIDES[:precision_by_column].key?(col.to_sym)
         format[:precision] = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:precision_by_column][col.to_sym]

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -8,23 +8,7 @@ module MiqReport::Formatting
     def get_available_formats(path, dt)
       col = path.split("-").last.to_sym
       sfx = col.to_s.split("__").last
-      is_break_sfx = (sfx && self.is_break_suffix?(sfx))
-      sub_type = MiqReportFormats.sub_type(col)
-      FORMATS.keys.inject({}) do |h, k|
-        # Ignore formats that don't include suffix if the column name has a break suffix
-        next(h) if is_break_sfx && (FORMATS[k][:suffixes].nil? || !FORMATS[k][:suffixes].include?(sfx.to_sym))
-
-        if FORMATS[k][:columns] && FORMATS[k][:columns].include?(col)
-          h[k] = FORMATS[k][:description]
-        elsif FORMATS[k][:sub_types] && FORMATS[k][:sub_types].include?(sub_type)
-          h[k] = FORMATS[k][:description]
-        elsif FORMATS[k][:data_types] && FORMATS[k][:data_types].include?(dt)
-          h[k] = FORMATS[k][:description]
-        elsif FORMATS[k][:suffixes] && FORMATS[k][:suffixes].include?(sfx.to_sym)
-          h[k] = FORMATS[k][:description]
-        end
-        h
-      end
+      MiqReportFormats.available_formats_for(col, sfx, dt)
     end
 
     def get_default_format(path, dt)

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -13,12 +13,8 @@ module MiqReport::Formatting
 
     def get_default_format(path, dt)
       col = path.split("-").last.to_sym
-      sfx = col.to_s.split("__").last
-      sfx = sfx.to_sym if sfx
-      MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_suffix][sfx] ||
-        MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_column][col] ||
-        MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][MiqReportFormats.sub_type(col)] ||
-        MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_data_type][dt]
+      sfx = col.to_s.split("__").last.try(:to_sym)
+      MiqReportFormats.default_format_for(col, sfx, dt)
     end
   end
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -9,7 +9,7 @@ module MiqReport::Formatting
       col = path.split("-").last.to_sym
       sfx = col.to_s.split("__").last
       is_break_sfx = (sfx && self.is_break_suffix?(sfx))
-      sub_type = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col]
+      sub_type = MiqReportFormats.sub_type(col)
       FORMATS.keys.inject({}) do |h, k|
         # Ignore formats that don't include suffix if the column name has a break suffix
         next(h) if is_break_sfx && (FORMATS[k][:suffixes].nil? || !FORMATS[k][:suffixes].include?(sfx.to_sym))
@@ -31,10 +31,9 @@ module MiqReport::Formatting
       col = path.split("-").last.to_sym
       sfx = col.to_s.split("__").last
       sfx = sfx.to_sym if sfx
-      sub_type = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col]
       MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_suffix][sfx] ||
         MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_column][col] ||
-        MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type] ||
+        MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][MiqReportFormats.sub_type(col)] ||
         MiqReportFormats::DEFAULTS_AND_OVERRIDES[:formats_by_data_type][dt]
     end
   end

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -7,13 +7,13 @@ module MiqReport::Formatting
     def get_available_formats(path, dt)
       col = path.split("-").last.to_sym
       sfx = col.to_s.split("__").last
-      MiqReportFormats.available_formats_for(col, sfx, dt)
+      MiqReport::Formats.available_formats_for(col, sfx, dt)
     end
 
     def get_default_format(path, dt)
       col = path.split("-").last.to_sym
       sfx = col.to_s.split("__").last.try(:to_sym)
-      MiqReportFormats.default_format_for(col, sfx, dt)
+      MiqReport::Formats.default_format_for(col, sfx, dt)
     end
   end
 
@@ -21,7 +21,7 @@ module MiqReport::Formatting
     format_name ||= self.class.get_default_format(col, nil)
     return nil unless format_name && format_name != :_none_
 
-    format = MiqReportFormats.details(format_name)
+    format = MiqReport::Formats.details(format_name)
     function_name = format[:function][:name]
 
     options = format.merge(format[:function]).slice(
@@ -47,7 +47,7 @@ module MiqReport::Formatting
     return value.to_s if format == :_none_ # Raw value was requested, do not attempt to format
 
     # Format name passed in as a symbol or string
-    format = MiqReportFormats.details(format) if (format.kind_of?(Symbol) || format.kind_of?(String)) && format != :_default_
+    format = MiqReport::Formats.details(format) if (format.kind_of?(Symbol) || format.kind_of?(String)) && format != :_default_
 
     # Look in this report object for column format
     self.col_formats ||= []
@@ -55,7 +55,7 @@ module MiqReport::Formatting
       idx = col.kind_of?(String) ? col_order.index(col) : col
       if idx
         col = col_order[idx]
-        format = MiqReportFormats.details(self.col_formats[idx])
+        format = MiqReport::Formats.details(self.col_formats[idx])
       end
     end
 
@@ -65,7 +65,7 @@ module MiqReport::Formatting
       dt = value.class.to_s.downcase.to_sym if dt.nil?
       dt = dt.to_sym unless dt.nil?
       sfx = col.to_s.split('__').last.try(:to_sym)
-      format = MiqReportFormats.default_format_details_for(col, sfx, dt)
+      format = MiqReport::Formats.default_format_details_for(col, sfx, dt)
     else
       format = format.deep_clone # Make sure we don't taint the original
     end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -760,7 +760,7 @@ class MiqExpression
     end
     if col
       result[:data_type] = col_type(model, col)
-      result[:format_sub_type] = MiqReport::FORMAT_DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col.to_sym] || result[:data_type]
+      result[:format_sub_type] = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col.to_sym] || result[:data_type]
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
       result[:sql_support] = model.attribute_supported_by_sql?(col.to_s)
       result[:excluded_by_preprocess_options] = self.exclude_col_by_preprocess_options?(col, options)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -760,7 +760,7 @@ class MiqExpression
     end
     if col
       result[:data_type] = col_type(model, col)
-      result[:format_sub_type] = MiqReportFormats.sub_type(col.to_sym) || result[:data_type]
+      result[:format_sub_type] = MiqReport::Formats.sub_type(col.to_sym) || result[:data_type]
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
       result[:sql_support] = model.attribute_supported_by_sql?(col.to_s)
       result[:excluded_by_preprocess_options] = self.exclude_col_by_preprocess_options?(col, options)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -760,7 +760,7 @@ class MiqExpression
     end
     if col
       result[:data_type] = col_type(model, col)
-      result[:format_sub_type] = MiqReportFormats::DEFAULTS_AND_OVERRIDES[:sub_types_by_column][col.to_sym] || result[:data_type]
+      result[:format_sub_type] = MiqReportFormats.sub_type(col.to_sym) || result[:data_type]
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
       result[:sql_support] = model.attribute_supported_by_sql?(col.to_s)
       result[:excluded_by_preprocess_options] = self.exclude_col_by_preprocess_options?(col, options)

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -23,6 +23,17 @@ class MiqReportFormats
       DEFAULTS_AND_OVERRIDES[:formats_by_data_type][datatype]
   end
 
+  def self.default_format_details_for(column, suffix, datatype)
+    format = FORMATS[default_format_for(column, suffix, datatype)]
+    if format
+      format = format.deep_clone # Make sure we don't taint the original
+      if DEFAULTS_AND_OVERRIDES[:precision_by_column].key?(column.to_sym)
+        format[:precision] = DEFAULTS_AND_OVERRIDES[:precision_by_column][column.to_sym]
+      end
+    end
+    format
+  end
+
   def self.sub_type(column)
     DEFAULTS_AND_OVERRIDES[:sub_types_by_column][column]
   end

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -34,6 +34,10 @@ class MiqReportFormats
     format
   end
 
+  def self.details(format_name)
+    FORMATS[format_name.try(:to_sym)]
+  end
+
   def self.sub_type(column)
     DEFAULTS_AND_OVERRIDES[:sub_types_by_column][column]
   end

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -2,4 +2,8 @@ class MiqReportFormats
   format_hash = YAML.load_file(ApplicationRecord::FIXTURE_DIR.join('miq_report_formats.yml')).freeze
   FORMATS                = format_hash[:formats].freeze
   DEFAULTS_AND_OVERRIDES = format_hash[:defaults_and_overrides].freeze
+
+  def self.sub_type(column)
+    DEFAULTS_AND_OVERRIDES[:sub_types_by_column][column]
+  end
 end

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -16,6 +16,13 @@ class MiqReportFormats
     end
   end
 
+  def self.default_format_for(column, suffix, datatype)
+    DEFAULTS_AND_OVERRIDES[:formats_by_suffix][suffix] ||
+      DEFAULTS_AND_OVERRIDES[:formats_by_column][column] ||
+      DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][MiqReportFormats.sub_type(column)] ||
+      DEFAULTS_AND_OVERRIDES[:formats_by_data_type][datatype]
+  end
+
   def self.sub_type(column)
     DEFAULTS_AND_OVERRIDES[:sub_types_by_column][column]
   end

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -1,0 +1,5 @@
+class MiqReportFormats
+  format_hash = YAML.load_file(ApplicationRecord::FIXTURE_DIR.join('miq_report_formats.yml')).freeze
+  FORMATS                = format_hash[:formats].freeze
+  DEFAULTS_AND_OVERRIDES = format_hash[:defaults_and_overrides].freeze
+end

--- a/lib/miq_report_formats.rb
+++ b/lib/miq_report_formats.rb
@@ -3,6 +3,19 @@ class MiqReportFormats
   FORMATS                = format_hash[:formats].freeze
   DEFAULTS_AND_OVERRIDES = format_hash[:defaults_and_overrides].freeze
 
+  def self.available_formats_for(column, suffix, datatype)
+    is_break_sfx = (suffix && MiqReport.is_break_suffix?(suffix))
+    FORMATS.each_with_object({}) do |(format_name, properties), result|
+      # Ignore formats that don't include suffix if the column name has a break suffix
+      next if is_break_sfx && (properties[:suffixes].nil? || !properties[:suffixes].include?(suffix.to_sym))
+      next unless (properties[:columns] && properties[:columns].include?(column)) ||
+                  (properties[:sub_types] && properties[:sub_types].include?(sub_type(column))) ||
+                  (properties[:data_types] && properties[:data_types].include?(datatype)) ||
+                  (properties[:suffixes] && properties[:suffixes].include?(suffix.to_sym))
+      result[format_name] = properties[:description]
+    end
+  end
+
   def self.sub_type(column)
     DEFAULTS_AND_OVERRIDES[:sub_types_by_column][column]
   end


### PR DESCRIPTION
## What
The `MiqReports` have pre-defined formats for columns in `db/fixtures/miq_report_formats.yml`

This pr wraps `miq_report_formats.yml` into a class.

## Why
Firstly, it is nice. The MiqReport class is already beefy. So, removing some of its responsibilities cannot hurt.

Secondly, we need return default formats for dynamic columns like *Storage Allocated SSD Cost* (See #12501). These columns are dynamic, so they cannot be hardcoded in that yaml. When we have this new class we can override the behavior more cleanly.

@miq-bot add_label core, refactoring, euwe/no
@miq-bot assign @gtanzillo 