### PR TITLE
Fix erratic ChargebackVm SCVMM test

### DIFF
--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -544,6 +544,7 @@ describe ChargebackVm do
     end
     let!(:rate_detail) do
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :source             => "compute_1",
                          :chargeback_rate_id => chargeback_rate.id,
                          :chargeback_tiers   => [tier],
                          :per_time           => 'hourly')


### PR DESCRIPTION
This test is failing erratically because of an implicit dependency on an
attribute defined in the chargeback rate detail factory. It is
sequential, so when the counter gets incremented by another test, this
test breaks. By setting it explicitly when the object gets built this
test should now pass every time.

To reproduce:

```
bundle exec rspec ./spec/models/chargeback_rate_detail_spec.rb[1:13] ./spec/models/chargeback_vm_spec.rb[1:12:1] --seed=23652
```

@miq-bot add-label bug, test
@miq-bot assign @hayesr 