### PR TITLE
Charge SCVMM's vm only until it is retired.

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -8,10 +8,12 @@ class Chargeback
       # Why we need this?
       #   1) We cannot charge for hours until the resources existed (vm provisioned in the middle of month)
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
+      #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
                                         consuption_start = [@start_time, resource.try(:created_on)].compact.max
-                                        consumption_end = [Time.current, @end_time].min
-                                        (consumption_end - consuption_start).round / 1.hour
+                                        consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
+                                        consumed = (consumption_end - consuption_start).round / 1.hour
+                                        consumed > 0 ? consumed : 0
                                       end
     end
 

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -10,9 +10,9 @@ class Chargeback
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
       #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
-                                        consuption_start = [@start_time, resource.try(:created_on)].compact.max
+                                        consumption_start = [@start_time, resource.try(:created_on)].compact.max
                                         consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
-                                        consumed = (consumption_end - consuption_start).round / 1.hour
+                                        consumed = (consumption_end - consumption_start).round / 1.hour
                                         consumed > 0 ? consumed : 0
                                       end
     end

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -12,7 +12,8 @@ class Chargeback
       extra_resources = cb_class.try(:extra_resources_without_rollups) || []
       timerange.step_value(interval_duration).each_cons(2) do |query_start_time, query_end_time|
         extra_resources.each do |resource|
-          yield ConsumptionWithoutRollups.new(resource, query_start_time, query_end_time)
+          consumption = ConsumptionWithoutRollups.new(resource, query_start_time, query_end_time)
+          yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end
 
         records = base_rollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => 'hourly')


### PR DESCRIPTION
Since we don't collect metric for SCVMM, we need to explicitly stop charging once the resource is retired.

Unfortunately, we don't store archived_on date atm. So, we need to rely on retirement.

@miq-bot add_label enhancement, chargeback
@miq-bot assign @gtanzillo 