### PR TITLE
Fix chargeback vm timezone-dependent specs

### DIFF
--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -231,8 +231,8 @@ describe ChargebackVm do
 
   context "Report a chargeback of a tenant" do
     let(:options_tenant) { base_options.merge(:tenant_id => @tenant.id) }
-    let(:start_time)  { Time.parse('2012-09-01 07:00:00').utc }
-    let(:finish_time) { Time.parse('2012-09-01 10:00:00').utc }
+    let(:start_time)  { Time.parse('2012-09-01 07:00:00Z').utc }
+    let(:finish_time) { Time.parse('2012-09-01 10:00:00Z').utc }
 
     before do
       @tenant = FactoryGirl.create(:tenant)


### PR DESCRIPTION
These are failing for the same reason as addressed in
26554e285972d3eec369aec26c70d65636ba5948 /
https://github.com/ManageIQ/manageiq/pull/13287

/cc @lpichler 
@miq-bot add-label bug, test
@miq-bot assign @gtanzillo 