### PR TITLE
Add list of providers to RBAC on catalog items

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -99,7 +99,7 @@ class OrchestrationTemplate < ApplicationRecord
 
   # List managers that may be able to deploy this template
   def self.eligible_managers
-    ExtManagementSystem.where(:type => eligible_manager_types.collect(&:name))
+    ExtManagementSystem.where(:type => eligible_manager_types)
   end
 
   delegate :eligible_managers, :to => :class

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -99,7 +99,7 @@ class OrchestrationTemplate < ApplicationRecord
 
   # List managers that may be able to deploy this template
   def self.eligible_managers
-    ExtManagementSystem.where(:type => eligible_manager_types)
+    Rbac::Filterer.filtered(ExtManagementSystem, :where_clause => {:type => eligible_manager_types})
   end
 
   delegate :eligible_managers, :to => :class

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -82,6 +82,7 @@ describe OrchestrationTemplate do
     let(:user_admin)   { FactoryGirl.create(:user_admin) }
     let(:tenant)       { FactoryGirl.create(:tenant) }
     let(:other_tenant) { FactoryGirl.create(:tenant) }
+    let!(:user)        { FactoryGirl.create(:user_with_group, :tenant => tenant) }
 
     before do
       allow(OrchestrationTemplate).to receive_messages(:eligible_manager_types =>
@@ -95,6 +96,12 @@ describe OrchestrationTemplate do
     it "lists all eligible managers for a template" do
       User.with_user(user_admin) do
         expect(@template.eligible_managers).to match_array([@aws, @openstack])
+      end
+    end
+
+    it "lists all eligible managers for a template regard to user's tenant" do
+      User.with_user(user) do
+        expect(@template.eligible_managers).to match_array([@openstack])
       end
     end
   end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -78,17 +78,24 @@ describe OrchestrationTemplate do
   end
 
   describe "#eligible_managers" do
+    let!(:miq_server)  { EvmSpecHelper.local_miq_server }
+    let(:user_admin)   { FactoryGirl.create(:user_admin) }
+    let(:tenant)       { FactoryGirl.create(:tenant) }
+    let(:other_tenant) { FactoryGirl.create(:tenant) }
+
     before do
       allow(OrchestrationTemplate).to receive_messages(:eligible_manager_types =>
                                                          [ManageIQ::Providers::Amazon::CloudManager,
                                                           ManageIQ::Providers::Openstack::CloudManager])
       @template = FactoryGirl.create(:orchestration_template)
-      @aws = FactoryGirl.create(:ems_amazon)
-      @openstack = FactoryGirl.create(:ems_openstack)
+      @aws = FactoryGirl.create(:ems_amazon, :tenant => other_tenant)
+      @openstack = FactoryGirl.create(:ems_openstack, :tenant => tenant)
     end
 
     it "lists all eligible managers for a template" do
-      expect(@template.eligible_managers).to match_array([@aws, @openstack])
+      User.with_user(user_admin) do
+        expect(@template.eligible_managers).to match_array([@aws, @openstack])
+      end
     end
   end
 


### PR DESCRIPTION
Add list of providers to RBAC in catalog items.

In catalog items, providers are listed by method OrchestrationTemplate#eligible_managers, 
so I added RBAC filtering here.

In UI list of providers in catalog items is [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/catalog_controller.rb#L1474)  and [here
](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/catalog_controller.rb#L1478) (there is changed `eligible_managers`):

<img width="1287" alt="screen shot 2017-01-09 at 10 39 30" src="https://cloud.githubusercontent.com/assets/14937244/21762300/3d9103e4-d658-11e6-8c8f-d89654607ce1.png">

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1387572

@miq-bot add_label bug, rbac
@miq-bot assign @gtanzillo 


