### PR TITLE
[DARGA] Don't lookup category names if no filtering on tag tree

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1118,7 +1118,7 @@ module OpsController::OpsRbac
     categories.sort_by { |c| c.description.downcase }.each do |category|
       kids_checked = false
       cat_node = {}
-      cat_node[:key] = category.name
+      cat_node[:key] = category.name if @edit.present? || @filters.present?
       cat_node[:title] = category.description
       cat_node[:tooltip] =  _("Category: %{description}") % {:description => category.description}
       cat_node[:addClass] = "cfme-no-cursor-node"      # No cursor pointer
@@ -1127,7 +1127,7 @@ module OpsController::OpsRbac
       cat_kids = []
       category.entries.sort_by { |e| e.description.downcase }.each do |tag|
         tag_node = {}
-        tag_node[:key] = [category.name, tag.name].join("-")
+        tag_node[:key] = [category.name, tag.name].join("-") if @edit.present? || @filters.present?
         tag_node[:title] = tag.description
         tag_node[:tooltip] =  _("Tag: %{description}") % {:description => tag.description}
         if (@edit && @edit[:new][:filters][tag_node[:key]] == @edit[:current][:filters][tag_node[:key]]) || ![tag_node[:key]].include?(@filters) # Check new vs current


### PR DESCRIPTION
It will no longer lookup category names if viewing the whole tree
since the category name was only used for filtering.

This removes a few hundred extra queries

https://bugzilla.redhat.com/show_bug.cgi?id=1412441

---

**NOTE:** This is backported #13308 - But the base code is very different.
The assumption was made that the `cat_node[:key]` and `cat_kids[:key]` works much the same as the `euwe` version.

Please open javascript console and be aware of javascript errors.