### PR TITLE
[DARGA] - Fixed button method to handle tagging button for missing entities.

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -411,13 +411,12 @@ module EmsCommon
       else
         process_vm_buttons(pfx)
         # Control transferred to another screen, so return
-        return if ["host_tag", "#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
-                   "host_compare", "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_retire",
-                   "#{pfx}_protect", "#{pfx}_ownership", "#{pfx}_refresh", "#{pfx}_right_size",
-                   "#{pfx}_reconfigure", "storage_tag", "ems_cluster_compare",
-                   "ems_cluster_protect", "ems_cluster_tag", "#{pfx}_resize", "#{pfx}_live_migrate",
-                   "#{pfx}_evacuate"].include?(params[:pressed]) &&
-                  @flash_array.nil?
+        return if (["#{pfx}_policy_sim", "host_scan", "host_refresh", "host_protect",
+                    "host_compare", "#{pfx}_compare", "#{pfx}_tag", "#{pfx}_retire",
+                    "#{pfx}_protect", "#{pfx}_ownership", "#{pfx}_refresh", "#{pfx}_right_size",
+                    "#{pfx}_reconfigure", "ems_cluster_compare", "ems_cluster_protect", "#{pfx}_resize",
+                    "#{pfx}_live_migrate", "#{pfx}_evacuate"].include?(params[:pressed]) ||
+                    params[:pressed].ends_with?("_tag")) && @flash_array.nil?
 
         unless ["host_edit", "#{pfx}_edit", "#{pfx}_miq_request_new", "#{pfx}_clone",
                 "#{pfx}_migrate", "#{pfx}_publish"].include?(params[:pressed])

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -134,6 +134,22 @@ describe EmsCloudController do
         expect(response.status).to eq 200
         expect(response.body).to include('vm/retire')
       end
+
+      it "when Tag Button is pressed for a Cloud provider Volumes" do
+        allow(controller).to receive(:role_allows).and_return(true)
+        ems = FactoryGirl.create("ems_vmware")
+        vm = FactoryGirl.create(:vm_vmware,
+                                :ext_management_system => ems,
+                                :storage               => FactoryGirl.create(:storage)
+                               )
+        post :button, :params => {:pressed         => "cloud_volume_tag",
+                                  "check_#{vm.id}" => "1",
+                                  :format          => :js,
+                                  :id              => ems.id,
+                                  :display         => 'cloud_volumes'}
+        expect(response.status).to eq 200
+        expect(response.body).to include("/ems_cloud/tagging_edit/#{ems.id}?db=CloudVolume&escape=false")
+      end
     end
   end
 


### PR DESCRIPTION
Code was throwing "Render and/or redirect were called multiple times" error when tagging button was pressed from list of cloud_volumes thru Cloud provider relationship.

https://bugzilla.redhat.com/show_bug.cgi?id=1394887

after fix tagging screen loads successfully for selected Cloud Volumes:
![after](https://cloud.githubusercontent.com/assets/3450808/21324633/9c003aa8-c5f0-11e6-904b-57596149951d.png)
