### PR TITLE
Remove unused chargeback columns from chargeback for container images

### DIFF
--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -10,12 +10,9 @@ class ChargebackContainerImage < Chargeback
     :cpu_cores_used_metric => :float,
     :fixed_compute_1_cost  => :float,
     :fixed_compute_2_cost  => :float,
-    :fixed_2_cost          => :float,
     :fixed_cost            => :float,
     :memory_used_cost      => :float,
     :memory_used_metric    => :float,
-    :net_io_used_cost      => :float,
-    :net_io_used_metric    => :float,
     :total_cost            => :float,
   )
 
@@ -79,8 +76,6 @@ class ChargebackContainerImage < Chargeback
       "fixed_cost"            => {:grouping => [:total]},
       "memory_used_cost"      => {:grouping => [:total]},
       "memory_used_metric"    => {:grouping => [:total]},
-      "net_io_used_cost"      => {:grouping => [:total]},
-      "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}
     }
   end

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -173,19 +173,6 @@
   :rate_type: Compute
   :default: false
   :rates:
-    - :description: Used CPU
-      :group: cpu
-      :source: used
-      :metric: cpu_usagemhz_rate_average
-      :per_time: hourly
-      :per_unit: megahertz
-      :measure: Hz Units
-      :type_currency: Dollars
-      :tiers:
-        - :start: 0
-          :finish: Infinity
-          :fixed_rate: 0.0
-          :variable_rate: 0.02
     - :description: Used CPU Cores
       :group: cpu_cores
       :source: used
@@ -198,18 +185,6 @@
           :finish: Infinity
           :fixed_rate: 1.0
           :variable_rate: 0.02
-    - :description: Allocated CPU Count
-      :group: cpu
-      :source: allocated
-      :metric: derived_vm_numvcpus
-      :per_time: hourly
-      :per_unit: cpu
-      :type_currency: Dollars
-      :tiers:
-        - :start: 0
-          :finish: Infinity
-          :fixed_rate: 1.0
-          :variable_rate: 0.0
     - :description: Used Memory
       :group: memory
       :source: used
@@ -223,49 +198,6 @@
           :finish: Infinity
           :fixed_rate: 0.0
           :variable_rate: 0.02
-    - :description: Allocated Memory
-      :group: memory
-      :source: allocated
-      :metric: derived_memory_available
-      :per_time: hourly
-      :per_unit: megabytes
-      :measure: Bytes Units
-      :type_currency: Dollars
-      :tiers:
-        - :start: 0
-          :finish: Infinity
-          :fixed_rate: 0.0
-          :variable_rate: 0.0
-    - :description: Used Network I/O
-      :group: net_io
-      :source: used
-      :metric: net_usage_rate_average
-      :per_time: hourly
-      :per_unit: kbps
-      :measure: Bytes per Second Units
-      :type_currency: Dollars
-      :tiers:
-        - :start: 0
-          :finish: 100
-          :fixed_rate: 0.5
-          :variable_rate: 0.0
-        - :start: 100
-          :finish: Infinity
-          :fixed_rate: 0.5
-          :variable_rate: 0.005
-    - :description: Used Disk I/O
-      :group: disk_io
-      :source: used
-      :metric: disk_usage_rate_average
-      :per_time: hourly
-      :per_unit: kbps
-      :measure: Bytes per Second Units
-      :type_currency: Dollars
-      :tiers:
-        - :start: 0
-          :finish: Infinity
-          :fixed_rate: 0.0
-          :variable_rate: 0.005
     - :description: Fixed Compute Cost 1
       :group: fixed
       :source: compute_1


### PR DESCRIPTION
Remove irrelevant columns from `Chargeback for container images`
and remove the measures from the default container image rate.

![screencapture-localhost-3000-chargeback-explorer-1481811781117](https://cloud.githubusercontent.com/assets/11256940/21227629/7f6948b8-c2e3-11e6-9264-fb7e00ebf6ec.png)

@simon3z @bazulay  
@miq-bot add_label chargeback, providers/containers