### PR TITLE
remove license badge

### DIFF
--- a/lib/generators/provider/templates/README.md
+++ b/lib/generators/provider/templates/README.md
@@ -9,7 +9,6 @@
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq-providers-<%= provider_name %>?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq-providers-<%= provider_name %>)
-[![License](http://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 ManageIQ plugin for the <%= class_name %> provider.
 


### PR DESCRIPTION
tiny PR to address comment in https://github.com/ManageIQ/manageiq-providers-amazon/pull/97

removes License badge from README in provider generator as there is a License file added already

@miq-bot add label enhancement, euwe/no
@miq-bot assign @Fryguy 