### PR TITLE
don't reference model in factory def

### DIFF
--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -26,11 +26,11 @@ FactoryGirl.define do
     end
 
     trait :system_type do
-      group_type MiqGroup::SYSTEM_GROUP
+      group_type { MiqGroup::SYSTEM_GROUP }
     end
 
     trait :tenant_type do
-      group_type MiqGroup::TENANT_GROUP
+      group_type { MiqGroup::TENANT_GROUP }
     end
   end
 end


### PR DESCRIPTION
PR #10042 replaced a string constant with an actual class constant. It is bad to define the same string constant in multiple places.

```diff
- group_type "system" # dont want to reference class from factory
+ group_type MiqGroup::SYSTEM_GROUP
```

So this change was good but ...

**before:**

The new factory was referencing `MiqGroup`. So the factory definition was loading `MiqGroup`. Which would not really matter except ...

The `test:migrations` task includes factory definitions, so `MiqGroup` was being loaded for migration tests. And this is bad.

**after:**

```diff
- group_type MiqGroup::SYSTEM_GROUP
+ group_type { MiqGroup::SYSTEM_GROUP }
```

Introducing a block here (not typical for a static values) defers the class reference until runtime when the factory is invoked. 

Since `test:migrations` never runs the factories, the block is not run, the class is not referenced, and the class is not loaded. Problem solved

---

I noticed this because a bug in `MiqGroup` broke `test:migrations` with a stack trace pointing to this line. We jump through such hoops with all our stubs to avoid loading models in our migration tests.

After this change, migrations ran correctly despite an issue in `MiqGroup`.
