### PR TITLE
Rename events "ExtManagementSystem Compliance *" -> "Provider Compliance *"

### DIFF
--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -35,6 +35,10 @@ ems_auth_unreachable,Provider Auth Unreachable,Default,auth_validation
 ems_auth_incomplete,Provider Auth Incomplete Credentials,Default,auth_validation
 ems_auth_error,Provider Auth Error,Default,auth_validation
 ems_performance_gap_detected,C & U Collection Gap Detected,Default,ems_operations
+# Compliance event names are derived from lowercased model name.
+extmanagementsystem_compliance_check,Provider Compliance Check,Default,compliance
+extmanagementsystem_compliance_passed,Provider Compliance Passed,Default,compliance
+extmanagementsystem_compliance_failed,Provider Compliance Failed,Default,compliance
 
 #
 # Host operations
@@ -201,7 +205,3 @@ containerreplicator_successfulcreate,Replicator Successfully Created Pod,Default
 containerreplicator_compliance_check,Replicator Compliance Check,Default,compliance
 containerreplicator_compliance_passed,Replicator Compliance Passed,Default,compliance
 containerreplicator_compliance_failed,Replicator Compliance Failed,Default,compliance
-
-extmanagementsystem_compliance_check,ExtManagementSystem Compliance Check,Default,compliance
-extmanagementsystem_compliance_passed,ExtManagementSystem Compliance Passed,Default,compliance
-extmanagementsystem_compliance_failed,ExtManagementSystem Compliance Failed,Default,compliance


### PR DESCRIPTION
Followup to #11002,
https://bugzilla.redhat.com/show_bug.cgi?id=1411337 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1411364 (euwe)

Before:

![ems-event-missing-icons](https://cloud.githubusercontent.com/assets/273688/20544711/02e0b4ce-b114-11e6-9003-be29839c52f8.png)
![screenshot-ems-policy](https://cloud.githubusercontent.com/assets/273688/21749706/d3cbf33e-d5ac-11e6-8983-38e00f0c1cb5.png)

After  (**this PRs only fixes the event name, icons fixed in UI PR ManageIQ/manageiq-ui-classic/pull/94**):

![screenshot-provider-events](https://cloud.githubusercontent.com/assets/273688/21749632/6ac47272-d5ab-11e6-8f0a-62a71ee3ce1b.png)
![screenshot-provider-policy](https://cloud.githubusercontent.com/assets/273688/21749672/1723890e-d5ac-11e6-8b33-e895360e279b.png)

Low-level names remain `extmanagementsystem_compliance_*`, should be backward compatible given existing policies with these events.

I thought this csv is loaded on every run, but it seems I needed `rake db:seed` to take effect.
