### PR TITLE
Added changes to show Catalog Item type in UI

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -10,6 +10,20 @@ class ServiceTemplate < ApplicationRecord
     "storage"         => _("Storage")
   }.freeze
 
+
+  CATALOG_ITEM_TYPES = {
+    "amazon"                => _("Amazon"),
+    "azure"                 => _("Azure"),
+    "generic"               => _("Generic"),
+    "generic_orchestration" => _("Orchestration"),
+    "generic_ansible_tower" => _("AnsibleTower"),
+    "google"                => _("Google"),
+    "microsoft"             => _("SCVMM"),
+    "openstack"             => _("OpenStack"),
+    "redhat"                => _("RHEV"),
+    "vmware"                => _("VMware")
+  }
+
   include ServiceMixin
   include OwnershipMixin
   include NewWithTypeStiMixin

--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -22,6 +22,7 @@ cols:
 - name
 - description
 - type_display
+- prov_type
 - display
 #- provision_cost
 - created_at
@@ -48,6 +49,7 @@ col_order:
 - description
 - tenant.name
 - type_display
+- prov_type
 - display
 - service_template_catalog.name
 #- provision_cost
@@ -59,6 +61,7 @@ headers:
 - Description
 - Tenant
 - Type
+- Item Type
 - Display in Catalog
 - Catalog
 #- Cost


### PR DESCRIPTION
Moved CATALOG_ITEM_TYPES and added virtual column in model so it can be used to display Catalog Item type in list view and other screens.

https://bugzilla.redhat.com/show_bug.cgi?id=1348239

@gmcculloug @dclarizio please review

see UI screenshots below show "Item Type" on list view and other screens

![after1](https://cloud.githubusercontent.com/assets/3450808/21993750/74a6951e-dbea-11e6-8bb5-14544535a5f3.png)
![after2](https://cloud.githubusercontent.com/assets/3450808/21993751/773ca070-dbea-11e6-8666-5d8c4f4219f7.png)
![after3](https://cloud.githubusercontent.com/assets/3450808/21993758/7a863778-dbea-11e6-906b-90f24b41bf3e.png)
