### PR TITLE
Correct requester in Dialog#content

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -95,7 +95,7 @@ class Dialog < ApplicationRecord
   def content(target = nil, resource_action = nil, all_attributes = false)
     return DialogSerializer.new.serialize(Array[self], all_attributes) if target.nil? && resource_action.nil?
 
-    workflow = ResourceActionWorkflow.new({}, @auth_user_obj, resource_action, :target => target)
+    workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => target)
 
     workflow.dialog.dialog_fields.each do |dialog_field|
       # Accessing dialog_field.values forces an update for any values coming from automate

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -45,6 +45,13 @@ describe Dialog do
     expect(dialog.label).to eq(dialog.name)
   end
 
+  describe "#content" do
+    it "returns the serialized content" do
+      dialog = FactoryGirl.create(:dialog, :description => "foo", :label => "bar")
+      expect(dialog.content).to match([hash_including("description" => "foo", "label" => "bar")])
+    end
+  end
+
   describe "#readonly?" do
     it "is not readonly if it no blueprint associated" do
       dialog = FactoryGirl.create(:dialog, :label => 'dialog')


### PR DESCRIPTION
`Dialog#content` depends on `ResourceActionWorkflow`, which requires a
requester object. The one that was being passed as the unassigned
variable `@auth_user_obj` (presumably copied/pasted from the API code) -
effectively `nil`. This doesn't seem to matter because the only method
called on the workflow (`#dialog`) does not use the requester
anywhere. Still, it would be better to new up this object with a valid
requester for the sake of fewer surprises.

@miq-bot add-label core
(not sure what other label best describes this)
@miq-bot assign @abellotti 