### PR TITLE
Use task queue for CRUD operations on auth key pair

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -10,7 +10,26 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
     ext_management_system.class::AuthKeyPair
   end
 
-  def self.create_key_pair(ext_management_system, options)
+  def self.create_key_pair_queue(userid, ext_management_system, options = {})
+    task_opts = {
+      :action => "creating Auth Key Pair for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => "ManageIQ::Providers::CloudManager::AuthKeyPair",
+      :method_name => 'create_key_pair',
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => [ext_management_system.id, options]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def self.create_key_pair(ems_id, options)
+    raise ArgumentError, _("ems cannot be nil") if ems_id.nil?
+    ext_management_system = ExtManagementSystem.find(ems_id)
+    raise ArgumentError, _("ems cannot be found") if ext_management_system.nil?
+
     klass = class_by_ems(ext_management_system)
     # TODO(maufart): add cloud_tenant to database table?
     created_key_pair = klass.raw_create_key_pair(ext_management_system, options)
@@ -19,6 +38,22 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
       :fingerprint => created_key_pair.fingerprint,
       :resource    => ext_management_system
     )
+  end
+
+  def delete_key_pair_queue(userid)
+    task_opts = {
+      :action => "deleting Auth Key Pair for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'delete_key_pair',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => resource.my_zone,
+      :args        => []
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
   def delete_key_pair

--- a/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
@@ -1,5 +1,5 @@
 describe ManageIQ::Providers::CloudManager::AuthKeyPair do
-  let(:ems) { FactoryGirl.build(:ems_cloud) }
+  let(:ems) { FactoryGirl.create(:ems_cloud) }
 
   context 'create and delete actions' do
     it "has methods" do
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::CloudManager::AuthKeyPair do
 
     # TODO(maufart): do we have any special approach to test module methods separately?
     it 'forces implement methods' do
-      expect { subject.class.create_key_pair ems, {} }.to raise_error NotImplementedError
+      expect { subject.class.create_key_pair ems.id, {} }.to raise_error NotImplementedError
       expect { subject.delete_key_pair }.to raise_error NotImplementedError
     end
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
@@ -6,11 +6,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
     it 'creates new key pair in nova' do
       service = double
       key_pairs = double
+      allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
       allow(ems).to receive(:connect).with(:service => 'Compute').and_return(service)
       allow(service).to receive(:key_pairs).and_return(key_pairs)
       allow(key_pairs).to receive(:create).with(key_pair_attributes).and_return(
         FactoryGirl.create :auth_key_pair_openstack)
-      subject.class.create_key_pair(ems, key_pair_attributes)
+      subject.class.create_key_pair(ems.id, key_pair_attributes)
     end
 
     it 'deletes existing key pair from nova' do


### PR DESCRIPTION
Uses task queue instead of making direct provider API calls from the UI. This PR contains the necessary model changes.