### PR TITLE
Document report options (inputs for chargeback)

### DIFF
--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -2,8 +2,8 @@ class Chargeback
   # ReportOptions are usualy stored in MiqReport.db_options[:options]
   ReportOptions = Struct.new(
     :interval,             # daily | weekly | monthly
-    :interval_size,
-    :end_interval_offset,
+    :interval_size,        # number of :intervals in the report (i.e. `12` months, `4` weeks)
+    :end_interval_offset,  # report ends :intervals ago (i.e. `3` months ago, or `2` weeks ago)
     :owner,                # userid
     :tenant_id,
     :tag,                  # like /managed/environment/prod (Mutually exclusive with :user)


### PR DESCRIPTION
The variables' names are not entirely obvious. So it perhaps make sense to shortly describe theirs meaning.

We cannot rename these variables, as existing custom chargeback are using them already (would need migration).

@miq-bot add_label chargeback, technical debt, euwe/no
@miq-bot assign @chrisarcand 