### PR TITLE
Add tenant to openstack instance factory so that tests match reality

### DIFF
--- a/spec/factories/vm_openstack.rb
+++ b/spec/factories/vm_openstack.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     vendor          "openstack"
     raw_power_state "ACTIVE"
     sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
+    cloud_tenant { FactoryGirl.create(:cloud_tenant_openstack) }
   end
 
   factory :vm_perf_openstack, :parent => :vm_openstack do


### PR DESCRIPTION
This patch causes Openstack VM fixtures to belong to a Cloud Tenant by default in order to better match reality. This is necessary for the tests in https://github.com/ManageIQ/manageiq-ui-classic/pull/110 to pass.