### PR TITLE
[EUWE] ops_rbac - group detail - don't render trees that are not visible

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1652,6 +1652,21 @@ function add_expanding_icon(element) {
   element.find('.pull-right').append("<a onclick='toggle_expansion(this)'> <i class='fa fa-angle-right'></i>");
 }
 
+function rbacGroupLoadTab(id) {
+  var lazy = $('#' + id).hasClass('lazy');
+  if (! lazy) {
+    // already loaded
+    return;
+  }
+
+  $('#' + id).removeClass('lazy');
+
+  miqJqueryRequest('/ops/rbac_group_load_tab?tab_id=' + id, {
+    beforeSend: true,
+    complete: true,
+  });
+}
+
 function chartData(type, data, data2) {
   if (type === undefined) {
     return;

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -202,7 +202,7 @@ class OpsController < ApplicationController
 
   def rbac_group_load_tab
     tab_id = params[:tab_id]
-    _, group_id, _ = TreeBuilder.extract_node_model_and_id(x_node)
+    _, group_id = TreeBuilder.extract_node_model_and_id(x_node)
     @sb[:active_rbac_group_tab] = tab_id
 
     rbac_group_get_details(group_id)

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -204,6 +204,7 @@ class OpsController < ApplicationController
     tab_id = params[:tab_id]
     _, group_id = TreeBuilder.extract_node_model_and_id(x_node)
     @sb[:active_rbac_group_tab] = tab_id
+    @edit = session[:edit]
 
     rbac_group_get_details(group_id)
 

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -239,7 +239,16 @@ class OpsController < ApplicationController
     end
 
     if x_active_tree == :rbac_tree
-      x_node_set("root", :rbac_tree) unless x_node(:rbac_tree)
+      node = x_node(:rbac_tree)
+      if node
+        kind = node.split('-').first
+
+        # default to the first tab in group detail
+        @sb[:active_rbac_group_tab] = "rbac_customer_tags" if kind == 'g'
+      else
+        x_node_set("root", :rbac_tree)
+      end
+
       @sb[:active_tab] ||= "rbac_details"
     end
 
@@ -316,6 +325,9 @@ class OpsController < ApplicationController
       end
     when :rbac_tree
       @sb[:active_tab] = "rbac_details"
+
+      # default to the first tab in group detail
+      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node[0] == 'g'
     when :diagnostics_tree
       case node[0]
       when "root"
@@ -326,7 +338,6 @@ class OpsController < ApplicationController
         @sb[:diag_selected_id] = nil
       when "svr"
         @sb[:active_tab] = "diagnostics_summary"
-        svr = MiqServer.find(from_cid(node[1]))
       end
     when :vmdb_tree
       nodes = x_node.split('-')

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -200,6 +200,30 @@ class OpsController < ApplicationController
     end
   end
 
+  def rbac_group_load_tab
+    tab_id = params[:tab_id]
+    _, group_id, _ = TreeBuilder.extract_node_model_and_id(x_node)
+    @sb[:active_rbac_group_tab] = tab_id
+
+    rbac_group_get_details(group_id)
+
+    presenter = ExplorerPresenter.new
+    r = proc { |opts| render_to_string(opts) }
+
+    rendered = case tab_id
+               when 'rbac_customer_tags'
+                 r[:partial => 'ops/rbac_group/customer_tags']
+               when 'rbac_hosts_clusters'
+                 r[:partial => 'ops/rbac_group/hosts_clusters']
+               when 'rbac_vms_templates'
+                 r[:partial => 'ops/rbac_group/vms_templates']
+               end
+
+    presenter.update(tab_id, rendered)
+
+    render :json => presenter.for_render
+  end
+
   private ############################
 
   def features

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -209,6 +209,10 @@ class OpsController < ApplicationController
     rbac_group_get_details(group_id)
 
     presenter = ExplorerPresenter.new
+
+    # needed to make tooolbar Configuration > Edit still work after lazy-loading a tab
+    presenter[:record_id] = group_id
+
     r = proc { |opts| render_to_string(opts) }
 
     rendered = case tab_id

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -943,13 +943,20 @@ module OpsController::OpsRbac
     [@group.get_managed_filters].flatten.each do |f|
       @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
     end
+
+    rbac_group_right_tree(@belongsto.keys)
+  end
+
+  def rbac_group_right_tree(selected)
     @tags_tree = TreeBuilderTags.new(:tags,
                                      :tags_tree,
                                      @sb,
                                      true,
-                                     :edit => @edit, :filters => @filters, :group => @group)
-    @hac_tree = build_belongsto_tree(@belongsto.keys, false, false)  # Build the Hosts & Clusters tree for this user
-    @vat_tree = build_belongsto_tree(@belongsto.keys, true, false)  # Build the VMs & Templates tree for this user
+                                     :edit    => @edit,
+                                     :filters => @filters,
+                                     :group   => @group)
+    @hac_tree = build_belongsto_tree(selected, false, false)  # Build the Hosts & Clusters tree for this user
+    @vat_tree = build_belongsto_tree(selected, true, false)  # Build the VMs & Templates tree for this user
   end
 
   def rbac_role_get_details(id)
@@ -1114,13 +1121,8 @@ module OpsController::OpsRbac
     @edit[:new][:group_tenant] = @group.tenant_id
 
     @edit[:current] = copy_hash(@edit[:new])
-    @tags_tree = TreeBuilderTags.new(:tags,
-                                     :tags_tree,
-                                     @sb,
-                                     true,
-                                     :edit => @edit, :filters => @filters, :group => @group)
-    @hac_tree = build_belongsto_tree(@edit[:new][:belongsto].keys, false, false)  # Build the Hosts & Clusters tree for this user
-    @vat_tree = build_belongsto_tree(@edit[:new][:belongsto].keys, true, false)  # Build the VMs & Templates tree for this user
+
+    rbac_group_right_tree(@edit[:new][:belongsto].keys)
   end
 
   # Set group record variables to new values

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -947,16 +947,22 @@ module OpsController::OpsRbac
     rbac_group_right_tree(@belongsto.keys)
   end
 
+  # this causes the correct tree to get instantiated, depending on the active tab
   def rbac_group_right_tree(selected)
-    @tags_tree = TreeBuilderTags.new(:tags,
-                                     :tags_tree,
-                                     @sb,
-                                     true,
-                                     :edit    => @edit,
-                                     :filters => @filters,
-                                     :group   => @group)
-    @hac_tree = build_belongsto_tree(selected, false, false)  # Build the Hosts & Clusters tree for this user
-    @vat_tree = build_belongsto_tree(selected, true, false)  # Build the VMs & Templates tree for this user
+    case @sb[:active_rbac_group_tab]
+    when 'rbac_customer_tags'
+      @tags_tree = TreeBuilderTags.new(:tags,
+                                       :tags_tree,
+                                       @sb,
+                                       true,
+                                       :edit    => @edit,
+                                       :filters => @filters,
+                                       :group   => @group)
+    when 'rbac_hosts_clusters'
+      @hac_tree = build_belongsto_tree(selected, false, false)  # Build the Hosts & Clusters tree for this user
+    when 'rbac_vms_templates'
+      @vat_tree = build_belongsto_tree(selected, true, false)  # Build the VMs & Templates tree for this user
+    end
   end
 
   def rbac_role_get_details(id)

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -897,6 +897,7 @@ module OpsController::OpsRbac
       rbac_user_get_details(id)
     when "g"
       @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqGroup"), :name => MiqGroup.find_by_id(from_cid(id)).description}
+      @edit = nil
       rbac_group_get_details(id)
     when "ur"
       @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqUserRole"), :name => MiqUserRole.find_by_id(from_cid(id)).name}
@@ -928,7 +929,6 @@ module OpsController::OpsRbac
   end
 
   def rbac_group_get_details(id)
-    @edit = nil
     @record = @group = MiqGroup.find_by_id(from_cid(id))
     get_tagdata(@group)
     # Build the belongsto filters hash

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1347,8 +1347,8 @@ module ApplicationHelper
   end
 
   def miq_tab_header(id, active = nil, options = {}, &_block)
-    tag_options = {:class     => "#{options[:class]} #{active == id ? 'active' : ''}",
-                   :id        => "#{id}_tab"}
+    tag_options = {:class => "#{options[:class]} #{active == id ? 'active' : ''}",
+                   :id    => "#{id}_tab"}
 
     tag_options['ng-click'] = options['ng-click'] if options.key?('ng-click')
     tag_options[:onclick] = options[:onclick] if options.key?(:onclick)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1347,10 +1347,13 @@ module ApplicationHelper
   end
 
   def miq_tab_header(id, active = nil, options = {}, &_block)
-    content_tag(:li,
-                :class     => "#{options[:class]} #{active == id ? 'active' : ''}",
-                :id        => "#{id}_tab",
-                'ng-click' => "changeAuthTab('#{id}');") do
+    tag_options = {:class     => "#{options[:class]} #{active == id ? 'active' : ''}",
+                   :id        => "#{id}_tab"}
+
+    tag_options['ng-click'] = options['ng-click'] if options.key?('ng-click')
+    tag_options[:onclick] = options[:onclick] if options.key?(:onclick)
+
+    content_tag(:li, tag_options) do
       content_tag(:a, :href => "##{id}", 'data-toggle' => 'tab') do
         yield
       end
@@ -1358,8 +1361,9 @@ module ApplicationHelper
   end
 
   def miq_tab_content(id, active = nil, options = {}, &_block)
-    content_tag(:div, :id => id, :class => "tab-pane #{options[:class]} #{active == id ? 'active' : ''}") do
-      yield
+    lazy = options[:lazy] && active != id
+    content_tag(:div, :id => id, :class => "tab-pane #{options[:class]} #{active == id ? 'active' : ''} #{lazy ? 'lazy' : ''}") do
+      yield unless lazy
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1362,7 +1362,13 @@ module ApplicationHelper
 
   def miq_tab_content(id, active = nil, options = {}, &_block)
     lazy = options[:lazy] && active != id
-    content_tag(:div, :id => id, :class => "tab-pane #{options[:class]} #{active == id ? 'active' : ''} #{lazy ? 'lazy' : ''}") do
+
+    classname = %w(tab-pane)
+    classname << options[:class] if options[:class]
+    classname << 'active' if active == id
+    classname << 'lazy' if lazy
+
+    content_tag(:div, :id => id, :class => classname.join(' ')) do
       yield unless lazy
     end
   end

--- a/app/views/layouts/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/_multi_auth_credentials.html.haml
@@ -6,24 +6,24 @@
     = legendtext
   #auth_tabs
     %ul.nav.nav-tabs
-      = miq_tab_header('default') do
+      = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
         = _("Default")
       - if %w(ems_cloud ems_infra).include?(params[:controller])
         - if @edit[:new][:emstype] == "rhevm"
-          = miq_tab_header('metrics') do
+          = miq_tab_header('metrics', nil, {'ng-click' => "changeAuthTab('metrics')"}) do
             = _("C & U Database")
         - if %w(openstack openstack_infra).include?(@edit[:new][:emstype])
-          = miq_tab_header('amqp') do
+          = miq_tab_header('amqp', nil, {'ng-click' => "changeAuthTab('amqp')"}) do
             = _("AMQP")
         - if %w(openstack_infra).include?(@edit[:new][:emstype])
-          = miq_tab_header('ssh_keypair') do
+          = miq_tab_header('ssh_keypair', nil, {'ng-click' => "changeAuthTab('ssh_keypair')"}) do
             = _("RSA key pair")
       - elsif !%w(ems_middleware).include?(params[:controller])
-        = miq_tab_header('remote') do
+        = miq_tab_header('remote', nil, {'ng-click' => "changeAuthTab('remote')"}) do
           = _("Remote Login")
-        = miq_tab_header('web') do
+        = miq_tab_header('web', nil, {'ng-click' => "changeAuthTab('web')"}) do
           = _("Web Services")
-        = miq_tab_header('ipmi') do
+        = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
           = _("IPMI")
 
     .tab-content

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -168,11 +168,11 @@
 
   #rbac_group_tabs
     %ul.nav.nav-tabs
-      = miq_tab_header('rbac_customer_tags', @sb[:active_rbac_group_tab]) do
+      = miq_tab_header('rbac_customer_tags', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_customer_tags')"}) do
         = _("%{current_tenant} Tags") % {:current_tenant => current_tenant.name}
-      = miq_tab_header('rbac_hosts_clusters', @sb[:active_rbac_group_tab]) do
+      = miq_tab_header('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_hosts_clusters')"}) do
         = _("%{title_for_hosts} & %{title_for_clusters}") % {:title_for_hosts => title_for_hosts, :title_for_clusters => title_for_clusters}
-      = miq_tab_header('rbac_vms_templates', @sb[:active_rbac_group_tab]) do
+      = miq_tab_header('rbac_vms_templates', @sb[:active_rbac_group_tab], {:onclick => "rbacGroupLoadTab('rbac_vms_templates')"}) do
         = _("VMs & Templates")
 
     .tab-content

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -176,11 +176,11 @@
         = _("VMs & Templates")
 
     .tab-content
-      = miq_tab_content('rbac_customer_tags', @sb[:active_rbac_group_tab]) do
+      = miq_tab_content('rbac_customer_tags', @sb[:active_rbac_group_tab], {:lazy => true}) do
         = render :partial => 'ops/rbac_group/customer_tags'
-      = miq_tab_content('rbac_hosts_clusters', @sb[:active_rbac_group_tab]) do
+      = miq_tab_content('rbac_hosts_clusters', @sb[:active_rbac_group_tab], {:lazy => true}) do
         = render :partial => 'ops/rbac_group/hosts_clusters'
-      = miq_tab_content('rbac_vms_templates', @sb[:active_rbac_group_tab]) do
+      = miq_tab_content('rbac_vms_templates', @sb[:active_rbac_group_tab], {:lazy => true}) do
         = render :partial => 'ops/rbac_group/vms_templates'
 
 :javascript

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -168,19 +168,19 @@
 
   #rbac_group_tabs
     %ul.nav.nav-tabs
-      = miq_tab_header('rbac_customer_tags') do
+      = miq_tab_header('rbac_customer_tags', @sb[:active_rbac_group_tab]) do
         = _("%{current_tenant} Tags") % {:current_tenant => current_tenant.name}
-      = miq_tab_header('rbac_hosts_clusters') do
+      = miq_tab_header('rbac_hosts_clusters', @sb[:active_rbac_group_tab]) do
         = _("%{title_for_hosts} & %{title_for_clusters}") % {:title_for_hosts => title_for_hosts, :title_for_clusters => title_for_clusters}
-      = miq_tab_header('rbac_vms_templates') do
+      = miq_tab_header('rbac_vms_templates', @sb[:active_rbac_group_tab]) do
         = _("VMs & Templates")
 
     .tab-content
-      = miq_tab_content('rbac_customer_tags') do
+      = miq_tab_content('rbac_customer_tags', @sb[:active_rbac_group_tab]) do
         = render :partial => 'ops/rbac_group/customer_tags'
-      = miq_tab_content('rbac_hosts_clusters') do
+      = miq_tab_content('rbac_hosts_clusters', @sb[:active_rbac_group_tab]) do
         = render :partial => 'ops/rbac_group/hosts_clusters'
-      = miq_tab_content('rbac_vms_templates') do
+      = miq_tab_content('rbac_vms_templates', @sb[:active_rbac_group_tab]) do
         = render :partial => 'ops/rbac_group/vms_templates'
 
 :javascript

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -165,60 +165,36 @@
   %hr
   %h3
     = @edit ? _("Assign Filters") : _("Assigned Filters (read only)")
+
   #rbac_group_tabs
     %ul.nav.nav-tabs
-      = miq_tab_header('customer_tags') do
-        = escape_javascript(current_tenant.name)
-        = _("Tags")
-      = miq_tab_header('hosts_clusters') do
+      = miq_tab_header('rbac_customer_tags') do
+        = _("%{current_tenant} Tags") % {:current_tenant => current_tenant.name}
+      = miq_tab_header('rbac_hosts_clusters') do
         = _("%{title_for_hosts} & %{title_for_clusters}") % {:title_for_hosts => title_for_hosts, :title_for_clusters => title_for_clusters}
-      = miq_tab_header('vms_templates') do
+      = miq_tab_header('rbac_vms_templates') do
         = _("VMs & Templates")
+
     .tab-content
-      = miq_tab_content('customer_tags') do
-        %br/
-        = _("This user is limited to items with the selected tags.")
-        %br/
-        %br/
-        = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})
-      = miq_tab_content('hosts_clusters') do
-        %br/
-        = _("This user is limited to the selected items and their children.")
-        %br/
-        %br/
-        #hac_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
-        = render(:partial => "layouts/tree",
-                 :locals  => {:tree_id           => "hac_treebox",
-                              :tree_name         => "hac_tree",
-                              :bs_tree           => @hac_tree,
-                              :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                              :check_url         => "ops/rbac_group_field_changed/#{@group.id || "new"}___",
-                              :highlight_changes => true,
-                              :checkboxes        => true})
-      = miq_tab_content('vms_templates') do
-        %br/
-        = _("This user is limited to the selected folders and their children.")
-        %br/
-        %br/
-        #vat_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
-        = render(:partial => "layouts/tree",
-                 :locals  => {:tree_id           => "vat_treebox",
-                              :tree_name         => "vat_tree",
-                              :bs_tree           => @vat_tree,
-                              :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                              :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
-                              :highlight_changes => true,
-                              :checkboxes        => true})
+      = miq_tab_content('rbac_customer_tags') do
+        = render :partial => 'ops/rbac_group/customer_tags'
+      = miq_tab_content('rbac_hosts_clusters') do
+        = render :partial => 'ops/rbac_group/hosts_clusters'
+      = miq_tab_content('rbac_vms_templates') do
+        = render :partial => 'ops/rbac_group/vms_templates'
+
 :javascript
   miq_tabs_init('#rbac_group_tabs');
-%script{:type => "text/javascript"}
-  - if get_vmdb_config[:authentication][:mode] == "httpd"
-    $('#user_id_ext_auth_form_group').show();
-    $('#user_id_form_group').hide();
-    $('#user_name_form_group').hide();
-    $('#user_password_form_group').hide();
-  - else
-    $('#user_id_ext_auth_form_group').hide();
-    $('#user_id_form_group').show();
-    $('#user_name_form_group').show();
-    $('#user_password_form_group').show();
+
+- if @edit
+  %script{:type => "text/javascript"}
+    - if get_vmdb_config[:authentication][:mode] == "httpd"
+      $('#user_id_ext_auth_form_group').show();
+      $('#user_id_form_group').hide();
+      $('#user_name_form_group').hide();
+      $('#user_password_form_group').hide();
+    - else
+      $('#user_id_ext_auth_form_group').hide();
+      $('#user_id_form_group').show();
+      $('#user_name_form_group').show();
+      $('#user_password_form_group').show();

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -1,5 +1,5 @@
-%br/
+%br
 = _("This user is limited to items with the selected tags.")
-%br/
-%br/
+%br
+%br
 = render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -1,0 +1,5 @@
+%br/
+= _("This user is limited to items with the selected tags.")
+%br/
+%br/
+= render(:partial => 'shared/tree', :locals => {:tree => @tags_tree, :name => @tags_tree.name})

--- a/app/views/ops/rbac_group/_hosts_clusters.html.haml
+++ b/app/views/ops/rbac_group/_hosts_clusters.html.haml
@@ -1,7 +1,7 @@
-%br/
+%br
 = _("This user is limited to the selected items and their children.")
-%br/
-%br/
+%br
+%br
 #hac_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
   = render(:partial => "layouts/tree",
            :locals  => {:tree_id           => "hac_treebox",

--- a/app/views/ops/rbac_group/_hosts_clusters.html.haml
+++ b/app/views/ops/rbac_group/_hosts_clusters.html.haml
@@ -1,0 +1,13 @@
+%br/
+= _("This user is limited to the selected items and their children.")
+%br/
+%br/
+#hac_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
+  = render(:partial => "layouts/tree",
+           :locals  => {:tree_id           => "hac_treebox",
+                        :tree_name         => "hac_tree",
+                        :bs_tree           => @hac_tree,
+                        :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
+                        :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :highlight_changes => true,
+                        :checkboxes        => true})

--- a/app/views/ops/rbac_group/_vms_templates.html.haml
+++ b/app/views/ops/rbac_group/_vms_templates.html.haml
@@ -1,7 +1,7 @@
-%br/
+%br
 = _("This user is limited to the selected folders and their children.")
-%br/
-%br/
+%br
+%br
 #vat_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
   = render(:partial => "layouts/tree",
            :locals  => {:tree_id           => "vat_treebox",

--- a/app/views/ops/rbac_group/_vms_templates.html.haml
+++ b/app/views/ops/rbac_group/_vms_templates.html.haml
@@ -1,0 +1,13 @@
+%br/
+= _("This user is limited to the selected folders and their children.")
+%br/
+%br/
+#vat_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
+  = render(:partial => "layouts/tree",
+           :locals  => {:tree_id           => "vat_treebox",
+                        :tree_name         => "vat_tree",
+                        :bs_tree           => @vat_tree,
+                        :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
+                        :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :highlight_changes => true,
+                        :checkboxes        => true})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2286,6 +2286,7 @@ Vmdb::Application.routes.draw do
         product_updates_list
         rbac_group_edit
         rbac_group_field_changed
+        rbac_group_load_tab
         rbac_group_seq_edit
         rbac_group_user_lookup
         rbac_groups_list

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -13,9 +13,13 @@ describe 'ops/_rbac_group_details.html.haml' do
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
       allow(view).to receive(:session).and_return(:assigned_filters => [])
       FactoryGirl.create(:classification, :name => 'folder_selected', :show => true)
+
+      sb = {}
+      view.instance_variable_set(:@sb, sb)
+
       @tags_tree = TreeBuilderTags.new(:tag,
                                        :tag_tree,
-                                       {},
+                                       sb,
                                        true,
                                        :edit => {}, :filters => {}, :group => @group)
     end


### PR DESCRIPTION
This is an euwe version of ManageIQ/manageiq-ui-classic#68 - lazy-load right-side trees in rbac group detail.

https://bugzilla.redhat.com/show_bug.cgi?id=1399345

@miq-bot add_label ui, enhancement
@miq-bot assign chessbyte