### PR TITLE
Fixed sporadic failing in config_spec

### DIFF
--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -14,7 +14,7 @@ describe VMDB::Config do
     it "normal" do
       resource = FactoryGirl.create(:miq_server)
       MiqRegion.seed
-      data = Settings.to_hash
+      data = {}
       data.store_path(:api, :token_ttl, "1.day")
       data = data.to_yaml
 


### PR DESCRIPTION
Only a few people experienced sporadic failing of ```config_spec.rb```  in local environment.

In failing test (testing if configuration could be saved from yaml) we do not need to load existing Settings (which may be updated in another test since Settings is global object).

@miq-bot bug

\cc @Fryguy 

