### PR TITLE
[api] expose Request Workflow class name

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -34,13 +34,13 @@ class MiqRequest < ApplicationRecord
   virtual_column  :v_approved_by_email,  :type => :string,   :uses => {:miq_approvals => :stamper}
   virtual_column  :stamped_on,           :type => :datetime, :uses => :miq_approvals
   virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
-  virtual_column  :v_class,              :type => :string,   :uses => :workflow
+  virtual_column  :v_workflow_class,     :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
 
   delegate :allowed_tags,                :to => :workflow,   :prefix => :v
-  delegate :class,                       :to => :workflow,   :prefix => :v
+  delegate :class,                       :to => :workflow,   :prefix => :v_workflow
 
   virtual_has_one :workflow
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -34,11 +34,13 @@ class MiqRequest < ApplicationRecord
   virtual_column  :v_approved_by_email,  :type => :string,   :uses => {:miq_approvals => :stamper}
   virtual_column  :stamped_on,           :type => :datetime, :uses => :miq_approvals
   virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
+  virtual_column  :v_class,              :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
 
   delegate :allowed_tags,                :to => :workflow,   :prefix => :v
+  delegate :class,                       :to => :workflow,   :prefix => :v
 
   virtual_has_one :workflow
 

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -246,17 +246,17 @@ RSpec.describe "Requests API" do
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_class"
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
 
-      expected_workflow = a_hash_including("id" => request.id, "workflow" => a_hash_including("values"))
-      expected_tags = a_hash_including("id" => request.id, "v_allowed_tags" => [a_hash_including("children")])
-      expected_class = a_hash_including(
-        "id"      => request.id,
-        "v_class" => {"instance_logger" => a_hash_including("klass" => request.workflow.class.to_s)})
+      expected_response = a_hash_including(
+        "id"               => request.id,
+        "workflow"         => a_hash_including("values"),
+        "v_allowed_tags"   => [a_hash_including("children")],
+        "v_workflow_class" => a_hash_including(
+          "instance_logger" => a_hash_including("klass" => request.workflow.class.to_s))
+      )
 
-      expect(response.parsed_body).to match(expected_workflow)
-      expect(response.parsed_body).to match(expected_tags)
-      expect(response.parsed_body).to match(expected_class)
+      expect(response.parsed_body).to match(expected_response)
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -229,27 +229,7 @@ RSpec.describe "Requests API" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "exposes workflow in the request resources" do
-      ems = FactoryGirl.create(:ems_vmware)
-      vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
-      request = FactoryGirl.create(:miq_provision_request,
-                                   :requester => @user,
-                                   :src_vm_id => vm_template.id,
-                                   :options   => {:owner_email => 'tester@example.com'})
-      FactoryGirl.create(:miq_dialog,
-                         :name        => "miq_provision_dialogs",
-                         :dialog_type => MiqProvisionWorkflow)
-
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "workflow"
-
-      expected = a_hash_including("id" => request.id, "workflow" => a_hash_including("values"))
-
-      expect(response.parsed_body).to match(expected)
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "exposes allowed_tags in the request resources" do
+    it "exposes various attributes in the request resources" do
       ems = FactoryGirl.create(:ems_vmware)
       vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
       request = FactoryGirl.create(:miq_provision_request,
@@ -266,11 +246,13 @@ RSpec.describe "Requests API" do
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "v_allowed_tags"
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags"
 
-      expected = a_hash_including("id" => request.id, "v_allowed_tags" => [a_hash_including("children")])
+      expected_workflow = a_hash_including("id" => request.id, "workflow" => a_hash_including("values"))
+      expected_tags = a_hash_including("id" => request.id, "v_allowed_tags" => [a_hash_including("children")])
 
-      expect(response.parsed_body).to match(expected)
+      expect(response.parsed_body).to match(expected_workflow)
+      expect(response.parsed_body).to match(expected_tags)
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -246,13 +246,17 @@ RSpec.describe "Requests API" do
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags"
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_class"
 
       expected_workflow = a_hash_including("id" => request.id, "workflow" => a_hash_including("values"))
       expected_tags = a_hash_including("id" => request.id, "v_allowed_tags" => [a_hash_including("children")])
+      expected_class = a_hash_including(
+        "id"      => request.id,
+        "v_class" => {"instance_logger" => a_hash_including("klass" => request.workflow.class.to_s)})
 
       expect(response.parsed_body).to match(expected_workflow)
       expect(response.parsed_body).to match(expected_tags)
+      expect(response.parsed_body).to match(expected_class)
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
Created a virtual_column for the workflow object's class name which is required in order to populate the `Catalog` tab in the Request Workflow in SUI.

`api/requests/<id>?attributes=v_workflow_class`

https://www.pivotaltracker.com/n/projects/1914499/stories/137409675