### PR TITLE
Vendor and OS icon cleanup

### DIFF
--- a/app/presenters/tree_node/ext_management_system.rb
+++ b/app/presenters/tree_node/ext_management_system.rb
@@ -1,6 +1,6 @@
 module TreeNode
   class ExtManagementSystem < Node
-    set_attribute(:image) { "100/vendor-#{@object.image_name}.png" }
+    set_attribute(:image) { "svg/vendor-#{@object.image_name}.svg" }
 
     set_attribute(:tooltip) do
       # # TODO: This should really leverage .base_model on an EMS

--- a/app/presenters/tree_node/miq_ae_namespace.rb
+++ b/app/presenters/tree_node/miq_ae_namespace.rb
@@ -15,7 +15,7 @@ module TreeNode
       when !@object.top_level_namespace
         '100/ae_domain.png'
       else
-        "100/vendor-#{@object.top_level_namespace.downcase}.png"
+        "svg/vendor-#{@object.top_level_namespace.downcase}.svg"
       end
       # rubocop:enable LiteralInCondition
     end

--- a/app/presenters/tree_node/windows_image.rb
+++ b/app/presenters/tree_node/windows_image.rb
@@ -1,5 +1,5 @@
 module TreeNode
   class WindowsImage < Node
-    set_attribute(:image, '100/os-windows_generic.png')
+    set_attribute(:image, 'svg/os-windows_generic.svg')
   end
 end

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -102,11 +102,11 @@ module ReportFormatter
         when "Vm"
           e_title = rec[:name]
           e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vendor.downcase}.png")
-          e_image = ActionController::Base.helpers.image_path("100/os-#{rec.os_image_name.downcase}.png")
+          e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "Host"
           e_title = rec[:name]
           e_icon = ActionController::Base.helpers.image_path("timeline/vendor-#{rec.vmm_vendor_display.downcase}.png")
-          e_image = ActionController::Base.helpers.image_path("100/os-#{rec.os_image_name.downcase}.png")
+          e_image = ActionController::Base.helpers.image_path("svg/os-#{rec.os_image_name.downcase}.svg")
         when "EventStream"
           ems_cloud = false
           if rec[:ems_id] && ExtManagementSystem.exists?(rec[:ems_id])
@@ -145,7 +145,7 @@ module ReportFormatter
             end
           end
           if rec[:vm_or_template_id] && Vm.exists?(rec[:vm_or_template_id])
-            e_image = ActionController::Base.helpers.image_path("100/os-#{Vm.find(rec[:vm_or_template_id]).os_image_name.downcase}.png")
+            e_image = ActionController::Base.helpers.image_path("svg/os-#{Vm.find(rec[:vm_or_template_id]).os_image_name.downcase}.svg")
           end
         else
           e_title = rec[:name] ? rec[:name] : row[mri.col_order.first].to_s

--- a/spec/presenters/tree_node/ext_management_system_spec.rb
+++ b/spec/presenters/tree_node/ext_management_system_spec.rb
@@ -63,7 +63,7 @@ describe TreeNode::ExtManagementSystem do
 
       describe '#image' do
         it 'returns with the image' do
-          expect(subject.image).to eq("100/vendor-#{object.image_name}.png")
+          expect(subject.image).to eq("svg/vendor-#{object.image_name}.svg")
         end
       end
     end

--- a/spec/presenters/tree_node/windows_image_spec.rb
+++ b/spec/presenters/tree_node/windows_image_spec.rb
@@ -5,5 +5,5 @@ describe TreeNode::WindowsImage do
   let(:object) { FactoryGirl.create(:windows_image) }
 
   include_examples 'TreeNode::Node#key prefix', 'wi-'
-  include_examples 'TreeNode::Node#image', '100/os-windows_generic.png'
+  include_examples 'TreeNode::Node#image', 'svg/os-windows_generic.svg'
 end


### PR DESCRIPTION
This PR replaces the remaining vendor and os PNG references in the tree nodes with SVGs.
https://www.pivotaltracker.com/n/projects/1613907/stories/129371557
