### PR TITLE
Fix invalid chargeback factories

### DIFF
--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,13 +1,10 @@
 FactoryGirl.define do
-  factory :chargeback_rate_detail, :traits => [:bytes] do
+  factory :chargeback_rate_detail do
     group   "unknown"
     source  "unknown"
     chargeback_rate
     detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency) }
-
-    trait :bytes do
-      detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure_bytes) }
-    end
+    detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure) }
 
     transient do
       tiers_params nil

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,12 +1,9 @@
 FactoryGirl.define do
-  factory :chargeback_rate_detail, :traits => [:euro, :bytes] do
+  factory :chargeback_rate_detail, :traits => [:bytes] do
     group   "unknown"
     source  "unknown"
     chargeback_rate
-
-    trait :euro do
-      detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency_EUR) }
-    end
+    detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency) }
 
     trait :bytes do
       detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure_bytes) }

--- a/spec/factories/chargeback_rate_detail_currency.rb
+++ b/spec/factories/chargeback_rate_detail_currency.rb
@@ -1,9 +1,6 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail_currency do
     code  "EUR"
-  end
-
-  factory :chargeback_rate_detail_currency_EUR, :parent => :chargeback_rate_detail_currency do
     name "Euro"
     full_name "Euro"
     symbol "€"

--- a/spec/factories/chargeback_rate_detail_measure.rb
+++ b/spec/factories/chargeback_rate_detail_measure.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail_measure do
     step  "1024"
-  end
-  factory :chargeback_rate_detail_measure_bytes, :parent => :chargeback_rate_detail_measure do
     name "Bytes Units"
     units_display %w(B KB MB GB TB)
     units %w(bytes kilobytes megabytes gigabytes terabytes)

--- a/spec/models/chargeback_rate_detail_currency_spec.rb
+++ b/spec/models/chargeback_rate_detail_currency_spec.rb
@@ -1,20 +1,20 @@
 describe ChargebackRateDetailCurrency do
   it "has a valid factory" do
-    expect(FactoryGirl.create(:chargeback_rate_detail_currency_EUR)).to be_valid
+    expect(FactoryGirl.create(:chargeback_rate_detail_currency)).to be_valid
   end
   it "is invalid without a code" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :code => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_currency, :code => nil)).not_to be_valid
   end
   it "is invalid without a name" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :name => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_currency, :name => nil)).not_to be_valid
   end
   it "is invalid without a full_name" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :full_name => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_currency, :full_name => nil)).not_to be_valid
   end
   it "is invalid without a symbol" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :symbol => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_currency, :symbol => nil)).not_to be_valid
   end
   it "is invalid without a unicode_hex" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_currency_EUR, :unicode_hex => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_currency, :unicode_hex => nil)).not_to be_valid
   end
 end

--- a/spec/models/chargeback_rate_detail_measure_spec.rb
+++ b/spec/models/chargeback_rate_detail_measure_spec.rb
@@ -1,30 +1,30 @@
 describe ChargebackRateDetailMeasure do
   it "has a valid factory" do
-    expect(FactoryGirl.create(:chargeback_rate_detail_measure_bytes)).to be_valid
+    expect(FactoryGirl.create(:chargeback_rate_detail_measure)).to be_valid
   end
 
   it "is invalid without a name" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :name => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure, :name => nil)).not_to be_valid
   end
 
   it "is invalid without a step" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => nil)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure, :step => nil)).not_to be_valid
   end
 
   it "is invalid with a step less than 0" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :step => -9)).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure, :step => -9)).not_to be_valid
   end
 
   it "is invalid with a empty array units" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => [])).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure, :units => [])).not_to be_valid
   end
 
   it "is invalid with a only one array units" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes, :units => ["KB"])).not_to be_valid
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure, :units => ["KB"])).not_to be_valid
   end
 
   it "is invalid with a units_display lenght diferent that the units lenght" do
-    expect(FactoryGirl.build(:chargeback_rate_detail_measure_bytes,
+    expect(FactoryGirl.build(:chargeback_rate_detail_measure,
                       :units         => %w(Bs KBs GBs),
                       :units_display => %w(kbps mbps))).not_to be_valid
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -65,7 +65,7 @@ describe ChargebackRateDetail do
 
       expect(cbd.hourly(rate)).to eq(0.0)
     end
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure)
     rate = 8.26
     [
       'hourly',   'megabytes',  rate,
@@ -89,7 +89,9 @@ describe ChargebackRateDetail do
 
   it "#rate_adjustment" do
     value = 10.gigabytes
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure,
+                              :units_display => %w(B KB MB GB TB),
+                              :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
     [
       'megabytes', value,
       'gigabytes', value / 1024,
@@ -146,7 +148,10 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "#per_unit_display_with_measurements" do
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure,
+                              :units_display => %w(B KB MB GB TB),
+                              :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
+
     cbd  = FactoryGirl.build(:chargeback_rate_detail,
                              :per_unit                          => 'megabytes',
                              :chargeback_rate_detail_measure_id => cbdm.id)
@@ -181,7 +186,10 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "diferents_per_units_rates_should_have_the_same_cost" do
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure,
+                              :units_display => %w(B KB MB GB TB),
+                              :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
+
     # should be the same cost. bytes to megabytes and gigabytes to megabytes
     cbd_bytes = FactoryGirl.build(:chargeback_rate_detail,
                                   :per_unit                          => 'bytes',
@@ -199,7 +207,10 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "#show_rates" do
-    cbm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    cbm = FactoryGirl.create(:chargeback_rate_detail_measure,
+                             :units_display => %w(B KB MB GB TB),
+                             :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
+
     cbc = FactoryGirl.create(:chargeback_rate_detail_currency, :code => "EUR")
 
     cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost,

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -200,7 +200,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
 
   it "#show_rates" do
     cbm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
-    cbc = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+    cbc = FactoryGirl.create(:chargeback_rate_detail_currency, :code => "EUR")
 
     cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost,
                             :chargeback_rate_detail_measure_id  => cbm.id,

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can list of all measures" do
-    measure = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    measure = FactoryGirl.create(:chargeback_rate_detail_measure)
 
     api_basic_authorize
     run_get '/api/measures'
@@ -111,7 +111,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can show an individual measure" do
-    measure = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+    measure = FactoryGirl.create(:chargeback_rate_detail_measure)
 
     api_basic_authorize
     run_get "/api/measures/#{measure.id}"

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can list of all currencies" do
-    currency = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+    currency = FactoryGirl.create(:chargeback_rate_detail_currency)
 
     api_basic_authorize
     run_get '/api/currencies'
@@ -83,7 +83,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can show an individual currency" do
-    currency = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+    currency = FactoryGirl.create(:chargeback_rate_detail_currency)
 
     api_basic_authorize
     run_get "/api/currencies/#{currency.id}"

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -70,7 +70,7 @@ describe "Rest API Collections" do
     end
 
     it "query Currencies" do
-      FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
+      FactoryGirl.create(:chargeback_rate_detail_currency)
       test_collection_query(:currencies, "/api/currencies", ChargebackRateDetailCurrency)
     end
 

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -75,7 +75,7 @@ describe "Rest API Collections" do
     end
 
     it "query Measures" do
-      FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+      FactoryGirl.create(:chargeback_rate_detail_measure)
       test_collection_query(:measures, "/api/measures", ChargebackRateDetailMeasure)
     end
 


### PR DESCRIPTION
These factories do not pass factory girl's built-in linter because they follow an anti-pattern of defining an "abstract" factory from which one or more fixture-style factories inherit. This can lead to obscure/brittle tests. To remedy this, I've removed child factories and given the "abstract" factories everything they need to build a valid model. Then, in the test body, I've updated to specify the attributes that are being tested when the object gets built, making them IMO more readable.

@miq-bot add-label test, technical debt
@miq-bot assign @jrafanie 