### PR TITLE
Fix format in providers view list in Infrastructure

### DIFF
--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -66,6 +66,7 @@ col_formats:
 -
 -
 -
+-
 - :megabytes_human
 
 # Column titles, in order


### PR DESCRIPTION
Fix Issue #13247 , format column of memory applied in vcores instead in memory.

I forgot add another line after reorder cols.

Before FIX
![captura de pantalla 2016-12-20 a las 23 03 45](https://cloud.githubusercontent.com/assets/3019213/21369714/851fdee2-c708-11e6-8bd0-f1903b24efc6.png)

After Fix
![captura de pantalla 2016-12-20 a las 23 05 48](https://cloud.githubusercontent.com/assets/3019213/21369721/8db31db2-c708-11e6-8cf4-0c16c1862878.png)


