### PR TITLE
Add metrics as a supported feature in the SupportsFeatureMixin

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -85,6 +85,7 @@ module SupportsFeatureMixin
     :events                     => 'Query for events',
     :launch_cockpit             => 'Launch Cockpit UI',
     :live_migrate               => 'Live Migration',
+    :metrics                    => 'Metrics',
     :migrate                    => 'Migration',
     :provisioning               => 'Provisioning',
     :publish                    => 'Publishing',


### PR DESCRIPTION
This adds "metrics" as a supported feature to the list. At a minimum, we will need to use this for the Azure provider as part of the effort towards supporting usgov environments.

https://bugzilla.redhat.com/show_bug.cgi?id=1403366