### PR TITLE
Fixed actions collection indentation

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -672,37 +672,37 @@
       - :name: create
         :identifier: picture_new
   :actions:
-      :description: Actions
-      :identifier: action
-      :options:
-      - :collection
-      :verbs: *gpd
-      :klass: MiqAction
-      :collection_actions:
-        :get:
-        - :name: read
-          :identifier: action_show_list
-        :post:
-        - :name: query
-          :identifier: action_show_list
-        - :name: create
-          :identifier: action_new
-        - :name: edit
-          :identifier: action_edit
-        - :name: delete
-          :identifier: action_delete
-      :resource_actions:
-        :get:
-        - :name: read
-          :identifier: action_show
-        :post:
-        - :name: edit
-          :identifier: action_edit
-        - :name: delete
-          :identifier: action_delete
-        :delete:
-        - :name: delete
-          :identifier: action_delete
+    :description: Actions
+    :identifier: action
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: MiqAction
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: action_show_list
+      :post:
+      - :name: query
+        :identifier: action_show_list
+      - :name: create
+        :identifier: action_new
+      - :name: edit
+        :identifier: action_edit
+      - :name: delete
+        :identifier: action_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: action_show
+      :post:
+      - :name: edit
+        :identifier: action_edit
+      - :name: delete
+        :identifier: action_delete
+      :delete:
+      - :name: delete
+        :identifier: action_delete
   :policies:
     :description: Policies
     :identifier: policy


### PR DESCRIPTION
Actions collection section in api.yml was indented one
extra level.

while yaml works fine with this, just fixing the alignment
to be consistent with all the other collections.
