### PR TITLE
Chargeback: Fix rate adjustment rounding bug

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -115,19 +115,20 @@ class ChargebackRateDetail < ApplicationRecord
   def rate_adjustment(hr)
     case metric
     when "cpu_usagemhz_rate_average" then
-      per_unit == 'megahertz' ? 1 : adjustment_measure('megahertz')
+      adjustment_measure('megahertz')
     when "derived_memory_used", "derived_memory_available" then
-      per_unit == 'megabytes' ? 1 : adjustment_measure('megabytes')
+      adjustment_measure('megabytes')
     when "net_usage_rate_average", "disk_usage_rate_average" then
-      per_unit == 'kbps' ? 1 : adjustment_measure('kbps')
+      adjustment_measure('kbps')
     when "derived_vm_allocated_disk_storage", "derived_vm_used_disk_storage" then
-      per_unit == 'bytes' ? 1 : adjustment_measure('bytes')
+      adjustment_measure('bytes')
     else 1
     end * hr
   end
 
   # Adjusts the hourly rate to the per unit by default
   def adjustment_measure(pu_destiny)
+    return 1 if per_unit == pu_destiny
     measure = detail_measure
     pos_pu_destiny = measure.units.index(pu_destiny)
     pos_per_unit = measure.units.index(per_unit)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -115,24 +115,24 @@ class ChargebackRateDetail < ApplicationRecord
   def rate_adjustment(hr)
     case metric
     when "cpu_usagemhz_rate_average" then
-      per_unit == 'megahertz' ? hr : hr = adjustment_measure(hr, 'megahertz')
+      per_unit == 'megahertz' ? hr : adjustment_measure('megahertz') * hr
     when "derived_memory_used", "derived_memory_available" then
-      per_unit == 'megabytes' ? hr : hr = adjustment_measure(hr, 'megabytes')
+      per_unit == 'megabytes' ? hr : adjustment_measure('megabytes') * hr
     when "net_usage_rate_average", "disk_usage_rate_average" then
-      per_unit == 'kbps' ? hr : hr = adjustment_measure(hr, 'kbps')
+      per_unit == 'kbps' ? hr : adjustment_measure('kbps') * hr
     when "derived_vm_allocated_disk_storage", "derived_vm_used_disk_storage" then
-      per_unit == 'bytes' ? hr : hr = adjustment_measure(hr, 'bytes')
+      per_unit == 'bytes' ? hr : adjustment_measure('bytes') * hr
     else hr
     end
   end
 
   # Adjusts the hourly rate to the per unit by default
-  def adjustment_measure(hr, pu_destiny)
+  def adjustment_measure(pu_destiny)
     measure = detail_measure
     pos_pu_destiny = measure.units.index(pu_destiny)
     pos_per_unit = measure.units.index(per_unit)
     jumps = pos_pu_destiny - pos_per_unit
-    hr.to_f * (measure.step**jumps)
+    measure.step.to_f**jumps
   end
 
   def affects_report_fields(report_cols)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -115,20 +115,10 @@ class ChargebackRateDetail < ApplicationRecord
 
   def rate_adjustment
     @rate_adjustment ||= if METRIC_UNITS[metric]
-                           adjustment_measure(METRIC_UNITS[metric])
+                           detail_measure.adjust(per_unit, METRIC_UNITS[metric])
                          else
                            1
                          end
-  end
-
-  # Adjusts the hourly rate to the per unit by default
-  def adjustment_measure(pu_destiny)
-    return 1 if per_unit == pu_destiny
-    measure = detail_measure
-    pos_pu_destiny = measure.units.index(pu_destiny)
-    pos_per_unit = measure.units.index(per_unit)
-    jumps = pos_pu_destiny - pos_per_unit
-    measure.step.to_f**jumps
   end
 
   def affects_report_fields(report_cols)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -131,12 +131,8 @@ class ChargebackRateDetail < ApplicationRecord
     measure = detail_measure
     pos_pu_destiny = measure.units.index(pu_destiny)
     pos_per_unit = measure.units.index(per_unit)
-    jumps = (pos_per_unit - pos_pu_destiny).abs
-    if pos_per_unit > pos_pu_destiny
-      hr.to_f / (measure.step**jumps)
-    else
-      hr * (measure.step**jumps)
-    end
+    jumps = pos_pu_destiny - pos_per_unit
+    hr.to_f * (measure.step**jumps)
   end
 
   def affects_report_fields(report_cols)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -115,15 +115,15 @@ class ChargebackRateDetail < ApplicationRecord
   def rate_adjustment(hr)
     case metric
     when "cpu_usagemhz_rate_average" then
-      per_unit == 'megahertz' ? hr : adjustment_measure('megahertz') * hr
+      per_unit == 'megahertz' ? 1 : adjustment_measure('megahertz')
     when "derived_memory_used", "derived_memory_available" then
-      per_unit == 'megabytes' ? hr : adjustment_measure('megabytes') * hr
+      per_unit == 'megabytes' ? 1 : adjustment_measure('megabytes')
     when "net_usage_rate_average", "disk_usage_rate_average" then
-      per_unit == 'kbps' ? hr : adjustment_measure('kbps') * hr
+      per_unit == 'kbps' ? 1 : adjustment_measure('kbps')
     when "derived_vm_allocated_disk_storage", "derived_vm_used_disk_storage" then
-      per_unit == 'bytes' ? hr : adjustment_measure('bytes') * hr
-    else hr
-    end
+      per_unit == 'bytes' ? 1 : adjustment_measure('bytes')
+    else 1
+    end * hr
   end
 
   # Adjusts the hourly rate to the per unit by default

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -102,27 +102,22 @@ class ChargebackRateDetail < ApplicationRecord
     hourly_rate
   end
 
-  # Scale the rate in the unit difine by user to the default unit of the metric
-  # It showing the default units of the metrics:
-  # cpu_usagemhz_rate_average --> megahertz
-  # derived_memory_used --> megabytes
-  # derived_memory_available -->megabytes
-  # net_usage_rate_average --> kbps
-  # disk_usage_rate_average --> kbps
-  # derived_vm_allocated_disk_storage --> bytes
-  # derived_vm_used_disk_storage --> bytes
+  # Scale the rate in the unit defined by user -> to the default unit of the metric
+  METRIC_UNITS = {
+    'cpu_usagemhz_rate_average'         => 'megahertz',
+    'derived_memory_used'               => 'megabytes',
+    'derived_memory_available'          => 'megabytes',
+    'net_usage_rate_average'            => 'kbps',
+    'disk_usage_rate_average'           => 'kbps',
+    'derived_vm_allocated_disk_storage' => 'bytes',
+    'derived_vm_used_disk_storage'      => 'bytes'
+  }.freeze
 
   def rate_adjustment(hr)
-    case metric
-    when "cpu_usagemhz_rate_average" then
-      adjustment_measure('megahertz')
-    when "derived_memory_used", "derived_memory_available" then
-      adjustment_measure('megabytes')
-    when "net_usage_rate_average", "disk_usage_rate_average" then
-      adjustment_measure('kbps')
-    when "derived_vm_allocated_disk_storage", "derived_vm_used_disk_storage" then
-      adjustment_measure('bytes')
-    else 1
+    if METRIC_UNITS[metric]
+      adjustment_measure(METRIC_UNITS[metric])
+    else
+      1
     end * hr
   end
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -57,10 +57,7 @@ class ChargebackRateDetail < ApplicationRecord
   def find_rate(value)
     fixed_rate = 0.0
     variable_rate = 0.0
-    tier_found, = chargeback_tiers.select do |tier|
-      tier.starts_with_zero? && value.zero? ||
-        value > (rate_adjustment * tier.start) && value <= (rate_adjustment * tier.finish)
-    end
+    tier_found = chargeback_tiers.detect { |tier| tier.includes?(value / rate_adjustment) }
     unless tier_found.nil?
       fixed_rate = tier_found.fixed_rate
       variable_rate = tier_found.variable_rate

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -16,7 +16,7 @@ class ChargebackRateDetailMeasure < ApplicationRecord
   def adjust(from_unit, to_unit)
     return 1 if from_unit == to_unit
     jumps = units.index(to_unit) - units.index(from_unit)
-    step.to_f**jumps
+    BigDecimal.new(step)**jumps
   end
 
   private def units_same_length

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -13,6 +13,12 @@ class ChargebackRateDetailMeasure < ApplicationRecord
     Hash[units_display.zip(units)]
   end
 
+  def adjust(from_unit, to_unit)
+    return 1 if from_unit == to_unit
+    jumps = units.index(to_unit) - units.index(from_unit)
+    step.to_f**jumps
+  end
+
   private def units_same_length
     unless (units.count == units_display.count)
       errors.add("Units Problem", "Units_display length diferent that the units length")

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -18,7 +18,7 @@ class ChargebackTier < ApplicationRecord
   end
 
   def includes?(value)
-    starts_with_zero? && value.zero? || value > start && value <= finish
+    starts_with_zero? && value.zero? || value > start && value.to_f <= finish
   end
 
   def starts_with_zero?

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -17,6 +17,10 @@ class ChargebackTier < ApplicationRecord
     end
   end
 
+  def includes?(value)
+    starts_with_zero? && value.zero? || value > start && value <= finish
+  end
+
   def starts_with_zero?
     start.zero?
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -109,7 +109,7 @@ describe ChargebackRateDetail do
     ].each_slice(2) do |per_unit, rate_adjustment|
       cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :metric => 'derived_memory_available',
        :chargeback_rate_detail_measure_id => cbdm.id)
-      expect(cbd.rate_adjustment(value)).to eq(rate_adjustment)
+      expect(cbd.rate_adjustment * value).to eq(rate_adjustment)
     end
   end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -92,7 +92,7 @@ describe ChargebackVm do
       @service << @vm1
       @service.save
 
-      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => admin)
+      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => admin, :created_on => month_beginning)
 
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         [@vm1, @vm2].each do |vm|
@@ -233,7 +233,8 @@ describe ChargebackVm do
     before do
       @tenant = FactoryGirl.create(:tenant)
       @tenant_child = FactoryGirl.create(:tenant, :ancestry => @tenant.id)
-      @vm_tenant = FactoryGirl.create(:vm_vmware, :tenant_id => @tenant_child.id, :name => "test_vm_tenant")
+      @vm_tenant = FactoryGirl.create(:vm_vmware, :tenant_id => @tenant_child.id,
+                                      :name => "test_vm_tenant", :created_on => month_beginning)
 
       Range.new(start_time, finish_time, true).step_value(1.hour).each do |t|
         @vm_tenant.metric_rollups <<


### PR DESCRIPTION
### What
- clean-up the rate adjusting code
- fix rounding bug

### Reproducer
Consider the following scenario with disk_allocation_metric:
  - hourly rate is _very_ small number per gigabyte
  - adjustment from bytes to gigabytes is very small number as well
  - the product of the two is extremly small number, hits limits and gets rounded

Found in #13269.

@miq-bot add_label chargeback, bug, euwe/no