### PR TITLE
MiqCapacityController - remove dead copypasta from MiqPolicyController

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -744,17 +744,6 @@ class MiqCapacityController < ApplicationController
     end
   end
 
-  def send_button_changes
-    changed = (@edit[:new] != @edit[:current])
-    render :update do |page|
-      page << javascript_prologue
-      if changed != session[:changed]
-        session[:changed] = changed
-        page << javascript_for_miq_button_visibility(changed)
-      end
-    end
-  end
-
   def util_build_tree(type, name)
     selected_node = x_node(name)
     if type == :bottlenecks

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -748,11 +748,6 @@ class MiqCapacityController < ApplicationController
     changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      if @action_type_changed || @tag_selected || @snmp_trap_refresh
-        page.replace("action_options_div", :partial => "action_options")
-      elsif @alert_refresh
-        page.replace("alert_details_div", :partial => "alert_details")
-      end
       if changed != session[:changed]
         session[:changed] = changed
         page << javascript_for_miq_button_visibility(changed)


### PR DESCRIPTION
The code is clearly not supposed to be in `MiqCapacityController`:

   * has been there since the initial commit
   * it checks for `@action_type_changed`, only set in `miq_policy_controller/miq_actions.rb`
   * it checks for `@tag_selected`, only set in `tree_builder_tags_spec.rb` and `miq_policy_controller/miq_actions.rb`
   * it checks for `@snmp_trap_refresh` only set in `miq_policy_controller/miq_actions.rb`
   * it updates `action_options_div`, only defined in `app/views/miq_policy/_action_options.html.haml`
   * it checks for `@alert_refresh`, only set in `miq_policy_controller/alerts.rb`
   * it updates `alert_details_div`, only defined in `app/views/miq_policy/_alert_details.html.haml`

EDIT: removed the whole `send_button_changes` method, because not only was most of it dead, it's also only ever called from `miq_policy_controller/*.rb`