### PR TITLE
Enhance Blueprint Versioning 

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -1,4 +1,6 @@
 class Blueprint < ApplicationRecord
+  has_many :versions, :class_name => 'Blueprint',
+           :foreign_key => :original_blueprint_id, :primary_key => :original_blueprint_id
   has_many :service_templates
   private  :service_templates, :service_templates=
 
@@ -7,6 +9,9 @@ class Blueprint < ApplicationRecord
   virtual_column :in_use?, :type => :boolean
 
   acts_as_miq_taggable
+
+  after_create :set_original_blueprint
+  default_value_for :active_version, false
 
   # the top of the service_templates, a bundle that contains child items
   def bundle
@@ -114,6 +119,10 @@ class Blueprint < ApplicationRecord
   end
 
   private
+
+  def set_original_blueprint
+    update_attributes!(:original_blueprint_id => id, :active_version => true) unless original_blueprint_id
+  end
 
   def parse_service_catalog
     ServiceTemplateCatalog.find_by(:id => ui_properties.fetch_path("service_catalog", "id"))

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -10,8 +10,8 @@ class Blueprint < ApplicationRecord
 
   acts_as_miq_taggable
 
-  after_create :set_original_blueprint
-  default_value_for :active_version, false
+  after_save :update_versions
+  default_value_for :active_version, true
 
   # the top of the service_templates, a bundle that contains child items
   def bundle
@@ -120,8 +120,10 @@ class Blueprint < ApplicationRecord
 
   private
 
-  def set_original_blueprint
-    update_attributes!(:original_blueprint_id => id, :active_version => true) unless original_blueprint_id
+  def update_versions
+    update_attributes!(:original_blueprint_id => id) unless original_blueprint_id
+    # Latest edited version will be set as the active version
+    versions.where.not(:id => id).update_all(:active_version => false)
   end
 
   def parse_service_catalog

--- a/db/migrate/20170103162338_add_original_blueprint_id.rb
+++ b/db/migrate/20170103162338_add_original_blueprint_id.rb
@@ -1,0 +1,6 @@
+class AddOriginalBlueprintId < ActiveRecord::Migration[5.0]
+  def change
+    add_column :blueprints, :original_blueprint_id, :bigint
+    add_column :blueprints, :active_version, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -170,6 +170,8 @@ blueprints:
 - ui_properties
 - created_at
 - updated_at
+- original_blueprint_id
+- active_version
 bottleneck_events:
 - id
 - timestamp

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -356,14 +356,15 @@ describe Blueprint do
       subject.save!
     end
 
-    it 'will be set to true if it has no other versions' do
+    it 'defaults to true' do
       expect(subject.active_version).to be_truthy
     end
 
-    it 'will be set to false if it has other versions' do
+    it 'will set latest saved blueprint to the active_version' do
       blueprint_2 = FactoryGirl.create(:blueprint, :original_blueprint_id => subject.id)
 
-      expect(blueprint_2.active_version).to be_falsey
+      expect(blueprint_2.active_version).to be_truthy
+      expect(subject.reload.active_version).to be_falsey
     end
   end
 end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -340,6 +340,32 @@ describe Blueprint do
       expect(subject).to be_in_use
     end
   end
+
+  describe '#versions' do
+    it 'returns all the versions of a blueprint' do
+      subject.save!
+      blueprint_2 = FactoryGirl.create(:blueprint, :original_blueprint_id => subject.id)
+
+      expect(subject.versions).to include(subject, blueprint_2)
+      expect(blueprint_2.versions).to include(subject, blueprint_2)
+    end
+  end
+
+  describe '#active_version' do
+    before do
+      subject.save!
+    end
+
+    it 'will be set to true if it has no other versions' do
+      expect(subject.active_version).to be_truthy
+    end
+
+    it 'will be set to false if it has other versions' do
+      blueprint_2 = FactoryGirl.create(:blueprint, :original_blueprint_id => subject.id)
+
+      expect(blueprint_2.active_version).to be_falsey
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
Background
-----------
Currently, Blueprints have a `version` number, but no way of chaining the different versions together or knowing the currently `active` version. A simple approach was needed to achieve these two basic objectives for Blueprint versioning.

Approach
-----------
This approach adds an `original_blueprint_id` column, so that each version has a link back to the original. Each subsequent version will have the `original_blueprint_id` of the first, "original", Blueprint. The `active_version` column allows for a single blueprint to serve as the active and for simple reverting to previous versions. 

There is some logic that still needs to be implemented (ie setting version numbers, ensuring only one active at a time, etc) which will be covered in upcoming PRs.

cc:  @Fryguy We talked about this a while back in Austin and how we needed more than just a `version` number. Thoughts on this approach? 

@miq-bot add_label enhancement, ui/service, sql migration
@miq-bot assign @Fryguy 

Links
-----------
* [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/135709341)