### PR TITLE
Rename the `:icon` parameter in tree nodes to `:image`

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -982,7 +982,7 @@ module ApplicationController::MiqRequestMethods
         :key         => dc[0],
         :title       => dc[0],
         :tooltip     => dc[0],
-        :icon        => ActionController::Base.helpers.image_path("100/folder.png"),
+        :image       => ActionController::Base.helpers.image_path("100/folder.png"),
         :cfmeNoClick => true,
         :addClass    => "cfme-bold-node",
         :expand      => true
@@ -995,7 +995,7 @@ module ApplicationController::MiqRequestMethods
           :key     => id,
           :tooltip => ou[0],
           :title   => ou[0],
-          :icon    => ActionController::Base.helpers.image_path("100/group.png")
+          :image   => ActionController::Base.helpers.image_path("100/group.png")
         }
         if ldap_ous == ou[1][:ou]
           # expand selected nodes parents when editing existing record
@@ -1032,7 +1032,7 @@ module ApplicationController::MiqRequestMethods
       :key     => id,
       :title   => node[0],
       :tooltip => node[0],
-      :icon    => ActionController::Base.helpers.image_path("100/group.png")
+      :image   => ActionController::Base.helpers.image_path("100/group.png")
     }
 
     if ldap_ous == node[1][:ou]
@@ -1074,7 +1074,7 @@ module ApplicationController::MiqRequestMethods
         @ci_node[:title] += " *" if t[:single_value]
         @ci_node[:tooltip] = t[:description]
         @ci_node[:addClass] = "cfme-no-cursor-node"      # No cursor pointer
-        @ci_node[:icon] = parent_icon
+        @ci_node[:image] = parent_icon
         @ci_node[:hideCheckbox] = @ci_node[:cfmeNoClick] = true
         @ci_node[:addClass] = "cfme-bold-node"  # Show node as different
         @ci_kids = []
@@ -1087,7 +1087,7 @@ module ApplicationController::MiqRequestMethods
           temp[:selectable] = false
           temp[:title] = temp[:tooltip] = c[1][:description]
           temp[:addClass] = "cfme-no-cursor-node"
-          temp[:icon] = child_icon
+          temp[:image] = child_icon
           if edit_mode              # Don't show checkboxes/radio buttons in non-edit mode
             if vm_tags && vm_tags.include?(c[0].to_i)
               temp[:select] = true

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -73,7 +73,7 @@ module ApplicationController::TreeSupport
           :checkable   => !@edit.nil?,
           :tooltip     => "#{ui_lookup(:table => "ems_infras")}: #{ems.name}",
           :cfmeNoClick => true,
-          :icon        => ActionController::Base.helpers.image_path("svg/vendor-#{ems.image_name}.svg")
+          :image       => ActionController::Base.helpers.image_path("svg/vendor-#{ems.image_name}.svg")
         }
         if @vat || @rp_only
           ems_node[:hideCheckbox] = true
@@ -129,7 +129,7 @@ module ApplicationController::TreeSupport
     # Handle Datacenter folders
     elsif folder.kind_of?(Datacenter)
       node[:tooltip] = _("Datacenter: %{name}") % {:name => folder.name}
-      node[:icon] = ActionController::Base.helpers.image_path("100/datacenter.png")
+      node[:image] = ActionController::Base.helpers.image_path("100/datacenter.png")
       if @vat || @rp_only
         node[:hideCheckbox] = true
       end
@@ -188,9 +188,9 @@ module ApplicationController::TreeSupport
     elsif folder.kind_of?(EmsFolder)
       node[:tooltip] = _("Folder: %{name}") % {:name => folder.name}
       if vat
-        node[:icon] = ActionController::Base.helpers.image_path("100/blue_folder.png")
+        node[:image] = ActionController::Base.helpers.image_path("100/blue_folder.png")
       else
-        node[:icon] = ActionController::Base.helpers.image_path("100/folder.png")
+        node[:image] = ActionController::Base.helpers.image_path("100/folder.png")
         if @vat || @rp_only
           node[:hideCheckbox] = true
         end
@@ -227,7 +227,7 @@ module ApplicationController::TreeSupport
         if folder.parent_cluster || @rp_only                  # Host is under a cluster, no checkbox
           node[:hideCheckbox] = true
         end
-        node[:icon] = ActionController::Base.helpers.image_path("100/host.png")
+        node[:image] = ActionController::Base.helpers.image_path("100/host.png")
         h_kids = []
         folder.resource_pools.sort_by { |rp| rp.name.downcase }.each do |rp|
           kid_node, kid_checked = user_get_tree_node(rp, node[:key], vat)
@@ -246,7 +246,7 @@ module ApplicationController::TreeSupport
     elsif folder.class == EmsCluster
       if !@rp_only || (@rp_only && folder.resource_pools.count > 0)
         node[:tooltip] = _("Cluster: %{name}") % {:name => folder.name}
-        node[:icon] = ActionController::Base.helpers.image_path("100/cluster.png")
+        node[:image] = ActionController::Base.helpers.image_path("100/cluster.png")
         node[:hideCheckbox] = true if @vat || @rp_only
         cl_kids = []
         folder.hosts.each do |h|                  # Get hosts
@@ -276,7 +276,7 @@ module ApplicationController::TreeSupport
     # Handle non-default Resource Pools
     elsif folder.kind_of?(ResourcePool)         # Resource Pool
       node[:tooltip] = _("Resource Pool: #%{name}") % {:name => folder.name}
-      node[:icon] = ActionController::Base.helpers.image_path(folder.vapp ? "100/vapp.png" : "100/resource_pool.png")
+      node[:image] = ActionController::Base.helpers.image_path(folder.vapp ? "100/vapp.png" : "100/resource_pool.png")
       rp_kids = []
       folder.resource_pools.each do |rp|        # Get the resource pool nodes
         kid_node, kid_checked = user_get_tree_node(rp, node[:key])

--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -25,7 +25,7 @@ class OpsController
       kids = []
       node = {
         :key         => "#{@role.id ? to_cid(@role.id) : "new"}___tab_#{section.id}",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
+        :image       => ActionController::Base.helpers.image_path('100/feature_node.png'),
         :title       => _(section.name),
         :tooltip     => _("%{title} Main Tab") % {:title => section.name},
         :checkable   => @edit,
@@ -66,7 +66,7 @@ class OpsController
       root = MiqProductFeature.feature_details(root_feature)
       root_node = {
         :key         => "#{@role.id ? to_cid(@role.id) : "new"}__#{root_feature}",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
+        :image       => ActionController::Base.helpers.image_path('100/feature_node.png'),
         :title       => _(root[:name]),
         :tooltip     => _(root[:description]) || _(root[:name]),
         :expand      => true,
@@ -78,7 +78,7 @@ class OpsController
       top_nodes = []
       @all_vm_node = {
         :key         => "#{@role.id ? to_cid(@role.id) : "new"}___tab_all_vm_rules",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
+        :image       => ActionController::Base.helpers.image_path('100/feature_node.png'),
         :title       => t = _("Access Rules for all Virtual Machines"),
         :tooltip     => t,
         :children    => [],
@@ -116,7 +116,7 @@ class OpsController
       kids = []
       node = {
         :key         => "#{@role.id ? to_cid(@role.id) : "new"}__#{feature}",
-        :icon        => ActionController::Base.helpers.image_path("100/feature_#{details[:feature_type]}.png"),
+        :image       => ActionController::Base.helpers.image_path("100/feature_#{details[:feature_type]}.png"),
         :title       => _(details[:name]),
         :tooltip     => _(details[:description]) || _(details[:name]),
         :checkable   => @edit,

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -114,7 +114,6 @@ class TreeBuilder
     while stack.any?
       node = stack.pop
       stack += node[:children] if node.key?(:children)
-      node[:image] = node.delete(:icon) if node.key?(:icon) && node[:icon].start_with?('/')
       node[:text] = node.delete(:title) if node.key?(:title)
       node[:nodes] = node.delete(:children) if node.key?(:children)
       node[:lazyLoad] = node.delete(:isLazy) if node.key?(:isLazy)
@@ -176,7 +175,7 @@ class TreeBuilder
   def add_root_node(nodes)
     root = nodes.first
     root[:title], root[:tooltip], icon, options = root_options
-    root[:icon] = ActionController::Base.helpers.image_path(icon || "100/folder.png")
+    root[:image] = ActionController::Base.helpers.image_path(icon || "100/folder.png")
     if options.present?
       root.merge!(options)
     end
@@ -206,7 +205,7 @@ class TreeBuilder
 
     child_nodes = children.map do |child|
       # already a node? FIXME: make a class for node
-      if child.kind_of?(Hash) && child.key?(:title) && child.key?(:key) && child.key?(:icon)
+      if child.kind_of?(Hash) && child.key?(:title) && child.key?(:key) && child.key?(:image)
         child
       else
         x_build_node_tree(child, nil, options)

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -3,7 +3,7 @@ class TreeBuilderNetwork < TreeBuilder
   has_kids_for Switch, [:x_get_tree_switch_kids]
 
   def override(node, _object, _pid, _options)
-    node[:cfmeNoClick] = true unless node[:icon].include?('100/currentstate-')
+    node[:cfmeNoClick] = true unless node[:image].include?('100/currentstate-')
   end
 
   def initialize(name, type, sandbox, build = true, root = nil, vm_kids = [])

--- a/app/presenters/tree_node/node.rb
+++ b/app/presenters/tree_node/node.rb
@@ -125,15 +125,15 @@ module TreeNode
         node[:tooltip] = tip
       end
 
-      node[:icon] = if !image
-                      nil
-                    elsif image.start_with?("/")
-                      image
-                    elsif image =~ %r{^[a-zA-Z0-9]+/}
-                      ActionController::Base.helpers.image_path(image)
-                    else
-                      ActionController::Base.helpers.image_path("100/#{image}")
-                    end
+      node[:image] = if !image
+                       nil
+                     elsif image.start_with?("/")
+                       image
+                     elsif image =~ %r{^[a-zA-Z0-9]+/}
+                       ActionController::Base.helpers.image_path(image)
+                     else
+                       ActionController::Base.helpers.image_path("100/#{image}")
+                     end
 
       node.delete_if { |_, v| v.nil? }
     end


### PR DESCRIPTION
This will allow us to use the icon parameter for fonticons and the image for images.
https://www.pivotaltracker.com/n/projects/1613907/stories/129371557