### PR TITLE
[api] expose allowed tags for a request workflow

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -33,10 +33,12 @@ class MiqRequest < ApplicationRecord
   virtual_column  :v_approved_by,        :type => :string,   :uses => :miq_approvals
   virtual_column  :v_approved_by_email,  :type => :string,   :uses => {:miq_approvals => :stamper}
   virtual_column  :stamped_on,           :type => :datetime, :uses => :miq_approvals
+  virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
-  virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
+
+  delegate :allowed_tags,                :to => :workflow,   :prefix => :v
 
   virtual_has_one :workflow
 
@@ -235,10 +237,6 @@ class MiqRequest < ApplicationRecord
   def v_approved_by_email
     emails = miq_approvals.inject([]) { |arr, a| arr << a.stamper.email unless a.stamper.nil? || a.stamper.email.nil?; arr }
     emails.join(", ")
-  end
-
-  def v_allowed_tags
-    workflow.allowed_tags
   end
 
   def get_options

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -36,6 +36,7 @@ class MiqRequest < ApplicationRecord
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
+  virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
 
   virtual_has_one :workflow
 
@@ -234,6 +235,10 @@ class MiqRequest < ApplicationRecord
   def v_approved_by_email
     emails = miq_approvals.inject([]) { |arr, a| arr << a.stamper.email unless a.stamper.nil? || a.stamper.email.nil?; arr }
     emails.join(", ")
+  end
+
+  def v_allowed_tags
+    workflow.allowed_tags
   end
 
   def get_options

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -324,6 +324,20 @@ describe MiqRequest do
       expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow).to receive(:password_helper).twice
       provision_request.workflow({}, {:allowed_hosts => [host], :skip_dialog_load => true}) { |_x| 'test' }
     end
+
+    it "returns the allowed tags" do
+      FactoryGirl.create(:miq_dialog,
+                         :name        => "miq_provision_dialogs",
+                         :dialog_type => MiqProvisionWorkflow)
+
+      FactoryGirl.create(:classification_department_with_tags)
+
+      tag = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
+      provision_request.add_tag(tag.name, tag.children.first.name)
+
+      expected = [a_hash_including(:children)]
+      expect(provision_request.v_allowed_tags).to match(expected)
+    end
   end
 
   context '#create_request_task' do

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -248,6 +248,31 @@ RSpec.describe "Requests API" do
       expect(response.parsed_body).to match(expected)
       expect(response).to have_http_status(:ok)
     end
+
+    it "exposes allowed_tags in the request resources" do
+      ems = FactoryGirl.create(:ems_vmware)
+      vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
+      request = FactoryGirl.create(:miq_provision_request,
+                                   :requester => @user,
+                                   :src_vm_id => vm_template.id,
+                                   :options   => {:owner_email => 'tester@example.com'})
+      FactoryGirl.create(:miq_dialog,
+                         :name        => "miq_provision_dialogs",
+                         :dialog_type => MiqProvisionWorkflow)
+
+      FactoryGirl.create(:classification_department_with_tags)
+
+      t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
+      request.add_tag(t.name, t.children.first.name)
+
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      run_get requests_url(request.id), :attributes => "v_allowed_tags"
+
+      expected = a_hash_including("id" => request.id, "v_allowed_tags" => [a_hash_including("children")])
+
+      expect(response.parsed_body).to match(expected)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "request update" do


### PR DESCRIPTION
Created a `virtual_column` for `allowed_tags` which is required in order to populate the `tags` tree in the Request Workflow in SUI

`api/requests/<id>?attributes=v_allowed_tags`

https://www.pivotaltracker.com/n/projects/1914499/stories/137139937