### PR TITLE
Ansible Tower objects modeling

### DIFF
--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -1,11 +1,2 @@
-class ConfigurationScript < ApplicationRecord
-  serialize :variables
-  serialize :survey_spec
-
-  acts_as_miq_taggable
-
-  belongs_to :inventory_root_group, :class_name => "EmsFolder"
-  belongs_to :manager,              :class_name => "ExtManagementSystem"
-
-  include ProviderObjectMixin
+class ConfigurationScript < ConfigurationScriptBase
 end

--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -8,7 +8,7 @@ class ConfigurationScriptBase < ApplicationRecord
   belongs_to :inventory_root_group, :class_name => "EmsFolder"
   belongs_to :manager,              :class_name => "ExtManagementSystem"
 
-  belongs_to :parent
+  belongs_to :parent,               :class_name => "ConfigurationScriptBase"
   has_many   :children,             :class_name => "ConfigurationScriptBase", :foreign_key => "parent_id"
 
   include ProviderObjectMixin

--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -1,0 +1,15 @@
+class ConfigurationScriptBase < ApplicationRecord
+  self.table_name = "configuration_scripts"
+  serialize :variables
+  serialize :survey_spec
+
+  acts_as_miq_taggable
+
+  belongs_to :inventory_root_group, :class_name => "EmsFolder"
+  belongs_to :manager,              :class_name => "ExtManagementSystem"
+
+  belongs_to :parent
+  has_many   :children,             :class_name => "ConfigurationScriptBase", :foreign_key => "parent_id"
+
+  include ProviderObjectMixin
+end

--- a/app/models/configuration_script_payload.rb
+++ b/app/models/configuration_script_payload.rb
@@ -1,0 +1,3 @@
+class ConfigurationScriptPayload < ConfigurationScriptBase
+  belongs_to :configuration_script_source
+end

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -1,0 +1,4 @@
+class ConfigurationScriptSource < ApplicationRecord
+  has_many    :configuration_script_payloads
+  belongs_to  :manager, :class_name => "ExtManagementSystem"
+end

--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/playbook.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/playbook.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Playbook < ConfigurationScriptPayload
+end

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -2,10 +2,11 @@ class ManageIQ::Providers::ConfigurationManager < ::ExtManagementSystem
   require_nested :InventoryGroup
   require_nested :InventoryRootGroup
 
-  has_many :configured_systems,     :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_profiles, :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_scripts,  :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :inventory_groups,       :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
+  has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :inventory_groups,             :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
+  has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"
 
   virtual_column  :total_configuration_profiles, :type => :integer
   virtual_column  :total_configured_systems, :type => :integer

--- a/db/migrate/20170109221226_create_configuration_script_sources.rb
+++ b/db/migrate/20170109221226_create_configuration_script_sources.rb
@@ -1,0 +1,11 @@
+class CreateConfigurationScriptSources < ActiveRecord::Migration[5.0]
+  def change
+    create_table :configuration_script_sources do |t|
+      t.belongs_to  :manager, :type => :bigint
+      t.string      :manager_ref
+      t.string      :name
+      t.string      :description
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170111033729_add_configuration_script_payload_and_configuration_script_source_to_configuration_scripts.rb
+++ b/db/migrate/20170111033729_add_configuration_script_payload_and_configuration_script_source_to_configuration_scripts.rb
@@ -1,0 +1,6 @@
+class AddConfigurationScriptPayloadAndConfigurationScriptSourceToConfigurationScripts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configuration_scripts, :parent_id,                        :bigint
+    add_column :configuration_scripts, :configuration_script_source_id,   :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -515,6 +515,14 @@ configuration_profiles_configuration_tags:
 - configuration_profile_id
 - configuration_tag_id
 - id
+configuration_script_sources:
+- id
+- manager_id
+- manager_ref
+- name
+- description
+- created_at
+- updated_at
 configuration_scripts:
 - id
 - manager_id
@@ -527,6 +535,8 @@ configuration_scripts:
 - survey_spec
 - inventory_root_group_id
 - type
+- parent_id
+- configuration_script_source_id
 configuration_tags:
 - id
 - type

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceConfigurationScript < MiqAeServiceModelBase
-    expose :inventory_root_group, :association => true
-    expose :manager,              :association => true
+  class MiqAeServiceConfigurationScript < MiqAeServiceConfigurationScriptBase
+    expose :run
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script.rb
@@ -1,5 +1,4 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationScript < MiqAeServiceConfigurationScriptBase
-    expose :run
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_base.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_base.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceConfigurationScriptBase < MiqAeServiceModelBase
+    expose :inventory_root_group, :association => true
+    expose :manager,              :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_payload.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_payload.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceConfigurationScriptPayload < MiqAeServiceConfigurationScriptBase
+    expose :run
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_payload.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_payload.rb
@@ -1,5 +1,4 @@
 module MiqAeMethodService
   class MiqAeServiceConfigurationScriptPayload < MiqAeServiceConfigurationScriptBase
-    expose :run
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Playbook < MiqAeServiceConfigurationScriptPayload
-    expose :run
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Playbook <
+      MiqAeServiceConfigurationScriptPayload
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Playbook < MiqAeServiceConfigurationScriptPayload
+    expose :run
+  end
+end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -11,7 +11,7 @@ module Rbac
       CloudVolume
       ConfigurationProfile
       ConfiguredSystem
-      ConfigurationScript
+      ConfigurationScriptBase
       Container
       ContainerBuild
       ContainerGroup

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -1,10 +1,17 @@
 FactoryGirl.define do
-  factory :configuration_script do
-    sequence(:name) { |n| "Configuration_script_#{seq_padded_for_sorting(n)}" }
+  factory :configuration_script_base do
+    sequence(:name) { |n| "Configuration_script_base_#{seq_padded_for_sorting(n)}" }
     sequence(:manager_ref) { SecureRandom.random_number(100) }
     variables :instance_ids => ['i-3434']
   end
 
-  factory :ansible_configuration_script, :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript", :parent => :configuration_script do
-  end
+  factory :configuration_script_payload, :class => "ConfigurationScriptPayload", :parent => :configuration_script_base
+  factory :ansible_playbook,
+          :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Playbook",
+          :parent => :configuration_script_payload
+
+  factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
+  factory :ansible_configuration_script,
+          :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript",
+          :parent => :configuration_script
 end

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -7,11 +7,11 @@ FactoryGirl.define do
 
   factory :configuration_script_payload, :class => "ConfigurationScriptPayload", :parent => :configuration_script_base
   factory :ansible_playbook,
-          :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Playbook",
+          :class  => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Playbook",
           :parent => :configuration_script_payload
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
   factory :ansible_configuration_script,
-          :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript",
+          :class  => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript",
           :parent => :configuration_script
 end

--- a/spec/factories/configuration_script_source.rb
+++ b/spec/factories/configuration_script_source.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :configuration_script_source do
+    sequence(:name) { |n| "configuration_script_source#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-playbook_spec.rb
@@ -1,0 +1,5 @@
+describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_Playbook do
+  it "get the service model class" do
+    expect { described_class }.not_to raise_error
+  end
+end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -802,11 +802,9 @@ describe Rbac::Filterer do
         it 'works when targets are empty' do
           User.with_user(user) do
             results = described_class.search(:class => 'ConfigurationScript').first
-            expect(results.length).to eq(2)
             expect(results).to match_array([ansible_configuration_script, ansible_configuration_script_with_tag])
 
             results = described_class.search(:class => 'ConfigurationScriptPayload').first
-            expect(results.length).to eq(2)
             expect(results).to match_array([ansible_playbook, ansible_playbook_with_tag])
           end
         end
@@ -830,11 +828,10 @@ describe Rbac::Filterer do
             end
           end
 
-          it 'lists only tagged Payload' do
+          it 'lists only tagged ConfigurationScriptPayload' do
             User.with_user(user) do
               results = described_class.search(:class => 'ConfigurationScriptPayload').first
-              expect(results.length).to eq(1)
-              expect(results.first).to eq(ansible_playbook_with_tag)
+              expect(results).to match_array([ansible_playbook_with_tag])
             end
           end
         end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -796,12 +796,18 @@ describe Rbac::Filterer do
       describe ".search" do
         let!(:ansible_configuration_script)          { FactoryGirl.create(:ansible_configuration_script) }
         let!(:ansible_configuration_script_with_tag) { FactoryGirl.create(:ansible_configuration_script) }
+        let!(:ansible_playbook)                      { FactoryGirl.create(:ansible_playbook) }
+        let!(:ansible_playbook_with_tag)             { FactoryGirl.create(:ansible_playbook) }
 
         it 'works when targets are empty' do
           User.with_user(user) do
             results = described_class.search(:class => 'ConfigurationScript').first
             expect(results.length).to eq(2)
             expect(results).to match_array([ansible_configuration_script, ansible_configuration_script_with_tag])
+
+            results = described_class.search(:class => 'ConfigurationScriptPayload').first
+            expect(results.length).to eq(2)
+            expect(results).to match_array([ansible_playbook, ansible_playbook_with_tag])
           end
         end
 
@@ -813,6 +819,7 @@ describe Rbac::Filterer do
             group.save!
 
             ansible_configuration_script_with_tag.tag_with(['/managed/environment/prod'].join(' '), :ns => '*')
+            ansible_playbook_with_tag.tag_with(['/managed/environment/prod'].join(' '), :ns => '*')
           end
 
           it 'lists only tagged ConfigurationScripts' do
@@ -820,6 +827,14 @@ describe Rbac::Filterer do
               results = described_class.search(:class => 'ConfigurationScript').first
               expect(results.length).to eq(1)
               expect(results.first).to eq(ansible_configuration_script_with_tag)
+            end
+          end
+
+          it 'lists only tagged Payload' do
+            User.with_user(user) do
+              results = described_class.search(:class => 'ConfigurationScriptPayload').first
+              expect(results.length).to eq(1)
+              expect(results.first).to eq(ansible_playbook_with_tag)
             end
           end
         end

--- a/spec/models/configuration_script_source_spec.rb
+++ b/spec/models/configuration_script_source_spec.rb
@@ -1,0 +1,19 @@
+describe ConfigurationScriptSource do
+  let(:manager) { FactoryGirl.create(:configuration_manager_ansible_tower, :provider) }
+  let(:configuration_script_source) { FactoryGirl.create(:configuration_script_source, :manager => manager) }
+  let!(:payloads) do
+    [FactoryGirl.create(:configuration_script_payload, :configuration_script_source => configuration_script_source),
+     FactoryGirl.create(:configuration_script_payload, :configuration_script_source => configuration_script_source)]
+  end
+
+  it "belongs_to the Ansible Tower manager" do
+    expect(configuration_script_source.manager).to eq(manager)
+    expect(manager.configuration_script_sources.size).to eq 1
+    expect(manager.configuration_script_sources.first).to be_a ConfigurationScriptSource
+  end
+
+  it "can have multiple configuration_script_payloads" do
+    expect(configuration_script_source.configuration_script_payloads.size).to eq 2
+    expect(payloads[0].configuration_script_source).to eq(configuration_script_source)
+  end
+end

--- a/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/configuration_manager/configuration_script_spec.rb
@@ -6,6 +6,7 @@ describe ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationS
   let(:job)          { AnsibleTowerClient::Job.new(connection.api, "id" => 1) }
   let(:job_template) { AnsibleTowerClient::JobTemplate.new(connection.api, "limit" => "", "id" => 1, "url" => "api/job_templates/1/", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
   let(:manager)      { FactoryGirl.create(:configuration_manager_ansible_tower, :provider, :configuration_script) }
+
   it "belongs_to the Ansible Tower manager" do
     expect(manager.configuration_scripts.size).to eq 1
     expect(manager.configuration_scripts.first.variables).to eq :instance_ids => ['i-3434']


### PR DESCRIPTION
This is far from ready. But before working on the migration and specs, I need to take input for the following before going too far,

* Do we want a base `Project` which can be subclassed to model `FilesystemBasedProject` and `ScmProject` *now*?
* Do we want to subclass Ansible `ConfigurationScript` to create `Playbook`?
* Also, attempting to reuse existing models e.g. `GitRreference` in the Ansible `ConfigurationProject`.  Strictly speaking, it should be a more generic `ScmRepo`.

======
**Updated**

Here are the approaches after discussing with @bdunne @Fryguy 
![img_1946](https://cloud.githubusercontent.com/assets/2421248/21871633/6bb60834-d831-11e6-9908-e95abb2dde2e.JPG)
The last one (with *) is what we are going after in this phase.