### PR TITLE
[EUWE] Do not stop and start evmserverd if it was not running

### DIFF
--- a/gems/pending/appliance_console/logfile_configuration.rb
+++ b/gems/pending/appliance_console/logfile_configuration.rb
@@ -9,14 +9,19 @@ module ApplianceConsole
     LOGFILE_DIRECTORY = Pathname.new("/var/www/miq/vmdb/log").freeze
     LOGFILE_NAME = "miq_logs".freeze
 
-    attr_accessor :disk
+    attr_accessor :disk, :evm_was_running
 
     include ApplianceConsole::Logging
 
+    def initialize
+      self.evm_was_running = LinuxAdmin::Service.new("evmserverd").running?
+    end
+
     def activate
-      stop_evm
+      stop_evm if evm_was_running
       initialize_logfile_disk
-      start_evm
+      start_evm if evm_was_running
+      true
     end
 
     def ask_questions


### PR DESCRIPTION
## This change is only needed in, and should only be applied to, the euwe branch.

This PR simply ensures the evmserverd service is not manipulated after logfile
configuration changes are made, if the evmserverd service was not running.

**To test this upstream:**

add an extra harddisk to the test appliance,
disable evmserverd
attempt to use the appliance_console to add a new logfile disk volume.
To disable the evmserverd service upstream do:

```
  systemctl stop evmserverd && systemctl disable evmserverd
  systemctl stop $APPLIANCE_PG_SERVICE && systemctl disable $APPLIANCE_PG_SERVICE
  echo "rm PG data"
  rm -rf $APPLIANCE_PG_DATA/*
  vmdb
  rm -f REGION config/database.yml GUID
```

After executing the above commands use the appliance_console to configure a new
logfile disk volume, ensuring no traceback is produced.

Manually pulled commit ManageIQ/manageiq-gems-pending/commit/5bf80c831ea436c855e4ba1beccea3883a9aa174

https://bugzilla.redhat.com/show_bug.cgi?id=1393349


