### PR TITLE
Restrict adding or editing custom attributes via API by section

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -91,6 +91,9 @@ module Api
         attribute["value"] = attribute.delete("field_type").safe_constantize.parse(attribute["value"])
       end
       attribute["section"] ||= "metadata" unless @req.action == "edit"
+      if attribute["section"].present? && !(CustomAttribute::ALLOWED_API_SECTIONS.include? attribute["section"])
+        raise "Invalid attribute section specified: #{attribute["section"]}"
+      end
       attribute
     rescue => err
       raise BadRequestError, "Invalid provider custom attributes specified - #{err}"

--- a/app/models/custom_attribute.rb
+++ b/app/models/custom_attribute.rb
@@ -1,5 +1,6 @@
 class CustomAttribute < ApplicationRecord
   ALLOWED_API_VALUE_TYPES = %w(DateTime Time Date).freeze
+  ALLOWED_API_SECTIONS = %w(metadata cluster_settings).freeze
   belongs_to :resource, :polymorphic => true
   serialize :serialized_value
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -179,15 +179,25 @@ describe "Providers API" do
       expect_bad_request("Must specify a name")
     end
 
+    it "prevents adding custom attribute to a provider with forbidden section" do
+      api_basic_authorize action_identifier(:providers, :edit)
+
+      run_post(provider_ca_url, gen_request(:add, [{"name" => "name3", "value" => "value3",
+                                                    "section" => "bad_section"}]))
+
+      expect_bad_request("Invalid provider custom attributes specified - " \
+                         "Invalid attribute section specified: bad_section")
+    end
+
     it "add custom attributes to a provider" do
       api_basic_authorize action_identifier(:providers, :edit)
 
       run_post(provider_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
-                                                   {"name" => "name2", "value" => "value2", "section" => "section2"}]))
+                                                   {"name" => "name2", "value" => "value2", "section" => "metadata"}]))
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including("name" => "name1", "value" => "value1", "section" => "metadata"),
-          a_hash_including("name" => "name2", "value" => "value2", "section" => "section2")
+          a_hash_including("name" => "name2", "value" => "value2", "section" => "metadata")
         )
       }
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
The only supported sections are: “metadata” and “cluster_settings”
