### PR TITLE
Revert gemfile dev priority

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ unless dependencies.detect { |d| d.name == "manageiq-providers-azure" }
 end
 
 unless dependencies.detect { |d| d.name == "manageiq-ui-classic" }
-  #gem "manageiq-ui-classic", :path => "../manageiq-ui-classic/"
   gem "manageiq-ui-classic", :git => "https://github.com/ManageIQ/manageiq-ui-classic", :branch => "master"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -150,6 +150,16 @@ end
 #
 # Custom Gemfile modifications
 #
+# To develop a gem locally and override its source to a checked out repo
+#   you can use this helper method in Gemfile.dev.rb e.g.
+#
+# override_gem 'manageiq-ui-classic', :path => File.expand_path("../manageiq-ui-classic", __dir__))
+#
+def override_gem(name, *args)
+  raise "Trying to override unknown gem #{name}" unless (dependency = dependencies.find { |d| d.name == name })
+  dependencies.delete(dependency)
+  gem name, *args
+end
 
 # Load developer specific Gemfile
 #   Developers can create a file called Gemfile.dev.rb containing any gems for

--- a/Gemfile
+++ b/Gemfile
@@ -3,21 +3,6 @@ raise "Ruby versions less than 2.2.2 are unsupported!" if RUBY_VERSION < "2.2.2"
 source 'https://rubygems.org'
 
 #
-# Custom Gemfile modifications
-#
-
-# Load developer specific Gemfile
-#   Developers can create a file called Gemfile.dev.rb containing any gems for
-#   their local development.  This can be any gem under evaluation that other
-#   developers may not need or may not easily install, such as rails-dev-boost,
-#   any git based gem, and compiled gems like rbtrace or memprof.
-dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
-eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
-
-# Load other additional Gemfiles
-Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }
-
-#
 # VMDB specific gems
 #
 
@@ -162,3 +147,18 @@ unless ENV["APPLIANCE"]
     gem "rspec-rails",      "~>3.5.0"
   end
 end
+
+#
+# Custom Gemfile modifications
+#
+
+# Load developer specific Gemfile
+#   Developers can create a file called Gemfile.dev.rb containing any gems for
+#   their local development.  This can be any gem under evaluation that other
+#   developers may not need or may not easily install, such as rails-dev-boost,
+#   any git based gem, and compiled gems like rbtrace or memprof.
+dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
+eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
+
+# Load other additional Gemfiles
+Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
I'd like to revert https://github.com/ManageIQ/manageiq/pull/13305

The reason was 
> Include Gemfile.dev early so that it can override gem dependencies such as manageiq-ui-classic.

But this is only true for dependencies that are wrapped in a `unless dependencies.detect` block. Other deps cannot be overridden anymore. Before it was possible though.

Before you could do
```ruby
dependencies.reject!{|d| d.name == "ansible_tower_client"}
gem "ansible_tower_client", :path => '../ansible_tower_client'
```

which is also the approach I take for my local plugin development.

The `unless` block in the Gemfile is for including the miq core Gemfile into a plugins [Gemfile](https://github.com/ManageIQ/manageiq-content/blob/master/Gemfile#L8).
Without this, it would fail.

@martinpovolny @Fryguy @bdunne 