### PR TITLE
Don't let Condition.subst make things taggable

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -101,9 +101,6 @@ class Condition < ApplicationRecord
       MiqPolicy.logger.debug("MIQ(condition-_subst_find): Find Expression after substitution: [#{expr}]")
     end
 
-    # Make rec class act as miq taggable if not already since the substitution fully relies on virtual tags
-    rec.class.acts_as_miq_taggable unless rec.respond_to?("tag_list") || rec.kind_of?(Hash)
-
     # <mode>/virtual/operating_system/product_name</mode>
     # <mode WE/JWSref=host>/managed/environment/prod</mode>
     expr.gsub!(/<(value|exist|count|registry)([^>]*)>([^<]+)<\/(value|exist|count|registry)>/im) { |_s| _subst(rec, $2.strip, $3.strip, $1.strip) }
@@ -124,7 +121,7 @@ class Condition < ApplicationRecord
       if ref.kind_of?(Hash)
         value = ref.fetch(tag, "")
       else
-        ref.nil? ? value = "" : value = ref.tag_list(:ns => tag)
+        ref.nil? ? value = "" : value = Tag.list(ref, :ns => tag)
       end
       value = MiqExpression.quote(value, ohash[:type] || "string")
     when "count"

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -121,7 +121,7 @@ class Condition < ApplicationRecord
       if ref.kind_of?(Hash)
         value = ref.fetch(tag, "")
       else
-        ref.nil? ? value = "" : value = Tag.list(ref, :ns => tag)
+        value = ref.nil? ? "" : Tag.list(ref, :ns => tag)
       end
       value = MiqExpression.quote(value, ohash[:type] || "string")
     when "count"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,21 +10,20 @@ class Tag < ApplicationRecord
 
   def self.list(taggable, options = {})
     ns = Tag.get_namespace(options)
-    return vtag_list(options) if ns[0..7] == "/virtual"
-    Tag.filter_ns(taggable.tags, ns).join(" ")
-  end
+    if ns[0..7] == "/virtual"
+      ns = Tag.get_namespace(options)
 
-  def self.vtag_list(taggable, options = {})
-    ns = Tag.get_namespace(options)
+      predicate = ns.split("/")[2..-1] # throw away /virtual
 
-    predicate = ns.split("/")[2..-1] # throw away /virtual
-
-    begin
-      predicate.inject(taggable) do |target, method|
-        target.public_send method
+      begin
+        predicate.inject(taggable) do |target, method|
+          target.public_send method
+        end
+      rescue NoMethodError
+        return ""
       end
-    rescue NoMethodError
-      return ""
+    else
+      Tag.filter_ns(taggable.tags, ns).join(" ")
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,7 @@ class Tag < ApplicationRecord
 
   def self.list(taggable, options = {})
     ns = Tag.get_namespace(options)
-    return vtag_list(options) if  ns[0..7] == "/virtual"
+    return vtag_list(options) if ns[0..7] == "/virtual"
     Tag.filter_ns(taggable.tags, ns).join(" ")
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -8,17 +8,17 @@ class Tag < ApplicationRecord
 
   before_destroy :remove_from_managed_filters
 
-  def self.list(taggable, options = {})
+  def self.list(object, options = {})
     ns = get_namespace(options)
     if ns[0..7] == "/virtual"
       predicate = ns.split("/")[2..-1] # throw away /virtual
       begin
-        predicate.inject(taggable) { |target, method| target.public_send method }
+        predicate.inject(object) { |target, method| target.public_send method }
       rescue NoMethodError
         ""
       end
     else
-      filter_ns(taggable.tags, ns).join(" ")
+      filter_ns(object.try(:tags) || [], ns).join(" ")
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,11 +12,8 @@ class Tag < ApplicationRecord
     ns = get_namespace(options)
     if ns[0..7] == "/virtual"
       predicate = ns.split("/")[2..-1] # throw away /virtual
-
       begin
-        predicate.inject(taggable) do |target, method|
-          target.public_send method
-        end
+        predicate.inject(taggable) { |target, method| target.public_send method }
       rescue NoMethodError
         return ""
       end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -26,7 +26,7 @@ class Tag < ApplicationRecord
       predicate.inject(taggable) do |target, method|
         target.public_send method
       end
-    rescue NoMethodError => err
+    rescue NoMethodError
       return ""
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,9 +19,6 @@ class Tag < ApplicationRecord
 
     predicate = ns.split("/")[2..-1] # throw away /virtual
 
-    # p "ns: [#{ns}]"
-    # p "predicate: [#{predicate.inspect}]"
-
     begin
       predicate.inject(taggable) do |target, method|
         target.public_send method

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,7 @@ class Tag < ApplicationRecord
       begin
         predicate.inject(taggable) { |target, method| target.public_send method }
       rescue NoMethodError
-        return ""
+        ""
       end
     else
       filter_ns(taggable.tags, ns).join(" ")

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,7 +9,7 @@ class Tag < ApplicationRecord
   before_destroy :remove_from_managed_filters
 
   def self.list(taggable, options = {})
-    ns = Tag.get_namespace(options)
+    ns = get_namespace(options)
     if ns[0..7] == "/virtual"
       predicate = ns.split("/")[2..-1] # throw away /virtual
 
@@ -21,7 +21,7 @@ class Tag < ApplicationRecord
         return ""
       end
     else
-      Tag.filter_ns(taggable.tags, ns).join(" ")
+      filter_ns(taggable.tags, ns).join(" ")
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,8 +11,6 @@ class Tag < ApplicationRecord
   def self.list(taggable, options = {})
     ns = Tag.get_namespace(options)
     if ns[0..7] == "/virtual"
-      ns = Tag.get_namespace(options)
-
       predicate = ns.split("/")[2..-1] # throw away /virtual
 
       begin

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -181,26 +181,7 @@ module ActsAsTaggable
   end
 
   def tag_list(options = {})
-    ns = Tag.get_namespace(options)
-    return vtag_list(options) if  ns[0..7] == "/virtual"
-    Tag.filter_ns(tags, ns).join(" ")
-  end
-
-  def vtag_list(options = {})
-    ns = Tag.get_namespace(options)
-
-    predicate = ns.split("/")[2..-1] # throw away /virtual
-
-    # p "ns: [#{ns}]"
-    # p "predicate: [#{predicate.inspect}]"
-
-    begin
-      predicate.inject(self) do |target, method|
-        target.public_send method
-      end
-    rescue NoMethodError => err
-      return ""
-    end
+    Tag.list(self, options)
   end
 
   def perf_tags

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -76,6 +76,18 @@ describe Condition do
         expect(Condition.subst(expr, @vm)).to eq('"0"')
       end
     end
+
+    it "does not change the scope for taggings when passed a Tag" do
+      tag = FactoryGirl.create(:tag, :name => "/managed/foo")
+      vm = FactoryGirl.create(:vm_vmware)
+      expr = "<value ref=tag, type=text>/virtual/name</value> == \"/managed/foo\""
+
+      described_class.subst(expr, tag)
+      vm.tag_add("foo", :ns => "/managed")
+      vm.reload
+
+      expect(vm.tags).to eq([tag])
+    end
   end
 
   describe ".do_eval" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,4 +1,12 @@
 describe Tag do
+  describe ".list" do
+    it "returns an empty string for something that is untaggable" do
+      account = FactoryGirl.create(:account)
+      actual = described_class.list(account)
+      expect(actual).to eq("")
+    end
+  end
+
   context ".filter_ns" do
     it "normal case" do
       tag1 = double


### PR DESCRIPTION
This method changes the class definition of the thing passed to it,
which breaks tagging if a Tag object is passed to it.

For this to work, it was necessary to take the required logic out of `ArTaggable` and put it at the class level of `Tag`.

Fixes #13180

@miq-bot add-label core, bug
@miq-bot assign @gtanzillo 