### PR TITLE
Model changes for alerts

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,4 +1,21 @@
+require 'ancestry'
+
 class MiqAlertStatus < ApplicationRecord
+  SEVERITY_LEVELS = %w(error warning info).freeze
+
+  has_ancestry
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
+  has_many :miq_alert_status_actions, -> { order "created_at" }, :dependent => :destroy
+  virtual_column :assignee, :type => :string
+
+  validates :severity, :acceptance => { :accept => SEVERITY_LEVELS }
+
+  def assignee
+    miq_alert_status_actions.where(:action_type => %w(assign unassign)).last.try(:assignee)
+  end
+
+  def assigned?
+    assignee.present?
+  end
 end

--- a/app/models/miq_alert_status_action.rb
+++ b/app/models/miq_alert_status_action.rb
@@ -1,0 +1,30 @@
+class MiqAlertStatusAction < ApplicationRecord
+  ACTION_TYPES = %w(assign acknowledge comment unassign unacknowledge).freeze
+
+  belongs_to :miq_alert_status
+  belongs_to :assignee, :class_name => 'User'
+  belongs_to :user
+  validates :action_type, :acceptance => { :accept => ACTION_TYPES }, :presence => true
+  validates :user, :presence => true
+  validates :miq_alert_status, :presence => true
+  validates :comment, :presence => true, :if => "action_type == 'comment'"
+  validates :assignee, :presence => true, :if => "action_type == 'assign'"
+  validates :assignee, :absence => true, :unless => "action_type == 'assign'"
+  validate :only_assignee_can_acknowledge
+
+  after_save :update_status_acknowledgement
+
+  def only_assignee_can_acknowledge
+    if action_type == 'acknowledge' && miq_alert_status.assignee.try(:id) != user.id
+      errors.add(:user, "that is not assigned cannot acknowledge")
+    end
+  end
+
+  def update_status_acknowledgement
+    if %w(assign unassign unacknowledge).include?(action_type)
+      miq_alert_status.update(:acknowledged => false)
+    elsif "acknowledge" == action_type
+      miq_alert_status.update(:acknowledged => true)
+    end
+  end
+end

--- a/db/migrate/20161102093322_add_missing_fields_to_alert_statuses.rb
+++ b/db/migrate/20161102093322_add_missing_fields_to_alert_statuses.rb
@@ -1,0 +1,9 @@
+class AddMissingFieldsToAlertStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :url,          :text
+    add_column :miq_alert_statuses, :severity,     :string
+    add_column :miq_alert_statuses, :ancestry,     :string
+    add_column :miq_alert_statuses, :acknowledged, :boolean
+    add_index  :miq_alert_statuses, :ancestry
+  end
+end

--- a/db/migrate/20161113091851_add_miq_alert_status_actions.rb
+++ b/db/migrate/20161113091851_add_miq_alert_status_actions.rb
@@ -1,0 +1,12 @@
+class AddMiqAlertStatusActions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :miq_alert_status_actions do |t|
+      t.string     :action_type
+      t.belongs_to :user,             :type => :bigint
+      t.string     :comment
+      t.belongs_to :assignee,         :type => :bigint
+      t.belongs_to :miq_alert_status, :type => :bigint
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4797,6 +4797,15 @@ miq_ae_workspaces:
 - setters
 - created_on
 - updated_on
+miq_alert_status_actions:
+- id
+- action_type
+- user_id
+- comment
+- assignee_id
+- miq_alert_status_id
+- created_at
+- updated_at
 miq_alert_statuses:
 - id
 - miq_alert_id
@@ -4804,6 +4813,10 @@ miq_alert_statuses:
 - resource_type
 - evaluated_on
 - result
+- url
+- severity
+- ancestry
+- acknowledged
 miq_alerts:
 - id
 - guid

--- a/spec/factories/miq_alert_status.rb
+++ b/spec/factories/miq_alert_status.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_alert_status do
+  end
+end

--- a/spec/factories/miq_alert_status_action.rb
+++ b/spec/factories/miq_alert_status_action.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :miq_alert_status_action do
+    action_type 'comment'
+    comment     'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  end
+end

--- a/spec/models/miq_alert_status_action_spec.rb
+++ b/spec/models/miq_alert_status_action_spec.rb
@@ -1,0 +1,86 @@
+describe MiqAlertStatusAction do
+  let(:alert) { FactoryGirl.create(:miq_alert_status) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:user2) { FactoryGirl.create(:user, :name => 'user2') }
+
+  describe "Validation" do
+    it "forbids unknown operations" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'churn', :user => user,
+                           :miq_alert_status => alert)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Action type must be accepted")
+    end
+
+    it "must be linked to a user" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'unassign', :user => nil,
+                           :miq_alert_status => alert)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User can't be blank")
+    end
+
+    it "must have a comment if the action_type is comment" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'comment', :user => user, :comment => nil,
+                           :miq_alert_status => alert)
+      end.to raise_error(ActiveRecord::RecordInvalid,
+                         "Validation failed: Comment can't be blank")
+    end
+
+    it "can have a comment if the action_type isn't comment" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'unassign', :user => user, :comment => 'Nope.',
+                           :miq_alert_status => alert)
+      end.to_not raise_error
+    end
+
+    it "cannot have an assignee if the action_type is not assign" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'unassign', :user => user, :assignee => user,
+                           :miq_alert_status => alert)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Assignee must be blank")
+    end
+
+    it "must have an assignee if the action_type is assign" do
+      expect do
+        FactoryGirl.create(:miq_alert_status_action, :action_type => 'assign', :user => user, :assignee => nil,
+                           :miq_alert_status => alert)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Assignee can't be blank")
+    end
+
+    it "should allow the currently assigned user to acknoledge the alert" do
+      FactoryGirl.create(
+        :miq_alert_status_action,
+        :action_type      => 'assign',
+        :assignee         => user,
+        :user             => user,
+        :miq_alert_status => alert
+      )
+      expect do
+        FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'acknowledge',
+          :user             => user,
+          :miq_alert_status => alert
+        )
+      end.to_not raise_error
+    end
+
+    it "should not allow a user not assigned to acknoledge the alert" do
+      FactoryGirl.create(
+        :miq_alert_status_action,
+        :action_type      => 'assign',
+        :assignee         => user,
+        :user             => user,
+        :miq_alert_status => alert
+      )
+      expect do
+        FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'acknowledge',
+          :user             => user2,
+          :miq_alert_status => alert
+        )
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User that is not assigned cannot acknowledge")
+    end
+  end
+end

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -1,0 +1,109 @@
+describe MiqAlertStatus do
+  let(:ems)                    { FactoryGirl.create(:ems_vmware, :name => 'ems') }
+  let(:alert_definition)       { FactoryGirl.create(:miq_alert) }
+  let(:alert)                  { FactoryGirl.create(:miq_alert_status) }
+  let(:user1)                  { FactoryGirl.create(:user, :name => 'user1') }
+  let(:user2)                  { FactoryGirl.create(:user, :name => 'user2') }
+  let(:acknowledgement_action) do
+    FactoryGirl.create(:miq_alert_status_action, :action_type => 'acknowledge', :user => user1,
+                       :miq_alert_status => alert)
+  end
+  let(:assignment_action) do
+    FactoryGirl.create(:miq_alert_status_action, :action_type => 'assign', :user => user1, :assignee => user1,
+                       :miq_alert_status => alert)
+  end
+
+  describe "Validation" do
+    it "should reject unexpected severities" do
+      expect do
+        FactoryGirl.create(:miq_alert_status, :severity => 'awsome')
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Severity must be accepted")
+    end
+  end
+
+  describe "#acknowledged?" do
+    it "should return false if there is no acknolegment history" do
+      expect(alert.acknowledged?).to be_falsey
+    end
+
+    it "should return true if acknowledged" do
+      alert.miq_alert_status_actions << assignment_action
+      Timecop.travel 1.minute do
+        alert.miq_alert_status_actions << acknowledgement_action
+      end
+      expect(alert.acknowledged?).to be_truthy
+      alert.save
+      expect(alert.acknowledged?).to be_truthy
+    end
+
+    it "should return false if unacknowledged" do
+      alert.miq_alert_status_actions << assignment_action
+      alert.save
+      alert.reload
+      Timecop.travel 1.minute do
+        alert.miq_alert_status_actions << acknowledgement_action
+      end
+      Timecop.travel 2.minutes do
+        FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'unacknowledge',
+          :user             => user1,
+          :miq_alert_status => alert
+        )
+      end
+      alert.reload
+      expect(alert.acknowledged?).to be_falsey
+    end
+
+    it "should return false if reassigned after acknowledgement" do
+      alert.miq_alert_status_actions << assignment_action
+      Timecop.travel 1.minute do
+        alert.miq_alert_status_actions << acknowledgement_action
+      end
+      Timecop.travel 2.minutes do
+        alert.miq_alert_status_actions << FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'assign',
+          :user             => user1,
+          :assignee         => user2,
+          :miq_alert_status => alert
+        )
+        expect(alert.acknowledged?).to be_falsey
+        alert.save
+        alert.reload
+        expect(alert.acknowledged?).to be_falsey
+      end
+
+      expect(alert.acknowledged?).to be_falsey
+    end
+  end
+
+  describe "#assignee" do
+    it "should return the last asignee" do
+      expect(alert.assignee).to be_nil
+      alert.miq_alert_status_actions = [assignment_action]
+      expect(alert.assignee).to eq(user1)
+      Timecop.travel 1.minute do
+        FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'assign',
+          :user             => user1,
+          :miq_alert_status => alert,
+          :assignee         => user2
+        )
+      end
+      alert.reload
+      expect(alert.assignee).to eq(user2)
+      Timecop.travel 2.minutes do
+        FactoryGirl.create(
+          :miq_alert_status_action,
+          :action_type      => 'unassign',
+          :user             => user1,
+          :miq_alert_status => alert
+        )
+      end
+      alert.reload
+      expect(alert.assignee).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Model changes extending ManageIQ alerting capability to support operation teams use cases:
- A ticketing system where privileged users could assign alerts for users to work on, assigned users can acknowledge them and everyone can comment on them
- Alerts could be coming in from external systems and can have severity / informational url attached to them
- Alerts can represent a situation going bad (e.g agent reports overheating CPU) and they can represent the situation returning to normal again (e.g agent reports CPU temperature is normal again)

These new entities are used in #11962 and #13025