### PR TITLE
Add alerts api as subcollection

### DIFF
--- a/app/controllers/api/alerts_controller.rb
+++ b/app/controllers/api/alerts_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class AlertsController < BaseController
+  end
+end

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -16,6 +16,7 @@ module Api
     include Subcollections::CloudNetworks
     include Subcollections::CustomAttributes
     include Subcollections::LoadBalancers
+    include Subcollections::Alerts
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)

--- a/app/controllers/api/subcollections/alerts.rb
+++ b/app/controllers/api/subcollections/alerts.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Alerts
+      def alerts_query_resource(object)
+        object.try(:miq_alert_statuses) || []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -647,6 +647,21 @@
       :get:
       - :name: read
         :identifier: load_balancer_show
+  :alerts:
+    :description: Alerts
+    :identifier: alert
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: MiqAlertStatus
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: alert_status_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: alert_status_show
   :notifications:
     :description: "User's past notifications"
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -652,6 +652,7 @@
     :identifier: alert
     :options:
     - :collection
+    - :subcollection
     :verbs: *g
     :klass: MiqAlertStatus
     :collection_actions:
@@ -846,6 +847,7 @@
     - :cloud_networks
     - :custom_attributes
     - :load_balancers
+    - :alerts
     :collection_actions:
       :get:
       - :name: read
@@ -913,6 +915,10 @@
       :get:
       - :name: show
         :identifier: load_balancer_show
+    :alerts_subcollection_actions:
+      :get:
+      - :name: show
+        :identifier: alert_status_show_list
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1932,7 +1932,26 @@
         :feature_type: admin
         :hidden: true
         :identifier: alert_delete
-
+  - :name: Alerts Statuses
+    :description: Everything under Alerts Statuses
+    :protected: true
+    :feature_type: node
+    :hidden: true
+    :identifier: alert_status
+    :children:
+    - :name: View
+      :description: View Alerts Statuses
+      :feature_type: view
+      :identifier: alert_status_view
+      :children:
+      - :name: List
+        :description: Display Lists of Alert Statuses
+        :feature_type: view
+        :identifier: alert_status_show_list
+      - :name: Show
+        :description: Display Individual Alert Status
+        :feature_type: view
+        :identifier: alert_status_show
 # Policy Simulation
 - :name: Simulation
   :description: Policy Simulation

--- a/spec/factories/miq_alert_status.rb
+++ b/spec/factories/miq_alert_status.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :miq_alert_status do
+  end
+end

--- a/spec/requests/api/alerts_spec.rb
+++ b/spec/requests/api/alerts_spec.rb
@@ -1,0 +1,17 @@
+describe "Alerts API" do
+  let(:alert_definition) { FactoryGirl.create(:miq_alert, :severity => "info") }
+
+  it "forbids access to actions without an appropriate role" do
+    api_basic_authorize
+    run_get(alerts_url)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "reads all alerts statuses" do
+    api_basic_authorize collection_action_identifier(:alerts, :read, :get)
+    alert_status_1, alert_status_2 = FactoryGirl.create_list(:miq_alert_status, 2)
+    run_get(alerts_url)
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["count"]).to eq(2)
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -299,6 +299,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:load_balancer)
       test_collection_query(:load_balancers, load_balancers_url, LoadBalancer)
     end
+
+    it 'query Alerts' do
+      FactoryGirl.create(:miq_alert_status)
+      test_collection_query(:alerts, alerts_url, MiqAlertStatus)
+    end
   end
 
   context "Collections Bulk Queries" do


### PR DESCRIPTION
Add miq_alert_status as a sub collection of providers.

The alerts api for is for new alert screens added #11962. The screen is scoped per provider and this PR adds the necessary link

Depends on #13025 and #13324