### PR TITLE
Fix custom button set tooltip spec

### DIFF
--- a/spec/presenters/tree_node/custom_button_set_spec.rb
+++ b/spec/presenters/tree_node/custom_button_set_spec.rb
@@ -2,9 +2,14 @@ require 'shared/presenters/tree_node/common'
 
 describe TreeNode::CustomButtonSet do
   subject { described_class.new(object, nil, {}) }
-  let(:object) { FactoryGirl.create(:custom_button_set) }
+  let(:object) { FactoryGirl.create(:custom_button_set, :description => "custom button set description") }
 
   include_examples 'TreeNode::Node#key prefix', 'cbg-'
   include_examples 'TreeNode::Node#image', '100/folder.png'
-  include_examples 'TreeNode::Node#tooltip prefix', 'Button Group'
+
+  describe "#tooltip" do
+    it "returns the prefixed title" do
+      expect(subject.tooltip).to eq("Button Group: custom button set description")
+    end
+  end
 end


### PR DESCRIPTION
This spec uses a shared example assuming that it behaves like all other
tree nodes, however:

* this attribute is based on the description of the object, not the name as it is in others
* it just so happens that the name will equal the description if run in
  isolation, because of the way the factory is defined
* incrementing the counter for the factory in another spec is sufficient
  to break this one

The simplest reproduction case is:

```
bundle exec rspec ./spec/models/custom_button_set_spec.rb[1:1:1] ./spec/presenters/tree_node/custom_button_set_spec.rb[1:3:1]
```

To remedy this I've a) updated the object to set a custom description
in the setup phase, b) broken this test out of the shared examples and
verified against the description that was set. This seemed more
straightforward than trying to accomodate for this case in the shared
example, which is used in many places.

This erratic test is causing many failures to builds in CI.

@miq-bot assign @jrafanie 
@miq-bot add-label test, bug
