### PR TITLE
Fix creating Kubernetes or OSE with `credentials.auth_key`

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -90,6 +90,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     [:auth_key]
   end
 
+  def supported_auth_attributes
+    %w(userid password auth_key)
+  end
+
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
     if options[:auth_type].to_s == "hawkular"

--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -20,10 +20,6 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
   end
 
-  def supported_auth_attributes
-    %w(userid password auth_key)
-  end
-
   def create_project(project)
     connect.create_project_request(project)
   rescue KubeException => e

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -370,8 +370,6 @@ describe "Providers API" do
         let(:containers_class) { klass }
 
         it "supports creation with auth_key specified" do
-          skip if name != "Openshift"
-
           api_basic_authorize collection_action_identifier(:providers, :create)
 
           run_post(providers_url, sample_containers.merge("credentials" => [containers_credentials]))


### PR DESCRIPTION
Passing `credentials` containing `auth_key` was failing with:

    Could not create the new provider - Unsupported credential attributes auth_key specified

Worked with Openshift.

(The recommended way to create Openshift with hawkular metrics is pass `connection_configurations`, which works.
But passing hostname/ip, port and `credentials` should work when you don't need a hawkular endpoint (and currently will still attempt metrics if there is hawkular on same hostname with default port 443).)

@miq-bot add-label bug, providers/containers, api

## Tests (this part already got merged in #13369)

Extended api/providers_spec.rb to run the container tests for all 3 concrete container manager classes, instead of just `Openshift::ContainerManager`.
I also tried using `shared_example` instead of loops, found the results less satisfactory.

This file now takes ~17s instead of ~15s.  IMO, despite exercising *mostly* the same mixing code it's well worth it:

- In addition to the bug I'm fixing now, this testing uncovered bug #13306!
  Marked that test pending, will address later.
- Beside 2 Manager Mixins included in 3 concrete manager classes, there are complex interactions with Authentication, Endpoint, AuthenticationMixin, UI + API, single-endpoint interfaces like `credentials` vs `connection_configurations`,  and fallbacks from hawkular endpoint to default endpoint...
  I find it very hard to reason about, and to even start simplifying it requires test coverage.

P.S. The "schedules a new credentials check if endpoint change" test is known to be a lie, should fail (#13167).  Will address in later PR.

@yaacov @dkorn Please review.