### PR TITLE
Add disabled_features for ems_azure

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,6 +107,9 @@
   :ems_azure:
     :disabled_regions: []
     :additional_regions: {}
+    :disabled_features:
+      :events: ['usgovarizona', 'usgoviowa', 'usgovtexas', 'usgovvirginia']
+      :metrics: ['usgovarizona', 'usgoviowa', 'usgovtexas', 'usgovvirginia']
 :ems_events:
   :history:
     :keep_ems_events: 6.months


### PR DESCRIPTION
This PR modifies the config/settings.yml file to add a new hash for :ems_azure called :disabled_regions. This will allow us to disable specific features on a per-region basis within the code base without disabling the entire region.

An initial set of values has been created for events and metrics.

This is a followup to https://github.com/ManageIQ/manageiq/pull/13178, and is part of the effort to deal with https://bugzilla.redhat.com/show_bug.cgi?id=1403366.