### PR TITLE
Container SSA: adding a missing 'last' after split

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -121,7 +121,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     if metadata.RepoDigests
       metadata.RepoDigests.each do |repo_digest|
         return nil if repo_digest == options[:docker_image_id]
-        msg << repo_digest.split('@')[0..11] + ", "
+        msg << repo_digest.split('@').last[0..11] + ", "
       end
     end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -51,7 +51,7 @@ class MockImageInspectorClient
 
   def fetch_metadata(*_args)
     if @repo_digest
-      OpenStruct.new('Id' => @for_id, 'RepoDigests' => [@repo_digest])
+      OpenStruct.new('Id' => @for_id, 'RepoDigests' => ["123456677899987765543322", @repo_digest])
     else
       OpenStruct.new('Id' => @for_id)
     end


### PR DESCRIPTION
a `last` was missing after the split to get the latest part of the split..

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1406023