### PR TITLE
[api] expose workflow on request resources

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -37,6 +37,8 @@ class MiqRequest < ApplicationRecord
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
 
+  virtual_has_one :workflow
+
   before_validation :initialize_attributes, :on => :create
 
   include MiqRequestMixin

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -228,6 +228,22 @@ RSpec.describe "Requests API" do
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
+
+    it "exposes workflow in the request resources" do
+      ems = FactoryGirl.create(:ems_vmware)
+      vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
+      request = FactoryGirl.create(:miq_provision_request, :requester => @user, :src_vm_id => vm_template.id, :options => {:owner_email => 'tester@miq.com'})
+      workflow_class = request.workflow_class
+      allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
+
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      run_get requests_url(request.id), :attributes => "workflow"
+
+      expected = a_hash_including("id" => request.id, "workflow" => a_hash_including("values"))
+
+      expect(response.parsed_body).to match(expected)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "request update" do

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -232,10 +232,12 @@ RSpec.describe "Requests API" do
     it "exposes workflow in the request resources" do
       ems = FactoryGirl.create(:ems_vmware)
       vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
-      request = FactoryGirl.create(:miq_provision_request, :requester => @user, :src_vm_id => vm_template.id, :options => {:owner_email => 'tester@miq.com'})
-      workflow_class = request.workflow_class
-      allow_any_instance_of(workflow_class).to receive(:get_dialogs).and_return(:dialogs => {})
+      request = FactoryGirl.create(:miq_provision_request,
+                                   :requester => @user,
+                                   :src_vm_id => vm_template.id,
+                                   :options   => {:owner_email => 'tester@example.com'})
 
+      MiqDialog.seed
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
       run_get requests_url(request.id), :attributes => "workflow"
 

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -236,8 +236,10 @@ RSpec.describe "Requests API" do
                                    :requester => @user,
                                    :src_vm_id => vm_template.id,
                                    :options   => {:owner_email => 'tester@example.com'})
+      FactoryGirl.create(:miq_dialog,
+                         :name        => "miq_provision_dialogs",
+                         :dialog_type => MiqProvisionWorkflow)
 
-      MiqDialog.seed
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
       run_get requests_url(request.id), :attributes => "workflow"
 


### PR DESCRIPTION
We need `workflow` as part of the `Request` resource API output in order to show the Request Workflow details in SUI.

`api/requests/<id>?attributes=workflow`

Sub task of https://www.pivotaltracker.com/n/projects/1914499/stories/135708235