### PR TITLE
Don't charge hours before Vm/Container/Project was created

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -4,12 +4,15 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
-    def past_hours_in_interval
-      # We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
-      @past_hours_in_interval ||= begin
-                                    past = (Time.current - @start_time).round / 1.hour
-                                    [past, hours_in_interval].min
-                                  end
+    def consumed_hours_in_interval
+      # Why we need this?
+      #   1) We cannot charge for hours until the resources existed (vm provisioned in the middle of month)
+      #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
+      @consumed_hours_in_interval ||= begin
+                                        consuption_start = [@start_time, resource.try(:created_on)].compact.max
+                                        consumption_end = [Time.current, @end_time].min
+                                        (consumption_end - consuption_start).round / 1.hour
+                                      end
     end
 
     def hours_in_month

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -19,7 +19,7 @@ class Chargeback
 
     def avg(metric)
       metric_sum = values(metric).sum
-      metric_sum / past_hours_in_interval
+      metric_sum / consumed_hours_in_interval
     end
 
     def none?(metric)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -233,7 +233,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def metric_and_cost_by(consumption)
     metric_value = metric_value_by(consumption)
-    [metric_value, hourly_cost(metric_value, consumption) * consumption.past_hours_in_interval]
+    [metric_value, hourly_cost(metric_value, consumption) * consumption.consumed_hours_in_interval]
   end
 
   def first_tier?(tier,tiers)

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -4,7 +4,7 @@ describe ChargebackContainerProject do
   let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
   let(:hourly_rate)       { 0.01 }
   let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
-  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
   let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
@@ -32,7 +32,8 @@ describe ChargebackContainerProject do
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems,
+                                  :created_on => month_beginning)
 
     temp = {:cb_rate => chargeback_rate, :object => ems}
     ChargebackRate.set_assignments(:compute, [temp])

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -16,7 +16,8 @@ describe ChargebackVm do
   let(:tag) { Tag.find_by_name('/managed/environment/prod') }
   let(:vm) do
     ems = FactoryGirl.create(:ems_vmware)
-    vm = FactoryGirl.create(:vm_vmware, :name => 'test_vm', :evm_owner => admin, :ems_ref => 'ems_ref')
+    vm = FactoryGirl.create(:vm_vmware, :name => 'test_vm', :evm_owner => admin, :ems_ref => 'ems_ref',
+                            :created_on => start_of_all_intervals)
     vm.tag_with(tag.name, :ns => '*')
     host = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware,
                                                                      :memory_mb => 8124, :cpu_total_cores => 1,

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -53,7 +53,8 @@ describe ChargebackVm do
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
 
-    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref")
+    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref",
+                              :created_on => month_beginning)
     @vm1.tag_with(@tag.name, :ns => '*')
 
     @host1   = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -527,7 +528,7 @@ describe ChargebackVm do
 
   context 'for SCVMM (hyper-v)' do
     let!(:vm1) do
-      vm = FactoryGirl.create(:vm_microsoft)
+      vm = FactoryGirl.create(:vm_microsoft, :created_on => report_run_time - 1.day)
       vm.tag_with(@tag.name, :ns => '*')
       vm
     end


### PR DESCRIPTION
## What
When calculating average consumption (like Mhz) we divide consumption by number of hours in the interval. However, when VM gets created in the middle of the month, we should divide only by number of hours that the resource lived. Similarly, we should charge the consumption only for the hours that the resource existed.

## Why
This becomes important for SCVMM. We charge for SCVMM without metric rollups. Hence, this case have higher chances to occur with SCVMM chargebacks. (Although it affects rollup-based chargebacks as well).

## Note
This pr builds on top of #13134.


@miq-bot add_label chargeback, bug
@miq-bot assign @gtanzillo 