### PR TITLE
Unify time zones in chargeback specs

### DIFF
--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,5 +1,5 @@
 describe ChargebackContainerImage do
-  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
   let(:hourly_rate)       { 0.01 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
@@ -28,7 +28,7 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+    Timecop.travel(Time.parse('2012-09-01 23:59:59').utc)
   end
 
   after do
@@ -38,9 +38,11 @@ describe ChargebackContainerImage do
   context "Daily" do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
 
     before do
-      ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
+      Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr, :with_data,
                                                         :timestamp                => t,
                                                         :parent_ems_id            => ems.id,

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,5 +1,5 @@
 describe ChargebackContainerProject do
-  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
   let(:hourly_rate)       { 0.01 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
@@ -23,7 +23,7 @@ describe ChargebackContainerProject do
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+    Timecop.travel(Time.parse('2012-09-01 23:59:59').utc)
   end
 
   after do
@@ -37,9 +37,11 @@ describe ChargebackContainerProject do
   context "Daily" do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
 
     before do
-      ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
+      Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr, :with_data,
                                                          :timestamp                => t,
                                                          :parent_ems_id            => ems.id,


### PR DESCRIPTION
Some other small change what I need for next refactoring.

there was used different time zone in report
options and for current time which was confusing
for some test cases.

there also used Range.new instead of enumeration.

We can add also case which are directly related  to different time zones later.

@miq-bot refactoring, chargeback, test
@miq-bot assign @chrisarcand 
