### PR TITLE
Fixed code to expect/set keys as strings instead of symbols in edit hash

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -698,7 +698,7 @@ class MiqAeClassController < ApplicationController
 
     @edit[:new][:fields] = @ae_class.ae_fields.sort_by { |a| [a.priority.to_i] }.collect do |fld|
       field_attributes.each_with_object({}) do |column, hash|
-        hash[column.to_sym] = fld.send(column)
+        hash[column] = fld.send(column)
       end
     end
 
@@ -1968,7 +1968,7 @@ class MiqAeClassController < ApplicationController
       field_attributes.each do |field|
         field_name = "field_#{field}".to_sym
         field_sym = field.to_sym
-        if field == :substitute
+        if field == "substitute"
           field_data[field_sym] = new_field[field_sym] = params[field_name] == "1" if params[field_name]
         elsif params[field_name]
           field_data[field_sym] = new_field[field_sym] = params[field_name]
@@ -1992,17 +1992,16 @@ class MiqAeClassController < ApplicationController
       @edit[:new][:fields].each_with_index do |fld, i|
         field_attributes.each do |field|
           field_name = "fields_#{field}_#{i}"
-          field_sym = field.to_sym
           if field == "substitute"
-            fld[field_sym] = params[field_name] == "1" if params[field_name]
+            fld[field] = params[field_name] == "1" if params[field_name]
           elsif %w(aetype datatype).include?(field)
             var_name = "fields_#{field}#{i}"
-            fld[field_sym] = params[var_name.to_sym] if params[var_name.to_sym]
+            fld[field] = params[var_name.to_sym] if params[var_name.to_sym]
           elsif field == "default_value"
-            fld[field_sym] = params[field_name] if params[field_name]
-            fld[field_sym] = params["fields_password_value_#{i}".to_sym] if params["fields_password_value_#{i}".to_sym]
-          else
-            fld[field_sym] = params[field_name] if params[field_name]
+            fld[field] = params[field_name] if params[field_name]
+            fld[field] = params["fields_password_value_#{i}".to_sym] if params["fields_password_value_#{i}".to_sym]
+          elsif params[field_name]
+            fld[field] = params[field_name]
           end
         end
       end
@@ -2014,8 +2013,9 @@ class MiqAeClassController < ApplicationController
         return
       end
       new_fields = {}
-      field_attributes.each_with_object({}) { |field| field = field.to_sym
-      new_fields[field] = @edit[:new_field][field]}
+      field_attributes.each do |field_attribute|
+        new_fields[field_attribute] = @edit[:new_field][field_attribute.to_sym]
+      end
       @edit[:new][:fields].push(new_fields)
       @edit[:new_field] = session[:field_data] = {}
     end

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -63,7 +63,7 @@
               %tr
                 %td
                   = link_to(image_tag(image_path("16/notequal-red.png"), :alt => (t = _("Click to delete this field from schema"))),
-                    {:action => "field_delete", :id => field[:id].to_s, :arr_id => i},
+                    {:action => "field_delete", :id => field["id"].to_s, :arr_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
@@ -72,10 +72,9 @@
                     :title                 => t)
                 - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                   %td
-                    - fname = fname.to_sym
                     - if %w(aetype datatype).include?(fname.to_s)
                       - combo_name = "fields_#{fname}#{i}"
-                      - combo_options  = (fname == :aetype ? @combo_xml : @dtype_combo_xml)
+                      - combo_options  = (fname == "aetype" ? @combo_xml : @dtype_combo_xml)
                       - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
                       #form-group
                         = select_tag(combo_name,
@@ -84,11 +83,11 @@
                           :class  => "selectpicker")
                       :javascript
                         miqSelectPickerEvent("#{combo_name}", "#{combo_url}")
-                    - elsif fname == :substitute
-                      = check_box_tag("fields_#{fname}_#{i}", "1", field[:substitute],
+                    - elsif fname == "substitute"
+                      = check_box_tag("fields_#{fname}_#{i}", "1", field["substitute"],
                         "data-miq_observe_checkbox" => {:url => url}.to_json)
-                    - elsif fname == :default_value
-                      - default_value = field[:default_value]
+                    - elsif fname == "default_value"
+                      - default_value = field["default_value"]
                       = text_field_tag("fields_default_value_#{i}", default_value,
                         :style             => field['datatype'] == "password" ? "display:none" : "",
                         "data-miq_observe" => obs)
@@ -119,8 +118,7 @@
                   :title                 => t)
               - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                 %td
-                  - fname = fname.to_sym
-                  - if %w(aetype datatype).include?(fname.to_s)
+                  - if %w(aetype datatype).include?(fname)
                     - combo_name = "field_#{fname}"
                     - combo_options  = @edit[:new]["#{fname}s".to_sym]
                     - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
@@ -131,10 +129,10 @@
                           :class  => "selectpicker")
                     :javascript
                       miqSelectPickerEvent("#{combo_name}", "#{combo_url}")
-                  - elsif fname == :substitute
+                  - elsif fname == "substitute"
                     - checked = !session[:field_data].blank? && session[:field_data][:substitute]
                     = check_box_tag("field_#{fname}", "1", checked, "data-miq_observe_checkbox" => {:url => url}.to_json)
-                  - elsif fname == :default_value
+                  - elsif fname == "default_value"
                     = text_field_tag("field_default_value", session[:field_data][:default_value],
                       :style             => session[:field_data][:datatype] == "password" ? "display:none" : "",
                       "data-miq_observe" => obs)

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -614,18 +614,54 @@ describe MiqAeClassController do
         :new_field        => {},
         :new              => {
           :datatypes => [],
+          :name      => 'freddie',
           :aetypes   => [],
           :fields    => [@cls.ae_fields.first]
         }
       }
-      controller.instance_variable_set(:@_params, "fields_default_value_0" => "Pebbles", :id => @cls.id)
+      controller.instance_variable_set(:@_params,
+                                       "fields_default_value_0" => "Pebbles",
+                                       "fields_name_0"          => "freddie",
+                                       :id                      => @cls.id)
       allow(controller).to receive(:render)
       controller.send(:fields_form_field_changed)
       expect(@cls.ae_fields.first.default_value).to eq("Wilma")
       controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
       controller.send(:update_fields)
       @cls.reload
+      expect(@cls.ae_fields.first.name).to eq("freddie")
       expect(@cls.ae_fields.first.default_value).to eq("Pebbles")
+    end
+
+    it "adds a new field to a class and saves the class with new field" do
+      field = {:aetype        => "attribute",
+               :default_value => "Wilma",
+               :name          => "name01"}
+      session[:field_data] = field
+      session[:edit] = {
+        :key              => "aefields_edit__#{@cls.id}",
+        :ae_class_id      => @cls.id,
+        :fields_to_delete => [],
+        :new_field        => {:name => "Bar", :default_value => "Foo"},
+        :new              => {
+          :datatypes => [],
+          :name      => 'fred',
+          :aetypes   => [],
+          :fields    => [@cls.ae_fields.first]
+        }
+      }
+      controller.instance_variable_set(:@_params,
+                                       "fields_default_value" => "Foo",
+                                       "fields_name"          => "Bar",
+                                       :id                    => @cls.id,
+                                       :button                => 'accept')
+      allow(controller).to receive(:render)
+      controller.send(:fields_form_field_changed)
+      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.send(:update_fields)
+      @cls.reload
+      expect(@cls.ae_fields.last.name).to eq("Bar")
+      expect(@cls.ae_fields.last.default_value).to eq("Foo")
     end
   end
 


### PR DESCRIPTION
This issue was introduced in https://github.com/ManageIQ/manageiq/pull/12322, some of the code is common between class schema editor and method editor that caused schema editor to break.
Fixed/Added affected spec tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1404788

@mkanoor please test/review