### PR TITLE
[WIP] Add new version method to Blueprint

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -33,7 +33,9 @@ class Blueprint < ApplicationRecord
   def deep_copy(new_attributes = {})
     self.class.transaction do
       dup.tap do |blueprint|
+        # Reset original_blueprint_d so that it is a new version
         # TODO: there may be other attributes that need to be reset for the new template
+        blueprint.original_blueprint_id = nil
         new_attributes.reverse_merge(:status => nil).each do |attr, value|
           blueprint.send("#{attr}=", value)
         end
@@ -46,6 +48,7 @@ class Blueprint < ApplicationRecord
   # On edit of a Blueprint via the API, a new version will be created
   def new_version(new_attributes = {})
     new_attributes['version'] = (version.to_f + 1).to_s unless new_attributes.key?('version')
+    new_attributes['original_blueprint_id'] = id
     deep_copy(new_attributes)
   end
 

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -43,6 +43,12 @@ class Blueprint < ApplicationRecord
     end
   end
 
+  # On edit of a Blueprint via the API, a new version will be created
+  def new_version(new_attributes = {})
+    new_attributes['version'] = (version.to_f + 0.1).to_s unless new_attributes.key?('version')
+    deep_copy(new_attributes)
+  end
+
   def create_bundle(options)
     options = options.with_indifferent_access
     self.class.transaction do

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -45,7 +45,7 @@ class Blueprint < ApplicationRecord
 
   # On edit of a Blueprint via the API, a new version will be created
   def new_version(new_attributes = {})
-    new_attributes['version'] = (version.to_f + 0.1).to_s unless new_attributes.key?('version')
+    new_attributes['version'] = (version.to_f + 1).to_s unless new_attributes.key?('version')
     deep_copy(new_attributes)
   end
 

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -103,6 +103,12 @@ describe Blueprint do
         expect(new_service_template.custom_button_sets).to_not                        include(custom_button_set)
         expect(new_service_template.custom_button_sets.first.custom_buttons).to_not   include(button_in_a_set)
       end
+
+      it 'has no other versions' do
+        new_bp = subject.deep_copy
+        expect(new_bp.versions.count).to eq(1)
+        expect(new_bp.active_version).to be_truthy
+      end
     end
 
     describe "#readonly?" do

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -349,7 +349,7 @@ describe Blueprint do
 
     it 'will create a new version' do
       new_version = subject.new_version(:name => 'new version')
-      expect(new_version.version).to eq('0.1')
+      expect(new_version.version).to eq('1.0')
       expect(new_version.original_blueprint_id).to eq(subject.id)
       expect(new_version.active_version).to be_truthy
       expect(subject.versions).to include(new_version)

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -340,6 +340,21 @@ describe Blueprint do
       expect(subject).to be_in_use
     end
   end
+
+  describe '#new_version' do
+    before do
+      subject.ui_properties = ui_properties
+      subject.save!
+    end
+
+    it 'will create a new version' do
+      new_version = subject.new_version(:name => 'new version')
+      expect(new_version.version).to eq('0.1')
+      expect(new_version.original_blueprint_id).to eq(subject.id)
+      expect(new_version.active_version).to be_truthy
+      expect(subject.versions).to include(new_version)
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
When editing a Blueprint, a new version needs to be created (and version number bumped). This is a simple method of creating a new version utilizing `deep_copy` to achieve this. The number to which the version  gets bumped is still tbd.

Depends on #13352 
[Pivotal ticket](https://www.pivotaltracker.com/story/show/135708775)

@miq-bot add_label enhancement, wip, ui/service 
