### PR TITLE
Extract chargeable field from chargeback

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -3,4 +3,24 @@ class ChargeableField < ApplicationRecord
 
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
+
+  def self.seed_fields
+    seed_data.each do |f|
+      rec = ChargeableField.find_by(:metric => f[:metric])
+      measure = f.delete(:measure)
+      if measure
+        f[:chargeback_rate_detail_measure_id] = ChargebackRateDetailMeasure.find_by!(:name => measure).id
+      end
+      if rec.nil?
+        create(f)
+      else
+        rec.update_attributes!(f)
+      end
+    end
+  end
+
+  def self.seed_data
+    fixture_file = File.join(FIXTURE_DIR, 'chargeable_fields.yml')
+    File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
+  end
 end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -1,0 +1,6 @@
+class ChargeableField < ApplicationRecord
+  belongs_to :measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
+
+  validates :metric, :uniqueness => true, :presence => true
+  validates :group, :source, :presence => true
+end

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -64,6 +64,7 @@ class ChargebackRate < ApplicationRecord
   def self.seed
     # seeding the measure fixture before seed the chargeback rates fixtures
     seed_chargeback_rate_measure
+    ChargeableField.seed_fields # Cannot use seed order until we refactor seed_chargeback_rate_measure
     # seeding the currencies
     seed_chargeback_rate_detail_currency
     seed_chargeback_rate
@@ -129,6 +130,9 @@ class ChargebackRate < ApplicationRecord
         rates.each do |rate_detail|
           measure = ChargebackRateDetailMeasure.find_by(:name => rate_detail.delete(:measure))
           currency = ChargebackRateDetailCurrency.find_by(:name => rate_detail.delete(:type_currency))
+          metric = rate_detail[:metric] || "#{rate_detail[:group]}_#{rate_detail[:source]}"
+          field = ChargeableField.find_by(:metric => metric)
+          rate_detail[:chargeable_field_id] = field.id
           unless measure.nil?
             rate_detail[:chargeback_rate_detail_measure_id] = measure.id
           end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -249,6 +249,8 @@ class ChargebackRateDetail < ApplicationRecord
         detail_new.detail_measure = ChargebackRateDetailMeasure.find_by(:name => detail[:measure])
         detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency])
         detail_new.metric = detail[:metric]
+        chargeable_metric = detail[:metric] || "#{detail[:group]}_#{detail[:source]}"
+        detail_new.chargeable_field = ChargeableField.find_by(:metric => chargeable_metric)
 
         detail[:tiers].sort_by { |tier| tier[:start] }.each do |tier|
           detail_new.chargeback_tiers << ChargebackTier.new(tier.slice(*ChargebackTier::FORM_ATTRIBUTES))

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,7 +12,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true
 
-  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric).freeze
+  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id).freeze
   PER_TIME_TYPES = {
     "hourly"  => _("Hourly"),
     "daily"   => _("Daily"),

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -1,5 +1,6 @@
 class ChargebackRateDetail < ApplicationRecord
   belongs_to :chargeback_rate
+  belongs_to :chargeable_field
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
   belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
   has_many :chargeback_tiers, :dependent => :destroy, :autosave => true

--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -1,0 +1,60 @@
+---
+- :metric: cpu_usagemhz_rate_average
+  :description: Used CPU
+  :group: cpu
+  :source: used
+  :measure: Hz Units
+- :metric: v_derived_cpu_total_cores_used
+  :description: Used CPU Cores
+  :group: cpu_cores
+  :source: used
+- :metric: derived_vm_numvcpus
+  :description: Allocated CPU Count
+  :group: cpu
+  :source: allocated
+- :metric: derived_memory_used
+  :description: Used Memory
+  :group: memory
+  :source: used
+  :measure: Bytes Units
+- :metric: derived_memory_available
+  :description: Allocated Memory
+  :group: memory
+  :source: allocated
+  :measure: Bytes Units
+- :metric: net_usage_rate_average
+  :description: Used Network I/O
+  :group: net_io
+  :source: used
+  :measure: Bytes per Second Units
+- :metric: disk_usage_rate_average
+  :description: Used Disk I/O
+  :group: disk_io
+  :source: used
+  :measure: Bytes per Second Units
+- :metric: fixed_compute_1
+  :description: Fixed Compute Cost 1
+  :group: fixed
+  :source: compute_1
+- :metric: fixed_compute_2
+  :description: Fixed Compute Cost 2
+  :group: fixed
+  :source: compute_2
+- :metric: derived_vm_allocated_disk_storage
+  :description: Allocated Disk Storag
+  :group: storage
+  :source: allocated
+  :measure: Bytes Units
+- :metric: derived_vm_used_disk_storage
+  :description: Used Disk Storag
+  :group: storage
+  :source: used
+  :measure: Bytes Units
+- :metric: fixed_storage_1
+  :group: fixed
+  :source: storage_1
+  :description: Fixed Storage Cost 1
+- :metric: fixed_storage_2
+  :group: fixed
+  :source: storage_2
+  :description: Fixed Storage Cost 2

--- a/db/migrate/20170109101053_create_chargeable_fields.rb
+++ b/db/migrate/20170109101053_create_chargeable_fields.rb
@@ -1,0 +1,11 @@
+class CreateChargeableFields < ActiveRecord::Migration[5.0]
+  def change
+    create_table :chargeable_fields do |t|
+      t.bigint :chargeback_rate_detail_measure_id
+      t.string :metric
+      t.string :group
+      t.string :source
+      t.string :description
+    end
+  end
+end

--- a/db/migrate/20170109124924_add_chargeable_field_to_chargeback_rate_detail.rb
+++ b/db/migrate/20170109124924_add_chargeable_field_to_chargeback_rate_detail.rb
@@ -1,0 +1,5 @@
+class AddChargeableFieldToChargebackRateDetail < ActiveRecord::Migration[5.0]
+  def change
+    add_column :chargeback_rate_details, :chargeable_field_id, :bigint
+  end
+end

--- a/db/migrate/20170109142011_extract_field_data_from_rate_detail.rb
+++ b/db/migrate/20170109142011_extract_field_data_from_rate_detail.rb
@@ -1,0 +1,39 @@
+class ExtractFieldDataFromRateDetail < ActiveRecord::Migration[5.0]
+  class ChargebackRate < ActiveRecord::Base
+  end
+
+  class ChargeableField < ActiveRecord::Base
+  end
+
+  class ChargebackRateDetail < ActiveRecord::Base
+    belongs_to :chargeback_rate
+    belongs_to :chargeable_field
+
+    def to_h
+      { :metric => metric, :source => source, :group => group, :description => description,
+        :chargeback_rate_detail_measure_id => chargeback_rate_detail_measure_id }
+    end
+
+    def metric
+      # fixed_compute_n and fixed_storage_n had metric=nil, we need it to have metric!=nil so we can reference it
+      self[:metric] || "#{group}_#{source}"
+    end
+  end
+
+  def up
+    # Cannot create in bulk, there are inconsistencies in the database. One would think that
+    # (:metric, :source, :group, :description) quaternion depends is function of :metric.
+    # Unfortunatelly it may not be. And we want it to be.
+    fields_cache = {}
+    ChargebackRateDetail.joins(:chargeback_rate).where(:chargeback_rates => {:default => true}).each do |rate|
+      rate.chargeable_field = ChargeableField.create!(rate.to_h)
+      rate.save!
+      fields_cache[rate.metric] = rate.chargeable_field
+    end
+
+    ChargebackRateDetail.where(:chargeable_field_id => nil).each do |rate|
+      rate.chargeable_field = fields_cache[rate.metric]
+      rate.save!
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -221,6 +221,7 @@ chargeback_rate_details:
 - updated_on
 - chargeback_rate_detail_measure_id
 - chargeback_rate_detail_currency_id
+- chargeable_field_id
 chargeback_rates:
 - id
 - guid

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -182,6 +182,13 @@ bottleneck_events:
 - message
 - context_data
 - future
+chargeable_fields:
+- id
+- chargeback_rate_detail_measure_id
+- metric
+- group
+- source
+- description
 chargeback_rate_detail_currencies:
 - id
 - code

--- a/spec/migrations/20170109142011_extract_field_data_from_rate_detail_spec.rb
+++ b/spec/migrations/20170109142011_extract_field_data_from_rate_detail_spec.rb
@@ -1,0 +1,44 @@
+require_migration
+
+describe ExtractFieldDataFromRateDetail do
+  class ExtractFieldDataFromRateDetail::ChargebackRateDetailMeasure < ActiveRecord::Base; end
+
+  let(:rate_stub) { migration_stub(:ChargebackRate) }
+  let(:detail_stub) { migration_stub(:ChargebackRateDetail) }
+  let(:field_stub) { migration_stub(:ChargeableField) }
+  let(:measure_stub) { migration_stub(:ChargebackRateDetailMeasure) }
+
+  let(:default_rate) { rate_stub.create!(:rate_type => 'Compute', :default => :true) }
+  let(:custom_rate) { rate_stub.create!(:rate_type => 'Compute') }
+  let(:measure_mhz) { measure_stub.create!(:name => 'Hz Units') }
+  let(:measure_bps) { measure_stub.create!(:name => 'Bytes per Second Units') }
+
+  let(:fields) do
+    [
+      {:metric => 'cpu_usagemhz_rate_average', :group => 'cpu', :source => 'used', :description => 'Used CPU',
+       :chargeback_rate_detail_measure_id => measure_mhz.id},
+      {:metric => 'derived_vm_numvcpus', :group => 'cpu', :source => 'allocated', :description => 'Allocated CPU Count',
+       :chargeback_rate_detail_measure_id => nil},
+      {:metric => 'disk_usage_rate_average', :group => 'disk_io', :source => 'used', :description => 'Used Disk I/O',
+       :chargeback_rate_detail_measure_id => measure_bps.id},
+    ]
+  end
+
+  migration_context :up do
+    it 'creates one field for each detail in default rate' do
+      fields.each do |field|
+        detail_stub.create!(field.merge(:chargeback_rate_id => default_rate.id))
+        detail_stub.create!(field.merge(:chargeback_rate_id => custom_rate.id))
+      end
+
+      migrate
+
+      created_fields = field_stub.all.collect(&:attributes).collect { |f| f.except('id').symbolize_keys }
+      expect(created_fields).to match_array(fields)
+
+      detail_stub.all.each do |d|
+        expect(d.chargeable_field.metric).to eq(d.metric)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is first step for #13375.

Because of repo split, we cannot remove (moved) columns from ChargebackRateDetail just yet, the ui-classic tests would fail.

Thus, #13375 will be fixed in series of prs.

@miq-bot add_label chargeback, technical debt, sql migration