### PR TITLE
Remove UTC conversion from report interval in chargeback

### DIFF
--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -40,14 +40,14 @@ class Chargeback
       ts = Time.now.in_time_zone(tz)
       case interval
       when 'daily'
-        start_time = (ts - start_interval_offset.days).beginning_of_day.utc
-        end_time   = (ts - end_interval_offset.days).end_of_day.utc
+        start_time = (ts - start_interval_offset.days).beginning_of_day
+        end_time   = (ts - end_interval_offset.days).end_of_day
       when 'weekly'
-        start_time = (ts - start_interval_offset.weeks).beginning_of_week.utc
-        end_time   = (ts - end_interval_offset.weeks).end_of_week.utc
+        start_time = (ts - start_interval_offset.weeks).beginning_of_week
+        end_time   = (ts - end_interval_offset.weeks).end_of_week
       when 'monthly'
-        start_time = (ts - start_interval_offset.months).beginning_of_month.utc
-        end_time   = (ts - end_interval_offset.months).end_of_month.utc
+        start_time = (ts - start_interval_offset.months).beginning_of_month
+        end_time   = (ts - end_interval_offset.months).end_of_month
       else
         raise _("interval '%{interval}' is not supported") % {:interval => interval}
       end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -300,7 +300,7 @@ describe ChargebackVm do
       let(:santiago_time_zone) { 'Santiago' }
 
       before do
-        Timecop.travel(Time.parse('2017-01-01 00:00:00Z').utc) # timezone: CLST -3 hours
+        Timecop.freeze("2017-01-01 01:00:00 +0100") # timezone: CLST -3 hours
 
         options[:ext_options][:tz] = santiago_time_zone
         options[:interval_size] = 12
@@ -324,11 +324,30 @@ describe ChargebackVm do
       let(:second_row_on_report) { subject.second }
 
       it "generates report with rows for Jun and July " do
+        puts "Time.now.to_s                                       " + Time.now.to_s
+        puts "Time.now.in_time_zone.to_s                          " + Time.now.in_time_zone.to_s
+        puts "Time.zone.now.to_s                                  " + Time.zone.now.to_s
+        puts "Time.now.in_time_zone(santiago_time_zone).to_s      " + Time.now.in_time_zone(santiago_time_zone).to_s
+        puts "Time.now.in_time_zone(santiago_time_zone).zone      " + Time.now.in_time_zone(santiago_time_zone).zone
         beginning_of_jun = metric_rollup_timestamp_jun.in_time_zone(santiago_time_zone).beginning_of_month
+        puts "metric_rollup_timestamp_jun.to_s                    " + metric_rollup_timestamp_jun.to_s
+        puts "metric_rollup_timestamp_jun.in_time_zone(santiago_time_zone)" + metric_rollup_timestamp_jun.in_time_zone(santiago_time_zone).to_s
+        puts "beginning_of_jun.to_s ^                             " + beginning_of_jun.to_s
+        puts "first_row_on_report.start_date.to_s                 " + first_row_on_report.start_date.to_s
+        puts "first_row_on_report.start_date.month.to_s           " + first_row_on_report.start_date.month.to_s
+        puts "Jun---"
+
         expect(first_row_on_report.start_date).to eq(beginning_of_jun)
         expect(first_row_on_report.start_date.month).to eq(6) # Jun
 
         beginning_of_july = metric_rollup_timestamp_july.in_time_zone(santiago_time_zone).beginning_of_month
+
+        puts "Jul MR" + beginning_of_july.to_s
+        puts "Jul" + metric_rollup_timestamp_july.to_s
+        puts "Jul" + second_row_on_report.start_date.to_s
+        puts "Jul" + second_row_on_report.start_date.month.to_s
+        puts "Jul---"
+
         expect(second_row_on_report.start_date).to eq(beginning_of_july)
         expect(second_row_on_report.start_date.month).to eq(7) # July
       end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -259,7 +259,8 @@ describe ChargebackVm do
 
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly') }
-    before  do
+
+    before do
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr, :with_data,
                                                   :timestamp                         => time,
@@ -281,6 +282,56 @@ describe ChargebackVm do
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
       expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
+    end
+
+    context "with different timezone" do
+      # CLT zone - belongs to date range Sun, 15 May, 00:00 - Sun, 14 Aug, 00:00
+      # and it is 4 hours behind UTC
+
+      # CLST (Chile Summer Time) for other months
+      # and it is 3 hours behind UTC
+
+      # timezone: CLT -4 hours behind UTC - this timestamp belongs to Jun(Thu, 30 Jun 2016 23:00:00 CLT -04:00)
+      let(:metric_rollup_timestamp_jun)  { Time.parse('2016-07-01 03:00:00Z').utc }
+
+      # timezone: CLT -4 hours behind UTC - this timestamp belongs to Jul(Fri, 01 Jul 2016 00:00:00 CLT -04:00)
+      let(:metric_rollup_timestamp_july) { Time.parse('2016-07-01 04:00:00Z').utc }
+
+      let(:santiago_time_zone) { 'Santiago' }
+
+      before do
+        Timecop.travel(Time.parse('2017-01-01 00:00:00Z').utc) # timezone: CLST -3 hours
+
+        options[:ext_options][:tz] = santiago_time_zone
+        options[:interval_size] = 12
+
+        @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr, :with_data,
+                                                  :timestamp => metric_rollup_timestamp_jun,
+                                                  :tag_names => "environment/prod", :parent_host_id => @host1.id,
+                                                  :parent_ems_cluster_id => @ems_cluster.id, :parent_ems_id => ems.id,
+                                                  :parent_storage_id => @storage.id, :resource_name => @vm1.name)
+
+        @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr, :with_data,
+                                                  :timestamp => metric_rollup_timestamp_july,
+                                                  :tag_names => "environment/prod", :parent_host_id => @host1.id,
+                                                  :parent_ems_cluster_id => @ems_cluster.id, :parent_ems_id => ems.id,
+                                                  :parent_storage_id => @storage.id, :resource_name => @vm1.name)
+      end
+
+      subject! { ChargebackVm.build_results_for_report_ChargebackVm(options).first }
+
+      let(:first_row_on_report)  { subject.first }
+      let(:second_row_on_report) { subject.second }
+
+      it "generates report with rows for Jun and July " do
+        beginning_of_jun = metric_rollup_timestamp_jun.in_time_zone(santiago_time_zone).beginning_of_month
+        expect(first_row_on_report.start_date).to eq(beginning_of_jun)
+        expect(first_row_on_report.start_date.month).to eq(6) # Jun
+
+        beginning_of_july = metric_rollup_timestamp_july.in_time_zone(santiago_time_zone).beginning_of_month
+        expect(second_row_on_report.start_date).to eq(beginning_of_july)
+        expect(second_row_on_report.start_date.month).to eq(7) # July
+      end
     end
 
     let(:fixed_rate) { 10.0 }


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq/pull/11648/commits/f3506b7ce9713a90ed1061b5ad8cb57d6cd402ed#diff-06b291c88bf5d62e6e8089364aa462d0L47

Issue is that whole report interval is so big that it contains winter and summer time zone and also thanks timezone shift it can merge months to one and can select MetricRollup to inproper month.

Example with Santiago time zone:
[CTL and CTLS timezones ](https://www.timeanddate.com/time/zone/chile/santiago)

Described also in spec: https://github.com/ManageIQ/manageiq/pull/13398/commits/82feaf5968187dd3e10985c62d04e9c44801e2db#diff-de9adf0bd8114667190fecb643922d79R287

Let's have two metric rollups with timestamps:
1.MetricRollup `2016-07-01 03:00:00 UTC` - 
this belongs to timestamp Jun `(Thu, 30 Jun 2016 23:00:00 CLT -04:00)`

2.MetricRollup `2016-07-01 04:00:00 UTC` -
this timestamp belongs to `Jul(Fri, 01 Jul 2016 00:00:00 CLT -04:00)`

So it should generates report with row for Jun and July. But because we was using UTC  in query for selection of [metric rollups for certain month.](https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/consumption_history.rb#L13) then both metric rollups fit in one month (6 - Jun)

before:
[date frame is (query_start_time...query_end_time)](https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/consumption_history.rb#L13)
`2016-07-01 03:00:00 UTC...2016-08-01 03:00:00 UTC`
and it selects both metric rollups

after:
[date frame are (query_start_time...query_end_time)](https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/consumption_history.rb#L13)
`Wed, 01 Jun 2016 00:00:00 CLT -04:00...Fri, 01 Jul 2016 00:00:00 CLT -04:00`
first metric rollup is select for month 6 -Jul

`Fri, 01 Jul 2016 00:00:00 CLT -04:00...Mon, 01 Aug 2016 00:00:00 CLT -04:00`
second metric rollup is select for month 7 -Jul

on report:
before (August is missing and Jun is doubled):
![screen shot 2017-01-25 at 14 32 57](https://cloud.githubusercontent.com/assets/14937244/22292392/408b3456-e30b-11e6-9bd3-790dc3be4e5b.png)

after:
![screen shot 2017-01-25 at 14 32 46](https://cloud.githubusercontent.com/assets/14937244/22292404/4f366ae8-e30b-11e6-9858-2f743c73e4c9.png)





