### PR TITLE
Add ConfigurationScript model to RBAC directly

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -11,6 +11,7 @@ module Rbac
       CloudVolume
       ConfigurationProfile
       ConfiguredSystem
+      ConfigurationScript
       Container
       ContainerBuild
       ContainerGroup


### PR DESCRIPTION
In Miq
`ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript`
is Ansible Tower Job Template

so the list in
Configuration ==> Management ==> Ansible Tower Job Templates
can be filtered by user's tags.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1409791


@miq-bot add_label rbac, bug, euwe/no
@miq-bot assign @gtanzillo 



