### PR TITLE
Purge miq alert statuses

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,4 +1,6 @@
 class MiqAlertStatus < ApplicationRecord
+  include_concern 'Purging'
+
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
 end

--- a/app/models/miq_alert_status/purging.rb
+++ b/app/models/miq_alert_status/purging.rb
@@ -1,0 +1,35 @@
+class MiqAlertStatus < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.miq_alert_status.history.keep_miq_alert_statuses.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.miq_alert_status.history.purge_window_size
+      end
+
+      def purge_queue
+        MiqQueue.put_unless_exists(
+          :class_name  => name,
+          :method_name => "purge",
+          :role        => "event",
+          :queue_name  => "ems"
+        )
+      end
+      alias_method :purge_timer, :purge_queue
+
+      def purge_scope(older_than)
+        # TODO: should happen only when ems no longer exists
+        where(arel_table[:timestamp].lt(older_than))
+      end
+
+      def purge_associated_records(ids)
+
+      end
+    end
+  end
+end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -121,6 +121,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "MiqReportResult", :method_name => "purge_timer", :zone => nil)
   end
 
+  def miq_alert_status_purge_timer
+    queue_work(:class_name => "MiqAlertStatus", :method_name => "purge_timer", :zone => nil)
+  end
+
   def storage_refresh_metrics
     queue_work(
       :class_name  => "StorageManager",

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -221,6 +221,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue :miq_report_result_purge_timer
     end
 
+    # Schedule - Prune old miq alert status Timer
+    every = worker_settings[:miq_alert_status_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue :miq_alert_status_purge_timer
+    end
+
     # Schedule every 24 hours
     at = worker_settings[:storage_file_collection_time_utc]
     if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1041,6 +1041,10 @@
   :history:
     :keep_policy_events: 6.months
     :purge_window_size: 1000
+:miq_alert_status:
+  :history:
+    :keep_miq_alert_statuses: 6.months
+    :purge_window_size: 1000
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
@@ -1400,6 +1404,7 @@
       :poll: 15.seconds
       :resync_rhn_mirror: 12.hours
       :report_result_purge_interval: 1.week
+      :miq_alert_status_purge_interval: 1.week
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds
       :service_retired_interval: 10.minutes


### PR DESCRIPTION
Purging miq_alert_statuses will allow removing the dependent destroy and having history for deleted entities.