### PR TITLE
Display flash message on import/export custom report

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -12,6 +12,7 @@ class ReportController < ApplicationController
 
   before_action :check_privileges
   before_action :get_session_data
+  before_action :set_flash_messages, :only => :tree_select, :if => proc { @sb.try(:[], :flash_msg) }
   after_action  :cleanup_action
   after_action  :set_session_data
   layout 'application', :except => [:render_txt, :render_csv, :render_pdf]
@@ -915,6 +916,11 @@ class ReportController < ApplicationController
 
   def widget_import_service
     @widget_import_service ||= WidgetImportService.new
+  end
+
+  def set_flash_messages
+    @flash_array = @sb[:flash_msg]
+    @sb[:flash_msg] = nil
   end
 
   menu_section :vi


### PR DESCRIPTION
The flash message was not displayed because of a redirection that handle ```tree_select``` and not setting ```@flash_array```. PR fixes that with specific before_action.

https://bugzilla.redhat.com/show_bug.cgi?id=1393244

