### PR TITLE
Automation engine restructure

### DIFF
--- a/config/initializers/miq_automation_engine.rb
+++ b/config/initializers/miq_automation_engine.rb
@@ -1,2 +1,2 @@
 $:.push(File.expand_path(File.join(Rails.root, "lib", "miq_automation_engine")))
-require 'engine/miq_ae_engine'
+require 'automation_engine'

--- a/lib/miq_automation_engine/automation_engine.rb
+++ b/lib/miq_automation_engine/automation_engine.rb
@@ -1,0 +1,5 @@
+require 'miq_ae_exception'
+
+require 'engine/miq_ae_engine'
+require 'engine/miq_ae_event'
+require 'engine/miq_ae_method_service'

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -1,6 +1,3 @@
-require 'miq_ae_exception'
-require 'engine/miq_ae_method_service'
-require 'engine/miq_ae_event'
 require 'uri'
 
 Dir.glob(Pathname.new(__dir__).join("miq_ae_engine/*.rb")) do |file|


### PR DESCRIPTION
MiqAeEngine should only load its components.  Create a new file to require the whole automation engine.