### PR TITLE
Update argument count for console requests through API

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -398,7 +398,7 @@ module Api
       task_id = queue_object_action(vm, desc,
                                     :method_name => "remote_console_acquire_ticket",
                                     :role        => "ems_operations",
-                                    :args => [@auth_user, protocol])
+                                    :args        => [@auth_user, MiqServer.my_server.id, protocol])
       # NOTE:
       # we are queuing the :remote_console_acquire_ticket and returning the task id and href.
       #

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/remote_console.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm
             "#{protocol} remote console requires the vm to be running.") if options[:check_if_running] && state != "on"
     end
 
-    def remote_console_acquire_ticket(_userid, _console_type)
+    def remote_console_acquire_ticket(_userid, _originating_server, _console_type)
       url = ext_management_system.with_provider_connection({:service => "Compute", :tenant_name => cloud_tenant.name}) do |con|
         response = con.get_vnc_console(ems_ref, 'novnc')
         return nil if response.body.fetch_path('console', 'type') != 'novnc'

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -1150,6 +1150,32 @@ describe "Vms API" do
     end
   end
 
+  context "Vm request console action" do
+    it "to an invalid vm" do
+      api_basic_authorize action_identifier(:vms, :request_console)
+
+      run_post(invalid_vm_url, gen_request(:request_console))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "to an invalid vm without appropriate role" do
+      api_basic_authorize
+
+      run_post(invalid_vm_url, gen_request(:request_console))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "to a single Vm" do
+      api_basic_authorize action_identifier(:vms, :request_console)
+
+      run_post(vm_url, gen_request(:request_console))
+
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* requesting console/i, :href => vm_url)
+    end
+  end
+
   context "Vm Tag subcollection" do
     let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
     let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }


### PR DESCRIPTION
Attempting to open an HTML5 console through the SUI does not work
due to a wrong number of arguments error server-side. This change
updates the enqueue to pass the correct arguments for the API controller
and for the openstack provider. The other providers already use the correct number of arguments.

https://bugzilla.redhat.com/show_bug.cgi?id=1405143

@miq-bot add_label blocker, api, euwe/yes
/cc @martinpovolny @imtayadeway @skateman 