### PR TITLE
Fix times in chargeback specs

### DIFF
--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -38,7 +38,7 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse('2012-09-01 23:59:59').utc)
+    Timecop.travel(Time.parse('2012-09-01 23:59:59Z').utc)
   end
 
   after do
@@ -48,8 +48,8 @@ describe ChargebackContainerImage do
   context "Daily" do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
-    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
-    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00Z').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00Z').utc }
 
     before do
       Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -38,7 +38,7 @@ describe ChargebackContainerProject do
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse('2012-09-01 23:59:59').utc)
+    Timecop.travel(Time.parse('2012-09-01 23:59:59Z').utc)
   end
 
   after do
@@ -52,8 +52,8 @@ describe ChargebackContainerProject do
   context "Daily" do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
-    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
-    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00Z').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00Z').utc }
 
     before do
       Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -67,7 +67,7 @@ describe ChargebackVm do
     temp = {:cb_rate => chargeback_rate, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
 
-    Timecop.travel(Time.parse('2012-09-01 23:59:59Z'))
+    Timecop.travel(Time.parse('2012-09-01 23:59:59Z').utc)
   end
 
   after do
@@ -124,8 +124,8 @@ describe ChargebackVm do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily') }
 
-    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
-    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00Z').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00Z').utc }
 
     before do
       Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|


### PR DESCRIPTION
These tests are using timecop to travel to specific
times. Unfortunately, those times are specific to the local timezone,
and are only after represented as UTC via
`Time.parse(time).utc`. Consequently, in some timezones the tests ask
for metrics for the wrong day and return nothing. This updates them to
parse UTC times everywhere so it should be the same for everyone.

Follow up to https://github.com/ManageIQ/manageiq/pull/13282

@miq-bot assign @gtanzillo 
@miq-bot add-label test, bug