### PR TITLE
Log parsed JSON body + query parameters instead of params

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -35,7 +35,7 @@ module Api
         @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
         return unless api_log_info?
         log_request("Request", @req.to_hash)
-        log_request("Parameters", @parameter_filter.filter(params.to_unsafe_h))
+        log_request("Parameters", @parameter_filter.filter(request.query_parameters.merge("body" => @req.json_body)))
         log_request_body
       end
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -63,8 +63,10 @@ describe "Logging" do
 
       log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
         "Parameters" => a_hash_including(
-          "resource" => a_hash_including(
-            "options" => a_hash_including("password" => "[FILTERED]")
+          "body" => a_hash_including(
+            "resource" => a_hash_including(
+              "options" => a_hash_including("password" => "[FILTERED]")
+            )
           )
         )
       )


### PR DESCRIPTION
In the API we parse the request body as JSON regardless of what comes in
the request, particularly with regard to the "Content-Type" header. In
#12213 I hoped to reveal this
behavior by not sending the "Content-Type" header in requests by
default, covering the behavior of that header with specific tests.

However, there is one place that uses `params` instead of the
JSON-parsed body: the logger. There is a test that verifies that logging
does not write sensitive data to the log (e.g. passwords) that works
when you set "Content-Type" to "application/json", but breaks when you
don't. This is bad because if you omit this header everything about the
request will appear to work as you would expect, except that the logger
will no longer properly filter your params.

In the solution I've used the same `@req.json_body` plus the query
parameters instead of `params.to_unsafe_h`. This will work regardless of
what is sent int he "Content-Type" header. It's not exactly
like-for-like however, as it omits some details about the request, but
I'd question whether they were relevant. Here's an example before and
after:

Before:

```ruby
params.to_unsafe_h # => {"action"=>"update", "resource"=>{"name"=>"new_service_1", "options"=>{"password"=>"SECRET"}}, "format"=>"json", "controller"=>"api/services", "service"=>{}}
```

After

```ruby
request.query_parameters.merge(@req.json_body) # => {"action"=>"create", "resource"=>{"name"=>"new_service_1", "options"=>{"password"=>"SECRET"}}}
```

@miq-bot add-label bug, api
@miq-bot assign @abellotti 
