### PR TITLE
allow virtual_attribute to have a sql alias

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -617,10 +617,11 @@ module ActiveRecord
       def select(*fields)
         return super if block_given? || fields.empty?
         # support virtual attributes by adding an alias to the sql phrase for the column
+        # it does not add an as() if the column already has an as
         # this code is based upon _select()
         fields.flatten!
         fields.map! do |field|
-          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
             arel.as(field.to_s)
           else
             field

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -663,6 +663,25 @@ describe VirtualFields do
         TestClass.create(:id => 2, :col1 => 20)
         expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
+
+      it "supports virtual attributes with as" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)).as("col2") })
+          def col2
+            if has_attribute?("col2")
+              col2
+            else
+              # typically we'd return col1
+              # but we're testing that virtual columns are working
+              # col1
+              raise "NOPE"
+            end
+          end
+        end
+
+        TestClass.create(:id => 2, :col1 => 20)
+        expect(TestClass.select(:col2).first[:col2]).to eq(20)
+      end
     end
 
     describe ".virtual_delegate" do


### PR DESCRIPTION
Typically, a `virtual_attribute` will not define a sql alias (`as`).
But it is needed for older versions of miq. So when code is introduced for
older versions of miq, they sometimes sneak in.

This allows both to work.

before
------

```
NoMethodError:
       undefined method 'as' for #<Arel::Nodes::As:0x007fa00c3b9170>
```

after
-----

```ruby
# => "looking good Billy Rae"
```
