### PR TITLE
Fix Azure orchestration stack specs

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -3,7 +3,7 @@ require 'azure-armrest'
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }
-  let(:orchestration_service) { double }
+  let(:orchestration_service) { double("orchestration service") }
   let(:the_raw_stack) do
     Azure::Armrest::TemplateDeployment.new(
       'id'         => 'one_id',

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -58,12 +58,12 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
 
     describe "#delete_stack" do
       it 'updates the stack' do
-        expect(orchestration_service).to receive(:delete)
+        expect(orchestration_service).to receive(:delete_associated_resources)
         subject.delete_stack
       end
 
       it 'catches errors from provider' do
-        expect(orchestration_service).to receive(:delete).and_raise('bad request')
+        expect(orchestration_service).to receive(:delete_associated_resources).and_raise('bad request')
         expect { subject.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
       end
     end


### PR DESCRIPTION
*  Update expected message in delete_stack tests

With the introduction of
ManageIQ/manageiq-providers-azure@5369c7d,
these tests are no longer expecting the correct message.

*  Give orchestration stack double a name

...so it will be easier to identify when something breaks.

Fixes the currently :red_circle: build

@miq-bot add-label bug