### PR TITLE
[DARGA] Revert Revert 8870:  Allow MiqExpression to filter on virtual_attributes with SQL

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -740,17 +740,8 @@ class MiqExpression
         ids = klass.find_tagged_with(:any => tag, :ns => ns).pluck(:id)
         clause = klass.send(:sanitize_sql_for_conditions, ["#{klass.table_name}.id IN (?)", ids])
       else
-        db, field = exp[operator]["field"].split(".")
-        model = db.constantize
-        assoc, field = field.split("-")
-        ref = model.reflect_on_association(assoc.to_sym)
-
-        inner_where = "#{field} = '#{exp[operator]["value"]}'"
-        if cond = ref.scope          # Include ref.options[:conditions] in inner select if exists
-          cond = extract_where_values(ref.klass, cond)
-          inner_where = "(#{inner_where}) AND (#{cond})"
-        end
-        clause = "#{model.table_name}.id IN (SELECT DISTINCT #{ref.foreign_key} FROM #{ref.table_name} WHERE #{inner_where})"
+        field = Field.parse(exp[operator]["field"])
+        clause = field.contains(exp[operator]["value"]).to_sql
       end
     when "is"
       col_name = exp[operator]["field"]
@@ -1922,46 +1913,6 @@ class MiqExpression
   end
 
   private
-
-  class WhereExtractionVisitor < Arel::Visitors::PostgreSQL
-    def visit_Arel_Nodes_SelectStatement(o, collector)
-      collector = o.cores.inject(collector) do |c, x|
-        visit_Arel_Nodes_SelectCore(x, c)
-      end
-    end
-
-    def visit_Arel_Nodes_SelectCore(o, collector)
-      unless o.wheres.empty?
-        len = o.wheres.length - 1
-        o.wheres.each_with_index do |x, i|
-          collector = visit(x, collector)
-          collector << AND unless len == i
-        end
-      end
-
-      collector
-    end
-  end
-
-  def extract_where_values(klass, scope)
-    relation = ActiveRecord::Relation.new klass, klass.arel_table, klass.predicate_builder
-    relation = relation.instance_eval(&scope)
-
-    begin
-      # This is basically ActiveRecord::Relation#to_sql, only using our
-      # custom visitor instance
-
-      connection = klass.connection
-      visitor    = WhereExtractionVisitor.new connection
-
-      arel  = relation.arel
-      binds = relation.bound_attributes
-      binds = connection.prepare_binds_for_database(binds)
-      binds.map! { |value| connection.quote(value) }
-      collect = visitor.accept(arel.ast, Arel::Collectors::Bind.new)
-      collect.substitute_binds(binds).join
-    end
-  end
 
   def self.determine_model(model, parts)
     model = model_class(model)

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -33,6 +33,16 @@ class MiqExpression::Field
     column_type == :string
   end
 
+  def reflections
+    klass = model
+    associations.collect do |association|
+      klass.reflect_on_association(association).tap do |reflection|
+        return unless reflection
+        klass = reflection.klass
+      end
+    end
+  end
+
   def target
     if associations.none?
       model

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -37,7 +37,7 @@ class MiqExpression::Field
     klass = model
     associations.collect do |association|
       klass.reflect_on_association(association).tap do |reflection|
-        return unless reflection
+        raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
         klass = reflection.klass
       end
     end

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -47,7 +47,7 @@ class MiqExpression::Field
     if associations.none?
       model
     else
-      associations.last.classify.constantize
+      reflections.last.klass
     end
   end
 

--- a/app/models/miq_expression/field.rb
+++ b/app/models/miq_expression/field.rb
@@ -53,7 +53,57 @@ class MiqExpression::Field
     arel_attribute.does_not_match(other, escape, case_sensitive)
   end
 
+  def contains(other)
+    raise unless associations.one?
+    reflection = reflections.first
+    arel = eq(other)
+    arel = arel.and(Arel::Nodes::SqlLiteral.new(extract_where_values(reflection.klass, reflection.scope))) if reflection.scope
+    model.arel_attribute(:id).in(
+      target.arel_table.where(arel).project(target.arel_table[reflection.foreign_key]).distinct
+    )
+  end
+
   private
+
+  class WhereExtractionVisitor < Arel::Visitors::PostgreSQL
+    def visit_Arel_Nodes_SelectStatement(o, collector)
+      collector = o.cores.inject(collector) do |c, x|
+        visit_Arel_Nodes_SelectCore(x, c)
+      end
+    end
+
+    def visit_Arel_Nodes_SelectCore(o, collector)
+      unless o.wheres.empty?
+        len = o.wheres.length - 1
+        o.wheres.each_with_index do |x, i|
+          collector = visit(x, collector)
+          collector << AND unless len == i
+        end
+      end
+
+      collector
+    end
+  end
+
+  def extract_where_values(klass, scope)
+    relation = ActiveRecord::Relation.new klass, klass.arel_table, klass.predicate_builder
+    relation = relation.instance_eval(&scope)
+
+    begin
+      # This is basically ActiveRecord::Relation#to_sql, only using our
+      # custom visitor instance
+
+      connection = klass.connection
+      visitor    = WhereExtractionVisitor.new connection
+
+      arel  = relation.arel
+      binds = relation.bound_attributes
+      binds = connection.prepare_binds_for_database(binds)
+      binds.map! { |value| connection.quote(value) }
+      collect = visitor.accept(arel.ast, Arel::Collectors::Bind.new)
+      collect.substitute_binds(binds).join
+    end
+  end
 
   def arel_attribute
     target.arel_attribute(column)

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe MiqExpression::Field do
       expect(field.reflections).to match([an_object_having_attributes(:klass => Account)])
     end
 
-    it "returns nil if the field has virtual associations" do
+    it "raises an error if the field has virtual associations" do
       field = described_class.new(Vm, ["processes"], "name")
-      expect(field.reflections).to be_nil
+      expect { field.reflections }.to raise_error(/One or more associations are invalid: processes/)
     end
 
-    it "returns nil if the field has invalid associations" do
+    it "raises an error if the field has invalid associations" do
       field = described_class.new(Vm, %w(foo bar), "name")
-      expect(field.reflections).to be_nil
+      expect { field.reflections }.to raise_error(/One or more associations are invalid: foo, bar/)
     end
   end
 

--- a/spec/models/miq_expression/field_spec.rb
+++ b/spec/models/miq_expression/field_spec.rb
@@ -58,6 +58,39 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#reflections" do
+    it "returns an empty array if there are no associations" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.reflections).to be_empty
+    end
+
+    it "returns the reflections of fields with one association" do
+      field = described_class.new(Vm, ["host"], "name")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Host)])
+    end
+
+    it "returns the reflections of fields with multiple associations" do
+      field = described_class.new(Vm, %w(host hardware), "guest_os")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Host),
+                                          an_object_having_attributes(:klass => Hardware)])
+    end
+
+    it "can handle associations which override the class name" do
+      field = described_class.new(Vm, ["users"], "name")
+      expect(field.reflections).to match([an_object_having_attributes(:klass => Account)])
+    end
+
+    it "returns nil if the field has virtual associations" do
+      field = described_class.new(Vm, ["processes"], "name")
+      expect(field.reflections).to be_nil
+    end
+
+    it "returns nil if the field has invalid associations" do
+      field = described_class.new(Vm, %w(foo bar), "name")
+      expect(field.reflections).to be_nil
+    end
+  end
+
   describe "#date?" do
     it "returns true for fields of column type :date" do
       field = described_class.new(Vm, [], "retires_on")

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -142,13 +142,13 @@ describe MiqExpression do
 
     it "generates the SQL for a CONTAINS expression with field" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.guest_applications-name", "value" => "foo"}).to_sql
-      expect(sql).to eq("vms.id IN (SELECT DISTINCT vm_or_template_id FROM guest_applications WHERE name = 'foo')")
+      expect(sql).to eq("\"vms\".\"id\" IN (SELECT DISTINCT \"guest_applications\".\"vm_or_template_id\" FROM \"guest_applications\" WHERE \"guest_applications\".\"name\" = 'foo')")
     end
 
     it "generates the SQL for a CONTAINS expression with field containing a scope" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.users-name", "value" => "foo"}).to_sql
-      expected = "vms.id IN (SELECT DISTINCT vm_or_template_id FROM accounts WHERE (name = 'foo') "\
-                 "AND (\"accounts\".\"accttype\" = 'user'))"
+      expected = "\"vms\".\"id\" IN (SELECT DISTINCT \"accounts\".\"vm_or_template_id\" FROM \"accounts\" "\
+                 "WHERE \"accounts\".\"name\" = 'foo' AND \"accounts\".\"accttype\" = 'user')"
       expect(sql).to eq(expected)
     end
 

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1098,7 +1098,7 @@ describe Rbac do
                                                 :miq_group      => group,
                                                 :results_format => :objects)
         expect(results.length).to eq(2)
-        expect(attrs[:total_count]).to eq(3)
+        expect(attrs[:total_count]).to eq(2)
       end
     end
 


### PR DESCRIPTION
Purpose
-------
Allows https://github.com/ManageIQ/manageiq/issues/10685 and https://github.com/ManageIQ/manageiq/issues/10704 to function with the intended performance benefits under darga.


Overview
--------
Previously this was attempted to be backported to darga via a cherry-pick, succeeded, but it was determined that it was causing tests to fail.  Re-opening this with a newer subset of darga to either see if those tests are still broken and if an easy resolution can be found, or if the PR actually requires other backporting prerequisites to function.

This PR was created by doing the following:

```
git revert -m1 70e9086
```

Which was the merge commit of #11205

At the time of this originally being backported, it was a last minute addition to be added into the release, and it was determined that omitting it was simpler then trying to get it worked into the build.


Links
-----
* Original PR this is merging:  https://github.com/ManageIQ/manageiq/pull/8870
* The reverting of backporting the above PR originally (this PR un does that revert):  https://github.com/ManageIQ/manageiq/pull/11205
* One of Tim's PRs needed for this PR to work:  https://github.com/ManageIQ/manageiq/issues/10685
* Another one of Tim's PRs needed for this PR to work:  https://github.com/ManageIQ/manageiq/issues/10704