### PR TITLE
Fixed setting of JS date variables.

### DIFF
--- a/app/views/ops/_diagnostics_timelines_tab.html.haml
+++ b/app/views/ops/_diagnostics_timelines_tab.html.haml
@@ -3,8 +3,8 @@
   - if @tl_record
     :javascript
       // Create from/to date JS vars to limit calendar selection range
-      ManageIQ.calendar.calDateFrom = new Date(#{@tl_options[:sdate]});
-      ManageIQ.calendar.calDateTo = new Date(#{@tl_options[:edate]});
+      ManageIQ.calendar.calDateFrom = new Date(#{@tl_options.date.start});
+      ManageIQ.calendar.calDateTo = new Date(#{@tl_options.date.end});
     = render :partial => 'layouts/tl_options'
     = render :partial => 'layouts/tl_detail'
   - else


### PR DESCRIPTION
Fixed code to use Tiemline::DateOptions to set From/To date JS variables. This specific occurrence was missed in https://github.com/ManageIQ/manageiq/pull/9291

https://bugzilla.redhat.com/show_bug.cgi?id=1405184

before:
error in log:
```
[----] F, [2016-12-16T13:05:01.295765 #9621:5c7d814] FATAL -- : Error caught: [ActionView::Template::Error] no member 'sdate' in struct
/home/hkataria/dev/manageiq/app/views/ops/_diagnostics_timelines_tab.html.haml:6:in `[]'
/home/hkataria/dev/manageiq/app/views/ops/_diagnostics_timelines_tab.html.haml:6:in `_app_views_ops__diagnostics_timelines_tab_html_haml__1444850123190882797_70280490498300'
```
![before](https://cloud.githubusercontent.com/assets/3450808/21273159/508df842-c390-11e6-91c0-03b1c3c7d011.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/21273121/1ba7b41a-c390-11e6-91d7-03102d53245f.png)
