### PR TITLE
Dropped unecessary and risky throwing away of first line in YAML file.

### DIFF
--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -44,11 +44,7 @@ module MiqReport::Seeding
     end
 
     def sync_from_file(filename, dir, typ)
-      fd = File.open(filename)
-      fd.gets # throw away "--- !ruby/object:MIQ_Report \r\n"
-      yml = YAML.load(fd.read)
-      fd.close
-
+      yml = YAML.load_file(filename)
       rpt = {}
       column_names.each { |c| rpt[c.to_sym] = yml[c] }
       rpt.delete :id


### PR DESCRIPTION
The original hack seems unnecessary, currenly all report files start with `---` line, there is no `!ruby/object:MiqReport` anywhere.
However if you forget the `---` line (which is optional in YAML), it would silently eat the first content line (which is frequently `title: ...`, resulting in inability to use the report by its name).

cc: @cben @gtanzillo 
