### PR TITLE
Case insensitive search of the current user's owned vms/services/etc.

### DIFF
--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -90,7 +90,7 @@ module OwnershipMixin
     private
 
     def user_owned(user)
-      where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:evm_owner_userid)]).eq(user.userid)))
+      where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:evm_owner_userid)]).eq(user.userid.downcase)))
     end
 
     def group_owned(miq_group)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -40,6 +40,11 @@ shared_examples_for "OwnershipMixin" do
           expect(described_class.user_or_group_owned(user, nil)).to eq([user_owned])
         end
 
+        it "with mixed case userid" do
+          user.update(:userid => "MixedCase")
+          expect(described_class.user_or_group_owned(user, nil)).to eq([user_owned])
+        end
+
         it "with same userid as another region" do
           user_owned.update!(:evm_owner => user_other_region)
           expect(described_class.user_or_group_owned(user, nil)).to eq([user_owned])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1401912

Note, we were only downcasing the userids in the users table,
so a mixed case logged in userid would never match.

This would cause a logged in self service user with mixed case
userid to not see vms they own.

This was broken here:
9b897c35a92d9d4

As part of:
https://github.com/ManageIQ/manageiq/pull/11992

We're fixing much like we did with groups here:
https://github.com/ManageIQ/manageiq/pull/12114

Note, #11992 was backported to euwe and the model changes were backported to darga in #12337