### PR TITLE
Fix bug where cached parent_rel_ids blew up

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -113,8 +113,14 @@ module RelationshipMixin
   # Returns the id in the relationship table for this record's parents
   # from this id, relationship records can be brought back and mapped to the resource of interest
   # NOTE: parent_id is read from ancestry field, while parent is a db hit (N+1)
+  # NOTE: relationships can be an array (from all_relationships cache) - so handle both Array and association
   def parent_rel_ids
-    relationships.where.not(:ancestry => [nil, ""]).select(:ancestry).collect(&:parent_id)
+    rel = relationships
+    if rel.kind_of?(Array) || rel.try(:loaded?)
+      rel.reject { |x| x.ancestry.blank? }.collect(&:parent_id)
+    else
+      rel.where.not(:ancestry => [nil, ""]).select(:ancestry).collect(&:parent_id)
+    end
   end
 
   # Returns all of the relationships of the parents of the record, [] for a root node

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -751,6 +751,32 @@ describe RelationshipMixin do
     end
   end
 
+  describe "#parent_rel_ids" do
+    it "works with relationships" do
+      pars = vms[8].with_relationship_type(test_rel_type, &:parent_rels)
+      pars_vms = pars.map(&:resource)
+      expect(pars_vms).to eq([vms[7]])
+    end
+  end
+
+  describe "#parent_rel_ids" do
+    it "works with relationships" do
+      ids = vms[8].with_relationship_type(test_rel_type, &:parent_rel_ids)
+      parent_vms = Relationship.where(:id => ids).map(&:resource)
+      expect(parent_vms).to eq([vms[7]])
+    end
+
+    it "works with cached relationships" do
+      ids = vms[8].with_relationship_type(test_rel_type) do |o|
+        # load relationships into the cache
+        o.all_relationships
+        o.parent_rel_ids
+      end
+      parent_vms = Relationship.where(:id => ids).map(&:resource)
+      expect(parent_vms).to eq([vms[7]])
+    end
+  end
+
   protected
 
   def build_relationship_tree(tree, rel_type = test_rel_type, base_factory = :vm_vmware)


### PR DESCRIPTION
When `relationships_all` is cached, `relationships` is an `Array`.
`parent_rel_ids` assumed that `relationships` was a `AR::Relation`.
Since `Array` does not support `where`, this was an issue.

before
------

```
undefined method 'where' for #<Array:0x007f9567fb6f40>
```

after
-----

works

aside
-----

I did go over the whole `relationships_mixin.rb` and could not find any other places that looked like they had this same assumption.

https://bugzilla.redhat.com/show_bug.cgi?id=1395376

First detected in https://github.com/ManageIQ/manageiq/pull/13249
