### PR TITLE
Validate users, dialogs, and miq_groups properly by region

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -12,7 +12,7 @@ class Dialog < ApplicationRecord
   virtual_has_one :content, :class_name => "Hash"
 
   before_destroy          :reject_if_has_resource_actions
-  validates :label, :uniqueness => {:conditions => -> { in_my_region } }
+  validates :label, :unique_within_region => true
 
   alias_attribute  :name, :label
 

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -19,7 +19,7 @@ class MiqGroup < ApplicationRecord
 
   delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
 
-  validates :description, :presence => true, :uniqueness => {:conditions => -> { in_my_region } }
+  validates :description, :presence => true, :unique_within_region => true
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid
-  validates :userid, :uniqueness => {:conditions => -> { in_my_region } }
+  validates :userid, :unique_within_region => {:match_case => false}
   validates :email, :format => {:with => MoreCoreExtensions::StringFormats::RE_EMAIL,
                                 :allow_nil => true, :message => "must be a valid email address"}
   validates_inclusion_of  :current_group, :in => proc { |u| u.miq_groups }, :allow_nil => true

--- a/lib/unique_within_region_validator.rb
+++ b/lib/unique_within_region_validator.rb
@@ -1,0 +1,15 @@
+class UniqueWithinRegionValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+    match_case = options.key?(:match_case) ? options[:match_case] : true
+    field_matches =
+      if match_case
+        record.class.where(attribute => value)
+      else
+        record.class.where("LOWER(#{attribute}) = ?", value.downcase)
+      end
+    unless field_matches.in_region(record.region_id).where.not(:id => record.id).empty?
+      record.errors.add(attribute, "is not unique within region #{record.region_id}")
+    end
+  end
+end

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -1,0 +1,73 @@
+describe UniqueWithinRegionValidator do
+  describe "#unique_within_region" do
+    let(:case_sensitive_class) do
+      Class.new(User).tap do |c|
+        c.class_eval do
+          validates :name, :unique_within_region => true
+        end
+      end
+    end
+
+    let(:case_insensitive_class) do
+      Class.new(User).tap do |c|
+        c.class_eval do
+          validates :name, :unique_within_region => {:match_case => false}
+        end
+      end
+    end
+
+    let(:test_name) { "thename" }
+
+    let(:in_first_region_id) do
+      FactoryGirl.create(
+        :user,
+        :id   => case_sensitive_class.id_in_region(1, 0),
+        :name => test_name
+      ).id
+    end
+
+    let(:also_in_first_region_id) do
+      FactoryGirl.create(
+        :user,
+        :id   => case_sensitive_class.id_in_region(2, 0),
+        :name => test_name.upcase
+      ).id
+    end
+
+    let(:in_second_region_id) do
+      FactoryGirl.create(
+        :user,
+        :id   => case_sensitive_class.id_in_region(2, 1),
+        :name => test_name
+      ).id
+    end
+
+    it "returns true if the field is unique for the records in the region" do
+      expect(case_sensitive_class.find(in_first_region_id).valid?).to be true
+      expect(case_sensitive_class.find(also_in_first_region_id).valid?).to be true
+      expect(case_sensitive_class.find(in_second_region_id).valid?).to be true
+    end
+
+    it "returns false if the field is not unique for the records in the region" do
+      in_first_region_rec      = case_sensitive_class.find(in_first_region_id)
+      also_in_first_region_rec = case_sensitive_class.find(also_in_first_region_id)
+      in_second_region_rec     = case_sensitive_class.find(in_second_region_id)
+
+      also_in_first_region_rec.name = in_first_region_rec.name
+
+      expect(in_first_region_rec.valid?).to be true
+      expect(also_in_first_region_rec.valid?).to be false
+      expect(in_second_region_rec.valid?).to be true
+    end
+
+    it "is case insensitive if match_case is set to false" do
+      in_first_region_rec      = case_insensitive_class.find(in_first_region_id)
+      also_in_first_region_rec = case_insensitive_class.find(also_in_first_region_id)
+      in_second_region_rec     = case_insensitive_class.find(in_second_region_id)
+
+      expect(in_first_region_rec.valid?).to be false
+      expect(also_in_first_region_rec.valid?).to be false
+      expect(in_second_region_rec.valid?).to be true
+    end
+  end
+end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -82,7 +82,7 @@ describe Dialog do
     it "with same label" do
       expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }.to_not raise_error
       expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }
-        .to raise_error(ActiveRecord::RecordInvalid, /Label has already been taken/)
+        .to raise_error(ActiveRecord::RecordInvalid, /Label is not unique within region/)
     end
 
     it "with different labels" do

--- a/spec/services/dialog_import_service_spec.rb
+++ b/spec/services/dialog_import_service_spec.rb
@@ -444,7 +444,7 @@ describe DialogImportService do
 
       expect do
         dialog_import_service.import(dialogs.first)
-      end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Label has already been taken')
+      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Label is not unique within region/)
     end
   end
 end


### PR DESCRIPTION
Previously we were trying to validate the uniqueness of fields by region using `in_my_region` with `conditions`, but this resulted in anything not in the current server's region being invalid.

This commit adds a custom validation to properly validate a given field's uniqueness scoped by the saved row's region.

Fixes #13274 

@kbrock @gtanzillo please review