### PR TITLE
Extract ServiceTemplateWorkflow API service

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -242,13 +242,6 @@ module Api
         action_result(false, err.to_s)
       end
 
-      def service_template_workflow(service_template, service_request)
-        resource_action = service_template.resource_actions.find_by_action("Provision")
-        workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => service_template)
-        service_request.each { |key, value| workflow.set_value(key, value) } if service_request.present?
-        workflow
-      end
-
       def validate_id(id, klass)
         raise NotFoundError, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
       end

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -81,7 +81,7 @@ module Api
         raise BadRequestError, "Must specify a service_template_href for adding a service_request"
       end
       service_template = resource_search(service_template_id, :service_templates, ServiceTemplate)
-      service_template_workflow(service_template, service_request)
+      ServiceTemplateWorkflow.create(service_template, service_request)
     end
 
     def check_validation(validation)

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -29,7 +29,7 @@ module Api
       def service_templates_order_resource(_object, type, id = nil, data = nil)
         klass = collection_class(:service_templates)
         service_template = resource_search(id, type, klass)
-        workflow = service_template_workflow(service_template, data || {})
+        workflow = ServiceTemplateWorkflow.create(service_template, data || {})
         request_result = workflow.submit_request
         errors = request_result[:errors]
         if errors.present?

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -286,4 +286,8 @@ class ServiceTemplate < ApplicationRecord
     service_template_catalog && display
   end
   alias orderable? validate_order
+
+  def provision_action
+    resource_actions.find_by_action("Provision")
+  end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -288,6 +288,6 @@ class ServiceTemplate < ApplicationRecord
   alias orderable? validate_order
 
   def provision_action
-    resource_actions.find_by_action("Provision")
+    resource_actions.find_by(:action => "Provision")
   end
 end

--- a/lib/services/api/service_template_workflow.rb
+++ b/lib/services/api/service_template_workflow.rb
@@ -1,7 +1,7 @@
 module Api
   class ServiceTemplateWorkflow
     def self.create(service_template, service_request)
-      resource_action = service_template.resource_actions.find_by_action("Provision")
+      resource_action = service_template.provision_action
       workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => service_template)
       service_request.each { |key, value| workflow.set_value(key, value) } if service_request.present?
       workflow

--- a/lib/services/api/service_template_workflow.rb
+++ b/lib/services/api/service_template_workflow.rb
@@ -1,0 +1,10 @@
+module Api
+  class ServiceTemplateWorkflow
+    def self.create(service_template, service_request)
+      resource_action = service_template.resource_actions.find_by_action("Provision")
+      workflow = ResourceActionWorkflow.new({}, User.current_user, resource_action, :target => service_template)
+      service_request.each { |key, value| workflow.set_value(key, value) } if service_request.present?
+      workflow
+    end
+  end
+end

--- a/spec/lib/services/api/service_template_workflow_spec.rb
+++ b/spec/lib/services/api/service_template_workflow_spec.rb
@@ -2,10 +2,7 @@ RSpec.describe Api::ServiceTemplateWorkflow do
   describe ".create" do
     it "creates a workflow" do
       provision_action = instance_double("Provision Action")
-      service_template = instance_double(
-        "ServiceTemplate",
-        :resource_actions => double(:find_by_action => provision_action)
-      )
+      service_template = instance_double("ServiceTemplate", :provision_action => provision_action)
       workflow = instance_double(ResourceActionWorkflow)
       user = instance_double(User)
       allow(User).to receive(:current_user).and_return(user)
@@ -18,10 +15,7 @@ RSpec.describe Api::ServiceTemplateWorkflow do
 
     it "creates a workflow and sets service request values if passed" do
       provision_action = instance_double("Provision Action")
-      service_template = instance_double(
-        "ServiceTemplate",
-        :resource_actions => double(:find_by_action => provision_action)
-      )
+      service_template = instance_double("ServiceTemplate", :provision_action => provision_action)
       workflow = instance_double(ResourceActionWorkflow)
       user = instance_double(User)
       allow(User).to receive(:current_user).and_return(user)

--- a/spec/lib/services/api/service_template_workflow_spec.rb
+++ b/spec/lib/services/api/service_template_workflow_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Api::ServiceTemplateWorkflow do
+  describe ".create" do
+    it "creates a workflow" do
+      provision_action = instance_double("Provision Action")
+      service_template = instance_double(
+        "ServiceTemplate",
+        :resource_actions => double(:find_by_action => provision_action)
+      )
+      workflow = instance_double(ResourceActionWorkflow)
+      user = instance_double(User)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(ResourceActionWorkflow).to(receive(:new)
+                                        .with(anything, user, provision_action, :target => service_template)
+                                        .and_return(workflow))
+
+      expect(described_class.create(service_template, {})).to be(workflow)
+    end
+
+    it "creates a workflow and sets service request values if passed" do
+      provision_action = instance_double("Provision Action")
+      service_template = instance_double(
+        "ServiceTemplate",
+        :resource_actions => double(:find_by_action => provision_action)
+      )
+      workflow = instance_double(ResourceActionWorkflow)
+      user = instance_double(User)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(ResourceActionWorkflow).to(receive(:new)
+                                        .with(anything, user, provision_action, :target => service_template)
+                                        .and_return(workflow))
+
+      expect(workflow).to receive(:set_value).with("text", "foo")
+
+      expect(described_class.create(service_template, "text" => "foo")).to be(workflow)
+    end
+  end
+end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -429,6 +429,14 @@ describe ServiceTemplate do
       end
     end
   end
+
+  describe "#provision_action" do
+    it "returns the provision action" do
+      provision_action = FactoryGirl.create(:resource_action, :action => "Provision")
+      service_template = FactoryGirl.create(:service_template, :resource_actions => [provision_action])
+      expect(service_template.provision_action).to eq(provision_action)
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
The `service_template_workflow` method was global, but only used by two API controllers. By extracting it into a service:
* it unclutters the base API controller
* it allows us to test it in isolation

Hence, I've added some tests for the new service. I don't love how much stubbing was needed to write isolated tests, but I did like that it put pressure on me to refactor a little bit, extracting a method into `ServiceTemplate` to avoid the nested stubs I started off with.

@miq-bot add-label api, refacoring, technical debt
@miq-bot assign @abellotti 
