### PR TITLE
Add parsing number of nics from RHV inventory

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -211,6 +211,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       result[:model] = hw_info[:product_name]
     end
 
+    result[:number_of_nics] = inv[:host_nics].count if inv[:host_nics]
+
     result
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_3_1_spec.rb
@@ -222,7 +222,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :cpu_type             => "Intel(R) Xeon(R) CPU           E5504  @ 2.00GHz",
       :manufacturer         => "",
       :model                => "",
-      :number_of_nics       => nil,
+      :number_of_nics       => 3,
       :memory_mb            => 56333,
       :memory_console       => nil,
       :cpu_sockets          => 2,


### PR DESCRIPTION
During refresh parse the number of nics a host has and put it in hardware.

This fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1397171