### PR TITLE
Remove set_config for ResourcePool and add missing gettext

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -160,16 +160,8 @@ module ApplicationController::ReportDownloads
 
     if @display == "download_pdf"
       @display = "main"
-      case @record
-      when VmOrTemplate
-        if @record.hardware.present?
-          @record_notes = @record.hardware.annotation || "<No notes have been entered for this VM>"
-        end
+      if @record.kind_of?(VmOrTemplate)
         get_host_for_vm(@record)
-        set_config(@record)
-      when ResourcePool
-        # FIXME: check if this can be put before the test (can we have other
-        # records than Vm and ResourcePool?)
         set_config(@record)
       end
 

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -121,13 +121,6 @@ module VmShowMixin
       tl_build_timeline                    # Create the timeline report
     end
 
-    unless @record.hardware.nil?
-      @record_notes = if @record.hardware.annotation.nil?
-                        _("<No notes have been entered for this VM>")
-                      else
-                        @record.hardware.annotation
-                      end
-    end
     set_config(@record)
     get_host_for_vm(@record)
     session[:tl_record_id] = @record.id

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -335,13 +335,6 @@ module VmCommon
       @showtype = "ontap_file_shares"
     end
 
-    unless @record.hardware.nil?
-      @record_notes = if @record.hardware.annotation.nil?
-                        _("<No notes have been entered for this VM>")
-                      else
-                        @record.hardware.annotation
-                      end
-    end
     set_config(@record)
     get_host_for_vm(@record)
     session[:tl_record_id] = @record.id


### PR DESCRIPTION
Compute -> Infrastructure -> ResourcePool -> choose one -> download PDF

`ResourcePool` doesn't have `hardware` that is set in `set_config`. 

Before:
`Error caught: [NoMethodError] undefined method 'hardware' for #<ResourcePool:0x007fecf6af6cf8>`
After:
Downloads a pdf

As said https://github.com/ManageIQ/manageiq/pull/13214#issuecomment-267615185 `@record_notes` was removed because it's never used.

@miq-bot add_label wip, ui, bug
