### PR TITLE
Disallow mocks/expectations on nil values

### DIFF
--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -89,7 +89,7 @@ describe ServiceTemplateProvisionTask do
           :tenant_id        => @admin.current_tenant.id,
         }
         allow(@request).to receive(:approved?).and_return(true)
-        allow(@task_0.source).to receive(:my_zone).and_return("special")
+        allow(@task_0).to receive(:source).and_return(double(:my_zone => "special"))
         expect(MiqQueue).to receive(:put).with(
           :class_name  => 'MiqAeEngine',
           :method_name => 'deliver',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
   end
   config.mock_with :rspec do |c|
     c.syntax = :expect
+    c.allow_message_expectations_on_nil = false
   end
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Removes warning

Raising prevents potential false positives. Fixes one such case.

cc/ @bzwei 