### PR TITLE
Moved UI gem dependencies to the UI repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,14 +104,6 @@ group :automate do
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb
-  # Unmodified gems
-  gem "angular-ui-bootstrap-rails",   "~>0.13.0"
-  gem "coffee-rails"
-  gem "jquery-hotkeys-rails"
-  gem "lodash-rails",                 "~>3.10.0"
-  gem "patternfly-sass",              "~>3.15.0"
-  gem "sass-rails"
-
   # Modified gems (forked on Github)
   gem "jquery-rjs",                   "=0.1.1",                       :git => "https://github.com/ManageIQ/jquery-rjs.git", :tag => "v0.1.1-1"
 end


### PR DESCRIPTION
The jquery-rjs is included from our fork on GitHub and there is no
support for unreleased gems in a gemspec. I also tried to move it
to the UI Gemfile, without any success. So until we don't push it
to Rubygems.org, it needs to stay in the main repo's Gemfile.

Parent issue:
https://github.com/ManageIQ/manageiq-ui-classic/issues/1

Merge after:
https://github.com/ManageIQ/manageiq-ui-classic/pull/48