### PR TITLE
[WIP] [PROTOTYPE] Prototype support for --expand=virtual_attributes

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -208,7 +208,14 @@ module Api
       def expand_virtual_attributes(json, type, resource)
         result = {}
         object_hash = {}
-        virtual_attributes_list(resource).each do |vattr|
+
+        virtual_attributes = virtual_attributes_list(resource)
+        if @req.expand?("virtual_attributes")
+          virtual_attributes |=
+            options_attribute_list(collection_class(type).virtual_attribute_names)
+        end
+
+        virtual_attributes.each do |vattr|
           attr_name, attr_base = split_virtual_attribute(vattr)
           value, value_result = if attr_base.blank?
                                   fetch_direct_virtual_attribute(type, resource, attr_name)


### PR DESCRIPTION
Prototype - DO NOT MERGE.

This was prototyped as "expand=virtual_attributes", the problem is that the list of virtual attributes can be quite large, and the data being returned could take a long time (e.g. metrics, etc), so the performance is not predictable. What we have today is probably best, if we want this to go forward, we'd need something like a whitelist of virtual attributes to return per class via expand=virtual_attributes and not the whole lot.

[skip ci]