### PR TITLE
Add Amazon block storage refresh worker class

### DIFF
--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -19,6 +19,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
     ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker
@@ -95,6 +96,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
     ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker


### PR DESCRIPTION
Specification of this class is required for MiQ to be aware of the new
refresh worker supporting Amazon block storage refresh parser.

This PR is required by https://github.com/ManageIQ/manageiq-providers-amazon/pull/101.

@miq-bot add_label providers/amazon