### PR TITLE
Don't download preloaded relationships

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -27,7 +27,7 @@ class Relationship < ApplicationRecord
     of_type = Array.wrap(options[:of_type])
     except_type = Array.wrap(options[:except_type])
     return relationships if of_type.empty? && except_type.empty?
-    if relationships.kind_of?(Array)
+    if relationships.kind_of?(Array) || relationships.try(:loaded?)
       relationships.reject { |r| r.filtered?(of_type, except_type) }
     else
       relationships.filtered(of_type, except_type)

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -90,6 +90,17 @@ describe Relationship do
       expect(filtered_results).not_to be_kind_of(Array)
       expect(filtered_results).to match_array(vms + hosts)
     end
+
+    it "uses preloaded data" do
+      vms.map(&:save!)
+      hosts.map(&:save!)
+      storages.map(&:save!)
+      rels = Relationship.all.load
+      filtered_results = Relationship.filter_by_resource_type(rels,
+                                                              :of_type     => %w(Host VmOrTemplate),
+                                                              :except_type => %w(Storage))
+      expect(filtered_results).to be_kind_of(Array)
+    end
   end
 
   describe ".filtered" do


### PR DESCRIPTION
In #13253, when `all_relationships` is local, there is no need to go to the database for filtering - do it locally.
This is in the same vein. When a relationship is loaded, just use the local version.

I do not have performance numbers for this.

risks:
As seen in #13253, sometimes code is written assuming `relationships` is an `Array` or an `association` and that assumption causes problems.
Here, this is changing that very same behavior. But since `filtered` currently returns an `Array` or an `association`, it seems this type of bug would have already surfaced, so it would be unlikely that it exists elsewhere - for `relationships`.

/cc @NickLaMuro 