### PR TITLE
Refactor MiqExpression#to_ruby CONTAINS

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -525,7 +525,21 @@ class MiqExpression
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "contains"
       exp[operator]["tag"] ||= exp[operator]["field"]
-      operands = operands2rubyvalue(operator, exp[operator], context_type)
+      operands = if context_type != "hash"
+                   ref, val = value2tag(preprocess_managed_tag(exp[operator]["tag"]), exp[operator]["value"])
+                   ["<exist ref=#{ref}>#{val}</exist>"]
+                 elsif context_type == "hash"
+                   # This is only for supporting reporting "display filters"
+                   # In the report object the tag value is actually the description and not the raw tag name.
+                   # So we have to trick it by replacing the value with the description.
+                   description = MiqExpression.get_entry_details(exp[operator]["tag"]).inject("") do|s, t|
+                     break(t.first) if t.last == exp[operator]["value"]
+                     s
+                   end
+                   val = exp[operator]["tag"].split(".").last.split("-").join(".")
+                   fld = "<value type=string>#{val}</value>"
+                   [fld, quote(description, "string")]
+                 end
       clause = operands.join(" #{normalize_operator(operator)} ")
     when "find"
       # FIND Vm.users-name = 'Administrator' CHECKALL Vm.users-enabled = 1
@@ -914,21 +928,7 @@ class MiqExpression
     # puts "Enter: operands2rubyvalue: operator: #{operator}, ops: #{ops.inspect}"
     operator = operator.downcase
 
-    if ops["tag"] && context_type != "hash"
-      ref, val = value2tag(preprocess_managed_tag(ops["tag"]), ops["value"])
-      ["<exist ref=#{ref}>#{val}</exist>"]
-    elsif ops["tag"] && context_type == "hash"
-      # This is only for supporting reporting "display filters"
-      # In the report object the tag value is actually the description and not the raw tag name.
-      # So we have to trick it by replacing the value with the description.
-      description = MiqExpression.get_entry_details(ops["tag"]).inject("") do|s, t|
-        break(t.first) if t.last == ops["value"]
-        s
-      end
-      val = ops["tag"].split(".").last.split("-").join(".")
-      fld = "<value type=string>#{val}</value>"
-      [fld, quote(description, "string")]
-    elsif ops["field"]
+    if ops["field"]
       if ops["field"] == "<count>"
         ["<count>", quote(ops["value"], "integer")]
       else

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -524,6 +524,7 @@ class MiqExpression
       operands = operands2rubyvalue(operator, exp[operator], context_type)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "contains"
+      exp[operator]["tag"] ||= exp[operator]["field"]
       operands = operands2rubyvalue(operator, exp[operator], context_type)
       clause = operands.join(" #{normalize_operator(operator)} ")
     when "find"
@@ -912,7 +913,6 @@ class MiqExpression
   def self.operands2rubyvalue(operator, ops, context_type)
     # puts "Enter: operands2rubyvalue: operator: #{operator}, ops: #{ops.inspect}"
     operator = operator.downcase
-    ops["tag"] = ops["field"] if operator == "contains" && !ops["tag"] # process values in contains as tags
 
     if ops["tag"] && context_type != "hash"
       ref, val = value2tag(preprocess_managed_tag(ops["tag"]), ops["value"])

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -532,7 +532,7 @@ class MiqExpression
                    # This is only for supporting reporting "display filters"
                    # In the report object the tag value is actually the description and not the raw tag name.
                    # So we have to trick it by replacing the value with the description.
-                   description = MiqExpression.get_entry_details(exp[operator]["tag"]).inject("") do|s, t|
+                   description = MiqExpression.get_entry_details(exp[operator]["tag"]).inject("") do |s, t|
                      break(t.first) if t.last == exp[operator]["value"]
                      s
                    end


### PR DESCRIPTION
`.operands2rubyvalue` tries to generalize the problem of generating the "ruby" output for expressions, but in generalizing we lose some important knowledge of the system here: `CONTAINS` is the only operator that deals with tags. It seems better to me to move this code closer to the only thing that ever needs it.

@miq-bot add-label core, refactoring
@miq-bot assign @gtanzillo 
