### PR TITLE
Picture :: creation of directory should be atomic

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -9,7 +9,7 @@ class Picture < ApplicationRecord
 
   URL_ROOT          = Rails.root.join("public").to_s
   DEFAULT_DIRECTORY = File.join(URL_ROOT, "pictures")
-  Dir.mkdir(DEFAULT_DIRECTORY) unless File.directory?(DEFAULT_DIRECTORY)
+  FileUtils.mkdir_p(DEFAULT_DIRECTORY)
 
   def self.directory
     @directory || DEFAULT_DIRECTORY
@@ -17,7 +17,7 @@ class Picture < ApplicationRecord
 
   def self.directory=(value)
     dir = File.join(URL_ROOT, url_path(value, URL_ROOT))
-    Dir.mkdir(dir) unless File.directory?(dir)
+    FileUtils.mkdir_p(dir)
     @directory = dir
   end
 


### PR DESCRIPTION
Otherwise parallel test suite may fail randomly.

Addressing *rare* test failure
```
bundler: failed to load command: rspec
(/home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/bin/rspec)
Errno::EEXIST: File exists @ dir_s_mkdir - /home/travis/build/ManageIQ/manageiq/public/pictures
  manageiq/app/models/picture.rb:12:in `mkdir'
  manageiq/app/models/picture.rb:12:in `<class:Picture>'
  manageiq/app/models/picture.rb:1:in `<top (required)>'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `require'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `block in require'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `require'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:380:in `block in require_or_load'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:37:in `block in load_interlock'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies/interlock.rb:12:in `block in loading'
  gems/activesupport-5.0.0.1/lib/active_support/concurrency/share_lock.rb:117:in  `exclusive'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies/interlock.rb:11:in `loading'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:37:in `load_interlock'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:358:in `require_or_load'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:511:in `load_missing_constant'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:203:in `const_missing'
  manageiq/spec/models/picture_spec.rb:1:in `<top (required)>'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `load'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `block in load'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
  gems/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `load'
  gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
  gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `each'
  gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
  gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:100:in `setup'
  gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
  gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
  gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
  gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
  bin/rspec:23:in `load'
  bin/rspec:23:in `<top (required)>'
```

Seen in https://travis-ci.org/ManageIQ/manageiq/builds/189444198

@miq-bot add_label euwe/no, spec, bug
@miq-bot assign @chrisarcand 