### PR TITLE
Give the AuthKeyPair model a proper display name.

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -743,6 +743,7 @@ en:
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
       ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job:         Ansible Tower Job
       ManageIQ::Providers::CloudManager:                                    Cloud Provider
+      ManageIQ::Providers::CloudManager::AuthKeyPair:                       Key Pair
       ManageIQ::Providers::CloudManager::Vm:                                Instance
       ManageIQ::Providers::Google::CloudManager::Vm:                        Instance (Google)
       ManageIQ::Providers::Openstack::CloudManager::Vm:                     Instance (OpenStack)


### PR DESCRIPTION
This fixes the problem reported in https://bugzilla.redhat.com/show_bug.cgi?id=1403911, where the entire internal path for Key Pairs was displayed in the expression editor (and maybe other places) because the dictionary didn't include a proper name.

![key_pair_display_name](https://cloud.githubusercontent.com/assets/628956/21909242/0c51b30c-d8e5-11e6-808d-718875461417.png)
