### PR TITLE
Openstack infra ssh keypair validation fixes

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -115,9 +115,11 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   end
 
   def verify_ssh_keypair_credentials(_options)
+    # Select one powered-on host in each cluster to verify
+    # ssh credentials against
     hosts.sort_by(&:ems_cluster_id)
          .slice_when { |i, j| i.ems_cluster_id != j.ems_cluster_id }
-         .map { |c| c.find { |h| h.power_state == 'on' } }
+         .map { |c| c.find { |h| h.power_state == 'on' } }.compact
          .all? { |h| h.verify_credentials('ssh_keypair') }
   end
   private :verify_ssh_keypair_credentials

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -117,7 +117,8 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   def verify_ssh_keypair_credentials(_options)
     # Select one powered-on host in each cluster to verify
     # ssh credentials against
-    hosts.sort_by(&:ems_cluster_id)
+    hosts.select(&:ems_cluster_id)
+         .sort_by(&:ems_cluster_id)
          .slice_when { |i, j| i.ems_cluster_id != j.ems_cluster_id }
          .map { |c| c.find { |h| h.power_state == 'on' } }.compact
          .all? { |h| h.verify_credentials('ssh_keypair') }

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -60,6 +60,7 @@ FactoryGirl.define do
     vmm_vendor  "unknown"
     ems_ref     "openstack-perf-host"
     ems_ref_obj "openstack-perf-host-nova-instance"
+    association :ems_cluster, factory: :ems_cluster_openstack
   end
 
   factory :host_openstack_infra_compute, :parent => :host_openstack_infra,

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -14,6 +14,29 @@ describe ManageIQ::Providers::Openstack::InfraManager do
     end
   end
 
+  context "verifying SSH keypair credentials" do
+    it "verifies Openstack SSH credentials successfully when all hosts report that the credentials are valid" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(true)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
+    end
+
+    it "fails to verify Openstack SSH credentials when any hosts report that the credentials are invalid" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_falsey
+    end
+
+    it "disregards powered off hosts when verifying Openstack SSH credentials" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "off")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
+    end
+  end
+
   context "validation" do
     before :each do
       @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)

--- a/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager_spec.rb
@@ -24,7 +24,7 @@ describe ManageIQ::Providers::Openstack::InfraManager do
 
     it "fails to verify Openstack SSH credentials when any hosts report that the credentials are invalid" do
       @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
-      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
+      host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on")
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
       expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_falsey
     end
@@ -32,6 +32,13 @@ describe ManageIQ::Providers::Openstack::InfraManager do
     it "disregards powered off hosts when verifying Openstack SSH credentials" do
       @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
       FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "off")
+      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
+      expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
+    end
+
+    it "disregards host with no ems_cluster" do
+      @ems = FactoryGirl.create(:ems_openstack_infra_with_authentication)
+      FactoryGirl.create(:host_openstack_infra, :ext_management_system => @ems, :state => "on", :ems_cluster => nil)
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::Host).to receive(:verify_credentials).and_return(false)
       expect(@ems.send(:verify_ssh_keypair_credentials, nil)).to be_truthy
     end


### PR DESCRIPTION
These are 2 fixes for OpenStack Infra SSH Key Pair validation code.

Contains code form https://github.com/ManageIQ/manageiq/pull/13159 and https://github.com/ManageIQ/manageiq/pull/13275

Solves:
https://bugzilla.redhat.com/show_bug.cgi?id=1376605
https://bugzilla.redhat.com/show_bug.cgi?id=1406443
