### PR TITLE
Virtual aggregates split

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -110,15 +110,6 @@ class EmsCluster < ApplicationRecord
   alias_method :storages,               :all_storages
   alias_method :datastores,             :all_storages    # Used by web-services to return datastores as the property name
 
-  alias_method :all_hosts,              :hosts
-  alias_method :all_host_ids,           :host_ids
-  alias_method :all_vms_and_templates,  :vms_and_templates
-  alias_method :all_vm_or_template_ids, :vm_or_template_ids
-  alias_method :all_vms,                :vms
-  alias_method :all_vm_ids,             :vm_ids
-  alias_method :all_miq_templates,      :miq_templates
-  alias_method :all_miq_template_ids,   :miq_template_ids
-
   # Direct Vm relationship methods
   def direct_vm_rels
     # Look for only the Vms at the second depth (default RP + 1)

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -12,7 +12,6 @@ class EmsFolder < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include RelationshipsAggregationMixin
-  aggregation_mixin_virtual_columns_use :all_relationships
   include MiqPolicyMixin
 
   virtual_has_many :vms_and_templates, :uses => :all_relationships

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -11,7 +11,7 @@ class EmsFolder < ApplicationRecord
   include RelationshipMixin
   self.default_relationship_type = "ems_metadata"
 
-  include AggregationMixin
+  include RelationshipsAggregationMixin
   aggregation_mixin_virtual_columns_use :all_relationships
   include MiqPolicyMixin
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -428,15 +428,6 @@ class ExtManagementSystem < ApplicationRecord
   alias_method :all_storages,           :storages
   alias_method :datastores,             :storages # Used by web-services to return datastores as the property name
 
-  alias_method :all_hosts,              :hosts
-  alias_method :all_host_ids,           :host_ids
-  alias_method :all_vms_and_templates,  :vms_and_templates
-  alias_method :all_vm_or_template_ids, :vm_or_template_ids
-  alias_method :all_vms,                :vms
-  alias_method :all_vm_ids,             :vm_ids
-  alias_method :all_miq_templates,      :miq_templates
-  alias_method :all_miq_template_ids,   :miq_template_ids
-
   #
   # Relationship methods
   #

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -73,14 +73,6 @@ class MiqEnterprise < ApplicationRecord
     PolicyEvent.all
   end
 
-  alias_method :all_vms_and_templates,  :vms_and_templates
-  alias_method :all_vm_or_template_ids, :vm_or_template_ids
-  alias_method :all_vms,                :vms
-  alias_method :all_vm_ids,             :vm_ids
-  alias_method :all_miq_templates,      :miq_templates
-  alias_method :all_miq_template_ids,   :miq_template_ids
-  alias_method :all_hosts,              :hosts
-  alias_method :all_host_ids,           :host_ids
   alias_method :all_storages,           :storages
 
   def get_reserve(field)

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -29,14 +29,6 @@ class MiqRegion < ApplicationRecord
   include MiqPolicyMixin
   include Metric::CiMixin
 
-  alias_method :all_vms_and_templates,  :vms_and_templates
-  alias_method :all_vm_or_template_ids, :vm_or_template_ids
-  alias_method :all_vms,                :vms
-  alias_method :all_vm_ids,             :vm_ids
-  alias_method :all_miq_templates,      :miq_templates
-  alias_method :all_miq_template_ids,   :miq_template_ids
-  alias_method :all_hosts,              :hosts
-  alias_method :all_host_ids,           :host_ids
   alias_method :all_storages,           :storages
 
   PERF_ROLLUP_CHILDREN = [:ext_management_systems, :storages]

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -8,18 +8,6 @@ module AggregationMixin
     virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :vms_and_templates
     virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :vms_and_templates
     virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :hosts
-
-    def self.aggregation_mixin_virtual_columns_use(hosts, vms = nil)
-      vms ||= hosts
-      define_virtual_include "aggregate_cpu_speed",       hosts
-      define_virtual_include "aggregate_cpu_total_cores", hosts
-      define_virtual_include "aggregate_physical_cpus",   hosts
-      define_virtual_include "aggregate_memory",          hosts
-      define_virtual_include "aggregate_disk_capacity",   hosts
-
-      define_virtual_include "aggregate_vm_cpus",   vms
-      define_virtual_include "aggregate_vm_memory", vms
-    end
   end
 
   def aggregate_cpu_speed(targets = nil)

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -8,6 +8,15 @@ module AggregationMixin
     virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :vms_and_templates
     virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :vms_and_templates
     virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :hosts
+
+    alias_method :all_hosts,              :hosts
+    alias_method :all_host_ids,           :host_ids
+    alias_method :all_vms_and_templates,  :vms_and_templates
+    alias_method :all_vm_or_template_ids, :vm_or_template_ids
+    alias_method :all_vms,                :vms
+    alias_method :all_vm_ids,             :vm_ids
+    alias_method :all_miq_templates,      :miq_templates
+    alias_method :all_miq_template_ids,   :miq_template_ids
   end
 
   def aggregate_cpu_speed(targets = nil)

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -40,38 +40,6 @@ module AggregationMixin
 
   # Default implementations which can be overridden with something more optimized
 
-  def all_vms_and_templates
-    descendants(:of_type => 'VmOrTemplate')
-  end
-
-  def all_vms
-    all_vms_and_templates.select { |v| v.kind_of?(Vm) }
-  end
-
-  def all_miq_templates
-    all_vms_and_templates.select { |v| v.kind_of?(MiqTemplate) }
-  end
-
-  def all_vm_or_template_ids
-    Relationship.resource_pairs_to_ids(descendant_ids(:of_type => 'VmOrTemplate'))
-  end
-
-  def all_vm_ids
-    all_vms.collect(&:id)
-  end
-
-  def all_miq_template_ids
-    all_miq_templates.collect(&:id)
-  end
-
-  def all_hosts
-    descendants(:of_type => 'Host')
-  end
-
-  def all_host_ids
-    Relationship.resource_pairs_to_ids(descendant_ids(:of_type => 'Host'))
-  end
-
   def all_storages
     hosts = all_hosts
     MiqPreloader.preload(hosts, :storages)

--- a/app/models/mixins/relationships_aggregation_mixin.rb
+++ b/app/models/mixins/relationships_aggregation_mixin.rb
@@ -1,25 +1,13 @@
 module RelationshipsAggregationMixin
   extend ActiveSupport::Concern
   included do
-    virtual_column :aggregate_cpu_speed,       :type => :integer, :uses => :hosts
-    virtual_column :aggregate_cpu_total_cores, :type => :integer, :uses => :hosts
-    virtual_column :aggregate_physical_cpus,   :type => :integer, :uses => :hosts
-    virtual_column :aggregate_memory,          :type => :integer, :uses => :hosts
-    virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :vms_and_templates
-    virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :vms_and_templates
-    virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :hosts
-
-    def self.aggregation_mixin_virtual_columns_use(hosts, vms = nil)
-      vms ||= hosts
-      define_virtual_include "aggregate_cpu_speed",       hosts
-      define_virtual_include "aggregate_cpu_total_cores", hosts
-      define_virtual_include "aggregate_physical_cpus",   hosts
-      define_virtual_include "aggregate_memory",          hosts
-      define_virtual_include "aggregate_disk_capacity",   hosts
-
-      define_virtual_include "aggregate_vm_cpus",   vms
-      define_virtual_include "aggregate_vm_memory", vms
-    end
+    virtual_column :aggregate_cpu_speed,       :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_cpu_total_cores, :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_physical_cpus,   :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_memory,          :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :all_relationships
+    virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :all_relationships
   end
 
   def aggregate_cpu_speed(targets = nil)

--- a/app/models/mixins/relationships_aggregation_mixin.rb
+++ b/app/models/mixins/relationships_aggregation_mixin.rb
@@ -1,0 +1,102 @@
+module RelationshipsAggregationMixin
+  extend ActiveSupport::Concern
+  included do
+    virtual_column :aggregate_cpu_speed,       :type => :integer, :uses => :hosts
+    virtual_column :aggregate_cpu_total_cores, :type => :integer, :uses => :hosts
+    virtual_column :aggregate_physical_cpus,   :type => :integer, :uses => :hosts
+    virtual_column :aggregate_memory,          :type => :integer, :uses => :hosts
+    virtual_column :aggregate_vm_cpus,         :type => :integer, :uses => :vms_and_templates
+    virtual_column :aggregate_vm_memory,       :type => :integer, :uses => :vms_and_templates
+    virtual_column :aggregate_disk_capacity,   :type => :integer, :uses => :hosts
+
+    def self.aggregation_mixin_virtual_columns_use(hosts, vms = nil)
+      vms ||= hosts
+      define_virtual_include "aggregate_cpu_speed",       hosts
+      define_virtual_include "aggregate_cpu_total_cores", hosts
+      define_virtual_include "aggregate_physical_cpus",   hosts
+      define_virtual_include "aggregate_memory",          hosts
+      define_virtual_include "aggregate_disk_capacity",   hosts
+
+      define_virtual_include "aggregate_vm_cpus",   vms
+      define_virtual_include "aggregate_vm_memory", vms
+    end
+  end
+
+  def aggregate_cpu_speed(targets = nil)
+    aggregate_hardware(:hosts, :aggregate_cpu_speed, targets)
+  end
+
+  def aggregate_cpu_total_cores(targets = nil)
+    aggregate_hardware(:hosts, :cpu_total_cores, targets)
+  end
+
+  def aggregate_physical_cpus(targets = nil)
+    aggregate_hardware(:hosts, :cpu_sockets, targets)
+  end
+
+  def aggregate_memory(targets = nil)
+    aggregate_hardware(:hosts, :memory_mb, targets)
+  end
+
+  def aggregate_vm_cpus(targets = nil)
+    aggregate_hardware(:vms_and_templates, :cpu_sockets, targets)
+  end
+
+  def aggregate_vm_memory(targets = nil)
+    aggregate_hardware(:vms_and_templates, :memory_mb, targets)
+  end
+
+  def aggregate_disk_capacity(targets = nil)
+    aggregate_hardware(:hosts, :disk_capacity, targets)
+  end
+
+  # Default implementations which can be overridden with something more optimized
+
+  def all_vms_and_templates
+    descendants(:of_type => 'VmOrTemplate')
+  end
+
+  def all_vms
+    all_vms_and_templates.select { |v| v.kind_of?(Vm) }
+  end
+
+  def all_miq_templates
+    all_vms_and_templates.select { |v| v.kind_of?(MiqTemplate) }
+  end
+
+  def all_vm_or_template_ids
+    Relationship.resource_pairs_to_ids(descendant_ids(:of_type => 'VmOrTemplate'))
+  end
+
+  def all_vm_ids
+    all_vms.collect(&:id)
+  end
+
+  def all_miq_template_ids
+    all_miq_templates.collect(&:id)
+  end
+
+  def all_hosts
+    descendants(:of_type => 'Host')
+  end
+
+  def all_host_ids
+    Relationship.resource_pairs_to_ids(descendant_ids(:of_type => 'Host'))
+  end
+
+  def all_storages
+    hosts = all_hosts
+    MiqPreloader.preload(hosts, :storages)
+    hosts.collect(&:storages).flatten.compact.uniq
+  end
+
+  def aggregate_hardware(from, field, targets = nil)
+    from      = from.to_s.singularize
+    select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
+    targets ||= send("all_#{from}_ids")
+    targets   = targets.collect(&:id) unless targets.first.kind_of?(Integer)
+    hdws      = Hardware.where("#{from}_id" => targets).select(select)
+
+    hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
+  end
+end

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -14,8 +14,6 @@ class ResourcePool < ApplicationRecord
   self.default_relationship_type = "ems_metadata"
 
   include RelationshipsAggregationMixin
-  aggregation_mixin_virtual_columns_use :all_relationships
-
   include MiqPolicyMixin
   include AsyncDeleteMixin
 

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -13,7 +13,7 @@ class ResourcePool < ApplicationRecord
   include RelationshipMixin
   self.default_relationship_type = "ems_metadata"
 
-  include AggregationMixin
+  include RelationshipsAggregationMixin
   aggregation_mixin_virtual_columns_use :all_relationships
 
   include MiqPolicyMixin

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -174,17 +174,6 @@ class Zone < ApplicationRecord
     storage_without_hosts + storage_without_ems
   end
 
-  # Used by AggregationMixin
-  alias_method :all_storages,           :storages
-  alias_method :all_hosts,              :hosts
-  alias_method :all_host_ids,           :host_ids
-  alias_method :all_vms_and_templates,  :vms_and_templates
-  alias_method :all_vm_or_template_ids, :vm_or_template_ids
-  alias_method :all_vms,                :vms
-  alias_method :all_vm_ids,             :vm_ids
-  alias_method :all_miq_templates,      :miq_templates
-  alias_method :all_miq_template_ids,   :miq_template_ids
-
   def display_name
     name
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -79,10 +79,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "972a9b434a5ec51ff10c13cd39b2b04d3bc977ee17c599a9206fb83ebe826d4b",
+      "message": "Possible SQL injection",
+      "file": "app/models/mixins/relationships_aggregation_mixin.rb",
+      "line": 86,
+      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Hardware.where(\"#{from.to_s.singularize}_id\" => send(\"all_#{from.to_s.singularize}_ids\").collect(&:id))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RelationshipsAggregationMixin",
+        "method": "aggregate_hardware"
+      },
+      "user_input": "from.to_s.singularize",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "b7c5d0a1acf9b6e1d8241cc62f61ddde1dd9f6e1b871b9bd99982135465d1f24",
       "message": "Possible SQL injection",
       "file": "app/models/mixins/aggregation_mixin.rb",
-      "line": 98,
+      "line": 63,
       "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Hardware.where(\"#{from.to_s.singularize}_id\" => send(\"all_#{from.to_s.singularize}_ids\").collect(&:id))",
       "render_path": null,
@@ -96,6 +115,6 @@
       "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
-  "updated": "2016-10-11 14:14:13 +0200",
-  "brakeman_version": "3.4.0"
+  "updated": "2016-12-20 15:25:32 -0500",
+  "brakeman_version": "3.4.1"
 }

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -47,24 +47,45 @@ describe ResourcePool do
       expect(@rp1.v_direct_vms).to eq(5)
       expect(@rp1.v_total_vms).to eq(15)
       expect(@rp1.total_vms).to eq(15)
+      expect(@rp1.vms.size).to eq(5)
+      expect(@rp1.vms_and_templates.size).to eq(5)
+      expect(@rp1.miq_templates.size).to eq(0)
 
       expect(@rp2.v_direct_vms).to eq(10)
       expect(@rp2.v_total_vms).to eq(10)
+      expect(@rp2.vms.size).to eq(10)
+      expect(@rp2.vms_and_templates.size).to eq(10)
+      expect(@rp2.miq_templates.size).to eq(0)
 
       expect(@rp3.v_direct_vms).to eq(15)
       expect(@rp3.v_total_vms).to eq(15)
+      expect(@rp3.vms.size).to eq(15)
+      expect(@rp3.vms_and_templates.size).to eq(15)
+      expect(@rp3.miq_templates.size).to eq(0)
 
       expect(@rp4.v_direct_vms).to eq(1)
       expect(@rp4.v_total_vms).to eq(3)
+      expect(@rp4.vms.size).to eq(1)
+      expect(@rp4.vms_and_templates.size).to eq(1)
+      expect(@rp4.miq_templates.size).to eq(0)
 
       expect(@rp5.v_direct_vms).to eq(0)
       expect(@rp5.v_total_vms).to eq(2)
+      expect(@rp5.vms.size).to eq(0)
+      expect(@rp5.vms_and_templates.size).to eq(0)
+      expect(@rp5.miq_templates.size).to eq(0)
 
       expect(@rp6.v_direct_vms).to eq(2)
       expect(@rp6.v_total_vms).to eq(2)
+      expect(@rp6.vms.size).to eq(2)
+      expect(@rp6.vms_and_templates.size).to eq(2)
+      expect(@rp6.miq_templates.size).to eq(0)
 
       expect(@rp7.v_direct_vms).to eq(0)
       expect(@rp7.v_total_vms).to eq(0)
+      expect(@rp7.vms.size).to eq(0)
+      expect(@rp7.vms_and_templates.size).to eq(0)
+      expect(@rp7.miq_templates.size).to eq(0)
     end
   end
 


### PR DESCRIPTION
Split out of #12427 

We have 2 types of virtual aggregates:
- One set based upon `all_associations.
- One set based upon good old fashioned `vms` and `hosts`. **<== the most interesting one.**

This splits the mixin into 2.

For the traditional associations, the next step is to condense `aggregate_hardware`, use `virtual_aggregate`, and potentially remove all/most of `AggregationMixin`.