### PR TITLE
[api] Use :allow_nil parameter while retrieving allowed_tags via workflow

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -39,7 +39,7 @@ class MiqRequest < ApplicationRecord
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
 
-  delegate :allowed_tags,                :to => :workflow,   :prefix => :v
+  delegate :allowed_tags,                :to => :workflow,   :prefix => :v,  :allow_nil => true
   delegate :class,                       :to => :workflow,   :prefix => :v_workflow
 
   virtual_has_one :workflow

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -259,6 +259,28 @@ RSpec.describe "Requests API" do
       expect(response.parsed_body).to match(expected_response)
       expect(response).to have_http_status(:ok)
     end
+
+    it "does not throw a DelegationError exception when workflow is nil" do
+      ems = FactoryGirl.create(:ems_vmware)
+      vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems)
+      request = FactoryGirl.create(:service_template_provision_request,
+                                   :requester   => @user,
+                                   :source_id   => vm_template.id,
+                                   :source_type => vm_template.class.name)
+
+      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
+
+      expected_response = a_hash_including(
+        "id"               => request.id,
+        "v_workflow_class" => {}
+      )
+
+      expect(response.parsed_body).to match(expected_response)
+      expect(response.parsed_body).not_to include("workflow")
+      expect(response.parsed_body).not_to include("v_allowed_tags")
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context "request update" do


### PR DESCRIPTION
Use `:allow_nil => true` parameter while delegating `workflow` to the `allowed_tags` method to avoid the exception below when `workflow` is nil.

```
  "error": {
    "kind": "internal_server_error",
    "message": "MiqRequest#v_allowed_tags delegated to workflow.allowed_tags, but workflow is nil:
```

https://www.pivotaltracker.com/n/projects/1914499/stories/137643447