### PR TITLE
ActiveMetrics phase 1

### DIFF
--- a/lib/active_metrics.rb
+++ b/lib/active_metrics.rb
@@ -1,4 +1,4 @@
+require 'active_metrics/connection_adapters/elasticsearch_adapter'
 require 'active_metrics/connection_adapters/hawkular_metrics_adapter'
 require 'active_metrics/connection_adapters/influxdb_adapter'
-require 'active_metrics/connection_adapters/miq_postgres_adapter'
 require 'active_metrics/base'

--- a/lib/active_metrics.rb
+++ b/lib/active_metrics.rb
@@ -1,0 +1,4 @@
+require 'active_metrics/connection_adapters/hawkular_metrics_adapter'
+require 'active_metrics/connection_adapters/influxdb_adapter'
+require 'active_metrics/connection_adapters/miq_postgres_adapter'
+require 'active_metrics/base'

--- a/lib/active_metrics/base.rb
+++ b/lib/active_metrics/base.rb
@@ -1,0 +1,22 @@
+module ActiveMetrics
+  class Base
+    class << self
+      attr_reader :connection_config
+    end
+
+    def self.establish_connection(config)
+      @connection = nil
+      @connection_config = config.symbolize_keys
+    end
+
+    def self.connection
+      @connection ||= begin
+        adapter = "#{connection_config[:adapter]}_adapter"
+        require "active_metrics/connection_adapters/#{adapter}"
+        adapter_class = ConnectionAdapters.const_get(adapter.classify)
+        raw_connection = adapter_class.create_connection(connection_config)
+        adapter_class.new(raw_connection)
+      end
+    end
+  end
+end

--- a/lib/active_metrics/connection_adapters/abstract_adapter.rb
+++ b/lib/active_metrics/connection_adapters/abstract_adapter.rb
@@ -20,8 +20,8 @@ module ActiveMetrics
       #   Also expected are either :resource or a :resource_type/:resource_id
       #     pair
       #   Optional key is :tags, which is an arbitrary set of key/value pairs.
-      def write(_metric)
-        raise NotImplementedError, "must implemented by the adapter"
+      def write(metric)
+        write_multiple(metric)
       end
 
       # Writes multiple metrics.
@@ -32,10 +32,8 @@ module ActiveMetrics
       #     Also expected are either :resource or a :resource_type/:resource_id
       #       pair
       #     Optional key is :tags, which is an arbitrary set of key/value pairs.
-      def write_multiple(*metrics)
-        # Default naive implementation. Can be overridden by the adapter.
-        metrics.flatten!
-        metrics.each { |metric| write(metric) }
+      def write_multiple(*_metrics)
+        raise NotImplementedError, "must implemented by the adapter"
       end
     end
   end

--- a/lib/active_metrics/connection_adapters/abstract_adapter.rb
+++ b/lib/active_metrics/connection_adapters/abstract_adapter.rb
@@ -1,0 +1,42 @@
+module ActiveMetrics
+  module ConnectionAdapters
+    class AbstractAdapter
+      def self.create_connection(_config)
+        raise NotImplementedError, "must implemented by the adapter"
+      end
+
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def raw_connection
+        @connection
+      end
+
+      # Writes a single metric.
+      #
+      # @param metric [Hash] the metric to write
+      #   Expected keys are :timestamp, :metric_name, and :value
+      #   Also expected are either :resource or a :resource_type/:resource_id
+      #     pair
+      #   Optional key is :tags, which is an arbitrary set of key/value pairs.
+      def write(_metric)
+        raise NotImplementedError, "must implemented by the adapter"
+      end
+
+      # Writes multiple metrics.
+      #
+      # @param metrics [Array<Hash>] the metrics to write
+      #   For each metric,
+      #     Expected keys are :timestamp, :metric_name, and :value
+      #     Also expected are either :resource or a :resource_type/:resource_id
+      #       pair
+      #     Optional key is :tags, which is an arbitrary set of key/value pairs.
+      def write_multiple(*metrics)
+        # Default naive implementation. Can be overridden by the adapter.
+        metrics.flatten!
+        metrics.each { |metric| write(metric) }
+      end
+    end
+  end
+end

--- a/lib/active_metrics/connection_adapters/elasticsearch_adapter.rb
+++ b/lib/active_metrics/connection_adapters/elasticsearch_adapter.rb
@@ -1,0 +1,45 @@
+require 'active_metrics/connection_adapters/abstract_adapter'
+
+module ActiveMetrics
+  module ConnectionAdapters
+    class ElasticsearchAdapter < AbstractAdapter
+      INDEX = "manageiq".freeze
+      TYPE  = "metrics".freeze
+
+      def self.create_connection(_config)
+        require 'elasticsearch'
+        Elasticsearch::Client.new # TODO: Use config parameters
+      end
+
+      def write_multiple(*metrics)
+        metrics.flatten!
+
+        points = metrics.collect { |metric| build_point(metric) }
+        raw_connection.bulk(:index => INDEX, :type => TYPE, :body => points)
+
+        metrics
+      end
+
+      private
+
+      def build_point(timestamp:, metric_name:, value:, resource: nil, resource_type: nil, resource_id: nil, tags: {})
+        if resource.nil? && (resource_type.nil? || resource_id.nil?)
+          raise ArgumentError, "missing resource or resource_type/resource_id pair"
+        end
+
+        {
+          :index => {
+            :data => {
+              :timestamp         => (timestamp.to_f * 1000).to_i, # ms precision
+              metric_name.to_sym => value,
+              :tags              => tags.symbolize_keys.merge(
+                :resource_type => resource ? resource.class.base_class.name : resource_type,
+                :resource_id   => resource ? resource.id : resource_id
+              )
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/active_metrics/connection_adapters/hawkular_metrics_adapter.rb
+++ b/lib/active_metrics/connection_adapters/hawkular_metrics_adapter.rb
@@ -16,10 +16,6 @@ module ActiveMetrics
         )
       end
 
-      def write(metric)
-        write_multiple(metric)
-      end
-
       def write_multiple(*metrics)
         metrics.flatten!
 

--- a/lib/active_metrics/connection_adapters/hawkular_metrics_adapter.rb
+++ b/lib/active_metrics/connection_adapters/hawkular_metrics_adapter.rb
@@ -1,0 +1,52 @@
+require 'active_metrics/connection_adapters/abstract_adapter'
+
+module ActiveMetrics
+  module ConnectionAdapters
+    class HawkularMetricsAdapter < AbstractAdapter
+      def self.create_connection(config)
+        db       = config[:database]
+        hostname = config[:hostname] || "localhost"
+        port     = (config[:port] || 8080).to_i
+
+        require 'hawkular/hawkular_client'
+        Hawkular::Metrics::Client.new(
+          URI::HTTP.build(:host => hostname, :port => port).to_s,
+          config.slice(:username, :password),
+          :tenant => db,
+        )
+      end
+
+      def write(metric)
+        write_multiple(metric)
+      end
+
+      def write_multiple(*metrics)
+        metrics.flatten!
+
+        metrics.group_by { |m| m[:metric_name] }.each do |metric_name, metrics_subset|
+          points = metrics_subset.map { |metric| build_point(metric) }
+          raw_connection.gauges.push_data(metric_name, points)
+        end
+
+        metrics
+      end
+
+      private
+
+      def build_point(timestamp:, _metric_name:, value:, resource: nil, resource_type: nil, resource_id: nil, tags: {})
+        if resource.nil? && (resource_type.nil? || resource_id.nil?)
+          raise ArgumentError, "missing resource or resource_type/resource_id pair"
+        end
+
+        {
+          :timestamp => (timestamp.to_f * 1000).to_i, # ms precision
+          :value     => value,
+          :tags      => tags.symbolize_keys.merge(
+            :resource_type => resource ? resource.class.base_class.name : resource_type,
+            :resource_id   => resource ? resource.id : resource_id
+          ),
+        }
+      end
+    end
+  end
+end

--- a/lib/active_metrics/connection_adapters/influxdb_adapter.rb
+++ b/lib/active_metrics/connection_adapters/influxdb_adapter.rb
@@ -15,10 +15,6 @@ module ActiveMetrics
         end
       end
 
-      def write(metric)
-        write_multiple(metric)
-      end
-
       def write_multiple(*metrics)
         metrics.flatten!
         points = metrics.map { |metric| build_point(metric) }

--- a/lib/active_metrics/connection_adapters/influxdb_adapter.rb
+++ b/lib/active_metrics/connection_adapters/influxdb_adapter.rb
@@ -1,0 +1,48 @@
+require 'active_metrics/connection_adapters/abstract_adapter'
+
+module ActiveMetrics
+  module ConnectionAdapters
+    class InfluxdbAdapter < AbstractAdapter
+      SERIES    = "metrics".freeze
+      PRECISION = "ms".freeze
+
+      def self.create_connection(config)
+        db = config[:database]
+
+        require 'influxdb'
+        InfluxDB::Client.new(db, :time_precision => PRECISION, :retry => 10).tap do |client|
+          client.create_database(db) unless client.list_databases.include?(db)
+        end
+      end
+
+      def write(metric)
+        write_multiple(metric)
+      end
+
+      def write_multiple(*metrics)
+        metrics.flatten!
+        points = metrics.map { |metric| build_point(metric) }
+        raw_connection.write_points(points)
+        metrics
+      end
+
+      private
+
+      def build_point(timestamp:, metric_name:, value:, resource: nil, resource_type: nil, resource_id: nil, tags: {})
+        if resource.nil? && (resource_type.nil? || resource_id.nil?)
+          raise ArgumentError, "missing resource or resource_type/resource_id pair"
+        end
+
+        {
+          :series    => SERIES,
+          :timestamp => (timestamp.to_f * 1000).to_i, # ms precision
+          :values    => { metric_name.to_sym => value },
+          :tags      => tags.symbolize_keys.merge(
+            :resource_type => resource ? resource.class.base_class.name : resource_type,
+            :resource_id   => resource ? resource.id : resource_id
+          ),
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates the initial ActiveMetrics framework with InfluxDB, HawkularMetrics, and ElasticSearch adapters.  This is heavily modeled on ActiveRecord, but does not reuse any of their code for fear of complicating things at such an early point in the development.  Ultimately this could become it's own gem, but I wanted to just get it in here to start fleshing out the interface before publicizing a new gem.

In order to use it, add the target database client gem to the Gemfile, and then create an initializer to setup the connection.  To use it, call `write` or `write_multiple` on the connection.

```ruby
# Gemfile
gem 'influxdb', :require => false

# config/initializers/active_metrics_db.rb
ActiveMetrics::Base.establish_connection(
  :adapter  => "influxdb",
  :database => "vmdb_#{Rails.env.downcase}",
  :host     => "localhost",
  :username => "root",
  :password => "smartvm",
)

# wherever
v = Vm.find(1)
ActiveMetrics::Base.connection.write_multiple(
  {
    :timestamp   => Time.parse(ts1),
    :metric_name => "cpu_usage_rate_average",
    :value       => "50.5",
    :resource    => v,  # Alternately, pass resource_id and resource_type separately
    :tags        => {:capture_interval_name => "realtime", :resource_name => v.name}
  },
  {
    :timestamp   => Time.parse(ts2),
    :metric_name => "cpu_usage_rate_average",
    :value       => "49.2",
    :resource    => v,
    :tags        => {:capture_interval_name => "realtime", :resource_name => v.name}
  }
)
```

---

Some things this PR does **NOT** do at the moment
- This PR only implements "write" functionality for the 3 adapters, and not yet read.  In discussions with @simon3z and @jameswnl, the thought is that the read side can be implemented in a similar fashion to how the ManageIQ Hawkular LiveMetrcs is implemented (perhaps just combining the two code sets there).  @simon3z said he has resources to do this, so I am handing off to him for phase 2+.
- This PR does not change the current C&U collection.  I've prototyped it locally by injecting writes to ActiveMetrics and it works fine.  I've also prototypes removing the current Postrges specific C&U code and replacing it with an MiqPostgresDatabase adapter.  This works as well, but it also takes all of the alerting and bottlenecking code, and I wasn't comfortable with moving *all* of that over yet.
- This PR uses a simple hash for the data points.  Eventually, it would probably make more sense to define an Object or Struct, but I want the read side to complete first to see if that will be the same structure.
- No real specs at the moment.  Given it connects to remote backends that don't exist and are optional, I have no idea how to properly test this without pointing to a real system.  Perhaps as a separate gem we'll have more flexibility.

@simon3z Please review.
cc @chessbyte, @blomquisg 
@jameswnl Can you point me to the code you wrote for the ElasticSearch adapter so I can include it in this PR?