### PR TITLE
api sort on sql friendly virtual attributes

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -171,13 +171,12 @@ module Api
       end
 
       def sort_directive(klass, attr, order, options)
-        if options.map(&:downcase).include?("ignore_case") && order
-          klass.arel_attribute(attr).lower.public_send(order.downcase)
-        elsif order
-          klass.arel_attribute(attr).public_send(order.downcase)
-        else
-          klass.arel_attribute(attr)
+        arel = klass.arel_attribute(attr)
+        if order
+          arel = arel.lower if options.map(&:downcase).include?("ignore_case")
+          arel = arel.desc if order.downcase == "desc"
         end
+        arel
       end
     end
   end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -103,8 +103,8 @@ describe "Querying" do
     end
 
     it 'supports sql friendly virtual attributes' do
-      host_foo =  FactoryGirl.create(:host, :hostname => 'foo')
-      host_bar =  FactoryGirl.create(:host, :hostname => 'bar')
+      host_foo =  FactoryGirl.create(:host, :name => 'foo')
+      host_bar =  FactoryGirl.create(:host, :name => 'bar')
       vm_foo = FactoryGirl.create(:vm, :name => 'vm_foo')
       vm_bar = FactoryGirl.create(:vm, :name => 'vm_bar')
       host_foo.vms << vm_foo
@@ -113,7 +113,7 @@ describe "Querying" do
       run_get vms_url, :sort_by => 'host_name', :sort_order => 'desc', :expand => 'resources'
 
       expect_query_result(:vms, 2, 2)
-      expect_result_resources_to_match_hash([{'name' => 'vm_bar'}, {'name' => 'vm_foo'}])
+      expect_result_resources_to_match_hash([{'name' => 'vm_foo'}, {'name' => 'vm_bar'}])
     end
 
     it 'does not support non sql friendly virtual attributes' do
@@ -124,20 +124,6 @@ describe "Querying" do
       expected = {
         'error' => a_hash_including(
           'message' => 'Vm cannot be sorted by aggressive_recommended_mem'
-        )
-      }
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body).to include(expected)
-    end
-
-    it 'does not support ignore_case on sql friendly virtual attributes' do
-      FactoryGirl.create(:vm)
-
-      run_get vms_url, :sort_by => 'host_name', :expand => 'resources', :sort_options => 'ignore_case'
-
-      expected = {
-        'error' => a_hash_including(
-          'message' => 'Vm cannot be sorted with ignored case'
         )
       }
       expect(response).to have_http_status(:bad_request)

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -129,6 +129,20 @@ describe "Querying" do
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
+
+    it 'does not support ignore_case on sql friendly virtual attributes' do
+      FactoryGirl.create(:vm)
+
+      run_get vms_url, :sort_by => 'host_name', :expand => 'resources', :sort_options => 'ignore_case'
+
+      expected = {
+        'error' => a_hash_including(
+          'message' => 'Vm cannot be sorted with ignored case'
+        )
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe "Filtering vms" do


### PR DESCRIPTION
This updates the sort directive to allow for sorting on sql friendly virtual attributes. Adds an additional error message to indicate the collection cannot be sorted by the non-sql friendly virtual attribute. 

* GitHub issue #13380 
* [Pivotal Issue](https://www.pivotaltracker.com/story/show/137158807)

@miq-bot assign @abellotti 
@miq-bot add_label api, enhancement 

cc: @jeff-phillips-18 