### PR TITLE
compare RepoDigest by sha digest only too

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -111,8 +111,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     end
   end
 
-  def verify_scanned_image_id
-    metadata = image_inspector_client.fetch_metadata
+  def verify_scanned_image_id(metadata)
     actual = metadata.Id
     return nil if actual == options[:docker_image_id]
     msg = "cannot analyze image %s with id %s: detected ids were %s" % [
@@ -121,7 +120,9 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     if metadata.RepoDigests
       metadata.RepoDigests.each do |repo_digest|
         return nil if repo_digest == options[:docker_image_id]
-        msg << repo_digest.split('@').last[0..11] + ", "
+        sha_digest = repo_digest.split('@').last
+        return nil if sha_digest == options[:docker_image_id].split('@').last
+        msg << ", #{sha_digest[0..11]}"
       end
     end
 
@@ -141,7 +142,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
       :guest_os      => IMAGES_GUEST_OS
     }
 
-    verify_error = verify_scanned_image_id
+    verify_error = verify_scanned_image_id(image_inspector_client.fetch_metadata)
     if verify_error
       _log.error(verify_error)
       return queue_signal(:abort_job, verify_error, 'error')

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -260,5 +260,61 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
         end
       end
     end
+
+    context '#verify_scanned_image_id' do
+      DOCKER_DAEMON_IMAGE_ID = '123456'.freeze
+
+      before(:each) do
+        @job.options[:docker_image_id] = IMAGE_ID
+        @job.options[:image_full_name] = IMAGE_NAME
+      end
+
+      it 'should report the error when the scanned Id is different than the Image Id' do
+        msg = @job.verify_scanned_image_id(OpenStruct.new(:Id => DOCKER_DAEMON_IMAGE_ID))
+        expect(msg).to eq "cannot analyze image #{IMAGE_NAME} with id #{IMAGE_ID[0..11]}:"\
+                          " detected ids were #{DOCKER_DAEMON_IMAGE_ID[0..11]}"
+      end
+
+      context 'checking RepoDigests' do
+        DOCKER_IMAGE_ID = "image_name@sha256:digest654321abcdef".freeze
+        OTHER_REPOD = "OTHER_REPOD".freeze
+
+        before(:each) do
+          @job.options[:docker_image_id] = DOCKER_IMAGE_ID
+          @job.options[:image_full_name] = "docker-pullable://" + DOCKER_IMAGE_ID
+        end
+
+        it 'checks that the Id is in RepoDigests' do
+          msg = @job.verify_scanned_image_id(OpenStruct.new(:Id          => DOCKER_DAEMON_IMAGE_ID,
+                                                            :RepoDigests => [DOCKER_IMAGE_ID],
+                                                           ))
+          expect(msg).to eq nil
+        end
+
+        it 'checks all the RepoDigests' do
+          msg = @job.verify_scanned_image_id(OpenStruct.new(:Id          => DOCKER_DAEMON_IMAGE_ID,
+                                                            :RepoDigests => [OTHER_REPOD, DOCKER_IMAGE_ID],
+                                                           ))
+          expect(msg).to eq nil
+        end
+
+        it 'compares RepoDigests hash part only' do
+          # in case the image didn't have a defined registry
+          msg = @job.verify_scanned_image_id(OpenStruct.new(:Id          => DOCKER_DAEMON_IMAGE_ID,
+                                                            :RepoDigests => ["reponame/" + DOCKER_IMAGE_ID],
+                                                           ))
+          expect(msg).to eq nil
+        end
+
+        it 'reports all attempted IDs' do
+          # in case the image didn't have a defined registry
+          msg = @job.verify_scanned_image_id(OpenStruct.new(:Id          => DOCKER_DAEMON_IMAGE_ID,
+                                                            :RepoDigests => [OTHER_REPOD],
+                                                           ))
+          expect(msg).to eq "cannot analyze image docker-pullable://#{DOCKER_IMAGE_ID} with id #{DOCKER_IMAGE_ID[0..11]}:"\
+                            " detected ids were #{DOCKER_DAEMON_IMAGE_ID[0..11]}, #{OTHER_REPOD}"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes images in Openshift are defined without a registry in their name, this will cause a mismatch in with the repo digest even if the image is pulled from the same repository.

Notice that if an image was pulled from one registry with it's repo digest and but defined without the registry in its name and then Docker deafults to pull that image from a different registry with a different repo digeset we wouldn't be able to verify that image id.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1408255