### PR TITLE
Fix FileUtil regression in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-chdir ManageIQ::Environment::APP_ROOT do
+Dir.chdir ManageIQ::Environment::APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
   ManageIQ::Environment.ensure_config_files


### PR DESCRIPTION
Fixes a regression introduced in #13278  where on `bin/setup` you'd get `/bin/setup:20:in <main>': undefined methodchdir' for main:Object (NoMethodError)`

The `FileUtils` requirement was moved and `include` removed, but we use `chdir` here.

I'm sure we'll want to make other changes here anyway but this is a quick fix to keep people from being blocked. 
