### PR TITLE
Miq expression column type

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -762,7 +762,8 @@ class MiqExpression
       model = ref.klass
     end
     if col
-      result[:data_type] = col_type(model, col)
+      f = Field.new(model, [], col)
+      result[:data_type] = f.column_type
       result[:format_sub_type] = MiqReport::Formats.sub_type(col.to_sym) || result[:data_type]
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
       result[:sql_support] = !result[:virtual_reflection] && model.attribute_supported_by_sql?(col.to_s)
@@ -1367,12 +1368,7 @@ class MiqExpression
     return nil if model.nil?
     return Field.parse(field).column_type if col.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
 
-    col_type(model, col)
-  end
-
-  def self.col_type(model, col)
-    model = model_class(model)
-    model.type_for_attribute(col).type
+    Field.new(model, [], col).column_type
   end
 
   def self.parse_field(field)
@@ -1626,6 +1622,9 @@ class MiqExpression
     end
   end
 
+  def self.create_field(model, associations, field_name)
+    Field.new(model, associations, field_name)
+  end
 
   private
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -747,16 +747,16 @@ class MiqExpression
       ref = model.reflection_with_virtual(assoc)
       result[:virtual_reflection] = true if model.virtual_reflection?(assoc)
 
-      unless result[:virtual_reflection]
-        cur_incl[assoc] ||= {}
-        cur_incl = cur_incl[assoc]
-      end
-
       unless ref
         result[:virtual_reflection] = true
         result[:sql_support] = false
         result[:virtual_column] = true
         return result
+      end
+
+      unless result[:virtual_reflection]
+        cur_incl[assoc] ||= {}
+        cur_incl = cur_incl[assoc]
       end
 
       model = ref.klass
@@ -765,7 +765,7 @@ class MiqExpression
       result[:data_type] = col_type(model, col)
       result[:format_sub_type] = MiqReport::Formats.sub_type(col.to_sym) || result[:data_type]
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
-      result[:sql_support] = model.attribute_supported_by_sql?(col.to_s)
+      result[:sql_support] = !result[:virtual_reflection] && model.attribute_supported_by_sql?(col.to_s)
       result[:excluded_by_preprocess_options] = self.exclude_col_by_preprocess_options?(col, options)
     end
     result

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -8,8 +8,13 @@ class MiqExpression::Field
   ParseError = Class.new(StandardError)
 
   def self.parse(field)
-    match = FIELD_REGEX.match(field) or raise ParseError, field
-    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
+    match = FIELD_REGEX.match(field) or return
+    model = match[:model_name].safe_constantize or return
+    new(model, match[:associations].to_s.split("."), match[:column])
+  end
+
+  def self.parse!(field)
+    parse(field) or raise ParseError, field
   end
 
   attr_reader :model, :associations, :column

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -19,6 +19,10 @@ class MiqExpression::Tag
     model.arel_attribute(:id).in(ids)
   end
 
+  def column_type
+    :string
+  end
+
   def equ?(other)
     other.try(:model) == model && other.try(:namespace) == namespace
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,9 +1,10 @@
 class MiqExpression::Tag
   def self.parse(tag)
     klass, ns = tag.split(".")
+    klass, ns = "nil", klass if ns.nil? # support managed-label
     ns = "/" + ns.split("-").join("/")
     ns = ns.sub(/(\/user_tag\/)/, "/user/") # replace with correct namespace for user tags
-    new(klass.constantize, ns)
+    new(klass.safe_constantize, ns)
   end
 
   attr_reader :model, :namespace
@@ -17,4 +18,9 @@ class MiqExpression::Tag
     ids = model.find_tagged_with(:any => value, :ns => namespace).pluck(:id)
     model.arel_attribute(:id).in(ids)
   end
+
+  def equ?(other)
+    other.try(:model) == model && other.try(:namespace) == namespace
+  end
+  alias == equ?
 end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -28,7 +28,7 @@ module Vmdb
     end
 
     def column_type(model, column)
-      MiqExpression.col_type(model, column)
+      MiqExpression.create_field(model, [], column).column_type
     end
 
     # Had to add timezone methods here, they are being called from models

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -163,6 +163,18 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#column_type" do
+    it "detects :string" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.column_type).to eq(:string)
+    end
+
+    it "detects :integer" do
+      field = described_class.new(Vm, [], "id")
+      expect(field.column_type).to eq(:integer)
+    end
+  end
+
   describe "sql detection" do
     it "detects if column is supported by sql with custom_attribute" do
       expect(MiqExpression::Field.parse("Vm-virtual_custom_attribute_example").attribute_supported_by_sql?).to be_falsey

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -52,9 +52,23 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(field).associations).to eq(%w(host hardware))
     end
 
+    it "will return nil when given a field with unsupported syntax" do
+      field = "Vm,host+name"
+      expect(described_class.parse(field)).to be_nil
+    end
+  end
+
+  describe "#parse!" do
+    it "can parse the model name" do
+      field = "Vm-name"
+      expect(described_class.parse(field).model).to be(Vm)
+    end
+
+    # this calls out to parse, so just needed to make sure one value worked
+
     it "will raise a parse error when given a field with unsupported syntax" do
       field = "Vm,host+name"
-      expect { described_class.parse(field) }.to raise_error(MiqExpression::Field::ParseError)
+      expect { described_class.parse!(field) }.to raise_error(MiqExpression::Field::ParseError)
     end
   end
 

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe MiqExpression::Tag do
+  describe ".parse" do
+    it "with managed-field" do
+      field = "managed.location"
+      expect(described_class.parse(field)).to eq(described_class.new(nil, "/location"))
+    end
+
+    it "with model.managed-in_field" do
+      field = "Vm.managed-service_level"
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level"))
+    end
+
+    it "with model.last.managed-in_field" do
+      field = "Vm.host.managed-environment"
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/host"))
+    end
+  end
+end

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -17,4 +17,10 @@ RSpec.describe MiqExpression::Tag do
       expect(described_class.parse(field)).to eq(described_class.new(Vm, "/host"))
     end
   end
+
+  describe "#column_type" do
+    it "is always a string" do
+      expect(described_class.new(Vm, "/host").column_type).to eq(:string)
+    end
+  end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1865,40 +1865,6 @@ describe MiqExpression do
     end
   end
 
-  describe ".parse_field" do
-    subject { described_class.parse_field(@field) }
-
-    it "with model-field__with_pivot_table_suffix" do
-      @field = "Vm-name__pv"
-      expect(subject).to eq(["Vm", [], "name"])
-    end
-
-    it "with managed-field" do
-      @field = "managed.location"
-      expect(subject).to eq(["managed", ["location"], "managed.location"])
-    end
-
-    it "with model.managed-in_field" do
-      @field = "Vm.managed-service_level"
-      expect(subject).to eq(["Vm", ["managed"], "service_level"])
-    end
-
-    it "with model.last.managed-in_field" do
-      @field = "Vm.host.managed-environment"
-      expect(subject).to eq(["Vm", ["host", "managed"], "environment"])
-    end
-
-    it "with valid model-in_field" do
-      @field = "Vm-cpu_limit"
-      expect(subject).to eq(["Vm", [], "cpu_limit"])
-    end
-
-    it "with field without model" do
-      @field = "storage"
-      expect(subject).to eq(["storage", [], "storage"])
-    end
-  end
-
   describe ".model_details" do
     before do
       # tags contain the root tenant's name

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2294,7 +2294,7 @@ describe MiqExpression do
       expect(col_info).to match(
         :data_type                      => nil,
         :excluded_by_preprocess_options => false,
-        :include                        => {:invalid => {}},
+        :include                        => {},
         :tag                            => false,
         :virtual_column                 => true,
         :sql_support                    => false,
@@ -2312,7 +2312,7 @@ describe MiqExpression do
         :include                        => {},
         :tag                            => false,
         :virtual_column                 => true,
-        :sql_support                    => true,
+        :sql_support                    => false,
         :virtual_reflection             => true
       )
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1836,8 +1836,7 @@ describe MiqExpression do
 
     it "with valid model-in_field" do
       @field = "Vm-cpu_limit"
-      allow(described_class).to receive_messages(:col_type => :some_type)
-      expect(subject).to eq(:some_type)
+      expect(subject).to eq(:integer)
     end
 
     it "with invalid model-in_field" do
@@ -1847,8 +1846,7 @@ describe MiqExpression do
 
     it "with valid model.association-in_field" do
       @field = "Vm.guest_applications-vendor"
-      allow(described_class).to receive_messages(:col_type => :some_type)
-      expect(subject).to eq(:some_type)
+      expect(subject).to eq(:string)
     end
 
     it "with invalid model.association-in_field" do
@@ -2158,6 +2156,36 @@ describe MiqExpression do
       )
     end
 
+    it "return column info for model-virtual field" do
+      field = "VmInfra-active"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => :boolean,
+        :excluded_by_preprocess_options => false,
+        :format_sub_type                => :boolean,
+        :include                        => {},
+        :tag                            => false,
+        :virtual_column                 => true,
+        :sql_support                    => true,
+        :virtual_reflection             => false
+      )
+    end
+
+    it "return column info for model-invalid" do
+      field = "ManageIQ::Providers::InfraManager::Vm-invalid"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => nil,
+        :excluded_by_preprocess_options => false,
+        :format_sub_type                => nil,
+        :include                        => {},
+        :tag                            => false,
+        :virtual_column                 => false,
+        :sql_support                    => false,
+        :virtual_reflection             => false
+      )
+    end
+
     it "return column info for managed-field" do
       tag = "managed-location"
       col_info = described_class.get_col_info(tag)
@@ -2238,6 +2266,35 @@ describe MiqExpression do
         :excluded_by_preprocess_options => false,
         :format_sub_type                => :bytes,
         :include                        => {},
+        :tag                            => false,
+        :virtual_column                 => true,
+        :sql_support                    => false,
+        :virtual_reflection             => true
+      )
+    end
+
+    it "return column info for model.virtualassociation..virtualassociation-invalid" do
+      field = "ManageIQ::Providers::InfraManager::Vm.service.user.vms-invalid"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => nil,
+        :excluded_by_preprocess_options => false,
+        :format_sub_type                => nil,
+        :include                        => {},
+        :tag                            => false,
+        :virtual_column                 => false,
+        :sql_support                    => false,
+        :virtual_reflection             => true
+      )
+    end
+
+    it "return column info for model.invalid-active" do
+      field = "ManageIQ::Providers::InfraManager::Vm.invalid-active"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => nil,
+        :excluded_by_preprocess_options => false,
+        :include                        => {:invalid => {}},
         :tag                            => false,
         :virtual_column                 => true,
         :sql_support                    => false,


### PR DESCRIPTION
**Top Level Goal:** Get the field meta-data collection out of `MiqExpression`.

- `MiqExpression#get_col_type` returns a hash with details of a database column.
- `MiqExpression::Field` is a wrapper around active record, but also knows about the context of the relationships used to access the column. So it knows that a native database field accessed through a virtual relationship is not actually sql friendly.

We are parsing report fields in many places of our code, and doing so differently.

This PR
-------

- `MiqExpression.column_type` is the same as `Field#column_type` - merge
- `MiqExpression.parse_field` is essentially `Field#parse`, and only used in 1 place - merge
- test for `parse_field` are duplicated for `get_col_type` (and `Field#parse`) - move to correct place (looks like I deleted, but I did not reduce coverage).

Followup PRs will remove some of these concepts from the controllers (which are no longer in this repo)