### PR TITLE
Ansible Tower Event Catcher

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/runner.rb
@@ -24,7 +24,10 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Run
 
   def event_monitor_handle
     @event_monitor_handle ||= begin
-      ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Stream.new(@ems)
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Stream.new(
+        @ems,
+        :poll_sleep => worker_settings[:poll]
+      )
     end
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/runner.rb
@@ -1,0 +1,30 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def stop_event_monitor
+    event_monitor_handle.stop
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.poll do |event|
+      _log.debug { "#{log_prefix} Received event #{event.id}" }
+      event_monitor_running
+      @queue.enq event
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event [#{event.id}]"
+    event_hash = ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
+  private
+
+  def event_monitor_handle
+    @event_monitor_handle ||= begin
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Stream.new(@ems)
+    end
+  end
+end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/stream.rb
@@ -2,10 +2,11 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Str
   class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
   end
 
-  def initialize(ems)
+  def initialize(ems, options = {})
     @ems = ems
     @last_activity = nil
     @stop_polling = false
+    @poll_sleep = options[:poll_sleep] || 20.seconds
   end
 
   def start
@@ -26,7 +27,7 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Str
               yield activity
               @last_activity = activity
             end
-            sleep(20)
+            sleep @poll_sleep
           end
         rescue => exception
           raise ProviderUnreachable, exception.message

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_catcher/stream.rb
@@ -1,0 +1,46 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher::Stream
+  class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
+  end
+
+  def initialize(ems)
+    @ems = ems
+    @last_activity = nil
+    @stop_polling = false
+  end
+
+  def start
+    @stop_polling = false
+  end
+
+  def stop
+    @stop_polling = true
+  end
+
+  def poll
+    @ems.with_provider_connection do |ansible|
+      catch(:stop_polling) do
+        begin
+          loop do
+            ansible.api.activity_stream.all(filter).each do |activity|
+              throw :stop_polling if @stop_polling
+              yield activity
+              @last_activity = activity
+            end
+            sleep(20)
+          end
+        rescue => exception
+          raise ProviderUnreachable, exception.message
+        end
+      end
+    end
+  end
+
+  private
+
+  def filter
+    {
+      :order_by      => 'timestamp',
+      :timestamp__gt => @last_activity ? @last_activity.timestamp : 1.minute.ago.to_s(:db)
+    }
+  end
+end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_parser.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventParser
   def self.event_to_hash(event, ems_id)
     {
-      :event_type => event.operation,
+      :event_type => "ansible_tower_#{event.operation}",
       :source     => "ANSIBLE_TOWER",
       :message    => event.changes.to_s,
       :timestamp  => event.timestamp,

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/event_parser.rb
@@ -1,0 +1,12 @@
+module ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    {
+      :event_type => event.operation,
+      :source     => "ANSIBLE_TOWER",
+      :message    => event.changes.to_s,
+      :timestamp  => event.timestamp,
+      :full_data  => event.to_h,
+      :ems_id     => ems_id
+    }
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -41,6 +41,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
+    ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Google::CloudManager::EventCatcher
@@ -130,6 +131,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::StorageManager::CinderManager::EventCatcher
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
+    ManageIQ::Providers::AnsibleTower::ConfigurationManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Google::CloudManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -230,6 +230,10 @@
       :name: Application
     :configuration:
       :critical:
+      - ansible_tower_create
+      - ansible_tower_update
+      - ansible_tower_delete
+      - ansible_tower_associate
       - ClusterReconfiguredEvent
       - EnterMaintenanceMode_Task_Complete
       - ExitMaintenanceMode_Task_Complete

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1201,6 +1201,8 @@
         :memory_threshold: 2.gigabytes
         :nice_delta: 1
         :poll: 1.seconds
+      :event_catcher_ansible_tower:
+        :poll: 1.seconds
       :event_catcher_redhat:
         :poll: 15.seconds
       :event_catcher_vmware:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1202,7 +1202,7 @@
         :nice_delta: 1
         :poll: 1.seconds
       :event_catcher_ansible_tower:
-        :poll: 1.seconds
+        :poll: 20.seconds
       :event_catcher_redhat:
         :poll: 15.seconds
       :event_catcher_vmware:


### PR DESCRIPTION
First version of event catcher for ansible tower provider

still open and for a follow up PR:

* should some events / activity_stream items be skipped?
* what events should make it into timelines?
* what events should trigger a refresh?
* what inventory items can we link to events?

@blomquisg @jameswnl @juliancheal  please review