### PR TITLE
Add alert statuses on ext_management_system

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -48,6 +48,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :policy_events,  -> { order "timestamp" }, :class_name => "PolicyEvent", :foreign_key => "ems_id"
 
   has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :miq_alert_statuses, :foreign_key => "ems_id"
   has_many :ems_folders,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :ems_clusters,   :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -206,6 +206,7 @@ class MiqAlert < ApplicationRecord
   def add_status_post_evaluate(target, result)
     status = miq_alert_statuses.find_or_initialize_by(:resource => target)
     status.result = result
+    status.ems_id = target.try(:ems_id)
     status.evaluated_on = Time.now.utc
     status.save
     miq_alert_statuses << status

--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -6,6 +6,7 @@ class MiqAlertStatus < ApplicationRecord
   has_ancestry
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
+  belongs_to :ext_management_system
   has_many :miq_alert_status_actions, -> { order "created_at" }, :dependent => :destroy
   virtual_column :assignee, :type => :string
 

--- a/db/migrate/20170110090935_add_ems_to_miq_alert_status.rb
+++ b/db/migrate/20170110090935_add_ems_to_miq_alert_status.rb
@@ -1,0 +1,5 @@
+class AddEmsToMiqAlertStatus < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :ems_id, :bigint
+  end
+end

--- a/db/migrate/20170115140217_update_ems_in_miq_alert_status.rb
+++ b/db/migrate/20170115140217_update_ems_in_miq_alert_status.rb
@@ -1,0 +1,16 @@
+class UpdateEmsInMiqAlertStatus < ActiveRecord::Migration[5.0]
+  class MiqAlertStatus < ActiveRecord::Base; end
+
+  def up
+    say_with_time("update ems_id in miq alert statuses") do
+      %w(vms hosts ems_clusters container_images).each do |alert_resource|
+        arel_table = Arel::Table.new(alert_resource.to_sym)
+        klass_name = alert_resource.classify
+        klass_name = 'VmOrTemplate' if alert_resource == 'vms'
+        join_sql = arel_table.project(arel_table[:ems_id])
+                             .where(arel_table[:id].eq(MiqAlertStatus.arel_table[:resource_id])).to_sql
+        MiqAlertStatus.where(:resource_type => klass_name).update_all("ems_id = (#{join_sql})")
+      end
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4827,6 +4827,7 @@ miq_alert_statuses:
 - severity
 - ancestry
 - acknowledged
+- ems_id
 miq_alerts:
 - id
 - guid

--- a/spec/migrations/20170115140217_update_ems_in_miq_alert_status_spec.rb
+++ b/spec/migrations/20170115140217_update_ems_in_miq_alert_status_spec.rb
@@ -1,0 +1,16 @@
+require_migration
+
+describe UpdateEmsInMiqAlertStatus do
+  let(:miq_alert_status_stub) { migration_stub(:MiqAlertStatus) }
+
+  migration_context :up do
+    it 'it sets ems_id for vms' do
+      ext = FactoryGirl.create(:ext_management_system)
+      vm = FactoryGirl.create(:vm_cloud, :ext_management_system => ext)
+      miq_alert_status = miq_alert_status_stub.create!(:resource_type => "VmOrTemplate", :resource_id => vm.id)
+      expect(miq_alert_status.ems_id).to be_nil
+      migrate
+      expect(miq_alert_status.reload.ems_id).to eq(ext.id)
+    end
+  end
+end


### PR DESCRIPTION
The reason for this pr is the coming alerts screen that is going to be scoped pr ems.
We will need to get all of an ems's miq_alert_statuses coming from different entities (vms, hosts, clusters)
The association is inlined to make the join simpler and avoid destroying performance.
