### PR TITLE
Add chargeback rates factories with custom parameters

### DIFF
--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -5,7 +5,22 @@ FactoryGirl.define do
     rate_type 'Compute'
 
     transient do
-      per_time 'hourly'
+      per_time      'hourly'
+      detail_params nil
+    end
+
+    after(:create) do |chargeback_rate, evaluator|
+      next unless evaluator.detail_params
+
+      evaluator.detail_params.each do |factory_name, chargeback_rate_params|
+        next unless chargeback_rate_params
+        next unless chargeback_rate_params[:tiers].kind_of?(Array)
+        params_hash = { :tiers_params => chargeback_rate_params[:tiers], :per_time => evaluator.per_time }
+        params_hash.merge!(chargeback_rate_params[:detail]) if chargeback_rate_params[:detail]
+        params = [factory_name, :tiers, params_hash]
+
+        chargeback_rate.chargeback_rate_details << FactoryGirl.create(*params)
+      end
     end
 
     trait :with_details do

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -12,8 +12,20 @@ FactoryGirl.define do
       detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure_bytes) }
     end
 
+    transient do
+      tiers_params nil
+    end
+
     trait :tiers do
-      chargeback_tiers { [FactoryGirl.create(:chargeback_tier)] }
+      after(:create) do |chargeback_rate_detail, evaluator|
+        if evaluator.tiers_params
+          evaluator.tiers_params.each do |tier|
+            chargeback_rate_detail.chargeback_tiers << FactoryGirl.create(*[:chargeback_tier, tier])
+          end
+        else
+          chargeback_rate_detail.chargeback_tiers << FactoryGirl.create(:chargeback_tier)
+        end
+      end
     end
 
     trait :tiers_with_three_intervals do


### PR DESCRIPTION
-  :chargeback_rate factory girl with possibility pass parameters for ChargebackRateDetail and ChargebackRateTier
-  using this factory

example:
```
FactoryGirl.create(:chargeback_rate,
  :detail_params =>
    :chargeback_rate_detail_cpu_used  =>
       {
         :tiers => [
            	     {:variable_rate => 10, :fixed_rate => 10, :start=> 0, :finish=> 50},
                     {:fixed_rate => 10, :start=> 50, :finish=> Float::Infinity}
                   ],
        :detail => {:source => 'compute_1'}
       }
)
```