### PR TITLE
Cleanup vmdb/log/* after build in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,8 @@ RUN source /etc/default/evm && \
     rm -rvf ${RUBY_GEMS_ROOT}/gems/rugged-*/vendor/libgit2/build && \
     rm -rvf ${RUBY_GEMS_ROOT}/cache/* && \
     rm -rvf /root/.bundle/cache && \
-    rm -rvf ${APP_ROOT}/tmp/cache/assets
+    rm -rvf ${APP_ROOT}/tmp/cache/assets && \
+    rm -rf ${APP_ROOT}/log/*
 
 ## Build SUI
 RUN source /etc/default/evm && \


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1406804

Related PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/138