### PR TITLE
Add helper for chargeback's specs

### DIFF
--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -45,8 +45,8 @@ describe ChargebackContainerProject do
     Timecop.return
   end
 
-  def used_average_for(metric, hours_in_interval)
-    @project.metric_rollups.sum(&metric) / hours_in_interval
+  def used_average_for(metric, hours_in_interval, resource)
+    resource.metric_rollups.sum(&metric) / hours_in_interval
   end
 
   context "Daily" do
@@ -70,19 +70,19 @@ describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day, @project)
       expect(subject.cpu_cores_used_metric).to eq(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
 
     it "memory" do
-      metric_used = used_average_for(:derived_memory_used, hours_in_day)
+      metric_used = used_average_for(:derived_memory_used, hours_in_day, @project)
       expect(subject.memory_used_metric).to eq(metric_used)
       expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
 
     it "net io" do
-      metric_used = used_average_for(:net_usage_rate_average, hours_in_day)
+      metric_used = used_average_for(:net_usage_rate_average, hours_in_day, @project)
       expect(subject.net_io_used_metric).to eq(metric_used)
       expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
@@ -110,19 +110,19 @@ describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
 
     it "memory" do
-      metric_used = used_average_for(:derived_memory_used, hours_in_month)
+      metric_used = used_average_for(:derived_memory_used, hours_in_month, @project)
       expect(subject.memory_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
 
     it "net io" do
-      metric_used = used_average_for(:net_usage_rate_average, hours_in_month)
+      metric_used = used_average_for(:net_usage_rate_average, hours_in_month, @project)
       expect(subject.net_io_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
@@ -149,7 +149,7 @@ describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
@@ -170,7 +170,7 @@ describe ChargebackContainerProject do
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
-      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month, @project)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
       expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
       expect(subject.tag_name).to eq('Production')

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,4 +1,6 @@
 describe ChargebackContainerProject do
+  include Spec::Support::ChargebackHelper
+
   let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
   let(:hourly_rate)       { 0.01 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
@@ -43,10 +45,6 @@ describe ChargebackContainerProject do
 
   after do
     Timecop.return
-  end
-
-  def used_average_for(metric, hours_in_interval, resource)
-    resource.metric_rollups.sum(&metric) / hours_in_interval
   end
 
   context "Daily" do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,9 +1,5 @@
 describe ChargebackVm do
-  def set_tier_param_for(metric, param, value, num_of_tier = 0)
-    tier = chargeback_rate.chargeback_rate_details.where(:metric => metric).first.chargeback_tiers[num_of_tier]
-    tier.send("#{param}=", value)
-    tier.save
-  end
+  include Spec::Support::ChargebackHelper
 
   let(:admin) { FactoryGirl.create(:user_admin) }
   let(:base_options) do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -112,10 +112,6 @@ describe ChargebackVm do
     end
   end
 
-  def used_average_for(metric, hours_in_interval, resource)
-    resource.metric_rollups.sum(&metric) / hours_in_interval
-  end
-
   context "Daily" do
     let(:hours_in_day) { 24 }
     let(:options) { base_options.merge(:interval => 'daily') }

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -112,8 +112,8 @@ describe ChargebackVm do
     end
   end
 
-  def used_average_for(metric, hours_in_interval)
-    @vm1.metric_rollups.sum(&metric) / hours_in_interval
+  def used_average_for(metric, hours_in_interval, resource)
+    resource.metric_rollups.sum(&metric) / hours_in_interval
   end
 
   context "Daily" do
@@ -141,7 +141,7 @@ describe ChargebackVm do
 
     it "cpu" do
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day, @vm1)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
       expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
@@ -155,7 +155,7 @@ describe ChargebackVm do
 
     it "cpu_vm_and_cpu_container_project" do
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day, @vm1)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
       expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
@@ -165,7 +165,7 @@ describe ChargebackVm do
 
     it "memory" do
       expect(subject.memory_allocated_metric).to eq(memory_available)
-      used_metric = used_average_for(:derived_memory_used, hours_in_day)
+      used_metric = used_average_for(:derived_memory_used, hours_in_day, @vm1)
       expect(subject.memory_used_metric).to eq(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
@@ -175,19 +175,19 @@ describe ChargebackVm do
     end
 
     it "disk io" do
-      used_metric = used_average_for(:disk_usage_rate_average, hours_in_day)
+      used_metric = used_average_for(:disk_usage_rate_average, hours_in_day, @vm1)
       expect(subject.disk_io_used_metric).to eq(used_metric)
       expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_day)
     end
 
     it "net io" do
-      used_metric = used_average_for(:net_usage_rate_average, hours_in_day)
+      used_metric = used_average_for(:net_usage_rate_average, hours_in_day, @vm1)
       expect(subject.net_io_used_metric).to eq(used_metric)
       expect(subject.net_io_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
     end
 
     it "storage" do
-      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
+      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day, @vm1)
       expect(subject.storage_used_metric).to eq(used_metric)
       expect(subject.storage_used_cost).to eq(used_metric / 1.gigabyte * count_hourly_rate * hours_in_day)
 
@@ -211,7 +211,7 @@ describe ChargebackVm do
 
       it "storage metrics" do
         expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
-        used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
+        used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day, @vm1)
         expect(subject.storage_used_metric).to eq(used_metric)
         expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
@@ -276,7 +276,7 @@ describe ChargebackVm do
 
     it "cpu" do
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, @vm1)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
       expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
@@ -292,7 +292,7 @@ describe ChargebackVm do
 
       it "cpu" do
         expect(subject.cpu_allocated_metric).to eq(cpu_count)
-        used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
+        used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, @vm1)
         expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
 
         fixed = fixed_rate * hours_in_month
@@ -307,7 +307,7 @@ describe ChargebackVm do
 
     it "memory" do
       expect(subject.memory_allocated_metric).to eq(memory_available)
-      used_metric = used_average_for(:derived_memory_used, hours_in_month)
+      used_metric = used_average_for(:derived_memory_used, hours_in_month, @vm1)
       expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
@@ -318,13 +318,13 @@ describe ChargebackVm do
     end
 
     it "disk io" do
-      used_metric = used_average_for(:disk_usage_rate_average, hours_in_month)
+      used_metric = used_average_for(:disk_usage_rate_average, hours_in_month, @vm1)
       expect(subject.disk_io_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
     end
 
     it "net io" do
-      used_metric = used_average_for(:net_usage_rate_average, hours_in_month)
+      used_metric = used_average_for(:net_usage_rate_average, hours_in_month, @vm1)
       expect(subject.net_io_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
     end
@@ -342,7 +342,7 @@ describe ChargebackVm do
 
       it "storage with only fixed rates" do
         expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
-        used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
+        used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month, @vm1)
         expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
         expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
@@ -357,7 +357,7 @@ describe ChargebackVm do
 
     it "storage" do
       expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
-      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
+      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month, @vm1)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
@@ -519,7 +519,7 @@ describe ChargebackVm do
 
     it "cpu" do
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, @vm1)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.tag_name).to eq('Production')
     end

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -1,0 +1,6 @@
+module Spec
+  module Support
+    module ChargebackHelper
+    end
+  end
+end

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -6,6 +6,10 @@ module Spec
         tier.send("#{param}=", value)
         tier.save
       end
+
+      def used_average_for(metric, hours_in_interval, resource)
+        resource.metric_rollups.sum(&metric) / hours_in_interval
+      end
     end
   end
 end

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -1,6 +1,11 @@
 module Spec
   module Support
     module ChargebackHelper
+      def set_tier_param_for(metric, param, value, num_of_tier = 0)
+        tier = chargeback_rate.chargeback_rate_details.where(:metric => metric).first.chargeback_tiers[num_of_tier]
+        tier.send("#{param}=", value)
+        tier.save
+      end
     end
   end
 end


### PR DESCRIPTION
In upcoming refactoring of chargeback specs, I think that will be usefull to have chargeback hepler,
where will be common methods for chargeback specs 

In this PR I am moving methods `set_tier_param_for` and `used_average_for` to the helper for now.

@miq-bot add_label test, refactoring, euwe/no
@miq-bot assign @chrisarcand 