### PR TITLE
fix_auth: allow config tables to have drb models

### DIFF
--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -13,6 +13,9 @@ end
 
 require 'active_support/all'
 require 'active_support/concern'
+# this gets around a bug if a user mistakingly
+# serializes a drb object into a configuration hash
+require 'drb'
 require 'manageiq-gems-pending'
 require_relative '../lib/vmdb/settings/walker'
 require 'fix_auth/auth_model'

--- a/tools/fix_auth/auth_config_model.rb
+++ b/tools/fix_auth/auth_config_model.rb
@@ -41,6 +41,10 @@ module FixAuth
 
         symbol_keys ? hash.deep_symbolize_keys! : hash.deep_stringify_keys!
         hash.to_yaml
+      rescue ArgumentError # undefined class/module
+        puts "potentially bad yaml:"
+        puts old_value
+        raise
       end
     end
   end


### PR DESCRIPTION
Sometimes we put `Drb` models into our configuration tables.
This is not desired, but here we are.

This change allows the user to run `fix_auth` to change an encryption key even though a table has
 faulty data in it.

In my case, the `miq_request_tasks.options` field had a bad entry:

```yaml
validated_inputs: !ruby/object:DRb::DRbUnknown
  name: Nori
  buf: !binary |-
    BAh7IjoHb3NJIgZ3BjoGRVQ6Dm9zX2FjY2Vzc0kiClcySzEyBjsGVDoQZGF0
    ...
```

/FYI @isimluk @gmcculloug @mkanoor @Fryguy 