### PR TITLE
Increment the ae_state_retries when on_exit sets retry

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
@@ -100,7 +100,7 @@ module MiqAeEngine
         # Process on_exit method
         process_state_step_with_error_handling(f, 'on_exit') do
           process_state_method(f, 'on_exit')
-          if @workspace.root['ae_result'] == 'retry' and !state_in_retry
+          if @workspace.root['ae_result'] == 'retry' && !state_in_retry
             increment_state_retries
           end
         end

--- a/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_state_machine.rb
@@ -96,8 +96,14 @@ module MiqAeEngine
           end
         end
 
+        state_in_retry = @workspace.root['ae_result'] == 'retry'
         # Process on_exit method
-        process_state_step_with_error_handling(f, 'on_exit') { process_state_method(f, 'on_exit') }
+        process_state_step_with_error_handling(f, 'on_exit') do
+          process_state_method(f, 'on_exit')
+          if @workspace.root['ae_result'] == 'retry' and !state_in_retry
+            increment_state_retries
+          end
+        end
         set_next_state(f, message)
       end
     end


### PR DESCRIPTION
The ae_state_retries is a counter that keeps track of the number of retries. Previously this was not being done when the 'on_exit' method sets the ae_result to retry. With this PR we will increment ae_state_retries when the on_exit method sets the ae_result to retry.

Links

* https://bugzilla.redhat.com/show_bug.cgi?id=1368058