### PR TITLE
Chargeback report :: fix formating of certain columns

### DIFF
--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -11,7 +11,9 @@ class MiqReport::Formats
       next unless (properties[:columns] && properties[:columns].include?(column)) ||
                   (properties[:sub_types] && properties[:sub_types].include?(sub_type(column))) ||
                   (properties[:data_types] && properties[:data_types].include?(datatype)) ||
-                  (properties[:suffixes] && properties[:suffixes].include?(suffix.to_sym))
+                  (properties[:suffixes] && properties[:suffixes].include?(suffix.to_sym)) ||
+                  (format_name == sub_type(column))
+
       result[format_name] = properties[:description]
     end
   end

--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -12,7 +12,8 @@ class MiqReport::Formats
                   (properties[:sub_types] && properties[:sub_types].include?(sub_type(column))) ||
                   (properties[:data_types] && properties[:data_types].include?(datatype)) ||
                   (properties[:suffixes] && properties[:suffixes].include?(suffix.to_sym)) ||
-                  (format_name == sub_type(column))
+                  format_name == sub_type(column) ||
+                  format_name == DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type(column)]
 
       result[format_name] = properties[:description]
     end

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -10,6 +10,11 @@ describe MiqReport::Formats do
           elsif name.ends_with?('_metric')
             expect(subj).not_to be_nil
           end
+
+          unless subj.nil?
+            options = described_class.available_formats_for(name.to_sym, name, datatype.first)
+            expect(options.keys).to include(subj)
+          end
         end
       end
     end

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -1,0 +1,17 @@
+describe MiqReport::Formats do
+  describe '.default_format_for' do
+    context 'for chargebacks' do
+      let(:columns) { Chargeback.descendants.collect(&:virtual_attributes_to_define).inject({}, &:merge) }
+      it 'works' do
+        columns.each do |name, datatype|
+          subj = described_class.default_format_for(name.to_sym, name.to_sym, datatype.first)
+          if name.ends_with?('_cost')
+            expect(subj).to eq(:currency_precision_2)
+          elsif name.ends_with?('_metric')
+            expect(subj).not_to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Reproducer
 - Go to report editor.
 - Create new chargeback
 - Select all columns
 - Go to formatting tab

## Problem
Some columns do no offer relevant formats. As a result chargeback reports are less intuitive than they could be.

@miq-bot add_label chargeback, reports, bug, euwe/no, wip
@miq-bot assign @gtanzillo 