### PR TITLE
New class to for determining the availability of embedded ansible

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -1,0 +1,23 @@
+class EmbeddedAnsible
+  APPLIANCE_ANSIBLE_DIRECTORY = "/opt/ansible-installer".freeze
+  ANSIBLE_ROLE                = "embedded_ansible".freeze
+
+  def self.available?
+    installed?
+  end
+
+  def self.enabled?
+    MiqServer.my_server(true).has_active_role?(ANSIBLE_ROLE)
+  end
+
+  def self.running?
+    # TODO
+    false
+  end
+
+  def self.installed?
+    path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
+    Dir.exist?(File.expand_path(path.to_s))
+  end
+  private_class_method :installed?
+end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -1,0 +1,27 @@
+describe EmbeddedAnsible do
+  before do
+    ENV["APPLIANCE_ANSIBLE_DIRECTORY"] = nil
+  end
+
+  context ".available?" do
+    it "returns true when installed in the default location" do
+      allow(Dir).to receive(:exist?).with("/opt/ansible-installer").and_return(true)
+
+      expect(described_class.available?).to be_truthy
+    end
+
+    it "returns true when installed in the custom location in env var" do
+      ENV["APPLIANCE_ANSIBLE_DIRECTORY"] = "/tmp"
+      allow(Dir).to receive(:exist?).with("/tmp").and_return(true)
+      allow(Dir).to receive(:exist?).with("/opt/ansible-installer").and_return(false)
+
+      expect(described_class.available?).to be_truthy
+    end
+
+    it "returns false when not installed" do
+      allow(Dir).to receive(:exist?).with("/opt/ansible-installer").and_return(false)
+
+      expect(described_class.available?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Since Ansible will not be available initially (because it's not open source) we need a way to ask whether ansible is available from within the application so that certain features can be turned off if it's not.

This PR answers that by check if a particular directory exists. If it does, ansible is considered to be available.

https://www.pivotaltracker.com/story/show/137134397

/cc @carbonin @jrafanie 