### PR TITLE
Add base block storage manager

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -1,6 +1,6 @@
 module EmsRefresh
   extend EmsRefresh::SaveInventory
-  extend EmsRefresh::SaveInventoryCinder
+  extend EmsRefresh::SaveInventoryBlockStorage
   extend EmsRefresh::SaveInventoryCloud
   extend EmsRefresh::SaveInventoryInfra
   extend EmsRefresh::SaveInventoryContainer

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -11,7 +11,7 @@ module EmsRefresh::SaveInventory
     when ManageIQ::Providers::ConfigurationManager          then save_configuration_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ContainerManager              then save_ems_container_inventory(ems, hashes, target)
     when ManageIQ::Providers::NetworkManager                then save_ems_network_inventory(ems, hashes, target)
-    when ManageIQ::Providers::StorageManager::CinderManager then save_ems_cinder_inventory(ems, hashes, target)
+    when ManageIQ::Providers::BlockStorageManager           then save_ems_block_storage_inventory(ems, hashes, target)
     when ManageIQ::Providers::StorageManager::SwiftManager  then save_ems_swift_inventory(ems, hashes, target)
     when ManageIQ::Providers::MiddlewareManager             then save_ems_middleware_inventory(ems, hashes, target)
     when ManageIQ::Providers::DatawarehouseManager          then save_ems_datawarehouse_inventory(ems, hashes, target)

--- a/app/models/ems_refresh/save_inventory_block_storage.rb
+++ b/app/models/ems_refresh/save_inventory_block_storage.rb
@@ -7,8 +7,8 @@
 #   - backing_links
 #
 
-module EmsRefresh::SaveInventoryCinder
-  def save_ems_cinder_inventory(ems, hashes, target = nil)
+module EmsRefresh::SaveInventoryBlockStorage
+  def save_ems_block_storage_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -32,9 +32,9 @@ module EmsRefresh::SaveInventoryCinder
     ]
 
     # Save and link other subsections
-    save_cinder_child_inventory(ems, hashes, child_keys, target)
+    save_block_storage_child_inventory(ems, hashes, child_keys, target)
 
-    link_cinder_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
+    link_block_storage_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
 
     ems.save!
     hashes[:id] = ems.id
@@ -44,7 +44,7 @@ module EmsRefresh::SaveInventoryCinder
     ems
   end
 
-  def save_cinder_cloud_volumes_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volumes_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volumes.reset
@@ -64,7 +64,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
-  def save_cinder_cloud_volume_backups_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volume_backups_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volume_backups.reset
@@ -84,7 +84,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volume_backups, hashes, :ems_ref)
   end
 
-  def save_cinder_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots.reset
@@ -103,7 +103,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volume_snapshots, hashes, :ems_ref)
   end
 
-  def save_cinder_backing_links_inventory(_ems, hashes, _target)
+  def save_block_storage_backing_links_inventory(_ems, hashes, _target)
     hashes.each do |dh|
       dh[:backing_id]   = dh[:backing_volume][:id]
       dh[:backing_type] = 'CloudVolume'
@@ -123,7 +123,7 @@ module EmsRefresh::SaveInventoryCinder
     end
   end
 
-  def link_cinder_volumes_to_base_snapshots(hashes)
+  def link_block_storage_volumes_to_base_snapshots(hashes)
     base_snapshot_to_volume = hashes.each_with_object({}) do |h, bsh|
       next unless (base_snapshot = h[:base_snapshot])
       (bsh[base_snapshot[:id]] ||= []) << h[:id]
@@ -134,7 +134,7 @@ module EmsRefresh::SaveInventoryCinder
     end
   end
 
-  def save_cinder_child_inventory(obj, hashes, child_keys, *args)
-    child_keys.each { |k| send("save_cinder_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
+  def save_block_storage_child_inventory(obj, hashes, child_keys, *args)
+    child_keys.each { |k| send("save_block_storage_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
   end
 end

--- a/app/models/manageiq/providers/block_storage_manager.rb
+++ b/app/models/manageiq/providers/block_storage_manager.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::BlockStorageManager < ManageIQ::Providers::StorageManager
+  has_many :cloud_volumes,          :foreign_key => :ems_id, :dependent => :destroy
+  has_many :cloud_volume_snapshots, :foreign_key => :ems_id, :dependent => :destroy
+  has_many :cloud_volume_backups,   :foreign_key => :ems_id, :dependent => :destroy
+
+  supports :block_storage
+end

--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -1,16 +1,12 @@
 #
 #
 
-class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::StorageManager
+class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::BlockStorageManager
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
-
-  has_many :cloud_volumes,                 :foreign_key => :ems_id, :dependent => :destroy
-  has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
-  has_many :cloud_volume_backups,          :foreign_key => :ems_id, :dependent => :destroy
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,
@@ -31,7 +27,6 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
            :to        => :parent_manager,
            :allow_nil => true
 
-  supports :block_storage
   supports :cinder_service do
     if parent_manager
       unsupported_reason_add(:cinder_service, parent_manager.unsupported_reason(:cinder_service)) unless

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-block_storage_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-block_storage_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_BlockStorageManager < MiqAeServiceExtManagementSystem
+  end
+end


### PR DESCRIPTION
While working on the Amazon block storage manager (EBS) I used Cinder
manager as a template. Once the provider and the refresh parser were
ready I noticed the collected data is not stored in the DB. Debugging led
me to `EmsRefresh` that specifically checked for the implementation
of CinderManager. Since Amazon block storage manager can reuse
most of the functionality and underlying models, I introduced an intermediate
base class for block storage managers.

However, since I couldn't find specific tests for the Cinder manager, I only ran
some of the tests that I thought might be relevant. I hope Travis will help me out
identifying any other that may be broken by the change.

I can use this base provider with the current implementation of the EBS 
[provider](https://github.com/ManageIQ/manageiq-providers-amazon/compare/master...gberginc:introduce_ebs_manager).

I would appreciate any comment if such a change makes
any sense? If it does, we'll have to add `object_storage_manager` as well
as we are also working on S3 provider.

@miq-bot add_label wip, providers, providers/storage, refactoring