### PR TITLE
[EUWE] updates to support SecurityGroupController

### DIFF
--- a/app/controllers/mixins/checked_id_mixin.rb
+++ b/app/controllers/mixins/checked_id_mixin.rb
@@ -1,0 +1,10 @@
+module Mixins
+  module CheckedIdMixin
+    def checked_item_id(hash = params)
+      return hash[:id] if hash[:id]
+
+      checked_items = find_checked_items
+      checked_items[0] if checked_items.length == 1
+    end
+  end
+end

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -14,8 +14,6 @@ class SecurityGroupController < ApplicationController
     %w(instances network_ports)
   end
 
-  menu_section :net
-
   def button
     @edit = session[:edit] # Restore @edit for adv search box
     params[:display] = @display if %w(vms instances images).include?(@display)


### PR DESCRIPTION
The SecurityGroup controller uses some newer functionality not yet
backported into Euwe.  This PR adds a mixin and removes other unsupported
functionality.