### PR TITLE
Pass through google proxy options to fog-google

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "draper",                         "~>3.0.0.pre1"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
-gem "fog-google",                     "~>0.3.0",       :require => false
+gem "fog-google",                     ">=0.5.1",       :require => false
 gem "fog-vcloud-director",            "~>0.1.8",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
@@ -92,6 +92,8 @@ gem "websocket-driver",               "~>0.6.3"
 # Modified gems (forked on Github)
 gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "https://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
+
+# Unmodified gems but not yet released
 
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.

--- a/Gemfile
+++ b/Gemfile
@@ -93,8 +93,6 @@ gem "websocket-driver",               "~>0.6.3"
 gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "https://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 
-# Unmodified gems but not yet released
-
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.
 # See miq_expression_spec Date/Time Support examples.

--- a/app/models/manageiq/providers/google/manager_mixin.rb
+++ b/app/models/manageiq/providers/google/manager_mixin.rb
@@ -34,8 +34,7 @@ module ManageIQ::Providers::Google::ManagerMixin
   end
 
   module ClassMethods
-    # TODO: (julian) add proxy_uri back in once supported.
-    def raw_connect(google_project, google_json_key, options, _proxy_uri = nil)
+    def raw_connect(google_project, google_json_key, options, proxy_uri = nil)
       require 'fog/google'
 
       config = {
@@ -44,6 +43,9 @@ module ManageIQ::Providers::Google::ManagerMixin
         :google_json_key_string => google_json_key,
         :app_name               => I18n.t("product.name"),
         :app_version            => Vmdb::Appliance.VERSION,
+        :google_client_options  => {
+          :proxy => proxy_uri
+        }
       }
 
       case options[:service]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -948,6 +948,11 @@
     :password:
     :port:
     :user:
+  :gce:
+    :host:
+    :password:
+    :port:
+    :user:
 :ldap_synchronization:
   :ldap_synchronization_schedule: "0 2 * * *"
 :log:

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -24,6 +24,22 @@ describe ManageIQ::Providers::Google::CloudManager do
         end
         @e.connect
       end
+
+      it "sends proxy uri when set to fog-google" do
+        Settings.http_proxy.gce = {
+          :host     => "192.168.24.99",
+          :port     => "1234",
+          :user     => "my_user",
+          :password => "my_password"
+        }
+
+        require 'fog/google'
+        expect(Fog::Compute::Google).to receive(:new) do |options|
+          expect(options.fetch_path(:google_client_options, :proxy).to_s)
+            .to eq("http://my_user:my_password@192.168.24.99:1234")
+        end
+        @e.connect
+      end
     end
 
     context "#validation" do


### PR DESCRIPTION
I was able to test this on a server running tinyproxy. Note that when `fog-google` cuts a gem then the Gemfile won't need to be modified.