### PR TITLE
[WIP] MiqExpression::Field more attributes

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1112,8 +1112,8 @@ class MiqExpression
            if field == :count
              :integer
            else
-             col_info = get_col_info(field)
-             [:bytes, :megabytes].include?(col_info[:format_sub_type]) ? :integer : col_info[:data_type]
+             f = parse_field_or_tag(field)
+             %i(bytes megabytes).include?(f.sub_type) ? :integer : f.column_type
            end
          end
 

--- a/lib/miq_expression/subst_mixin.rb
+++ b/lib/miq_expression/subst_mixin.rb
@@ -103,7 +103,7 @@ module MiqExpression::SubstMixin
       if first_exp.key?("field") # Base token settings on exp type
         field = exp[exp.keys.first]["field"]
         acc[token][:field]      = field
-        acc[token][:value_type] = MiqExpression.get_col_info(field)[:format_sub_type]
+        acc[token][:value_type] = MiqExpression.parse_field_or_tag(field).try(:sub_type)
       elsif first_exp.key?("tag")
         acc[token][:tag]   = first_exp["tag"]
       elsif first_exp.key?("count")


### PR DESCRIPTION
**blocked:**

- [x] #13243 first 5 commits: trim and fix bugs in `get_col_type`
- [x] #13576 next 5 commits: extract simple methods
- [x] ~~#13803 extraction `tag?` check~~
- [x] #16884 1 commit: fix `Field#attribute_supported_by_sql?`
- [x] #16931 MiqExpression Column parsing
- [x] #18345 deprecate `:virtual_relation` and `:virtual_column`
- [x] #18347 introduce `Field#includes`

### High Level Goal:

#### Before

`MiqExpression` is big and does 2 main things:

- convert expressions into ruby / human / arel.
- provide active record metadata for models / tables.

#### After

- `MiqExpression` handles conversion and ruby / human / arel
- `MiqExpression::Field` handles AR metadata.

#### How

`MiqExpression#get_col_type` is the main method that provides metadata. It is a prime candidate for removal:

1. Enhance `Field` to be able to provide all the meta data currently needed by `get_col_info`.
2. Change `MiqExpression#get_col_info` to only use `Field` methods.
3. Change references from `get_col_info` to `parse_field_or_tag` and `Field` methods. 
4. Remove `get_col_type`.

**Fun fact:** Step 2 ensures the values from `Field` and `get_col_info` are the same, and it will be sample code that shows how to derive any field in the `get_col_info` hash.

**Goal of this PR**

First 2 bullets: Enhance `Field#get_col_info` so it will only use `Field` methods.