### PR TITLE
Fixing refresh for multi managed domain environment.

### DIFF
--- a/app/models/ems_refresh/save_inventory_middleware.rb
+++ b/app/models/ems_refresh/save_inventory_middleware.rb
@@ -41,7 +41,8 @@ module EmsRefresh::SaveInventoryMiddleware
     hashes.each do |h|
       h[:domain_id] = domain[:id]
     end
-    save_inventory_multi(domain.middleware_server_groups, hashes, deletes, [:ems_ref], nil, [:middleware_domain])
+    save_inventory_multi(domain.middleware_server_groups, hashes, deletes, [:ems_ref], nil, [:middleware_domain,
+                                                                                             :_object])
     store_ids_for_new_records(domain.middleware_server_groups, hashes, :ems_ref)
   end
 
@@ -60,7 +61,9 @@ module EmsRefresh::SaveInventoryMiddleware
       server_group_id = h.fetch_path(:middleware_server_group, :id)
       if server_group_id.nil?
         nativeid = h.fetch_path(:middleware_server_group, :nativeid)
+        feed = h.fetch_path(:feed)
         server_group_id = MiddlewareServerGroup.where('nativeid' => nativeid)
+                                               .where('feed' => feed)
                                                .order('created_at')
                                                .try(:last)
                                                .try(:id) unless nativeid.nil?

--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -47,14 +47,12 @@ module ManageIQ::Providers
 
       def fetch_domains_with_servers
         @data[:middleware_domains] = []
-        @data[:middleware_server_groups] = []
         @ems.feeds.each do |feed|
           @ems.domains(feed).each do |domain|
             parsed_domain = parse_middleware_domain(feed, domain)
-            fetch_server_groups(feed)
 
             # add the server groups to the domain
-            parsed_domain[:middleware_server_groups] = @data[:middleware_server_groups]
+            parsed_domain[:middleware_server_groups] = fetch_server_groups(feed)
             @data[:middleware_domains] << parsed_domain
             @data_index.store_path(:middleware_domains, :by_ems_ref, parsed_domain[:ems_ref], parsed_domain)
 
@@ -65,10 +63,10 @@ module ManageIQ::Providers
       end
 
       def fetch_server_groups(feed)
-        @ems.server_groups(feed).each do |group|
+        @ems.server_groups(feed).map do |group|
           parsed_group = parse_middleware_server_group(group)
-          @data[:middleware_server_groups] << parsed_group
           @data_index.store_path(:middleware_server_groups, :by_name, parsed_group[:name], parsed_group)
+          parsed_group
         end
       end
 


### PR DESCRIPTION
Fixes how server groups are associated with domains and servers with server groups when multiple domains are present.

It does 3 things, all are needed.
1. adding `_object` to ignored keys - this fixes the https://bugzilla.redhat.com/show_bug.cgi?id=1394040
2. the feed id must match when finding the appropriate server group - fixes https://bugzilla.redhat.com/show_bug.cgi?id=1403775
3. resetting the `@data[:middleware_server_groups]` during the refresh for each feed. This led to the bug that if there were 2 domains the second had the server groups from the first one.

@miq-bot add_labels providers/hawkular, bug