### PR TITLE
Chargebacks without rollups :: Allocated metrics for HyperV

### DIFF
--- a/spec/models/chargeback/consumption_without_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_without_rollups_spec.rb
@@ -1,0 +1,21 @@
+describe Chargeback::ConsumptionWithoutRollups do
+  let(:cores) { 7 }
+  let(:mem_mb) { 1777 }
+  let(:disk_size) { 12_345 }
+  let(:hardware) do
+    FactoryGirl.build(:hardware,
+                      :cpu_total_cores => cores,
+                      :memory_mb       => mem_mb,
+                      :disks           => [FactoryGirl.build(:disk, :size => disk_size)])
+  end
+  let(:vm) { FactoryGirl.build(:vm_microsoft, :hardware => hardware) }
+  let(:consumption) { described_class.new(vm, nil, nil) }
+
+  describe '#avg' do
+    it 'returns current values' do
+      expect(consumption.avg('derived_vm_numvcpus')).to eq(cores)
+      expect(consumption.avg('derived_memory_available')).to eq(mem_mb)
+      expect(consumption.avg('derived_vm_allocated_disk_storage')).to eq(disk_size)
+    end
+  end
+end


### PR DESCRIPTION
We don't have usage rollups for SCVMM, so we charge only based on allocation.

![allocated_compute_for_hyperv](https://cloud.githubusercontent.com/assets/6666052/21351780/b36e46b6-c6be-11e6-87d0-e7729ef9d621.jpg)

Depends on #13229 (merged).

@miq-bot add_label enhancement, chargeback
@miq-bot assign @gtanzillo 