### PR TITLE
Support AAArModel for attribute_supported_by_sql

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -45,7 +45,7 @@ module VirtualArel
     # - it is an attribute that is virtual and has arel defined
     def attribute_supported_by_sql?(name)
       load_schema
-      attribute_alias?(name) ||
+      try(:attribute_alias?, name) ||
         (has_attribute?(name) && (!virtual_attribute?(name) || !!_virtual_arel[name.to_s]))
     end
     private

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -501,6 +501,12 @@ describe VirtualFields do
       it "does not support bogus columns" do
         expect(TestClass.attribute_supported_by_sql?(:bogus_junk)).to be_falsey
       end
+
+      it "supports on an aaar class" do
+        c = Class.new(ActsAsArModel)
+
+        expect(c.attribute_supported_by_sql?(:col)).to eq(false)
+      end
     end
 
     describe ".virtual_delegate" do


### PR DESCRIPTION
introduced the bug in #12438 commit ae34cd3ef80bce80b45144f62f8f13f7c1c59b78

`ActsAsArModel` does not implement `attribute_alias?`
So `model.attribute_supported_by_sql?(:x)` was throwing an exception.

Using a `try` to only call `attribute_alias?` if it is implemented.