### PR TITLE
[wip] Fix Job namespacing

### DIFF
--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -40,7 +40,7 @@ module VmOrTemplate::Scanning
     begin
       self.last_scan_attempt_on = Time.now.utc
       save
-      job = Job.create_job("VmScan", options)
+      job = ::Job.create_job("VmScan", options)
       return job
     rescue => err
       _log.log_backtrace(err)


### PR DESCRIPTION
~~This addresses two issues:~~

~~* If `app/models/job/state_machine.rb` is loaded before `app/models/job.rb`, then `Job` will be loaded as an empty class.~~
* There is an erratic failure in which `Job` starts pointing to another
object in the `ManageIQ::Providers::Vmware::InfraManager::Vm`
namespace. This ensures that it always points to the top level `Job` model.

EDIT: Before this change, the build will fail consistently with seed
46777 in CI.

@miq-bot add-label core, bug
@miq-bot assign @Fryguy 