### PR TITLE
container provider: add External Logging Support SupportFeature

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers
   class ContainerManager < BaseManager
     include AvailabilityMixin
+    include SupportsFeatureMixin
 
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_groups, :foreign_key => :ems_id, :dependent => :destroy
@@ -22,6 +23,12 @@ module ManageIQ::Providers
     has_many :computer_systems, :through => :container_nodes
 
     virtual_column :port_show, :type => :string
+
+    supports :external_logging_support do
+      unless respond_to?(:external_logging_route_name)
+        unsupported_reason_add(:external_logging_support, _('This provider type does not support external_logging_support'))
+      end
+    end
 
     # required by aggregate_hardware
     alias :all_computer_systems :computer_systems

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   DEFAULT_PORT = 8443
+  DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME = "logging-kibana-ops".freeze
 
   included do
     has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
@@ -55,5 +56,17 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
       @clients[kubernetes] ||= connect(:service => 'kubernetes', :version => api_version)
       @clients[openshift].respond_to?(method_name) ? @clients[openshift] : @clients[kubernetes]
     end
+  end
+
+  def external_logging_route_name
+    DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME
+  end
+
+  def external_logging_query
+    nil # should be empty to return all
+  end
+
+  def external_logging_path
+    '/'
   end
 end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -73,6 +73,7 @@ module SupportsFeatureMixin
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',
     :create_security_group      => 'Security Group Creation',
+    :external_logging_support   => 'Launch External Logging UI',
     :swift_service              => 'Swift storage service',
     :delete                     => 'Deletion',
     :delete_aggregate           => 'Host Aggregate Deletion',

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3696,6 +3696,10 @@
       :description: Check Compliance of Last Known Configuration
       :feature_type: control
       :identifier: ems_container_check_compliance
+    - :name: Launch External Logging
+      :description: Open External Logging from Container Provider
+      :feature_type: control
+      :identifier: ems_container_launch_external_logging_support
     - :name: Container Deployments
       :description: Container Deployments
       :feature_type: node


### PR DESCRIPTION
Adding common logging launch as a feature mixin.
Provider link will land on pre configured dashboard that is controlled in `common_logging_path`

resubmmiting #10648 without the UI part.
corresponding UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/36