### PR TITLE
perf_capture_enabled :: deprecate one of the duplicate methods

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -512,13 +512,14 @@ class ExtManagementSystem < ApplicationRecord
     [MiqRegion.my_region].compact unless interval_name == 'realtime'
   end
 
-  def perf_capture_enabled
+  def perf_capture_enabled?
     return @perf_capture_enabled unless @perf_capture_enabled.nil?
     return @perf_capture_enabled = true if ems_clusters.any?(&:perf_capture_enabled?)
     return @perf_capture_enabled = true if hosts.any?(&:perf_capture_enabled?)
     @perf_capture_enabled = false
   end
-  alias_method :perf_capture_enabled?, :perf_capture_enabled
+  alias_method :perf_capture_enabled, :perf_capture_enabled?
+  Vmdb::Deprecation.deprecate_methods(self, :perf_capture_enabled => :perf_capture_enabled?)
 
   ###################################
   # Event Monitor

--- a/app/models/metric/ci_mixin/targets.rb
+++ b/app/models/metric/ci_mixin/targets.rb
@@ -18,6 +18,7 @@ module Metric::CiMixin::Targets
     @perf_capture_enabled ||= (perf_capture_always? || self.is_tagged_with?("capture_enabled", :ns => "/performance"))
   end
   alias_method :perf_capture_enabled, :perf_capture_enabled?
+  Vmdb::Deprecation.deprecate_methods(self, :perf_capture_enabled => :perf_capture_enabled?)
 
   # TODO: Should enabling a Host also enable the cluster?
   def perf_capture_enabled=(enable)

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -97,8 +97,9 @@ class MiqEnterprise < ApplicationRecord
     # No rollup parents
   end
 
-  def perf_capture_enabled
+  def perf_capture_enabled?
     @perf_capture_enabled ||= ext_management_systems.any?(&:perf_capture_enabled?)
   end
-  alias_method :perf_capture_enabled?, :perf_capture_enabled
+  alias_method :perf_capture_enabled, :perf_capture_enabled?
+  Vmdb::Deprecation.deprecate_methods(self, :perf_capture_enabled => :perf_capture_enabled?)
 end # class MiqEnterprise

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -148,31 +148,31 @@ describe EmsCluster do
     end
 
     it "Initially Performance capture for cluster and its hosts should not be set" do
-      expect(@cluster.perf_capture_enabled).to eq(false)
-      expect(@host1.perf_capture_enabled).to eq(false)
-      expect(@host2.perf_capture_enabled).to eq(false)
+      expect(@cluster.perf_capture_enabled?).to eq(false)
+      expect(@host1.perf_capture_enabled?).to eq(false)
+      expect(@host2.perf_capture_enabled?).to eq(false)
     end
 
     it "Performance capture for cluster and its hosts should be set" do
       @cluster.perf_capture_enabled_host_ids = [@host1.id, @host2.id]
-      expect(@cluster.perf_capture_enabled).to eq(true)
-      expect(@host1.perf_capture_enabled).to eq(true)
-      expect(@host2.perf_capture_enabled).to eq(true)
+      expect(@cluster.perf_capture_enabled?).to eq(true)
+      expect(@host1.perf_capture_enabled?).to eq(true)
+      expect(@host2.perf_capture_enabled?).to eq(true)
     end
 
     it "Performance capture for cluster and only 1 hosts should be set" do
       @cluster.perf_capture_enabled_host_ids = [@host2.id]
-      expect(@cluster.perf_capture_enabled).to eq(true)
-      expect(@host1.perf_capture_enabled).to eq(false)
-      expect(@host2.perf_capture_enabled).to eq(true)
+      expect(@cluster.perf_capture_enabled?).to eq(true)
+      expect(@host1.perf_capture_enabled?).to eq(false)
+      expect(@host2.perf_capture_enabled?).to eq(true)
     end
 
     it "Performance capture for cluster and its hosts should get unset" do
       @cluster.perf_capture_enabled_host_ids = [@host2.id]
       @cluster.perf_capture_enabled_host_ids = []
-      expect(@cluster.perf_capture_enabled).to eq(false)
-      expect(@host1.perf_capture_enabled).to eq(false)
-      expect(@host2.perf_capture_enabled).to eq(false)
+      expect(@cluster.perf_capture_enabled?).to eq(false)
+      expect(@host1.perf_capture_enabled?).to eq(false)
+      expect(@host2.perf_capture_enabled?).to eq(false)
     end
   end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1352,7 +1352,7 @@ describe Metric do
       selected_types << t.class.name
 
       expected_enabled = case t
-                         # Vm's perf_capture_enabled is its availability_zone's perf_capture setting,
+                         # Vm's perf_capture_enabled? is its availability_zone's perf_capture setting,
                          #   or true if it has no availability_zone
                          when Vm then                t.availability_zone ? t.availability_zone.perf_capture_enabled? : true
                          when AvailabilityZone then  t.perf_capture_enabled?


### PR DESCRIPTION
 Deprecate `perf_capture_enabled` without question mark and leave `perf_capture_enabled?`.

Let's have a single way to do it. That's what our python friends (and zen practitioners) mean when they say: There should be one — and preferably only one — obvious way to do it.