### PR TITLE
Add storage manager mixins

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -1,13 +1,13 @@
 module EmsRefresh
   extend EmsRefresh::SaveInventory
-  extend EmsRefresh::SaveInventoryCinder
+  extend EmsRefresh::SaveInventoryBlockStorage
   extend EmsRefresh::SaveInventoryCloud
   extend EmsRefresh::SaveInventoryInfra
   extend EmsRefresh::SaveInventoryContainer
   extend EmsRefresh::SaveInventoryMiddleware
   extend EmsRefresh::SaveInventoryDatawarehouse
   extend EmsRefresh::SaveInventoryNetwork
-  extend EmsRefresh::SaveInventorySwift
+  extend EmsRefresh::SaveInventoryObjectStorage
   extend EmsRefresh::SaveInventoryHelper
   extend EmsRefresh::SaveInventoryProvisioning
   extend EmsRefresh::SaveInventoryConfiguration

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -11,8 +11,7 @@ module EmsRefresh::SaveInventory
     when ManageIQ::Providers::ConfigurationManager          then save_configuration_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ContainerManager              then save_ems_container_inventory(ems, hashes, target)
     when ManageIQ::Providers::NetworkManager                then save_ems_network_inventory(ems, hashes, target)
-    when ManageIQ::Providers::StorageManager::CinderManager then save_ems_cinder_inventory(ems, hashes, target)
-    when ManageIQ::Providers::StorageManager::SwiftManager  then save_ems_swift_inventory(ems, hashes, target)
+    when ManageIQ::Providers::StorageManager                then save_ems_storage_inventory(ems, hashes, target)
     when ManageIQ::Providers::MiddlewareManager             then save_ems_middleware_inventory(ems, hashes, target)
     when ManageIQ::Providers::DatawarehouseManager          then save_ems_datawarehouse_inventory(ems, hashes, target)
     end
@@ -345,5 +344,15 @@ module EmsRefresh::SaveInventory
 
       new_vm
     end
+  end
+
+  #
+  # Storage managers can support many different types of storages. We thus rely
+  # on the supports feature of the manager to choose which parts of the
+  # inventory to save.
+  #
+  def save_ems_storage_inventory(ems, hashes, target = nil)
+    save_ems_block_storage_inventory(ems, hashes, target) if ems.supports?(:block_storage)
+    save_ems_object_storage_inventory(ems, hashes, target) if ems.supports?(:object_storage)
   end
 end

--- a/app/models/ems_refresh/save_inventory_block_storage.rb
+++ b/app/models/ems_refresh/save_inventory_block_storage.rb
@@ -7,8 +7,8 @@
 #   - backing_links
 #
 
-module EmsRefresh::SaveInventoryCinder
-  def save_ems_cinder_inventory(ems, hashes, target = nil)
+module EmsRefresh::SaveInventoryBlockStorage
+  def save_ems_block_storage_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -32,9 +32,9 @@ module EmsRefresh::SaveInventoryCinder
     ]
 
     # Save and link other subsections
-    save_cinder_child_inventory(ems, hashes, child_keys, target)
+    save_block_storage_child_inventory(ems, hashes, child_keys, target)
 
-    link_cinder_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
+    link_block_storage_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
 
     ems.save!
     hashes[:id] = ems.id
@@ -44,7 +44,7 @@ module EmsRefresh::SaveInventoryCinder
     ems
   end
 
-  def save_cinder_cloud_volumes_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volumes_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volumes.reset
@@ -64,7 +64,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
-  def save_cinder_cloud_volume_backups_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volume_backups_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volume_backups.reset
@@ -84,7 +84,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volume_backups, hashes, :ems_ref)
   end
 
-  def save_cinder_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
+  def save_block_storage_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots.reset
@@ -103,7 +103,7 @@ module EmsRefresh::SaveInventoryCinder
     store_ids_for_new_records(ems.cloud_volume_snapshots, hashes, :ems_ref)
   end
 
-  def save_cinder_backing_links_inventory(_ems, hashes, _target)
+  def save_block_storage_backing_links_inventory(_ems, hashes, _target)
     hashes.each do |dh|
       dh[:backing_id]   = dh[:backing_volume][:id]
       dh[:backing_type] = 'CloudVolume'
@@ -123,7 +123,7 @@ module EmsRefresh::SaveInventoryCinder
     end
   end
 
-  def link_cinder_volumes_to_base_snapshots(hashes)
+  def link_block_storage_volumes_to_base_snapshots(hashes)
     base_snapshot_to_volume = hashes.each_with_object({}) do |h, bsh|
       next unless (base_snapshot = h[:base_snapshot])
       (bsh[base_snapshot[:id]] ||= []) << h[:id]
@@ -134,7 +134,7 @@ module EmsRefresh::SaveInventoryCinder
     end
   end
 
-  def save_cinder_child_inventory(obj, hashes, child_keys, *args)
-    child_keys.each { |k| send("save_cinder_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
+  def save_block_storage_child_inventory(obj, hashes, child_keys, *args)
+    child_keys.each { |k| send("save_block_storage_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
   end
 end

--- a/app/models/ems_refresh/save_inventory_object_storage.rb
+++ b/app/models/ems_refresh/save_inventory_object_storage.rb
@@ -5,8 +5,8 @@
 #     - cloud_object_store_objects
 #
 
-module EmsRefresh::SaveInventorySwift
-  def save_ems_swift_inventory(ems, hashes, target = nil)
+module EmsRefresh::SaveInventoryObjectStorage
+  def save_ems_object_storage_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -16,7 +16,7 @@ module EmsRefresh::SaveInventorySwift
       return
     end
 
-    _log.info("#{log_header} Saving EMS Swift Inventory...")
+    _log.info("#{log_header} Saving EMS Object Storage Inventory...")
     if debug_trace
       require 'yaml'
       _log.debug "#{log_header} hashes:\n#{YAML.dump(hashes)}"
@@ -28,21 +28,21 @@ module EmsRefresh::SaveInventorySwift
     ]
 
     # Save and link other subsections
-    save_swift_child_inventory(ems, hashes, child_keys, target)
+    save_object_storage_child_inventory(ems, hashes, child_keys, target)
 
     ems.save!
     hashes[:id] = ems.id
 
-    _log.info("#{log_header} Saving EMS Swift Inventory...Complete")
+    _log.info("#{log_header} Saving EMS Object Storage Inventory...Complete")
 
     ems
   end
 
-  def save_swift_child_inventory(obj, hashes, child_keys, *args)
-    child_keys.each { |k| send("save_swift_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
+  def save_object_storage_child_inventory(obj, hashes, child_keys, *args)
+    child_keys.each { |k| send("save_object_storage_#{k}_inventory", obj, hashes[k], *args) if hashes.key?(k) }
   end
 
-  def save_swift_cloud_object_store_containers_inventory(ems, hashes, target = nil)
+  def save_object_storage_cloud_object_store_containers_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_object_store_containers.reset
@@ -61,7 +61,7 @@ module EmsRefresh::SaveInventorySwift
     store_ids_for_new_records(ems.cloud_object_store_containers, hashes, :ems_ref)
   end
 
-  def save_swift_cloud_object_store_objects_inventory(ems, hashes, target = nil)
+  def save_object_storage_cloud_object_store_objects_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.cloud_object_store_objects.reset

--- a/app/models/manageiq/providers/storage_manager/block_mixin.rb
+++ b/app/models/manageiq/providers/storage_manager/block_mixin.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers::StorageManager::BlockMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :cloud_volumes,          :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_volume_snapshots, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_volume_backups,   :foreign_key => :ems_id, :dependent => :destroy
+
+    supports :block_storage
+  end
+end

--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -8,9 +8,7 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
   require_nested :RefreshWorker
   require_nested :Refresher
 
-  has_many :cloud_volumes,                 :foreign_key => :ems_id, :dependent => :destroy
-  has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
-  has_many :cloud_volume_backups,          :foreign_key => :ems_id, :dependent => :destroy
+  include ManageIQ::Providers::StorageManager::BlockMixin
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,
@@ -31,7 +29,6 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
            :to        => :parent_manager,
            :allow_nil => true
 
-  supports :block_storage
   supports :cinder_service do
     if parent_manager
       unsupported_reason_add(:cinder_service, parent_manager.unsupported_reason(:cinder_service)) unless

--- a/app/models/manageiq/providers/storage_manager/object_mixin.rb
+++ b/app/models/manageiq/providers/storage_manager/object_mixin.rb
@@ -1,0 +1,10 @@
+module ManageIQ::Providers::StorageManager::ObjectMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+
+    supports :object_storage
+  end
+end

--- a/app/models/manageiq/providers/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager.rb
@@ -3,8 +3,7 @@ class ManageIQ::Providers::StorageManager::SwiftManager < ManageIQ::Providers::S
   require_nested :RefreshWorker
   require_nested :Refresher
 
-  has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
-  has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+  include ManageIQ::Providers::StorageManager::ObjectMixin
 
   delegate :authentication_check,
            :authentication_status,
@@ -24,7 +23,6 @@ class ManageIQ::Providers::StorageManager::SwiftManager < ManageIQ::Providers::S
            :to        => :parent_manager,
            :allow_nil => true
 
-  supports :object_storage
   supports :swift_service do
     if parent_manager
       unsupported_reason_add(:swift_service, parent_manager.unsupported_reason(:swift_service)) unless


### PR DESCRIPTION
Previously the only provider supporting the block and object storage
were Cinder and Swift managers. OpenStack provider was the one actually
integrating them for managing cloud volumes, snapshots, objects, ...

We are now extending the Amazon provider, integrating the EBS (Elastic
Block Store) and S3 (object store). This patch adds two mixins for block
and object store managers. It also alters the save inventory to allow
storage managers to support multiple storage types.

Since Amazon services will be using the same inventory structure,
corresponding `save_inventory_cinder` and `save_inventory_swift` have
been renamed to suit block and object storage.

This PR replaces #13351 based on the comments received.

@miq-bot add_label providers, providers/storage, refactoring
@miq-bot assign roliveri