### PR TITLE
temporarily force rails to < 5.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "paperclip",                      "~>4.3.0"
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.0.0", ">= 5.0.0.1"
+gem "rails",                          "~>5.0.0", ">= 5.0.0.1", "< 5.0.1"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"


### PR DESCRIPTION
This is to prevent all the tests breaking with.. after rails 5.0.1 came out.

```
ActiveModel::MissingAttributeError:
       can't write unknown attribute `region_number`
```

Obviously this is temporary, pending a real fix.