### PR TITLE
Respect passed port when creating Kubernetes provider

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager.rb
@@ -15,9 +15,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager < ManageIQ::Providers::C
 
   include ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
-  DEFAULT_PORT = 6443
-  default_value_for :port, DEFAULT_PORT
-
   # This is the API version that we use and support throughout the entire code
   # (parsers, events, etc.). It should be explicitly selected here and not
   # decided by the user nor out of control in the defaults of kubeclient gem

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -3,6 +3,16 @@ require 'MiqContainerGroup/MiqContainerGroup'
 module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
   extend ActiveSupport::Concern
 
+  DEFAULT_PORT = 6443
+  included do
+    default_value_for :port do |provider|
+      # port is not a column on this table, it's delegated to endpoint.
+      # This may confuse `default_value_for` to apply when we do have a port;
+      # checking `provider.port` first prevents this from overriding it.
+      provider.port || provider.class::DEFAULT_PORT
+    end
+  end
+
   module ClassMethods
     def raw_api_endpoint(hostname, port, path = '')
       URI::HTTPS.build(:host => hostname, :port => port.presence.try(:to_i), :path => path)

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -7,9 +7,6 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
 
   included do
     has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
-    default_value_for :port do |provider|
-      provider.port || DEFAULT_PORT
-    end
   end
 
   # This is the API version that we use and support throughout the entire code

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -19,7 +19,7 @@ describe "Providers API" do
   let(:default_credentials) { {"userid" => "admin1", "password" => "password1"} }
   let(:metrics_credentials) { {"userid" => "admin2", "password" => "password2", "auth_type" => "metrics"} }
   let(:compound_credentials) { [default_credentials, metrics_credentials] }
-  let(:openshift_credentials) do
+  let(:containers_credentials) do
     {
       "auth_type" => "bearer",
       "auth_key"  => SecureRandom.hex
@@ -42,6 +42,7 @@ describe "Providers API" do
       -----END CERTIFICATE-----
     EOPEM
   end
+
   let(:sample_vmware) do
     {
       "type"      => "ManageIQ::Providers::Vmware::InfraManager",
@@ -61,11 +62,17 @@ describe "Providers API" do
       "certificate_authority" => certificate_authority,
     }
   end
-  let(:sample_openshift) do
+
+  CONTAINERS_CLASSES = {
+    "Kubernetes"          => "ManageIQ::Providers::Kubernetes::ContainerManager",
+    "OpenshiftEnterprise" => "ManageIQ::Providers::OpenshiftEnterprise::ContainerManager",
+    "Openshift"           => "ManageIQ::Providers::Openshift::ContainerManager",
+  }.freeze
+  let(:sample_containers) do
     {
-      "type"                  => "ManageIQ::Providers::Openshift::ContainerManager",
+      "type"                  => containers_class,
       "name"                  => "sample openshift",
-      "port"                  => 8443,
+      "port"                  => 18_443,
       "hostname"              => "sample_openshift.provider.com",
       "ipaddress"             => "100.200.300.3",
       "security_protocol"     => "something",
@@ -77,7 +84,7 @@ describe "Providers API" do
       "endpoint"       => {
         "role"                  => "default",
         "hostname"              => "sample_openshift_multi_end_point.provider.com",
-        "port"                  => 8444,
+        "port"                  => 18_443,
         "security_protocol"     => "something",
         "certificate_authority" => certificate_authority,
       },
@@ -92,7 +99,7 @@ describe "Providers API" do
       "endpoint"       => {
         "role"                  => "default",
         "hostname"              => "sample_openshift_multi_end_point.provider.com",
-        "port"                  => "8443",
+        "port"                  => "28443",
         "security_protocol"     => "something else",
         "certificate_authority" => certificate_authority,
       },
@@ -107,7 +114,7 @@ describe "Providers API" do
       "endpoint"       => {
         "role"                  => "hawkular",
         "hostname"              => "sample_openshift_multi_end_point.provider.com",
-        "port"                  => "443",
+        "port"                  => 1_443,
         "security_protocol"     => "something",
         "certificate_authority" => certificate_authority,
       },
@@ -117,10 +124,10 @@ describe "Providers API" do
       }
     }
   end
-  let(:sample_openshift_multi_end_point) do
+  let(:sample_containers_multi_end_point) do
     {
-      "type"                      => "ManageIQ::Providers::Openshift::ContainerManager",
-      "name"                      => "sample openshift with multiple endpoints",
+      "type"                      => containers_class,
+      "name"                      => "sample containers provider with multiple endpoints",
       "connection_configurations" => [default_connection, hawkular_connection]
     }
   end
@@ -358,24 +365,32 @@ describe "Providers API" do
       expect(endpoint).to have_endpoint_attributes(sample_rhevm)
     end
 
-    it "supports openshift creation with auth_key specified" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+    CONTAINERS_CLASSES.each do |name, klass|
+      context name do
+        let(:containers_class) { klass }
 
-      run_post(providers_url, sample_openshift.merge("credentials" => [openshift_credentials]))
+        it "supports creation with auth_key specified" do
+          pending if name != "Openshift"
 
-      expect(response).to have_http_status(:ok)
-      expected = {
-        "results" => [
-          a_hash_including({"id" => kind_of(Integer)}.merge(sample_openshift.except(*ENDPOINT_ATTRS)))
-        ]
-      }
-      expect(response.parsed_body).to include(expected)
+          api_basic_authorize collection_action_identifier(:providers, :create)
 
-      provider_id = response.parsed_body["results"].first["id"]
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
-      ems = ExtManagementSystem.find(provider_id)
-      expect(ems.authentications.size).to eq(1)
-      expect(ems).to have_endpoint_attributes(sample_openshift)
+          run_post(providers_url, sample_containers.merge("credentials" => [containers_credentials]))
+
+          expect(response).to have_http_status(:ok)
+          expected = {
+            "results" => [
+              a_hash_including({"id" => kind_of(Integer)}.merge(sample_containers.except(*ENDPOINT_ATTRS)))
+            ]
+          }
+          expect(response.parsed_body).to include(expected)
+
+          provider_id = response.parsed_body["results"].first["id"]
+          expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
+          ems = ExtManagementSystem.find(provider_id)
+          expect(ems.authentications.size).to eq(1)
+          expect(ems).to have_endpoint_attributes(sample_containers)
+        end
+      end
     end
 
     it "supports single provider creation via action" do
@@ -457,33 +472,40 @@ describe "Providers API" do
       expect(ExtManagementSystem.exists?(p2_id)).to be_truthy
     end
 
-    it "supports provider with multiple endpoints creation" do
-      def token(connection)
-        connection["authentication"]["auth_key"]
+    CONTAINERS_CLASSES.each do |name, klass|
+      context name do
+        let(:containers_class) { klass }
+
+        def token(connection)
+          connection["authentication"]["auth_key"]
+        end
+
+        it "supports provider with multiple endpoints creation" do
+          pending("https://github.com/ManageIQ/manageiq/issues/13306") if name == "Kubernetes"
+
+          api_basic_authorize collection_action_identifier(:providers, :create)
+
+          run_post(providers_url, gen_request(:create, sample_containers_multi_end_point))
+
+          expect(response).to have_http_status(:ok)
+          expected = {"id"   => a_kind_of(Integer),
+                      "type" => containers_class,
+                      "name" => "sample containers provider with multiple endpoints"}
+          results = response.parsed_body["results"]
+          expect(results.first).to include(expected)
+
+          provider_id = results.first["id"]
+          expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
+          provider = ExtManagementSystem.find(provider_id)
+          expect(provider).to have_endpoint_attributes(default_connection["endpoint"])
+          expect(provider.authentication_token).to eq(token(default_connection))
+
+          expect(provider.connection_configurations.hawkular.endpoint).to have_endpoint_attributes(
+            hawkular_connection["endpoint"]
+          )
+          expect(provider.authentication_token(:hawkular)).to eq(token(hawkular_connection))
+        end
       end
-
-      api_basic_authorize collection_action_identifier(:providers, :create)
-
-      run_post(providers_url, gen_request(:create, sample_openshift_multi_end_point))
-
-      expect(response).to have_http_status(:ok)
-      expected = {"id"   => a_kind_of(Integer),
-                  "type" => "ManageIQ::Providers::Openshift::ContainerManager",
-                  "name" => "sample openshift with multiple endpoints"}
-      results = response.parsed_body["results"]
-      expect(results.first).to include(expected)
-
-      provider_id = results.first["id"]
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
-      provider = ExtManagementSystem.find(provider_id)
-
-      expect(provider).to have_endpoint_attributes(default_connection["endpoint"])
-      expect(provider.authentication_token).to eq(token(default_connection))
-
-      expect(provider.connection_configurations.hawkular.endpoint).to have_endpoint_attributes(
-        hawkular_connection["endpoint"]
-      )
-      expect(provider.authentication_token(:hawkular)).to eq(token(hawkular_connection))
     end
   end
 
@@ -543,46 +565,52 @@ describe "Providers API" do
       expect(provider.authentication_userid).to eq("superadmin")
     end
 
-    it "does not schedule a new credentials check if endpoint does not change" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+    CONTAINERS_CLASSES.each do |name, klass|
+      context name do
+        let(:containers_class) { klass }
 
-      provider = FactoryGirl.create(:ext_management_system, sample_openshift_multi_end_point)
-      MiqQueue.where(:method_name => "authentication_check_types",
-                     :class_name  => "ExtManagementSystem",
-                     :instance_id => provider.id).delete_all
+        it "does not schedule a new credentials check if endpoint does not change" do
+          api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      run_post(providers_url(provider.id), gen_request(:edit,
-                                                       "connection_configurations" => [default_connection,
-                                                                                       hawkular_connection]))
+          provider = FactoryGirl.create(:ext_management_system, sample_containers_multi_end_point)
+          MiqQueue.where(:method_name => "authentication_check_types",
+                         :class_name  => "ExtManagementSystem",
+                         :instance_id => provider.id).delete_all
 
-      queue_jobs = MiqQueue.where(:method_name => "authentication_check_types",
-                                  :class_name  => "ExtManagementSystem",
-                                  :instance_id => provider.id)
-      expect(queue_jobs).to be
-      expect(queue_jobs.length).to eq(0)
-    end
+          run_post(providers_url(provider.id), gen_request(:edit,
+                                                           "connection_configurations" => [default_connection,
+                                                                                           hawkular_connection]))
 
-    it "schedules a new credentials check if endpoint change" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+          queue_jobs = MiqQueue.where(:method_name => "authentication_check_types",
+                                      :class_name  => "ExtManagementSystem",
+                                      :instance_id => provider.id)
+          expect(queue_jobs).to be
+          expect(queue_jobs.length).to eq(0)
+        end
 
-      provider = FactoryGirl.create(:ext_management_system, sample_openshift_multi_end_point)
-      MiqQueue.where(:method_name => "authentication_check_types",
-                     :class_name  => "ExtManagementSystem",
-                     :instance_id => provider.id).delete_all
+        it "schedules a new credentials check if endpoint change" do
+          api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      run_post(providers_url(provider.id), gen_request(:edit,
-                                                       "connection_configurations" => [updated_connection,
-                                                                                       hawkular_connection]))
+          provider = FactoryGirl.create(:ext_management_system, sample_containers_multi_end_point)
+          MiqQueue.where(:method_name => "authentication_check_types",
+                         :class_name  => "ExtManagementSystem",
+                         :instance_id => provider.id).delete_all
 
-      provider.reload
-      expect(provider).to have_endpoint_attributes(updated_connection["endpoint"])
+          run_post(providers_url(provider.id), gen_request(:edit,
+                                                           "connection_configurations" => [updated_connection,
+                                                                                           hawkular_connection]))
 
-      queue_jobs = MiqQueue.where(:method_name => "authentication_check_types",
-                                  :class_name  => "ExtManagementSystem",
-                                  :instance_id => provider.id)
-      expect(queue_jobs).to be
-      expect(queue_jobs.length).to eq(1)
-      expect(queue_jobs[0].args[0][0]).to eq(:bearer)
+          provider.reload
+          expect(provider).to have_endpoint_attributes(updated_connection["endpoint"])
+
+          queue_jobs = MiqQueue.where(:method_name => "authentication_check_types",
+                                      :class_name  => "ExtManagementSystem",
+                                      :instance_id => provider.id)
+          expect(queue_jobs).to be
+          expect(queue_jobs.length).to eq(1)
+          expect(queue_jobs[0].args[0][0]).to eq(:bearer)
+        end
+      end
     end
 
     it "supports additions of credentials" do

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -481,8 +481,6 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation" do
-          pending("https://github.com/ManageIQ/manageiq/issues/13306") if name == "Kubernetes"
-
           api_basic_authorize collection_action_identifier(:providers, :create)
 
           run_post(providers_url, gen_request(:create, sample_containers_multi_end_point))


### PR DESCRIPTION
A superficial attempt at fixing #13306, just for Kubernetes.

**Depends on #13317 for tests, see only second commit for the fix here.**

TODO: pretty sure same affects Hawkular and Datawarehouse providers;
and might affect many other virtual fields?
https://github.com/ManageIQ/manageiq/search?utf8=%E2%9C%93&q=default_value_for

Centralized the default port logic in Kubernetes::ContainerManagerMixin — this simplification might be worth it even if we find generic solution.

Verified that this preserves the DEFAULT_PORT consts that UI uses:
https://github.com/ManageIQ/manageiq-ui-classic/blob/a9d1ccace8ae1967c27d3250d7847e24714de32a/app/controllers/ems_common.rb#L895-L900
however I'm not sure that UI logic is doing anything?  It's in `get_form_data` parsing incoming params, but UI doesn't allow pressing [Validate] nor [Save] with unfilled port.  What would be desired is for Add New Provider to fill port field depending on chosen provider type, but AFAICT this wasn't happening before either (always prefilled with 8443).

- Do we need this default **at all**?!
  Perhaps in API if creating without missing port?  YES, see [below](https://github.com/ManageIQ/manageiq/pull/13369#issuecomment-273723994).

@miq-bot add-label providers/containers, api, bug, wip