### PR TITLE
Delete crufty file paths in .gitignore/.codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,7 +17,6 @@ exclude_paths:
 - "db/fixtures/**/*.yml"
 - "db/migrate/20130923182042_collapsed_initial_migration.rb"
 - "locale/"
-- "public/javascripts/timeline/"
 - "spec/"
 - "test/"
 - "tmp/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,6 @@ exclude_paths:
 - "**.xml"
 - "**.yaml"
 - "**.yml"
-- "app/assets/javascripts/dhtmlx*/"
 - "config/dictionary_strings.rb"
 - "config/model_attributes.rb"
 - "config/yaml_strings.rb"

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ log/*.txt
 log/call_graph_*.html
 
 # product/
-product/license
 product/automate
 
 # public/

--- a/.gitignore
+++ b/.gitignore
@@ -82,16 +82,11 @@ product/automate
 # public/
 /public/assets/
 /public/doc/
-public/dhtmlx_test.html
-public/dhtmlx_test_cal.html
 public/test_grid.xml
 public/test_grid-0.xml
 public/upload
 public/pictures/
 public/ui/
-
-# public/dhtmlx/
-public/dhtmlx/dhtmlxtoolbar.js.orig
 
 # public/javascripts/
 public/javascripts/jmaki.js

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ SyntaxCheck
 xfer_*.xml
 Thumbs.db
 
-# app/controllers/
-app/controllers/new_module.rb
-
 # app/views/layouts/
 app/views/layouts/_center_buttons_1.rhtml
 app/views/layouts/_center_buttons_new.rhtml
@@ -81,8 +78,6 @@ product/automate
 # public/
 /public/assets/
 /public/doc/
-public/test_grid.xml
-public/test_grid-0.xml
 public/upload
 public/pictures/
 public/ui/

--- a/.gitignore
+++ b/.gitignore
@@ -35,17 +35,6 @@ SyntaxCheck
 xfer_*.xml
 Thumbs.db
 
-# app/views/layouts/
-app/views/layouts/_center_buttons_1.rhtml
-app/views/layouts/_center_buttons_new.rhtml
-app/views/layouts/_center_buttons_jmaki.rhtml
-
-# app/views/vm/
-app/views/vm/.fuse_hidden0000208f00000004
-app/views/vm/_main_old.rhtml
-app/views/vm/_main_new.rhtml
-app/views/vm/.fuse_hidden0000228d0000000a
-
 # bin/
 bin/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -99,23 +99,6 @@ public/javascripts/jmaki-uncompressed.js
 public/javascripts/glue.js
 public/javascripts/system-glue.js
 
-# public/stylesheets/
-public/stylesheets/jmaki-standard.css
-public/stylesheets/dhtmlXGrid.css
-public/stylesheets/jmaki-2-row-right-sidebar-footer.css
-public/stylesheets/jmaki-centered.css
-public/stylesheets/jmaki-3column-fixed-sidebars.css
-public/stylesheets/jmaki-2column-footer.css
-public/stylesheets/jmaki-3column.css
-public/stylesheets/container-2fixed-right-sidebars.css
-public/stylesheets/jmaki-right-sidebar.css
-public/stylesheets/container-right-sidebars.css
-public/stylesheets/jmaki-standard-footer.css
-public/stylesheets/jmaki-2fixed-right-sidebars.css
-public/stylesheets/jmaki-3column-footer.css
-public/stylesheets/jmaki-standard-no-sidebars.css
-public/stylesheets/jmaki-standard-right-sidebar.css
-
 # spec/
 spec/replication/util/data/euwe_migrations
 

--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,6 @@ public/upload
 public/pictures/
 public/ui/
 
-# public/javascripts/
-public/javascripts/jmaki.js
-public/javascripts/jmaki-uncompressed.js
-public/javascripts/glue.js
-public/javascripts/system-glue.js
-
 # spec/
 spec/replication/util/data/euwe_migrations
 


### PR DESCRIPTION
Most of the deletions here are for ignoring:
* assets referencing the old public location. Note, even the newer app/assets directories don't exist due to https://github.com/ManageIQ/manageiq/pull/13303, so ✂️ 
* legacy cruft that's no longer needed

There might be more to delete here but I got tired of spelunking git history
