### PR TITLE
The default compute rate for containers should not be editable

### DIFF
--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -171,7 +171,7 @@
 - :description: Default Container Image Rate
   :guid: b47a0ef0-4335-11df-aba8-001d09066d99
   :rate_type: Compute
-  :default: false
+  :default: true
   :rates:
     - :description: Used CPU
       :group: cpu


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1410012

Next, we should have the new category: Compute for Containers

/cc @zeari 

@miq-bot add_label chargeback, bug
@miq-bot assign @gtanzillo 