### PR TITLE
[EUWE] peg rails to 5.0.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "paperclip",                      "~>4.3.0"
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.0.0", ">= 5.0.0.1"
+gem "rails",                          "~>5.0.0.1"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"


### PR DESCRIPTION
Rails 5.0.1 introduces some changes that breaks our virtual attributes implementation

This pegs us to 5.0.0.1 and higher (but less than 5.0.1)