### PR TITLE
Toolbar refactoring: Time profiles

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -452,9 +452,6 @@ class ApplicationHelper::ToolbarBuilder
       return res
     end
 
-    return false if role_allows?(:feature => "my_settings_time_profiles") && @layout == "configuration" &&
-                    @tabform == "ui_4"
-
     return false if id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report"
 
     # don't check for feature RBAC if id is miq_request_approve/deny


### PR DESCRIPTION
Removed unnecessary `#role_allows_feature?` call from `#hide_button?`. Each button in the `time_profiles_center` has its own feature described in `miq_product_features.yml`. This toolbar center only gets rendered when `@layout == 'configuration' && @tabform == 'ui4'`. The `@layout` and `@tabform` are already checked in `toolbar_chooser.rb`. and don't have to be checked for in `#hide_button?` again.

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/136408691