### PR TITLE
s/@auth_user_obj/User.current_user/

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class AutomateController < BaseController
     def show
-      ae_browser = MiqAeBrowser.new(@auth_user_obj)
+      ae_browser = MiqAeBrowser.new(User.current_user)
       begin
         resources = ae_browser.search(@req.c_suffix, ae_search_options)
       rescue => err

--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -47,7 +47,7 @@ module Api
     end
 
     def current_tenant
-      @auth_user_obj.current_tenant || Tenant.default_tenant
+      User.current_user.current_tenant || Tenant.default_tenant
     end
   end
 end

--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -11,7 +11,7 @@ module Api
       parameters  = hash_fetch(data, "parameters")
       requester   = hash_fetch(data, "requester")
 
-      AutomationRequest.create_from_ws(version_str, @auth_user_obj, uri_parts, parameters, requester)
+      AutomationRequest.create_from_ws(version_str, User.current_user, uri_parts, parameters, requester)
     end
 
     def approve_resource(type, id, data)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -218,7 +218,7 @@ module Api
       end
 
       def submit_custom_action_dialog(resource, custom_button, data)
-        wf = ResourceActionWorkflow.new({}, @auth_user_obj, custom_button.resource_action, :target => resource)
+        wf = ResourceActionWorkflow.new({}, User.current_user, custom_button.resource_action, :target => resource)
         data.each { |key, value| wf.set_value(key, value) } if data.present?
         wf_result = wf.submit_request
         raise StandardError, Array(wf_result[:errors]).join(", ") if wf_result[:errors].present?
@@ -244,7 +244,7 @@ module Api
 
       def service_template_workflow(service_template, service_request)
         resource_action = service_template.resource_actions.find_by_action("Provision")
-        workflow = ResourceActionWorkflow.new({}, @auth_user_obj, resource_action, :target => service_template)
+        workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => service_template)
         service_request.each { |key, value| workflow.set_value(key, value) } if service_request.present?
         workflow
       end

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -22,8 +22,8 @@ module Api
                                       :token       => @auth_token,
                                       :x_miq_group => request.headers[HttpHeaders::MIQ_GROUP],
                                       :user        => @auth_user)
-        if @auth_user_obj
-          group = @auth_user_obj.current_group
+        if User.current_user
+          group = User.current_user.current_group
           log_request("Authorization", :user   => @auth_user,
                                        :group  => group.description,
                                        :role   => group.miq_user_role_name,

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -145,7 +145,7 @@ module Api
       def resource_search(id, type, klass)
         validate_id(id, klass)
         target = respond_to?("find_#{type}") ? public_send("find_#{type}", id) : klass.find(id)
-        res = Rbac.filtered_object(target, :user => @auth_user_obj, :class => klass)
+        res = Rbac.filtered_object(target, :user => User.current_user, :class => klass)
         raise ForbiddenError, "Access to the resource #{type}/#{id} is forbidden" unless res
         res
       end
@@ -175,7 +175,7 @@ module Api
         sort_options = sort_params(klass) if res.respond_to?(:reorder)
         res = res.reorder(sort_options) if sort_options.present?
 
-        options = {:user => @auth_user_obj}
+        options = {:user => User.current_user}
         options[:order] = sort_options if sort_options.present?
         options[:offset], options[:limit] = expand_paginate_params if paginate_params?
         options[:filter] = miq_expression if miq_expression
@@ -407,7 +407,7 @@ module Api
 
       def api_user_role_allows?(action_identifier)
         return true unless action_identifier
-        @auth_user_obj.role_allows?(:identifier => action_identifier)
+        User.current_user.role_allows?(:identifier => action_identifier)
       end
 
       def render_actions(resource)

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -2,7 +2,7 @@ module Api
   class ContainerDeploymentsController < BaseController
     def create_resource(_type, _id, data)
       deployment = ContainerDeployment.new
-      deployment.create_deployment(data, @auth_user_obj)
+      deployment.create_deployment(data, User.current_user)
     end
 
     def options

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,11 +1,11 @@
 module Api
   class NotificationsController < BaseController
     def notifications_search_conditions
-      {:user_id => @auth_user_obj.id}
+      {:user_id => User.current_user.id}
     end
 
     def find_notifications(id)
-      @auth_user_obj.notification_recipients.find(id)
+      User.current_user.notification_recipients.find(id)
     end
 
     def mark_as_seen_resource(type, id = nil, _data = nil)

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -15,7 +15,7 @@ module Api
       ems_custom_attrs  = hash_fetch(data, "ems_custom_attributes")
       miq_custom_attrs  = hash_fetch(data, "miq_custom_attributes")
 
-      MiqProvisionVirtWorkflow.from_ws(version_str, @auth_user_obj, template_fields, vm_fields, requester, tags,
+      MiqProvisionVirtWorkflow.from_ws(version_str, User.current_user, template_fields, vm_fields, requester, tags,
                                        additional_values, ems_custom_attrs, miq_custom_attrs)
     end
 

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -28,7 +28,7 @@ module Api
     end
 
     def import_resource(_type, _id, data)
-      options = data.fetch("options", {}).symbolize_keys.merge(:user => @auth_user_obj)
+      options = data.fetch("options", {}).symbolize_keys.merge(:user => User.current_user)
       result, meta = MiqReport.import_from_hash(data["report"], options)
       action_result(meta[:level] == :info, meta[:message], :result => result)
     end
@@ -62,7 +62,7 @@ module Api
     def fetch_schedule_data(data)
       schedule_data = data.except(*SCHEDULE_ATTRS_TO_TRANSFORM)
 
-      schedule_data['userid'] = @auth_user_obj.userid
+      schedule_data['userid'] = User.current_user.userid
       schedule_data['run_at'] = {
         :start_time => data['start_date'],
         :tz         => data['time_zone'],
@@ -76,7 +76,7 @@ module Api
       schedule_options = {
         :send_email       => data['send_email'] || false,
         :email_url_prefix => email_url_prefix,
-        :miq_group_id     => @auth_user_obj.current_group_id
+        :miq_group_id     => User.current_user.current_group_id
       }
       schedule_data['sched_action'] = {:method  => "run_report",
                                        :options => schedule_options}

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -17,7 +17,7 @@ module Api
       # We must authorize the user based on the request type klass
       authorize_request(typed_request_klass)
 
-      user = RequestParser.parse_user(data) || @auth_user_obj
+      user = RequestParser.parse_user(data) || User.current_user
       auto_approve = RequestParser.parse_auto_approve(data)
 
       begin
@@ -33,7 +33,7 @@ module Api
       request = resource_search(id, type, request_klass)
 
       request_options = RequestParser.parse_options(data)
-      user = RequestParser.parse_user(data) || @auth_user_obj
+      user = RequestParser.parse_user(data) || User.current_user
 
       begin
         request.update_request(request_options, user)
@@ -68,13 +68,13 @@ module Api
 
     def find_requests(id)
       klass = collection_class(:requests)
-      return klass.find(id) if @auth_user_obj.admin?
-      klass.find_by!(:requester => @auth_user_obj, :id => id)
+      return klass.find(id) if User.current_user.admin?
+      klass.find_by!(:requester => User.current_user, :id => id)
     end
 
     def requests_search_conditions
-      return {} if @auth_user_obj.admin?
-      {:requester => @auth_user_obj}
+      return {} if User.current_user.admin?
+      {:requester => User.current_user}
     end
 
     private

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -11,7 +11,7 @@ module Api
         super
       else
         create_service_order_with_service_requests(service_requests)
-        ServiceOrder.cart_for(@auth_user_obj)
+        ServiceOrder.cart_for(User.current_user)
       end
     end
 
@@ -37,14 +37,14 @@ module Api
 
     def find_service_orders(id)
       if id == USER_CART_ID
-        ServiceOrder.cart_for(@auth_user_obj)
+        ServiceOrder.cart_for(User.current_user)
       else
-        ServiceOrder.find_for_user(@auth_user_obj, id)
+        ServiceOrder.find_for_user(User.current_user, id)
       end
     end
 
     def service_orders_search_conditions
-      {:user => @auth_user_obj, :tenant => @auth_user_obj.current_tenant}
+      {:user => User.current_user, :tenant => User.current_user.current_tenant}
     end
 
     def copy_resource(type, id, data)

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -28,7 +28,7 @@ module Api
     def edit_resource(type, id, data)
       request = resource_search(id, type, collection_class(:service_requests))
       request_options = RequestParser.parse_options(data)
-      user = RequestParser.parse_user(data) || @auth_user_obj
+      user = RequestParser.parse_user(data) || User.current_user
       request.update_request(request_options, user)
     rescue => err
       raise BadRequestError, "Could not update the service request - #{err}"
@@ -36,13 +36,13 @@ module Api
 
     def find_service_requests(id)
       klass = collection_class(:service_requests)
-      return klass.find(id) if @auth_user_obj.admin?
-      klass.find_by!(:requester => @auth_user_obj, :id => id)
+      return klass.find(id) if User.current_user.admin?
+      klass.find_by!(:requester => User.current_user, :id => id)
     end
 
     def service_requests_search_conditions
-      return {} if @auth_user_obj.admin?
-      {:requester => @auth_user_obj}
+      return {} if User.current_user.admin?
+      {:requester => User.current_user}
     end
 
     def add_approver_resource(type, id, data)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -150,7 +150,7 @@ module Api
 
     def submit_reconfigure_dialog(svc, data)
       ra = svc.reconfigure_resource_action
-      wf = ResourceActionWorkflow.new({}, @auth_user_obj, ra, :target => svc)
+      wf = ResourceActionWorkflow.new({}, User.current_user, ra, :target => svc)
       data.each { |key, value| wf.set_value(key, value) } if data.present?
       wf_result = wf.submit_request
       raise StandardError, Array(wf_result[:errors]).join(", ") if wf_result[:errors].present?

--- a/app/controllers/api/subcollections/features.rb
+++ b/app/controllers/api/subcollections/features.rb
@@ -75,7 +75,7 @@ module Api
       end
 
       def resource_search_by_criteria(criteria, search_val, klass)
-        Rbac.filtered(klass.where(criteria => search_val), :user => @auth_user_obj).first
+        Rbac.filtered(klass.where(criteria => search_val), :user => User.current_user).first
       end
     end
   end

--- a/app/controllers/api/subcollections/service_requests.rb
+++ b/app/controllers/api/subcollections/service_requests.rb
@@ -68,7 +68,7 @@ module Api
       end
 
       def remove_service_request(target, service_request)
-        target.class.remove_from_cart(service_request, @auth_user_obj)
+        target.class.remove_from_cart(service_request, User.current_user)
         action_result(true, "Removing #{service_request_ident(service_request)}")
       rescue => e
         action_result(false, e.to_s)

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -117,7 +117,7 @@ module Api
 
       def define_service_template_dialog(st, dialog_fields)
         resource_action = st.resource_actions.find_by_action("Provision")
-        workflow = ResourceActionWorkflow.new({}, @auth_user_obj, resource_action, :target => st)
+        workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => st)
         dialog_fields.each { |key, value| workflow.set_value(key, value) }
         workflow.dialog
       end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      (id == @auth_user_obj.id) ? validate_self_user_data(data) : validate_user_data(data)
+      (id == User.current_user.id) ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
       parse_set_settings(data, resource_search(id, type, collection_class(type)))
       super
@@ -43,14 +43,14 @@ module Api
 
     def delete_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for deleting a user" unless id
-      raise BadRequestError, "Cannot delete user of current request" if id.to_i == @auth_user_obj.id
+      raise BadRequestError, "Cannot delete user of current request" if id.to_i == User.current_user.id
       super
     end
 
     private
 
     def update_target_is_api_user?
-      @auth_user_obj.id == @req.c_id.to_i
+      User.current_user.id == @req.c_id.to_i
     end
 
     def parse_set_group(data)


### PR DESCRIPTION
In #13121 it was discussed that the `@auth_user_obj` variable would be
better replaced with `User.current_user`, which it should always be once
authentication is done.

EDIT: there is one remaining reference [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog.rb#L98) which I haven't renamed because it's outside of the Api::BaseController and looks like a bug. I will follow this up with a fix for that in a separate PR.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 