### PR TITLE
Fix expectation on nil

### DIFF
--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -75,8 +75,11 @@ describe ServiceTemplateProvisionTask do
 
     describe "#deliver_to_automate" do
       it "delivers to the queue when the state is not active" do
-        @task_0.state = 'pending'
-        automate_args = {
+        @task_0.state         = 'pending'
+        zone                  = FactoryGirl.create(:zone, :name => "special")
+        orchestration_manager = FactoryGirl.create(:ext_management_system, :zone => zone)
+        @task_0.source        = FactoryGirl.create(:service_template_orchestration, :orchestration_manager => orchestration_manager)
+        automate_args         = {
           :object_type      => 'ServiceTemplateProvisionTask',
           :object_id        => @task_0.id,
           :namespace        => 'Service/Provisioning/StateMachines',
@@ -89,7 +92,6 @@ describe ServiceTemplateProvisionTask do
           :tenant_id        => @admin.current_tenant.id,
         }
         allow(@request).to receive(:approved?).and_return(true)
-        allow(@task_0.source).to receive(:my_zone).and_return("special")
         expect(MiqQueue).to receive(:put).with(
           :class_name  => 'MiqAeEngine',
           :method_name => 'deliver',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
   config.mock_with :rspec do |c|
+    c.allow_message_expectations_on_nil = false
     c.syntax = :expect
   end
 


### PR DESCRIPTION
Expectations shouldn't be allowed on `nil`.  Disable it in the rspec configuration and fix the existing offender.

Was producing the following warning:
  WARNING: An expectation of `:my_zone` was set on `nil`.
  To allow expectations on `nil` and suppress this message,
  set `config.allow_message_expectations_on_nil` to `true`.
  To disallow expectations on `nil`,
  set `config.allow_message_expectations_on_nil` to `false`.