### PR TITLE
Add Amazon block storage automation models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolume < MiqAeServiceCloudVolume
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager < MiqAeServiceManageIQ_Providers_StorageManager
+  end
+end


### PR DESCRIPTION
With the introduction of Amazon block storage manager we are required to
define automation service models for newly created provider models.
Currently only the storage manager, cloud volume and cloud volume
snapshot models are used.

Depends on https://github.com/ManageIQ/manageiq-providers-amazon/pull/101.

@miq-bot add_label providers/amazon, automate/model