### PR TITLE
Inconsistent attribute names inside Automate Engine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -264,7 +264,7 @@ module MiqAeEngine
       # process Array::servers => MiqServer::2,MiqServer::3,MiqServer::4
       key = args_key.split(CLASS_SEPARATOR).last
       value = args.delete(args_key)
-      args[key] = load_array_objects_from_string(value)
+      args[key.downcase] = load_array_objects_from_string(value)
     end
 
     def process_args_attribute(args, args_key)
@@ -273,7 +273,7 @@ module MiqAeEngine
         key, klass = get_key_name_and_klass_from_key(args_key)
         value = args.delete(args_key)
         args["#{key}_id"] = value unless @attributes.key?(key)
-        args[key] = MiqAeObject.convert_value_based_on_datatype(value, klass)
+        args[key.downcase] = MiqAeObject.convert_value_based_on_datatype(value, klass)
       else
         args[args_key.downcase] = args.delete(args_key) if args_key != args_key.downcase
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -273,7 +273,7 @@ module MiqAeEngine
         key, klass = get_key_name_and_klass_from_key(args_key)
         value = args.delete(args_key)
         args["#{key}_id"] = value unless @attributes.key?(key)
-        args[key.downcase] = MiqAeObject.convert_value_based_on_datatype(value, klass)
+        args[key] = MiqAeObject.convert_value_based_on_datatype(value, klass)
       else
         args[args_key.downcase] = args.delete(args_key) if args_key != args_key.downcase
       end

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -75,15 +75,14 @@ describe MiqAeEngine::MiqAeObject do
   end
 
   it "#process_args_as_attributes with mixed types and case insensitive" do
-    result = @miq_obj.process_args_as_attributes({"Array::VMs" => "VmOrTemplate::#{@vm.id}",
-                                                  "Name" => "fred"})
+    result = @miq_obj.process_args_as_attributes("Array::VMs" => "VmOrTemplate::#{@vm.id}",
+                                                 "Name"       => "fred")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(1)
     expect(result["name"]).to eq("fred")
     expect(result["Name"]).to be_nil
     expect(result["VMs"]).to be_nil
   end
-
 
   it "#process_args_as_attributes with an array" do
     vm2 = FactoryGirl.create(:vm_vmware)

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -74,6 +74,17 @@ describe MiqAeEngine::MiqAeObject do
     expect(result["vms"].length).to eq(1)
   end
 
+  it "#process_args_as_attributes with mixed types and case insensitive" do
+    result = @miq_obj.process_args_as_attributes({"Array::VMs" => "VmOrTemplate::#{@vm.id}",
+                                                  "Name" => "fred"})
+    expect(result["vms"]).to be_kind_of(Array)
+    expect(result["vms"].length).to eq(1)
+    expect(result["name"]).to eq("fred")
+    expect(result["Name"]).to be_nil
+    expect(result["VMs"]).to be_nil
+  end
+
+
   it "#process_args_as_attributes with an array" do
     vm2 = FactoryGirl.create(:vm_vmware)
     result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}"})

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -79,9 +79,9 @@ describe MiqAeEngine::MiqAeObject do
                                                  "Name"       => "fred")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(1)
+    expect(result["VMs"]).to be_nil
     expect(result["name"]).to eq("fred")
     expect(result["Name"]).to be_nil
-    expect(result["VMs"]).to be_nil
   end
 
   it "#process_args_as_attributes with an array" do


### PR DESCRIPTION
Inside the Automate Engine we convert the attribute name for
 simple data types to lowercase, but for Array types we dont
 convert the attribute name to lowercase.

This PR converts all attribute names to lowercase.

This is inconsistent.
e.g. Array::VM=VM::100&Name=fred

would yield 2 attribute names VM and name. The "name" got converted to
lowercase but VM didn't.

When the methods access these variables using $evm.root we internally
convert it to lowercase at access time

$evm.root['VM']        gets converted to $evm.root['vm']
$evm.root['vm']        gets converted to $evm.root['vm']
$evm.root['Name']      gets converted to $evm.root['name']

If the caller passed in Array::VM=VM::100&Name=fred
$evm.root['VM'] fails because the method layer converts it to lowercase
and internally it has preserved its original case

This is not that prevalent since most of the attribute names that embed
the class type are generated internally and they always lowercase the
name. We have seen this manifest itself when using Tag controls using
dialogs and the user names the tag with mixed case e.g.
TagControl would be stored in the engine as dialog_TagControl but when
the methods try to access $evm.root['dialog_TagControl'] the method
layer would lowercase it and not find the attribute.


Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1408482


Steps for Testing/QA
---------------------

* Create Dialog with TagControl and use mixed case name e.g. TagControl
* Write an Automate Method which can be called from the Dialog to access the TagControl
```
     desc = $evm.root['dialog_TagControl'].first.description
     $evm.log(:info, "Description #{desc}")
```
Screen Shot attached
<img width="1149" alt="screen shot 2017-01-10 at 5 53 36 pm" src="https://cloud.githubusercontent.com/assets/6452699/21828310/cd2d8652-d75d-11e6-8620-c7b421ef7e00.png">
