### PR TITLE
performance: reduce the api objects for RHV provider.

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -3,8 +3,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
 
   require 'ovirtsdk4'
   require 'singleton'
-  
-  @@connection
+  @@connection = nil
 
   included do
     process_api_features_support
@@ -33,7 +32,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     # Create the underlying connection according to the version of the oVirt API requested by
     # the caller:
     connect_method = "raw_connect_v#{version}".to_sym
-    if @@connection and @@connection.test
+    if @@connection && @@connection.test
       default_endpoint.path = version == 4 ? '/ovirt-engine/api' : connection.api_path
       # return connection via singleton instance
       _log.info('Using stored connection')

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -2,7 +2,9 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   extend ActiveSupport::Concern
 
   require 'ovirtsdk4'
-  @connection
+  require 'singleton'
+  
+  @@connection
 
   included do
     process_api_features_support
@@ -31,19 +33,21 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     # Create the underlying connection according to the version of the oVirt API requested by
     # the caller:
     connect_method = "raw_connect_v#{version}".to_sym
-    unless @connection.nil?
+    if @@connection and @@connection.test
       default_endpoint.path = version == 4 ? '/ovirt-engine/api' : connection.api_path
-      return @connection
+      # return connection via singleton instance
+      _log.info('Using stored connection')
+      return @@connection
     end
 
     # reinitialize the connection
-    _log.info("reinitialize the connection")
-    @connection = self.class.public_send(connect_method, server, port, path, username, password, service, compress)
+    _log.info('about to connect ovirtsdk')
+    @@connection = self.class.public_send(connect_method, server, port, path, username, password, service, compress)
 
     # Copy the API path to the endpoints table:
     default_endpoint.path = version == 4 ? '/ovirt-engine/api' : connection.api_path
 
-    @connection
+    @@connection
   end
 
   def supports_port?


### PR DESCRIPTION
due to an performance issue on RHV side, we found the appliance hit the db connection pool.
by reducing the amount of new api objects we can clearly see an improvement.

seems like this change can be implemented on any provider.
@masayag 
@pkliczewski 