### PR TITLE
Tenant admin should not be able to create groups in other tenants.

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -286,9 +286,11 @@ class Tenant < ApplicationRecord
   #     [["tenant/tenant2/project4", 4]]
   #   ]
   def self.tenant_and_project_names
-    tenants_and_projects = Tenant.in_my_region.select(:id, :ancestry, :divisible, :use_config_for_attributes, :name)
+    all_tenants_and_projects = Tenant.in_my_region.select(:id, :ancestry, :divisible, :use_config_for_attributes, :name)
+    tenants_by_id = all_tenants_and_projects.index_by(&:id)
+
+    tenants_and_projects = Rbac.filtered(Tenant.in_my_region.select(:id, :ancestry, :divisible, :use_config_for_attributes, :name))
                            .to_a.sort_by { |t| [t.ancestry || "", t.name] }
-    tenants_by_id = tenants_and_projects.index_by(&:id)
 
     tenants_and_projects.partition(&:divisible?).map do |tenants|
       tenants.map do |t|


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-classic/issues/134

This is only a part of the fix. The 2nd part needs fixing on the
manageiq-ui-classic side.

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/134

https://github.com/ManageIQ/manageiq-ui-classic/pull/151