### PR TITLE
Blueprint deep_copy with no bundle 

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -37,7 +37,7 @@ class Blueprint < ApplicationRecord
         new_attributes.reverse_merge(:status => nil).each do |attr, value|
           blueprint.send("#{attr}=", value)
         end
-        copy_service_template(blueprint, bundle, true)
+        copy_service_template(blueprint, bundle, true) if bundle
         blueprint.save!
       end
     end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -103,6 +103,12 @@ describe Blueprint do
         expect(new_service_template.custom_button_sets).to_not                        include(custom_button_set)
         expect(new_service_template.custom_button_sets.first.custom_buttons).to_not   include(button_in_a_set)
       end
+
+      it 'can copy a blueprint that does not have a bundle' do
+        expect do
+          subject.deep_copy
+        end.to change(Blueprint, :count).by(1)
+      end
     end
 
     describe "#readonly?" do


### PR DESCRIPTION
While working further on Blueprints, I noticed that `deep_copy` of a Blueprint fails if the Blueprint does not have a bundle. This PR adds in a quick fix for that, as well as adds a test for this case.

@miq-bot assign @chriskacerguis 
@miq-bot add_label ui/service, bug, euwe/no
(Euwe no because this error is caused by recent changes to Blueprints)