### PR TITLE
Automate Retry with Server Affinity

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -134,7 +134,9 @@ module MiqAeEngine
 
           message = "Requeuing #{options.inspect} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
           _log.info(message)
-          deliver_queue(options, :deliver_on => deliver_on)
+          queue_options = {:deliver_on => deliver_on}
+          queue_options[:server_guid] = MiqServer.my_guid if ws.root['ae_retry_server_affinity']
+          deliver_queue(options, queue_options)
         else
           if ae_result.casecmp('error').zero?
             message = "Error delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate: #{ws.root['ae_message']}"

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -61,6 +61,7 @@ module MiqAeEngine
         @workspace.root['ae_state']  = f['name'] if @workspace.root['ae_state'].blank?
         @workspace.root['ae_result'] = 'ok'      if @workspace.root['ae_result'].blank?
         @workspace.root['ae_next_state'] = ''
+        @workspace.root['ae_retry_server_affinity'] = false
 
         # Do not proceed further unless this state is runnable
         return unless state_runnable?(f)

--- a/spec/lib/miq_automation_engine/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_state_machine_retry_spec.rb
@@ -13,7 +13,6 @@ describe "MiqAeStateMachineRetry" do
     @root_class      = "TOP_OF_THE_WORLD"
     @root_instance   = "EVEREST"
     @user            = FactoryGirl.create(:user_with_group)
-    @miq_server      = FactoryGirl.create(:miq_server)
     @automate_args   = {:namespace        => @namespace,
                         :class_name       => @root_class,
                         :instance_name    => @root_instance,
@@ -21,8 +20,7 @@ describe "MiqAeStateMachineRetry" do
                         :miq_group_id     => @user.current_group_id,
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
-    allow(MiqServer).to receive(:my_zone).and_return('default')
-    allow(MiqServer).to receive(:my_server).and_return(@miq_server)
+    EvmSpecHelper.create_guid_miq_server_zone
     clear_domain
   end
 
@@ -35,6 +33,8 @@ describe "MiqAeStateMachineRetry" do
       $evm.root['ae_result'] = 'retry'
     RUBY
   end
+
+  alias_method :retry_script, :perpetual_retry_script
 
   def perpetual_restart_script_with_nextstate
     <<-'RUBY'
@@ -53,6 +53,13 @@ describe "MiqAeStateMachineRetry" do
   def simpleton_script
     <<-'RUBY'
       $evm.root['ae_result'] = 'ok'
+    RUBY
+  end
+
+  def retry_server_affinity_script
+    <<-'RUBY'
+      $evm.root['ae_result'] = 'retry'
+      $evm.root['ae_retry_server_affinity'] = true
     RUBY
   end
 
@@ -239,5 +246,27 @@ describe "MiqAeStateMachineRetry" do
     expect(ws).not_to be_nil
     q = MiqQueue.where(:state => 'ready').first
     expect(q.args[0][:state]).to eql('state2')
+  end
+
+  it "retry with server affinity set" do
+    setup_model(retry_server_affinity_script)
+    send_ae_request_via_queue(@automate_args)
+    status, _message, ws = deliver_ae_request_from_queue
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
+    expect(MiqQueue.count).to eq(2)
+    q = MiqQueue.where(:state => 'ready').first
+    expect(q[:server_guid]).to eql(MiqServer.my_guid)
+  end
+
+  it "retry without server affinity set" do
+    setup_model(retry_script)
+    send_ae_request_via_queue(@automate_args)
+    status, _message, ws = deliver_ae_request_from_queue
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
+    expect(MiqQueue.count).to eq(2)
+    q = MiqQueue.where(:state => 'ready').first
+    expect(q[:server_guid]).to be_nil
   end
 end


### PR DESCRIPTION
An automate method retry can happen in any of the servers in the zone.
If a customers automate method had started a process on a specific
server, they would like to have the retry happen on the same server.
This PR optionally allows an automate method to have the retries happen
on the same server using an attribute in the $evm.root object accessible
to automate methods. The name of the attribute is called
**ae_retry_server_affinity**

e.g. To enable the retry to happen on the same server use

_$evm.root['ae_retry_server_affinity'] = true_


Links 
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1408850

Steps for Testing/QA
---------------------
Create a multi server environment (zone)
Write a simple automate method that forces a retry along with some condition to prevent it from perpetually doing a retry

           $evm.root['ae_result'] = 'retry'
           $evm.root['ae_retry_server_affinity'] = true
Incorporate the method into the provisioning workflow (the reason for this is so its delivered via the Queue)
Monitor the log file to see on which servers the methods were executed.

Please note that you can't try this with simulation since that doesn't go thru the queue
