### PR TITLE
Chargeback no longer depend on MetricRollup

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -62,7 +62,7 @@ class Chargeback < ActsAsArModel
       classification = self.class.classification_for_perf(metric_rollup_record)
       self.tag_name = classification.present? ? classification.description : _('<Empty>')
     else
-      init_extra_fields(metric_rollup_record)
+      init_extra_fields(consumption)
     end
     self.start_date, self.end_date, self.display_range = options.report_step_range(consumption.timestamp)
     self.interval_name = options.interval

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -20,7 +20,7 @@ class Chargeback < ActsAsArModel
       rates_to_apply = rates.get(consumption)
 
       key = consumption.key(self)
-      data[key] ||= new(options, consumption.first_metric_rollup_record)
+      data[key] ||= new(options, consumption)
 
       chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
       data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
@@ -54,7 +54,8 @@ class Chargeback < ActsAsArModel
     @options.tag_hash[tag]
   end
 
-  def initialize(options, metric_rollup_record)
+  def initialize(options, consumption)
+    metric_rollup_record = consumption.first_metric_rollup_record
     @options = options
     super()
     if @options[:groupby_tag].present?
@@ -63,10 +64,10 @@ class Chargeback < ActsAsArModel
     else
       init_extra_fields(metric_rollup_record)
     end
-    self.start_date, self.end_date, self.display_range = options.report_step_range(metric_rollup_record.timestamp)
+    self.start_date, self.end_date, self.display_range = options.report_step_range(consumption.timestamp)
     self.interval_name = options.interval
     self.chargeback_rates = ''
-    self.entity = metric_rollup_record.resource
+    self.entity = consumption.resource
   end
 
   def calculate_costs(consumption, rates)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -19,7 +19,7 @@ class Chargeback < ActsAsArModel
     ConsumptionHistory.for_report(self, options) do |consumption|
       rates_to_apply = rates.get(consumption)
 
-      key = consumption.key(self)
+      key = report_row_key(consumption)
       data[key] ||= new(options, consumption)
 
       chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
@@ -33,14 +33,14 @@ class Chargeback < ActsAsArModel
     [data.values]
   end
 
-  def self.report_row_key(metric_rollup_record)
-    ts_key = @options.start_of_report_step(metric_rollup_record.timestamp)
+  def self.report_row_key(consumption)
+    ts_key = @options.start_of_report_step(consumption.timestamp)
     if @options[:groupby_tag].present?
-      classification = classification_for_perf(metric_rollup_record)
+      classification = classification_for_perf(consumption.first_metric_rollup_record)
       classification_id = classification.present? ? classification.id : 'none'
       "#{classification_id}_#{ts_key}"
     else
-      default_key(metric_rollup_record, ts_key)
+      default_key(consumption.first_metric_rollup_record, ts_key)
     end
   end
 

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -10,30 +10,12 @@ class Chargeback < ActsAsArModel
     :fixed_compute_metric => :integer,
   )
 
-  VIRTUAL_COL_USES = {
-    "v_derived_cpu_total_cores_used" => "cpu_usage_rate_average"
-  }
-
   def self.build_results_for_report_chargeback(options)
     _log.info("Calculating chargeback costs...")
     @options = options = ReportOptions.new_from_h(options)
 
     rates = RatesCache.new
-
-    base_rollup = MetricRollup.includes(
-      :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes, {:container_image => :custom_attributes}],
-      :parent_host        => :tags,
-      :parent_ems_cluster => :tags,
-      :parent_storage     => :tags,
-      :parent_ems         => :tags)
-                              .select(*Metric::BASE_COLS).order("resource_id, timestamp")
-    perf_cols = MetricRollup.attribute_names
-    rate_cols = ChargebackRate.where(:default => true).flat_map do |rate|
-      rate.chargeback_rate_details.map(&:metric).select { |metric| perf_cols.include?(metric.to_s) }
-    end
-
-    rate_cols.map! { |x| VIRTUAL_COL_USES.include?(x) ? VIRTUAL_COL_USES[x] : x }.flatten!
-    base_rollup = base_rollup.select(*rate_cols)
+    base_rollup = ConsumptionHistory.base_rollup_scope
 
     timerange = options.report_time_range
     data = {}

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -21,7 +21,7 @@ class Chargeback < ActsAsArModel
       # and rates are selected by first MetricRollup record
       rates_to_apply = rates.get(first_metric_rollup)
 
-      key = report_row_key(first_metric_rollup)
+      key = consumption.key(self)
       data[key] ||= new(options, first_metric_rollup)
 
       chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -16,13 +16,13 @@ class Chargeback < ActsAsArModel
 
     data = {}
     rates = RatesCache.new
-    ConsumptionHistory.for_report(self, options) do |consumption, first_metric_rollup|
+    ConsumptionHistory.for_report(self, options) do |consumption|
       # we need to select ChargebackRates for groups of MetricRollups records
       # and rates are selected by first MetricRollup record
-      rates_to_apply = rates.get(first_metric_rollup)
+      rates_to_apply = rates.get(consumption.first_metric_rollup_record)
 
       key = consumption.key(self)
-      data[key] ||= new(options, first_metric_rollup)
+      data[key] ||= new(options, consumption.first_metric_rollup_record)
 
       chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
       data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -40,12 +40,12 @@ class Chargeback < ActsAsArModel
       classification_id = classification.present? ? classification.id : 'none'
       "#{classification_id}_#{ts_key}"
     else
-      default_key(consumption.first_metric_rollup_record, ts_key)
+      default_key(consumption, ts_key)
     end
   end
 
-  def self.default_key(metric_rollup_record, ts_key)
-    "#{metric_rollup_record.resource_id}_#{ts_key}"
+  def self.default_key(consumption, ts_key)
+    "#{consumption.resource_id}_#{ts_key}"
   end
 
   def self.classification_for(consumption)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -17,9 +17,7 @@ class Chargeback < ActsAsArModel
     data = {}
     rates = RatesCache.new
     ConsumptionHistory.for_report(self, options) do |consumption|
-      # we need to select ChargebackRates for groups of MetricRollups records
-      # and rates are selected by first MetricRollup record
-      rates_to_apply = rates.get(consumption.first_metric_rollup_record)
+      rates_to_apply = rates.get(consumption)
 
       key = consumption.key(self)
       data[key] ||= new(options, consumption.first_metric_rollup_record)

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -5,8 +5,12 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
+    def first_metric_rollup_record
+      @rollups.first
+    end
+
     def key(cb_class)
-      cb_class.report_row_key(@rollups.first)
+      cb_class.report_row_key(first_metric_rollup_record)
     end
 
     def max(metric)

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -11,10 +11,6 @@ class Chargeback
       @rollups.first
     end
 
-    def key(cb_class)
-      cb_class.report_row_key(first_metric_rollup_record)
-    end
-
     def max(metric)
       values(metric).max
     end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,6 +1,6 @@
 class Chargeback
   class Consumption
-    delegate :timestamp, :resource, :to => :first_metric_rollup_record
+    delegate :timestamp, :resource, :resource_id, :resource_name, :parent_ems, :to => :first_metric_rollup_record
 
     def initialize(metric_rollup_records, start_time, end_time)
       @rollups = metric_rollup_records

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,6 +1,8 @@
 class Chargeback
   class Consumption
-    delegate :timestamp, :resource, :resource_id, :resource_name, :parent_ems, :to => :first_metric_rollup_record
+    delegate :timestamp, :resource, :resource_id, :resource_name, :resource_type, :parent_ems,
+             :hash_features_affecting_rate, :tag_list_with_prefix, :parents_determining_rate,
+             :to => :first_metric_rollup_record
 
     def initialize(metric_rollup_records, start_time, end_time)
       @rollups = metric_rollup_records

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -9,10 +9,6 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
-    def first_metric_rollup_record
-      @rollups.first
-    end
-
     def tag_names
       first_metric_rollup_record.tag_names.split('|')
     end
@@ -43,6 +39,10 @@ class Chargeback
     def values(metric)
       @values ||= {}
       @values[metric] ||= @rollups.collect(&metric.to_sym).compact
+    end
+
+    def first_metric_rollup_record
+      @fmrr ||= @rollups.first
     end
   end
 end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -5,6 +5,10 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
+    def key(cb_class)
+      cb_class.report_row_key(@rollups.first)
+    end
+
     def max(metric)
       values(metric).max
     end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -11,6 +11,10 @@ class Chargeback
       @rollups.first
     end
 
+    def tag_names
+      first_metric_rollup_record.tag_names.split('|')
+    end
+
     def max(metric)
       values(metric).max
     end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,5 +1,7 @@
 class Chargeback
   class Consumption
+    delegate :timestamp, :resource, :to => :first_metric_rollup_record
+
     def initialize(metric_rollup_records, start_time, end_time)
       @rollups = metric_rollup_records
       @start_time, @end_time = start_time, end_time

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -1,0 +1,25 @@
+class Chargeback
+  class ConsumptionHistory
+    VIRTUAL_COL_USES = {
+      'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
+    }.freeze
+
+    def self.base_rollup_scope
+      base_rollup = MetricRollup.includes(
+        :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes,
+                                {:container_image => :custom_attributes}],
+        :parent_host        => :tags,
+        :parent_ems_cluster => :tags,
+        :parent_storage     => :tags,
+        :parent_ems         => :tags)
+                                .select(*Metric::BASE_COLS).order('resource_id, timestamp')
+
+      perf_cols = MetricRollup.attribute_names
+      rate_cols = ChargebackRate.where(:default => true).flat_map do |rate|
+        rate.chargeback_rate_details.map(&:metric).select { |metric| perf_cols.include?(metric.to_s) }
+      end
+      rate_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.flatten!
+      base_rollup.select(*rate_cols)
+    end
+  end
+end

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -22,7 +22,7 @@ class Chargeback
           metric_rollup_records = metric_rollup_records.select { |x| x.resource.present? }
           consumption = Consumption.new(metric_rollup_records, query_start_time, query_end_time)
           next if metric_rollup_records.empty?
-          yield(consumption, metric_rollup_records.first)
+          yield(consumption)
         end
       end
     end

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -4,6 +4,29 @@ class Chargeback
       'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
     }.freeze
 
+    def self.for_report(cb_class, options)
+      base_rollup = base_rollup_scope
+      timerange = options.report_time_range
+      interval_duration = options.duration_of_report_step
+
+      timerange.step_value(interval_duration).each_cons(2) do |query_start_time, query_end_time|
+        records = base_rollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => 'hourly')
+        records = cb_class.where_clause(records, options)
+        records = Metric::Helper.remove_duplicate_timestamps(records)
+        next if records.empty?
+        _log.info("Found #{records.length} records for time range #{[query_start_time, query_end_time].inspect}")
+
+        # we are building hash with grouped calculated values
+        # values are grouped by resource_id and timestamp (query_start_time...query_end_time)
+        records.group_by(&:resource_id).each do |_, metric_rollup_records|
+          metric_rollup_records = metric_rollup_records.select { |x| x.resource.present? }
+          consumption = Consumption.new(metric_rollup_records, query_start_time, query_end_time)
+          next if metric_rollup_records.empty?
+          yield(consumption, metric_rollup_records.first)
+        end
+      end
+    end
+
     def self.base_rollup_scope
       base_rollup = MetricRollup.includes(
         :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes,
@@ -21,5 +44,6 @@ class Chargeback
       rate_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.flatten!
       base_rollup.select(*rate_cols)
     end
+    private_class_method :base_rollup_scope
   end
 end

--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -1,6 +1,9 @@
 class Chargeback
   class RatesCache
-    def get(perf)
+    def get(consumption)
+      # we need to select ChargebackRates for groups of MetricRollups records
+      # and rates are selected by first MetricRollup record
+      perf = consumption.first_metric_rollup_record
       @rates ||= {}
       @rates[perf.hash_features_affecting_rate] ||= rates(perf)
     end

--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -3,23 +3,22 @@ class Chargeback
     def get(consumption)
       # we need to select ChargebackRates for groups of MetricRollups records
       # and rates are selected by first MetricRollup record
-      perf = consumption.first_metric_rollup_record
       @rates ||= {}
-      @rates[perf.hash_features_affecting_rate] ||= rates(perf)
+      @rates[consumption.hash_features_affecting_rate] ||= rates(consumption)
     end
 
     private
 
-    def rates(metric_rollup_record)
-      rates = ChargebackRate.get_assigned_for_target(metric_rollup_record.resource,
-                                                     :tag_list => metric_rollup_record.tag_list_with_prefix,
-                                                     :parents  => metric_rollup_record.parents_determining_rate)
+    def rates(consumption)
+      rates = ChargebackRate.get_assigned_for_target(consumption.resource,
+                                                     :tag_list => consumption.tag_list_with_prefix,
+                                                     :parents  => consumption.parents_determining_rate)
 
-      if metric_rollup_record.resource_type == Container.name && rates.empty?
+      if consumption.resource_type == Container.name && rates.empty?
         rates = [ChargebackRate.find_by(:description => "Default Container Image Rate", :rate_type => "Compute")]
       end
 
-      metric_rollup_record_tags = metric_rollup_record.tag_names.split("|")
+      metric_rollup_record_tags = consumption.tag_names
 
       unique_rates_by_tagged_resources(rates, metric_rollup_record_tags)
     end

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -53,12 +53,12 @@ class ChargebackContainerImage < Chargeback
     @options[:groupby] == 'project' ? "#{project.id}_#{ts_key}" : "#{project.id}_#{image.id}_#{ts_key}"
   end
 
-  def self.image(perf)
-    @data_index.fetch_path(:container_image, :by_container_id, perf.resource_id)
+  def self.image(consumption)
+    @data_index.fetch_path(:container_image, :by_container_id, consumption.resource_id)
   end
 
-  def self.project(perf)
-    @data_index.fetch_path(:container_project, :by_container_id, perf.resource_id)
+  def self.project(consumption)
+    @data_index.fetch_path(:container_project, :by_container_id, consumption.resource_id)
   end
 
   def self.where_clause(records, _options)
@@ -87,13 +87,14 @@ class ChargebackContainerImage < Chargeback
 
   private
 
-  def init_extra_fields(perf)
-    self.project_name  = self.class.project(perf).name
-    self.image_name    = self.class.image(perf).try(:full_name) || _('Deleted') # until image archiving is implemented
-    self.project_uid   = self.class.project(perf).ems_ref
-    self.provider_name = perf.parent_ems.try(:name)
-    self.provider_uid  = perf.parent_ems.try(:guid)
-    self.archived      = self.class.project(perf).archived? ? _('Yes') : _('No')
-    self.entity        = self.class.image(perf)
+  def init_extra_fields(consumption)
+    self.project_name  = self.class.project(consumption).name
+    # until image archiving is implemented
+    self.image_name    = self.class.image(consumption).try(:full_name) || _('Deleted')
+    self.project_uid   = self.class.project(consumption).ems_ref
+    self.provider_name = consumption.parent_ems.try(:name)
+    self.provider_uid  = consumption.parent_ems.try(:guid)
+    self.archived      = self.class.project(consumption).archived? ? _('Yes') : _('No')
+    self.entity        = self.class.image(consumption)
   end
 end # class ChargebackContainerImage

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -70,11 +70,11 @@ class ChargebackContainerProject < Chargeback
 
   private
 
-  def init_extra_fields(perf)
-    self.project_name  = perf.resource_name
-    self.project_uid   = perf.resource.ems_ref
-    self.provider_name = perf.parent_ems.try(:name)
-    self.provider_uid  = perf.parent_ems.try(:guid)
-    self.archived      = perf.resource.archived? ? _('Yes') : _('No')
+  def init_extra_fields(consumption)
+    self.project_name  = consumption.resource_name
+    self.project_uid   = consumption.resource.ems_ref
+    self.provider_name = consumption.parent_ems.try(:name)
+    self.provider_uid  = consumption.parent_ems.try(:guid)
+    self.archived      = consumption.resource.archived? ? _('Yes') : _('No')
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -92,9 +92,9 @@ class ChargebackVm < Chargeback
     }
   end
 
-  def self.vm_owner(perf)
+  def self.vm_owner(consumption)
     @vm_owners ||= vms.each_with_object({}) { |vm, res| res[vm.id] = vm.evm_owner_name }
-    @vm_owners[perf.resource_id] ||= perf.resource.evm_owner_name
+    @vm_owners[consumption.resource_id] ||= consumption.resource.evm_owner_name
   end
 
   def self.vms
@@ -134,13 +134,13 @@ class ChargebackVm < Chargeback
 
   private
 
-  def init_extra_fields(perf)
-    self.vm_id         = perf.resource_id
-    self.vm_name       = perf.resource_name
-    self.vm_uid        = perf.resource.ems_ref
-    self.vm_guid       = perf.resource.try(:guid)
-    self.owner_name    = self.class.vm_owner(perf)
-    self.provider_name = perf.parent_ems.try(:name)
-    self.provider_uid  = perf.parent_ems.try(:guid)
+  def init_extra_fields(consumption)
+    self.vm_id         = consumption.resource_id
+    self.vm_name       = consumption.resource_name
+    self.vm_uid        = consumption.resource.ems_ref
+    self.vm_guid       = consumption.resource.try(:guid)
+    self.owner_name    = self.class.vm_owner(consumption)
+    self.provider_name = consumption.parent_ems.try(:name)
+    self.provider_uid  = consumption.parent_ems.try(:guid)
   end
 end # class Chargeback

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -794,40 +794,41 @@ describe ChargebackVm do
   describe '#initialize' do
     let(:report_options) { Chargeback::ReportOptions.new }
     let(:vm_owners)     { {@vm1.id => @vm1.evm_owner_name} }
-    let(:metric_rollup) do
-      FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
-                        :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                        :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
-                        :resource => @vm1, :resource_name => @vm1.name)
+    let(:consumption) { Chargeback::Consumption.new([metric_rollup], nil, nil) }
+    let(:shared_extra_fields) do
+      {'vm_name' => @vm1.name, 'owner_name' => admin.name, 'vm_uid' => 'ems_ref', 'vm_guid' => @vm1.guid,
+       'vm_id' => @vm1.id}
     end
+    subject { ChargebackVm.new(report_options, consumption).attributes }
 
     before do
       ChargebackVm.instance_variable_set(:@vm_owners, vm_owners)
     end
 
-    it 'sets extra fields' do
-      extra_fields = ChargebackVm.new(report_options, metric_rollup).attributes
-      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => ems.name,
-                         "provider_uid" => ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
-                         "vm_id" => @vm1.id}
+    context 'with parent ems' do
+      let(:metric_rollup) do
+        FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
+                          :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
+                          :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
+                          :resource => @vm1, :resource_name => @vm1.name)
+      end
 
-      expect(extra_fields).to include(expected_fields)
+      it 'sets extra fields' do
+        is_expected.to include(shared_extra_fields.merge('provider_name' => ems.name, 'provider_uid' => ems.guid))
+      end
     end
 
-    let(:metric_rollup_without_ems) do
-      FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
-                        :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                        :parent_storage_id => @storage.id,
-                        :resource => @vm1, :resource_name => @vm1.name)
-    end
+    context 'when parent ems is missing' do
+      let(:metric_rollup) do
+        FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
+                          :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
+                          :parent_storage_id => @storage.id,
+                          :resource => @vm1, :resource_name => @vm1.name)
+      end
 
-    it 'sets extra fields when parent ems is missing' do
-      extra_fields = ChargebackVm.new(report_options, metric_rollup_without_ems).attributes
-      expected_fields = {"vm_name" => @vm1.name, "owner_name" => admin.name, "provider_name" => nil,
-                         "provider_uid" => nil, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
-                         "vm_id" => @vm1.id}
-
-      expect(extra_fields).to include(expected_fields)
+      it 'sets extra fields when parent ems is missing' do
+        is_expected.to include(shared_extra_fields.merge('provider_name' => nil, 'provider_uid' => nil))
+      end
     end
   end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -764,10 +764,11 @@ describe ChargebackVm do
                                                :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                                                :resource => @vm1)
     end
+    let(:consumption) { Chargeback::Consumption.new([metric_rollup], nil, nil) }
 
     before do
       ChargebackRate.set_assignments(:compute, [rate_assignment_options])
-      @rate = Chargeback::RatesCache.new.get(metric_rollup).first
+      @rate = Chargeback::RatesCache.new.get(consumption).first
       @assigned_rate = ChargebackRate.get_assignments("Compute").first
     end
 
@@ -848,6 +849,7 @@ describe ChargebackVm do
                          :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                          :resource => @vm1)
     end
+    let(:consumption) { Chargeback::Consumption.new([metric_rollup], nil, nil) }
 
     before do
       @storage.tag_with([classification_1.tag.name, classification_2.tag.name], :ns => '*')
@@ -857,7 +859,7 @@ describe ChargebackVm do
     it "return only one chargeback rate according to tag name of Vm" do
       [rate_assignment_options_1, rate_assignment_options_2].each do |rate_assignment|
         metric_rollup.tag_names = rate_assignment[:tag].first.tag.send(:name_path)
-        uniq_rates = chargeback_vm.send(:get, metric_rollup)
+        uniq_rates = chargeback_vm.get(consumption)
         expect([rate_assignment[:cb_rate]]).to match_array(uniq_rates)
       end
     end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -783,7 +783,8 @@ describe ChargebackVm do
     let(:timestamp_key) { 'Fri, 13 May 2016 10:40:00 UTC +00:00' }
     let(:beginning_of_day) { timestamp_key.in_time_zone.beginning_of_day }
     let(:metric_rollup) { FactoryGirl.build(:metric_rollup_vm_hr, :timestamp => timestamp_key, :resource => @vm1) }
-    subject { described_class.report_row_key(metric_rollup) }
+    let(:consumption) { Chargeback::Consumption.new([metric_rollup], nil, nil) }
+    subject { described_class.report_row_key(consumption) }
     before do
       described_class.instance_variable_set(:@options, report_options)
     end


### PR DESCRIPTION
## What
Extract MetricRollup manipulation into `Consumption` and `ConsumptionHistory` classes.

## Why
Needed for upcoming chargebacks without metric rollups.

## Details
Previously, chargeback relied on existing metric_rollups and chargeback code was tightly bound to metric_rollup class. In future, we want to charge for VMs that do not have metric_rollups assigned.

Thus, we need to break the bound between chargeback code and metric_rollups. We need chargeback code to depend only on `Consumption` class fetching this class from `ConsumptionHistory`. Then we can change `Consumption` to operate over VMs without metric_rollups.

/cc @lpichler -- Thanks for consultation, sir!

@miq-bot add_label chargeback, refactoring, euwe/no
@miq-bot assign @gtanzillo 
