### PR TITLE
Retrieve middleware JDBC Drivers for a feed.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -139,6 +139,14 @@ module ManageIQ::Providers
       end
     end
 
+    def jdbc_drivers(feed)
+      with_provider_connection do |connection|
+        path = ::Hawkular::Inventory::CanonicalPath.new(:feed_id          => hawk_escape_id(feed),
+                                                        :resource_type_id => hawk_escape_id('JDBC Driver'))
+        connection.inventory.list_resources_for_type(path.to_s, :fetch_properties => true)
+      end
+    end
+
     def child_resources(resource_path, recursive = false)
       with_provider_connection do |connection|
         connection.inventory.list_child_resources(resource_path, recursive)


### PR DESCRIPTION
This is the backend providing the JDBC drivers that are loaded for a particular middleware feed. This is used when selecting a JDBC driver when Adding a Datasource for Hawkular.

* See https://github.com/ManageIQ/manageiq-ui-classic/pull/82 for further details.
* This PR is required by https://github.com/ManageIQ/manageiq-ui-classic/pull/82
* This is the backend piece originally split out from https://github.com/ManageIQ/manageiq/pull/12381 due to UI repo split
@miq-bot add_label providers/hawkular, wip
