### PR TITLE
Re-add logging the action, controller, format

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -35,7 +35,10 @@ module Api
         @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
         return unless api_log_info?
         log_request("Request", @req.to_hash)
-        log_request("Parameters", @parameter_filter.filter(request.query_parameters.merge("body" => @req.json_body)))
+        unfiltered_params = request.query_parameters
+                                   .merge(params.permit(:action, :controller, :format).to_h)
+                                   .merge("body" => @req.json_body)
+        log_request("Parameters", @parameter_filter.filter(unfiltered_params))
         log_request_body
       end
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -63,7 +63,10 @@ describe "Logging" do
 
       log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
         "Parameters" => a_hash_including(
-          "body" => a_hash_including(
+          "action"     => "update",
+          "format"     => "json",
+          "controller" => "api/services",
+          "body"       => a_hash_including(
             "resource" => a_hash_including(
               "options" => a_hash_including("password" => "[FILTERED]")
             )


### PR DESCRIPTION
In #13257 logging was changed in a way which omitted the action,
controller and format from being logged for the sake of restoring the
build to green.  This revision restores that behavior and adds testing
to ensure that this data gets logged.

@miq-bot assign @abellotti 
@miq-bot add-label api, bug