### PR TITLE
MiqExpression#fields returns the list of Fields

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1616,6 +1616,25 @@ class MiqExpression
     end
   end
 
+  def fields(expression = exp)
+    case expression
+    when Array
+      expression.flat_map { |x| fields(x) }
+    when Hash
+      return [] if expression.empty?
+
+      if (val = expression["field"] || expression["count"] || expression["tag"])
+        ret = []
+        ret << Field.parse(val) if Field.is_field?(val)
+        val = expression["value"]
+        ret << Field.parse(val) if Field.is_field?(val)
+        ret
+      else
+        fields(expression.values)
+      end
+    end
+  end
+
   private
 
   # example:

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2613,4 +2613,20 @@ describe MiqExpression do
       include_examples :coerces_value_to_integer
     end
   end
+
+  describe "#fields" do
+    it "extracts fields" do
+      expression = {
+        "AND" => [
+          {">=" => {"field" => "EmsClusterPerformance-cpu_usagemhz_rate_average", "value" => "0"}},
+          {"<"  => {"field" => "Vm-name", "value" => "5"}}
+        ]
+      }
+      actual = described_class.new(expression).fields.sort_by(&:column)
+      expect(actual).to contain_exactly(
+        an_object_having_attributes(:model => EmsClusterPerformance, :column => "cpu_usagemhz_rate_average"),
+        an_object_having_attributes(:model => Vm, :column => "name")
+      )
+    end
+  end
 end


### PR DESCRIPTION
When determining performance of a report, it is necessary to look at the fields in the `condition` portion of a report.

This provides `MiqExpression#fields` to extract those fields.