### PR TITLE
Added 'VMware ESXi' to the list of known operating systems

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -25,7 +25,7 @@ class OperatingSystem < ApplicationRecord
     ["linux_centos",    %w(centos)],
     ["linux_debian",    %w(debian)],
     ["linux_coreos",    %w(coreos)],
-    ["linux_esx",       %w(vmnixx86 vmnix-x86 vmwareesxserver esxserver)],
+    ["linux_esx",       %w(vmnixx86 vmnix-x86 vmwareesxserver esxserver vmwareesxi)],
     ["linux_solaris",   %w(solaris)],
     ["linux_generic",   %w(linux)]
   ]


### PR DESCRIPTION
OS ```VMware ESXi``` was not listed as known operating system and image name representing ```VMware ESXi``` was not defined

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1395376

@miq-bot add-label bug, reporting

\cc @gtanzillo @kbrock 

BEFORE:
<img width="745" alt="os image before" src="https://cloud.githubusercontent.com/assets/6556758/21324112/70195476-c5ee-11e6-8113-656049e5dce2.png">




AFTER:
<img width="699" alt="os image after" src="https://cloud.githubusercontent.com/assets/6556758/21324124/7a23bbc8-c5ee-11e6-8ac4-a99744b91bcf.png">
