### PR TITLE
Increase fog-google version to v0.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "draper",                         "~>3.0.0.pre1"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
-gem "fog-google",                     ">=0.5.1",       :require => false
+gem "fog-google",                     ">=0.5.2",       :require => false
 gem "fog-vcloud-director",            "~>0.1.8",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"


### PR DESCRIPTION
Bump the fog-google gem version to fix a regression in fog-google
https://github.com/fog/fog-google/pull/190

https://github.com/ManageIQ/manageiq/pull/13459#issuecomment-272374511

cc @selmanj 