### PR TITLE
[DARGA] Case insensitive search of the current user

### DIFF
--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -112,7 +112,7 @@ module OwnershipMixin
     private
 
     def user_owned(user)
-      where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:evm_owner_userid)]).eq(user.userid)))
+      where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:evm_owner_userid)]).eq(user.userid.downcase)))
     end
 
     def group_owned(miq_group)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -42,6 +42,12 @@ shared_examples "miq ownership" do
 
           expect(described_class.user_or_group_owned(owning_user, owning_user.current_group)).to eq([owned_resource])
         end
+
+        it "with mixed case userid" do
+          owned_resource.update(:evm_owner => owning_user)
+          owning_user.update(:userid => "MixedCase")
+          expect(described_class.user_or_group_owned(owning_user, nil)).to eq([owned_resource])
+        end
       end
 
       context "only with a group" do


### PR DESCRIPTION
Backport of #13226 to darga.  The test code was conflicted and needed to be manually resolved.

https://bugzilla.redhat.com/show_bug.cgi?id=1401912

Note, we were only downcasing the userids in the users table,
so a mixed case logged in userid would never match.

This would cause a logged in self service user with mixed case
userid to not see vms they own.

This was broken here:
9b897c35a92d9d4

As part of:
https://github.com/ManageIQ/manageiq/pull/11992

We're fixing much like we did with groups here:
https://github.com/ManageIQ/manageiq/pull/12114

Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.

Guidelines:
* Keep Pull Request titles short and to the point, ideally under 72 characters
* Provide as much context/info in the description as necessary to get the reviewer up to the same domain knowledge level as yourself
* Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible

Links [Optional]
----------------

* http://documentation.for/library/that/I/am/adding
* [PR relevant issue or pull_request](#123)

Steps for Testing/QA [Optional]
-------------------------------

If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.
