### PR TITLE
Fix Incorrect zoom out icon on C&U charts

### DIFF
--- a/app/helpers/charting_helper.rb
+++ b/app/helpers/charting_helper.rb
@@ -31,6 +31,7 @@ module ChartingHelper
   end
 
   def zoom_icon(zoom_url)
-    zoom_url =~ /clear$/ ? '24/chart_unzoom.png' : '16/chart_zoom.png'
+    # could be just url or something like "javascript:miqAsyncAjax('/host/perf_chart_chooser/10000000000017?chart_idx=0')"
+    zoom_url =~ /clear('\))?$/ ? '24/chart_unzoom.png' : '16/chart_zoom.png'
   end
 end


### PR DESCRIPTION
 Incorrect zoom out icon on C&U charts. 

Screenshots
----------------
Before:
![zoom_out](https://cloud.githubusercontent.com/assets/9535558/21346830/6376be26-c6a6-11e6-9d52-34f4c9e36bd8.png)

After:
![screencapture-localhost-3000-host-show-10000000000017-1482228658207](https://cloud.githubusercontent.com/assets/9535558/21346578/341b1e3e-c6a5-11e6-8255-84f0b8fe2ad7.png)

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1402107


Steps for Testing/QA 
-------------------------------


