### PR TITLE
Add new method OrchestrationTemplate#deployment_options

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -97,6 +97,37 @@ class OrchestrationTemplate < ApplicationRecord
     raise NotImplementedError, _("parameter_groups must be implemented in subclass")
   end
 
+  # Basic options for all templates, each subclass should add more type/provider specific deployment options
+  # Return array of OrchestrationParameters. (Deployment options are different from parameters, but they use same class)
+  def deployment_options(_manager_class = nil)
+    tenant_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "tenant_name",
+      :label       => "Tenant",
+      :data_type   => "string",
+      :description => "Tenant where the stack will be deployed",
+      :required    => true,
+      :constraints => [
+        OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(
+          :fqname => "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
+        )
+      ]
+    )
+
+    stack_name_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "stack_name",
+      :label       => "Stack Name",
+      :data_type   => "string",
+      :description => "Name of the stack",
+      :required    => true,
+      :constraints => [
+        OrchestrationTemplate::OrchestrationParameterPattern.new(
+          :pattern => '^[A-Za-z][A-Za-z0-9\-]*$'
+        )
+      ]
+    )
+    [tenant_opt, stack_name_opt]
+  end
+
   # List managers that may be able to deploy this template
   def self.eligible_managers
     Rbac::Filterer.filtered(ExtManagementSystem, :where_clause => {:type => eligible_manager_types})

--- a/app/models/orchestration_template/orchestration_parameter.rb
+++ b/app/models/orchestration_template/orchestration_parameter.rb
@@ -26,6 +26,7 @@ class OrchestrationTemplate
     attr_accessor :data_type
     attr_accessor :default_value
     attr_accessor :hidden
+    attr_accessor :required
     attr_writer   :constraints
 
     def initialize(hash = {})
@@ -38,6 +39,10 @@ class OrchestrationTemplate
 
     def hidden?
       !!hidden
+    end
+
+    def required?
+      !!required
     end
   end
 end

--- a/app/models/orchestration_template_hot.rb
+++ b/app/models/orchestration_template_hot.rb
@@ -33,8 +33,32 @@ class OrchestrationTemplateHot < OrchestrationTemplate
         :description   => val['description'],
         :hidden        => val['hidden'] == true,
         :constraints   => val.key?('constraints') ? parse_constraints(val['constraints']) : nil,
+        :required      => true
       )
     end
+  end
+
+  def deployment_options(_manager_class = nil)
+    onfailure_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "stack_onfailure",
+      :label       => "On Failure",
+      :data_type   => "string",
+      :description => "Select what to do if stack creation failed",
+      :constraints => [
+        OrchestrationTemplate::OrchestrationParameterAllowed.new(
+          :allowed_values => {'ROLLBACK' => 'Rollback', 'DO_NOTHING' => 'Do nothing'}
+        )
+      ]
+    )
+
+    timeout_opt = OrchestrationTemplate::OrchestrationParameter.new(
+      :name        => "stack_timeout",
+      :label       => "Timeout(minutes, optional)",
+      :data_type   => "integer",
+      :description => "Abort the creation if it does not complete in a proper time window",
+    )
+
+    super << onfailure_opt << timeout_opt
   end
 
   def self.eligible_manager_types

--- a/spec/models/orchestration_template_azure_spec.rb
+++ b/spec/models/orchestration_template_azure_spec.rb
@@ -31,6 +31,7 @@ describe OrchestrationTemplateAzure do
       :data_type     => "securestring",
       :default_value => nil,
       :hidden        => true,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -43,6 +44,7 @@ describe OrchestrationTemplateAzure do
       :data_type     => "string",
       :default_value => nil,
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -55,6 +57,7 @@ describe OrchestrationTemplateAzure do
       :data_type     => "string",
       :default_value => "Free",
       :hidden        => false,
+      :required      => true,
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -80,5 +83,22 @@ describe OrchestrationTemplateAzure do
       template = OrchestrationTemplateAzure.new(:content => "invalid string")
       expect(template.validate_format).not_to be_nil
     end
+  end
+
+  describe '#deployment_options' do
+    it do
+      options = subject.deployment_options
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[2], "resource_group", :OrchestrationParameterAllowedDynamic, false)
+      assert_deployment_option(options[3], "new_resource_group", :OrchestrationParameterPattern, false)
+      assert_deployment_option(options[4], "deploy_mode", :OrchestrationParameterAllowed, false)
+    end
+  end
+
+  def assert_deployment_option(option, name, constraint_type, required)
+    expect(option.name).to eq(name)
+    expect(option.required?).to eq(required)
+    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize)
   end
 end

--- a/spec/models/orchestration_template_cfn_spec.rb
+++ b/spec/models/orchestration_template_cfn_spec.rb
@@ -34,6 +34,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "AWS::EC2::KeyPair::KeyName",
       :default_value => nil,
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -46,6 +47,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "List<AWS::EC2::Subnet::Id>",
       :default_value => nil,
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -58,6 +60,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "List<String>",
       :default_value => nil,
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -70,6 +73,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "String",
       :default_value => "m1.small",
       :hidden        => false,
+      :required      => true
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -89,6 +93,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "Number",
       :default_value => "1",
       :hidden        => false,
+      :required      => true,
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -109,6 +114,7 @@ describe OrchestrationTemplateCfn do
       :data_type     => "String",
       :default_value => nil,
       :hidden        => true,
+      :required      => true,
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(2)
@@ -140,5 +146,36 @@ describe OrchestrationTemplateCfn do
       template = OrchestrationTemplateCfn.new(:content => "invalid string")
       expect(template.validate_format).not_to be_nil
     end
+  end
+
+  describe '#deployment_options' do
+    it 'generates deployment options for AWS' do
+      options = subject.deployment_options('ManageIQ::Providers::Amazon::CloudManager')
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
+      assert_deployment_option(options[4], "stack_notifications", 'text', nil, false)
+      assert_deployment_option(options[5], "stack_capabilities", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[6], "stack_resource_types", 'text', nil, false)
+      assert_deployment_option(options[7], "stack_role", 'string', nil, false)
+      assert_deployment_option(options[8], "stack_tags", 'text', nil, false)
+      assert_deployment_option(options[9], "stack_policy", 'text', nil, false)
+    end
+
+    it 'generates deployment options for OpenStack' do
+      options = subject.deployment_options('ManageIQ::Providers::Openstack::CloudManager')
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
+    end
+  end
+
+  def assert_deployment_option(option, name, data_type = 'string', constraint_type, required)
+    expect(option.name).to eq(name)
+    expect(option.data_type).to eq(data_type)
+    expect(option.required?).to eq(required)
+    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize) if constraint_type
   end
 end

--- a/spec/models/orchestration_template_cfn_spec.rb
+++ b/spec/models/orchestration_template_cfn_spec.rb
@@ -154,13 +154,13 @@ describe OrchestrationTemplateCfn do
       assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
       assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
       assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
-      assert_deployment_option(options[4], "stack_notifications", 'text', nil, false)
+      assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
+      assert_deployment_option(options[4], "stack_notifications", nil, false, 'text')
       assert_deployment_option(options[5], "stack_capabilities", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[6], "stack_resource_types", 'text', nil, false)
-      assert_deployment_option(options[7], "stack_role", 'string', nil, false)
-      assert_deployment_option(options[8], "stack_tags", 'text', nil, false)
-      assert_deployment_option(options[9], "stack_policy", 'text', nil, false)
+      assert_deployment_option(options[6], "stack_resource_types", nil, false, 'text')
+      assert_deployment_option(options[7], "stack_role", nil, false)
+      assert_deployment_option(options[8], "stack_tags", nil, false, 'text')
+      assert_deployment_option(options[9], "stack_policy", nil, false, 'text')
     end
 
     it 'generates deployment options for OpenStack' do
@@ -168,11 +168,11 @@ describe OrchestrationTemplateCfn do
       assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
       assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
       assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
+      assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
     end
   end
 
-  def assert_deployment_option(option, name, data_type = 'string', constraint_type, required)
+  def assert_deployment_option(option, name, constraint_type, required, data_type = 'string')
     expect(option.name).to eq(name)
     expect(option.data_type).to eq(data_type)
     expect(option.required?).to eq(required)

--- a/spec/models/orchestration_template_hot_spec.rb
+++ b/spec/models/orchestration_template_hot_spec.rb
@@ -181,11 +181,11 @@ describe OrchestrationTemplateHot do
       assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
       assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
       assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
-      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
+      assert_deployment_option(options[3], "stack_timeout", nil, false, 'integer')
     end
   end
 
-  def assert_deployment_option(option, name, data_type = 'string', constraint_type, required)
+  def assert_deployment_option(option, name, constraint_type, required, data_type = 'string')
     expect(option.name).to eq(name)
     expect(option.data_type).to eq(data_type)
     expect(option.required?).to eq(required)

--- a/spec/models/orchestration_template_hot_spec.rb
+++ b/spec/models/orchestration_template_hot_spec.rb
@@ -45,6 +45,7 @@ describe OrchestrationTemplateHot do
       :data_type     => "string",
       :default_value => "m1.small",
       :hidden        => false,
+      :required      => true
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -64,6 +65,7 @@ describe OrchestrationTemplateHot do
       :data_type     => "string",  # HOT has type comma_delimited_list, but all examples use type string. Why?
       :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby",
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -76,6 +78,7 @@ describe OrchestrationTemplateHot do
       :data_type     => "string",
       :default_value => "F18-x86_64-cfntools",
       :hidden        => false,
+      :required      => true
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -95,6 +98,7 @@ describe OrchestrationTemplateHot do
       :data_type     => "number",
       :default_value => 50_000,
       :hidden        => false,
+      :required      => true
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(1)
@@ -114,7 +118,8 @@ describe OrchestrationTemplateHot do
       :description   => "Admin password",
       :data_type     => "string",
       :default_value => nil,
-      :hidden        => true
+      :hidden        => true,
+      :required      => true
     )
     constraints = parameter.constraints
     expect(constraints.size).to eq(3)
@@ -149,6 +154,7 @@ describe OrchestrationTemplateHot do
       :data_type     => "json",
       :default_value => nil,
       :hidden        => false,
+      :required      => true,
       :constraints   => [],
     )
   end
@@ -167,5 +173,22 @@ describe OrchestrationTemplateHot do
       template = OrchestrationTemplateHot.new(:content => ":-Invalid:\n-String")
       expect(template.validate_format).not_to be_nil
     end
+  end
+
+  describe '#deployment_options' do
+    it do
+      options = subject.deployment_options
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[2], "stack_onfailure", :OrchestrationParameterAllowed, false)
+      assert_deployment_option(options[3], "stack_timeout", 'integer', nil, false)
+    end
+  end
+
+  def assert_deployment_option(option, name, data_type = 'string', constraint_type, required)
+    expect(option.name).to eq(name)
+    expect(option.data_type).to eq(data_type)
+    expect(option.required?).to eq(required)
+    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize) if constraint_type
   end
 end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -325,4 +325,18 @@ describe OrchestrationTemplate do
       end
     end
   end
+
+  describe "#deployment_options" do
+    it do
+      options = subject.deployment_options
+      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
+      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+    end
+  end
+
+  def assert_deployment_option(option, name, constraint_type, required)
+    expect(option.name).to eq(name)
+    expect(option.required?).to eq(required)
+    expect(option.constraints[0]).to be_kind_of("OrchestrationTemplate::#{constraint_type}".constantize)
+  end
 end


### PR DESCRIPTION
Currently https://github.com/ManageIQ/manageiq-ui-classic/blob/af1d4de64e0cfff016f35239f61528f6c137f2dc/app/services/orchestration_template_dialog_service.rb#L25 uses many `if...else` to handle differences from various templates. This work introduces `#deployment_options` method from each type of the templates to help simply the service dialog generation. 

Each `#deployment_options` implementation provides type specific options which later will be converted to a component in the service dialog. The code simplification for `OrchestrationTemplateDialogService` will be committed with a separate PR since it is now in the manageiq-ui-classic repository. 