### PR TITLE
[WIP] Blueprint new_version API action

### DIFF
--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -14,6 +14,13 @@ module Api
       blueprint
     end
 
+    def new_version_resource(type, id, data)
+      blueprint = resource_search(id, type, Blueprint)
+      blueprint.new_version(data)
+    rescue => err
+      raise BadRequestError, "Failed to create a new version - #{err}"
+    end
+
     private
 
     def set_additional_attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -147,6 +147,8 @@
         :identifier: blueprint_delete
       - :name: publish
         :identifier: blueprint_publish
+      - :name: new_version
+        :identifier: blueprint_edit
     :resource_actions:
       :get:
       - :name: read
@@ -158,6 +160,8 @@
         :identifier: blueprint_delete
       - :name: publish
         :identifier: blueprint_publish
+      - :name: new_version
+        :identifier: blueprint_edit
       :delete:
       - :name: delete
         :identifier: blueprint_delete

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -304,6 +304,21 @@ RSpec.describe "Blueprints API" do
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:bad_request)
     end
+
+    it 'creates a new version' do
+      blueprint = FactoryGirl.create(:blueprint)
+      api_basic_authorize action_identifier(:blueprints, :edit)
+
+      run_post(blueprints_url(blueprint.id), :action => 'new_version', :name => 'foo_bar')
+
+      expected = {
+        'name'                  => 'foo_bar',
+        'original_blueprint_id' => blueprint.id
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+      expect(response.parsed_body['id']).to_not equal(blueprint.id)
+    end
   end
 
   describe "DELETE /api/blueprints/:id" do


### PR DESCRIPTION
This is a WIP as it is dependent on both #13352 and #13456. When a Blueprint is "Edited" it should automatically become a new version. This will use the `new_version` method and return the newly created version of the Blueprint.

Links
----------------
* [Pivotal Ticket](https://www.pivotaltracker.com/story/show/135708893)

@miq-bot add_label wip, enhancement, api
@miq-bot assign @abellotti 