### PR TITLE
Environment setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be requi
 gem "ancestry",                       "~>2.2.1",       :require => false
 gem "ansible_tower_client",           "~>0.4.1",       :require => false
 gem "aws-sdk",                        "~>2",           :require => false
+gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -34,6 +34,14 @@ module Environment
     system!('gem install bundler --conservative')
   end
 
+  def self.bundle_install
+    system('bundle check') || system!('bundle install')
+  end
+
+  def self.bundle_update
+    system!('bundle update')
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -42,6 +42,21 @@ module Environment
     system!('bundle update')
   end
 
+  def self.create_database
+    puts "\n== Updating database =="
+    system!("#{APP_ROOT.join("bin/rails")} db:create")
+  end
+
+  def self.migrate_database
+    puts "\n== Updating database =="
+    system!("#{APP_ROOT.join("bin/rails")} db:migrate")
+  end
+
+  def self.seed_database
+    puts "\n== Seeding database =="
+    system!("#{APP_ROOT.join("bin/rails")} db:seed GOOD_MIGRATIONS=skip")
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -18,4 +18,23 @@ module Environment
       FileUtils.cp(APP_ROOT.join(source), file)
     end
   end
+
+  def self.while_updating_bower
+    # Run bower in a thread and continue to do the non-js stuff
+    puts "Updating bower assets in parallel..."
+    bower_thread = Thread.new { update_bower }
+
+    yield
+
+    bower_thread.join
+    puts "Updating bower assets complete."
+  end
+
+  def self.update_bower
+    system!("bower update --allow-root -F --silent --config.analytics=false")
+  end
+
+  def self.system!(*args)
+    system(*args) || abort("\n== Command #{args} failed ==")
+  end
 end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -30,6 +30,10 @@ module Environment
     puts "Updating bower assets complete."
   end
 
+  def self.install_bundler
+    system!('gem install bundler --conservative')
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -72,6 +72,11 @@ module Environment
     system!("#{APP_ROOT.join("bin/rails")} evm:compile_assets")
   end
 
+  def self.clear_logs_and_temp
+    puts "\n== Removing old logs and tempfiles =="
+    system!("#{APP_ROOT.join("bin/rails")} log:clear tmp:clear")
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -57,6 +57,11 @@ module Environment
     system!("#{APP_ROOT.join("bin/rails")} db:seed GOOD_MIGRATIONS=skip")
   end
 
+  def self.setup_test_environment
+    puts "\n== Resetting tests =="
+    system!("#{APP_ROOT.join("bin/rails")} test:vmdb:setup")
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -1,0 +1,21 @@
+require 'fileutils'
+require 'pathname'
+
+module Environment
+  APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
+
+  def self.ensure_config_files
+    config_files = {
+      "certs/v2_key.dev"        => "certs/v2_key",
+      "config/cable.yml.sample" => "config/cable.yml",
+      "config/database.pg.yml"  => "config/database.yml",
+    }
+
+    config_files.each do |source, dest|
+      file = APP_ROOT.join(dest)
+      next if file.exist?
+      puts "Copying #{file} from template..."
+      FileUtils.cp(APP_ROOT.join(source), file)
+    end
+  end
+end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -62,6 +62,11 @@ module Environment
     system!("#{APP_ROOT.join("bin/rails")} test:vmdb:setup")
   end
 
+  def self.reset_automate_domain
+    puts "\n== Resetting Automate Domains =="
+    system!("#{APP_ROOT.join("bin/rails")} evm:automate:reset")
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/environment.rb
+++ b/bin/environment.rb
@@ -67,6 +67,11 @@ module Environment
     system!("#{APP_ROOT.join("bin/rails")} evm:automate:reset")
   end
 
+  def self.compile_assets
+    puts "\n== Recompiling assets =="
+    system!("#{APP_ROOT.join("bin/rails")} evm:compile_assets")
+  end
+
   def self.update_bower
     system!("bower update --allow-root -F --silent --config.analytics=false")
   end

--- a/bin/setup
+++ b/bin/setup
@@ -21,26 +21,26 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir Environment::APP_ROOT do
+chdir ManageIQ::Environment::APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
-  Environment.ensure_config_files
+  ManageIQ::Environment.ensure_config_files
 
   puts '== Installing dependencies =='
-  Environment.while_updating_bower do
-    Environment.install_bundler
-    Environment.bundle_install
+  ManageIQ::Environment.while_updating_bower do
+    ManageIQ::Environment.install_bundler
+    ManageIQ::Environment.bundle_install
 
     if options[:do_db]
       # Note, we deviate from the default rails db:setup here because
       # it invokes the db:setup rake task which creates the db from the
       # schema (and seeds it), but doesn't run through migrations.
-      Environment.create_database
-      Environment.migrate_database
-      Environment.seed_database
+      ManageIQ::Environment.create_database
+      ManageIQ::Environment.migrate_database
+      ManageIQ::Environment.seed_database
     end
 
-    Environment.setup_test_environment if options[:do_tests]
+    ManageIQ::Environment.setup_test_environment if options[:do_tests]
   end
-  Environment.clear_logs_and_temp
+  ManageIQ::Environment.clear_logs_and_temp
 end

--- a/bin/setup
+++ b/bin/setup
@@ -40,10 +40,7 @@ chdir Environment::APP_ROOT do
       Environment.seed_database
     end
 
-    if options[:do_tests]
-      puts "\n== Preparing tests =="
-      system! "bin/rails test:vmdb:setup"
-    end
+    Environment.setup_test_environment if options[:do_tests]
   end
 
   puts "\n== Removing old logs and tempfiles =="

--- a/bin/setup
+++ b/bin/setup
@@ -20,14 +20,11 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-# path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
-
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+chdir Environment::APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
   Environment.ensure_config_files

--- a/bin/setup
+++ b/bin/setup
@@ -17,10 +17,6 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
-end
-
 chdir ManageIQ::Environment::APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.

--- a/bin/setup
+++ b/bin/setup
@@ -42,7 +42,5 @@ chdir Environment::APP_ROOT do
 
     Environment.setup_test_environment if options[:do_tests]
   end
-
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  Environment.clear_logs_and_temp
 end

--- a/bin/setup
+++ b/bin/setup
@@ -1,9 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'environment'
-require 'pathname'
 require 'optparse'
-require 'fileutils'
-include FileUtils
 
 options = {:do_tests => true, :do_db => true}
 OptionParser.new do |opts|

--- a/bin/setup
+++ b/bin/setup
@@ -29,7 +29,7 @@ chdir Environment::APP_ROOT do
   puts '== Installing dependencies =='
   Environment.while_updating_bower do
     Environment.install_bundler
-    system('bundle check') || system!('bundle install')
+    Environment.bundle_install
 
     if options[:do_db]
       # Note, we deviate from the default rails db:setup here because

--- a/bin/setup
+++ b/bin/setup
@@ -28,7 +28,7 @@ chdir Environment::APP_ROOT do
 
   puts '== Installing dependencies =='
   Environment.while_updating_bower do
-    system! 'gem install bundler --conservative'
+    Environment.install_bundler
     system('bundle check') || system!('bundle install')
 
     if options[:do_db]

--- a/bin/setup
+++ b/bin/setup
@@ -35,14 +35,9 @@ chdir Environment::APP_ROOT do
       # Note, we deviate from the default rails db:setup here because
       # it invokes the db:setup rake task which creates the db from the
       # schema (and seeds it), but doesn't run through migrations.
-      puts "\n== Preparing database =="
-      system! "bin/rails db:create"
-
-      puts "\n== Migrating database =="
-      system! "bin/rails db:migrate"
-
-      puts "\n== Seeding database =="
-      system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
+      Environment.create_database
+      Environment.migrate_database
+      Environment.seed_database
     end
 
     if options[:do_tests]

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require_relative 'environment'
 require 'pathname'
 require 'optparse'
 require 'fileutils'
@@ -29,6 +30,7 @@ end
 chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
+  Environment.ensure_config_files
 
   puts '== Installing dependencies =='
   # Run bower in a thread and continue to do the non-js stuff
@@ -38,17 +40,6 @@ chdir APP_ROOT do
   end
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
-
-  puts "\n== Copying sample files =="
-  unless File.exist?("config/database.yml")
-    system! "cp config/database.pg.yml config/database.yml"
-  end
-  unless File.exist?("config/cable.yml")
-    system! "cp config/cable.yml.sample config/cable.yml"
-  end
-  unless File.exist?("certs/v2_key")
-    system! "cp certs/v2_key.dev certs/v2_key"
-  end
 
   if options[:do_db]
     # Note, we deviate from the default rails db:setup here because

--- a/bin/setup
+++ b/bin/setup
@@ -27,35 +27,29 @@ chdir Environment::APP_ROOT do
   Environment.ensure_config_files
 
   puts '== Installing dependencies =='
-  # Run bower in a thread and continue to do the non-js stuff
-  puts "Updating bower assets in parallel..."
-  bower_thread = Thread.new do
-    system! "bower install --allow-root -F --silent --config.analytics=false"
+  Environment.while_updating_bower do
+    system! 'gem install bundler --conservative'
+    system('bundle check') || system!('bundle install')
+
+    if options[:do_db]
+      # Note, we deviate from the default rails db:setup here because
+      # it invokes the db:setup rake task which creates the db from the
+      # schema (and seeds it), but doesn't run through migrations.
+      puts "\n== Preparing database =="
+      system! "bin/rails db:create"
+
+      puts "\n== Migrating database =="
+      system! "bin/rails db:migrate"
+
+      puts "\n== Seeding database =="
+      system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
+    end
+
+    if options[:do_tests]
+      puts "\n== Preparing tests =="
+      system! "bin/rails test:vmdb:setup"
+    end
   end
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
-
-  if options[:do_db]
-    # Note, we deviate from the default rails db:setup here because
-    # it invokes the db:setup rake task which creates the db from the
-    # schema (and seeds it), but doesn't run through migrations.
-    puts "\n== Preparing database =="
-    system! "bin/rails db:create"
-
-    puts "\n== Migrating database =="
-    system! "bin/rails db:migrate"
-
-    puts "\n== Seeding database =="
-    system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
-  end
-
-  if options[:do_tests]
-    puts "\n== Preparing tests =="
-    system! "bin/rails test:vmdb:setup"
-  end
-
-  bower_thread.join
-  puts "Done running `bower update`."
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative 'environment'
+require_relative '../lib/manageiq/environment'
 require 'optparse'
 
 options = {:do_tests => true, :do_db => true}

--- a/bin/update
+++ b/bin/update
@@ -23,11 +23,7 @@ chdir Environment::APP_ROOT do
     Environment.migrate_database
     Environment.seed_database
 
-    unless ENV["SKIP_TEST_RESET"]
-      puts "\n== Resetting tests =="
-      system! "bin/rails test:vmdb:setup"
-    end
-
+    Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
     unless ENV["SKIP_AUTOMATE_RESET"]
       puts "\n== Resetting Automate Domains =="
       system! "bin/rails evm:automate:reset"

--- a/bin/update
+++ b/bin/update
@@ -1,8 +1,5 @@
 #!/usr/bin/env ruby
 require_relative 'environment'
-require 'pathname'
-require 'fileutils'
-include FileUtils
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/update
+++ b/bin/update
@@ -4,14 +4,11 @@ require 'pathname'
 require 'fileutils'
 include FileUtils
 
-# path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
-
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+chdir Environment::APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
   Environment.ensure_config_files

--- a/bin/update
+++ b/bin/update
@@ -11,39 +11,33 @@ chdir Environment::APP_ROOT do
   Environment.ensure_config_files
 
   puts '== Installing dependencies =='
-  # Run bower in a thread and continue to do the non-js stuff
-  puts "Updating bower assets in parallel..."
-  bower_thread = Thread.new do
-    system! "bower update --allow-root -F --silent --config.analytics=false"
-  end
-  system! 'gem install bundler --conservative'
+  Environment.while_updating_bower do
+    system! 'gem install bundler --conservative'
 
-  # TODO: This unlocks your dependencies and installs all updates.
-  # From: https://github.com/ManageIQ/manageiq/pull/11137
-  # It should be system('bundle check') || system!('bundle install').
-  # If we need a "reset all the things" script, we should call it bin/reset.
-  system! 'bundle update'
+    # TODO: This unlocks your dependencies and installs all updates.
+    # From: https://github.com/ManageIQ/manageiq/pull/11137
+    # It should be system('bundle check') || system!('bundle install').
+    # If we need a "reset all the things" script, we should call it bin/reset.
+    system! 'bundle update'
 
-  puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+    puts "\n== Updating database =="
+    system! 'bin/rails db:migrate'
 
-  puts "\n== Seeding database =="
-  system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
+    puts "\n== Seeding database =="
+    system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
 
-  unless ENV["SKIP_TEST_RESET"]
-    puts "\n== Resetting tests =="
-    system! "bin/rails test:vmdb:setup"
-  end
+    unless ENV["SKIP_TEST_RESET"]
+      puts "\n== Resetting tests =="
+      system! "bin/rails test:vmdb:setup"
+    end
 
-  unless ENV["SKIP_AUTOMATE_RESET"]
-    puts "\n== Resetting Automate Domains =="
-    system! "bin/rails evm:automate:reset"
+    unless ENV["SKIP_AUTOMATE_RESET"]
+      puts "\n== Resetting Automate Domains =="
+      system! "bin/rails evm:automate:reset"
+    end
   end
 
   # Make sure bower is done before compiling assets
-  bower_thread.join
-  puts "Done running `bower update`."
-
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="
     system! "bin/rails evm:compile_assets"

--- a/bin/update
+++ b/bin/update
@@ -20,11 +20,8 @@ chdir Environment::APP_ROOT do
     # If we need a "reset all the things" script, we should call it bin/reset.
     Environment.bundle_update
 
-    puts "\n== Updating database =="
-    system! 'bin/rails db:migrate'
-
-    puts "\n== Seeding database =="
-    system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
+    Environment.migrate_database
+    Environment.seed_database
 
     unless ENV["SKIP_TEST_RESET"]
       puts "\n== Resetting tests =="

--- a/bin/update
+++ b/bin/update
@@ -1,10 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../lib/manageiq/environment'
 
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
-end
-
 chdir ManageIQ::Environment::APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
@@ -16,7 +12,7 @@ chdir ManageIQ::Environment::APP_ROOT do
 
     # TODO: This unlocks your dependencies and installs all updates.
     # From: https://github.com/ManageIQ/manageiq/pull/11137
-    # It should be system('bundle check') || system!('bundle install').
+    # It should be 'bundle check' || 'bundle install'.
     # If we need a "reset all the things" script, we should call it bin/reset.
     ManageIQ::Environment.bundle_update
 

--- a/bin/update
+++ b/bin/update
@@ -18,7 +18,7 @@ chdir Environment::APP_ROOT do
     # From: https://github.com/ManageIQ/manageiq/pull/11137
     # It should be system('bundle check') || system!('bundle install').
     # If we need a "reset all the things" script, we should call it bin/reset.
-    system! 'bundle update'
+    Environment.bundle_update
 
     puts "\n== Updating database =="
     system! 'bin/rails db:migrate'

--- a/bin/update
+++ b/bin/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative 'environment'
+require_relative '../lib/manageiq/environment'
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/update
+++ b/bin/update
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require_relative 'environment'
 require 'pathname'
 require 'fileutils'
 include FileUtils
@@ -10,18 +11,10 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-def dev_warn_and_exit_if_missing(file, sample)
-  if ENV.fetch('RAILS_ENV', 'development') == 'development' && !File.exist?(file)
-    warn "Your #{file} is missing, please run 'cp #{sample} #{file}' and try again."
-    exit 1
-  end
-end
-
 chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
-  dev_warn_and_exit_if_missing('config/cable.yml', 'config/cable.yml.sample')
-  dev_warn_and_exit_if_missing('config/database.yml', 'config/database.pg.yml')
+  Environment.ensure_config_files
 
   puts '== Installing dependencies =='
   # Run bower in a thread and continue to do the non-js stuff

--- a/bin/update
+++ b/bin/update
@@ -28,6 +28,6 @@ chdir Environment::APP_ROOT do
   end
 
   # Make sure bower is done before compiling assets
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
+  Environment.clear_logs_and_temp
 end

--- a/bin/update
+++ b/bin/update
@@ -28,11 +28,6 @@ chdir Environment::APP_ROOT do
   end
 
   # Make sure bower is done before compiling assets
-  if ENV['RAILS_ENV'] == 'production'
-    puts "\n== Recompiling assets =="
-    system! "bin/rails evm:compile_assets"
-  end
-
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 end

--- a/bin/update
+++ b/bin/update
@@ -12,7 +12,7 @@ chdir Environment::APP_ROOT do
 
   puts '== Installing dependencies =='
   Environment.while_updating_bower do
-    system! 'gem install bundler --conservative'
+    Environment.install_bundler
 
     # TODO: This unlocks your dependencies and installs all updates.
     # From: https://github.com/ManageIQ/manageiq/pull/11137

--- a/bin/update
+++ b/bin/update
@@ -5,29 +5,29 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir Environment::APP_ROOT do
+chdir ManageIQ::Environment::APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
-  Environment.ensure_config_files
+  ManageIQ::Environment.ensure_config_files
 
   puts '== Installing dependencies =='
-  Environment.while_updating_bower do
-    Environment.install_bundler
+  ManageIQ::Environment.while_updating_bower do
+    ManageIQ::Environment.install_bundler
 
     # TODO: This unlocks your dependencies and installs all updates.
     # From: https://github.com/ManageIQ/manageiq/pull/11137
     # It should be system('bundle check') || system!('bundle install').
     # If we need a "reset all the things" script, we should call it bin/reset.
-    Environment.bundle_update
+    ManageIQ::Environment.bundle_update
 
-    Environment.migrate_database
-    Environment.seed_database
+    ManageIQ::Environment.migrate_database
+    ManageIQ::Environment.seed_database
 
-    Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
-    Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
+    ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+    ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
   end
 
   # Make sure bower is done before compiling assets
-  Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
-  Environment.clear_logs_and_temp
+  ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
+  ManageIQ::Environment.clear_logs_and_temp
 end

--- a/bin/update
+++ b/bin/update
@@ -24,10 +24,7 @@ chdir Environment::APP_ROOT do
     Environment.seed_database
 
     Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
-    unless ENV["SKIP_AUTOMATE_RESET"]
-      puts "\n== Resetting Automate Domains =="
-      system! "bin/rails evm:automate:reset"
-    end
+    Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
   end
 
   # Make sure bower is done before compiling assets

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -32,7 +32,8 @@ module ManageIQ
     end
 
     def self.install_bundler
-      system!('gem install bundler --conservative')
+      system!("echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc") if ENV['CI']
+      system!("gem install bundler -v '#{bundler_version}' --conservative")
     end
 
     def self.bundle_install

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -24,6 +24,7 @@ module ManageIQ
       # Run bower in a thread and continue to do the non-js stuff
       puts "Updating bower assets in parallel..."
       bower_thread = Thread.new { update_bower }
+      bower_thread.abort_on_exception = true
 
       yield
 

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -79,6 +79,14 @@ module ManageIQ
       system!("#{APP_ROOT.join("bin/rails")} log:clear tmp:clear")
     end
 
+    def self.write_region_file(region_number = 1)
+      File.write(APP_ROOT.join("REGION"), region_number.to_s)
+    end
+
+    def self.create_database_user
+      system!(%q(psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres))
+    end
+
     def self.update_bower
       system!("bower update --allow-root -F --silent --config.analytics=false")
     end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -3,7 +3,7 @@ require 'pathname'
 
 module ManageIQ
   module Environment
-    APP_ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
+    APP_ROOT = Pathname.new(__dir__).join("../..")
 
     def self.ensure_config_files
       config_files = {

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -82,6 +82,11 @@ module ManageIQ
       system!("bower update --allow-root -F --silent --config.analytics=false")
     end
 
+    def self.bundler_version
+      gemfile = APP_ROOT.join("Gemfile")
+      File.read(gemfile).match(/gem\s+['"]bundler['"],\s+['"](.+?)['"]/)[1]
+    end
+
     def self.system!(*args)
       system(*args) || abort("\n== Command #{args} failed ==")
     end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -1,87 +1,89 @@
 require 'fileutils'
 require 'pathname'
 
-module Environment
-  APP_ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
+module ManageIQ
+  module Environment
+    APP_ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
 
-  def self.ensure_config_files
-    config_files = {
-      "certs/v2_key.dev"        => "certs/v2_key",
-      "config/cable.yml.sample" => "config/cable.yml",
-      "config/database.pg.yml"  => "config/database.yml",
-    }
+    def self.ensure_config_files
+      config_files = {
+        "certs/v2_key.dev"        => "certs/v2_key",
+        "config/cable.yml.sample" => "config/cable.yml",
+        "config/database.pg.yml"  => "config/database.yml",
+      }
 
-    config_files.each do |source, dest|
-      file = APP_ROOT.join(dest)
-      next if file.exist?
-      puts "Copying #{file} from template..."
-      FileUtils.cp(APP_ROOT.join(source), file)
+      config_files.each do |source, dest|
+        file = APP_ROOT.join(dest)
+        next if file.exist?
+        puts "Copying #{file} from template..."
+        FileUtils.cp(APP_ROOT.join(source), file)
+      end
     end
-  end
 
-  def self.while_updating_bower
-    # Run bower in a thread and continue to do the non-js stuff
-    puts "Updating bower assets in parallel..."
-    bower_thread = Thread.new { update_bower }
+    def self.while_updating_bower
+      # Run bower in a thread and continue to do the non-js stuff
+      puts "Updating bower assets in parallel..."
+      bower_thread = Thread.new { update_bower }
 
-    yield
+      yield
 
-    bower_thread.join
-    puts "Updating bower assets complete."
-  end
+      bower_thread.join
+      puts "Updating bower assets complete."
+    end
 
-  def self.install_bundler
-    system!('gem install bundler --conservative')
-  end
+    def self.install_bundler
+      system!('gem install bundler --conservative')
+    end
 
-  def self.bundle_install
-    system('bundle check') || system!('bundle install')
-  end
+    def self.bundle_install
+      system('bundle check') || system!('bundle install')
+    end
 
-  def self.bundle_update
-    system!('bundle update')
-  end
+    def self.bundle_update
+      system!('bundle update')
+    end
 
-  def self.create_database
-    puts "\n== Updating database =="
-    system!("#{APP_ROOT.join("bin/rails")} db:create")
-  end
+    def self.create_database
+      puts "\n== Updating database =="
+      system!("#{APP_ROOT.join("bin/rails")} db:create")
+    end
 
-  def self.migrate_database
-    puts "\n== Updating database =="
-    system!("#{APP_ROOT.join("bin/rails")} db:migrate")
-  end
+    def self.migrate_database
+      puts "\n== Updating database =="
+      system!("#{APP_ROOT.join("bin/rails")} db:migrate")
+    end
 
-  def self.seed_database
-    puts "\n== Seeding database =="
-    system!("#{APP_ROOT.join("bin/rails")} db:seed GOOD_MIGRATIONS=skip")
-  end
+    def self.seed_database
+      puts "\n== Seeding database =="
+      system!("#{APP_ROOT.join("bin/rails")} db:seed GOOD_MIGRATIONS=skip")
+    end
 
-  def self.setup_test_environment
-    puts "\n== Resetting tests =="
-    system!("#{APP_ROOT.join("bin/rails")} test:vmdb:setup")
-  end
+    def self.setup_test_environment
+      puts "\n== Resetting tests =="
+      system!("#{APP_ROOT.join("bin/rails")} test:vmdb:setup")
+    end
 
-  def self.reset_automate_domain
-    puts "\n== Resetting Automate Domains =="
-    system!("#{APP_ROOT.join("bin/rails")} evm:automate:reset")
-  end
+    def self.reset_automate_domain
+      puts "\n== Resetting Automate Domains =="
+      system!("#{APP_ROOT.join("bin/rails")} evm:automate:reset")
+    end
 
-  def self.compile_assets
-    puts "\n== Recompiling assets =="
-    system!("#{APP_ROOT.join("bin/rails")} evm:compile_assets")
-  end
+    def self.compile_assets
+      puts "\n== Recompiling assets =="
+      system!("#{APP_ROOT.join("bin/rails")} evm:compile_assets")
+    end
 
-  def self.clear_logs_and_temp
-    puts "\n== Removing old logs and tempfiles =="
-    system!("#{APP_ROOT.join("bin/rails")} log:clear tmp:clear")
-  end
+    def self.clear_logs_and_temp
+      puts "\n== Removing old logs and tempfiles =="
+      system!("#{APP_ROOT.join("bin/rails")} log:clear tmp:clear")
+    end
 
-  def self.update_bower
-    system!("bower update --allow-root -F --silent --config.analytics=false")
-  end
+    def self.update_bower
+      system!("bower update --allow-root -F --silent --config.analytics=false")
+    end
 
-  def self.system!(*args)
-    system(*args) || abort("\n== Command #{args} failed ==")
+    def self.system!(*args)
+      system(*args) || abort("\n== Command #{args} failed ==")
+    end
   end
 end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'pathname'
 
 module Environment
-  APP_ROOT = Pathname.new(File.expand_path('../../', __FILE__))
+  APP_ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
 
   def self.ensure_config_files
     config_files = {

--- a/tools/ci/setup_ruby_env.sh
+++ b/tools/ci/setup_ruby_env.sh
@@ -1,4 +1,3 @@
-echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
-travis_retry gem install bundler -v ">= 1.11.1"
+./tools/ci/setup_ruby_environment.rb
 export BUNDLE_WITHOUT=development
 export BUNDLE_GEMFILE=${PWD}/Gemfile

--- a/tools/ci/setup_ruby_environment.rb
+++ b/tools/ci/setup_ruby_environment.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+require_relative '../../lib/manageiq/environment'
+ManageIQ::Environment.install_bundler

--- a/tools/ci/setup_vmdb_configs.rb
+++ b/tools/ci/setup_vmdb_configs.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require_relative '../../lib/manageiq/environment'
+ManageIQ::Environment.write_region_file
+ManageIQ::Environment.ensure_config_files
+ManageIQ::Environment.create_database_user

--- a/tools/ci/setup_vmdb_configs.sh
+++ b/tools/ci/setup_vmdb_configs.sh
@@ -1,5 +1,1 @@
-echo "1" > REGION
-cp certs/v2_key.dev certs/v2_key
-cp config/database.pg.yml config/database.yml
-cp config/cable.yml.sample config/cable.yml
-psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
+./tools/ci/setup_vmdb_configs.rb


### PR DESCRIPTION
There is a lot of duplication of commands or procedures in
- bin/setup
- bin/update
- tools/ci/*

This is an effort to consolidate all of this into a single maintainable file.  This can be reused in Provider gems and plugins to simplify setup.  The intent is to move the code into a file that can be reused, not change any functionality.