### PR TITLE
Convert views to have valid sort orders

### DIFF
--- a/product/views/ChargebackRate.yaml
+++ b/product/views/ChargebackRate.yaml
@@ -43,7 +43,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- description
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/CimBaseStorageExtent.yaml
+++ b/product/views/CimBaseStorageExtent.yaml
@@ -68,7 +68,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/CimStorageExtent.yaml
+++ b/product/views/CimStorageExtent.yaml
@@ -61,7 +61,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
+++ b/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
@@ -67,7 +67,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- key
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/CloudObjectStoreObject.yaml
+++ b/product/views/CloudObjectStoreObject.yaml
@@ -67,7 +67,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- key
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/ConfigurationProfile.yaml
+++ b/product/views/ConfigurationProfile.yaml
@@ -60,7 +60,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- description
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/FirewallRule.yaml
+++ b/product/views/FirewallRule.yaml
@@ -55,7 +55,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/FloatingIp.yaml
+++ b/product/views/FloatingIp.yaml
@@ -58,7 +58,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- address
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript.yaml
@@ -59,7 +59,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- hostname
+- name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/MiqGroup.yaml
+++ b/product/views/MiqGroup.yaml
@@ -52,7 +52,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- description
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OntapFileShare.yaml
+++ b/product/views/OntapFileShare.yaml
@@ -66,7 +66,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OntapLogicalDisk.yaml
+++ b/product/views/OntapLogicalDisk.yaml
@@ -72,7 +72,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OntapStorageSystem.yaml
+++ b/product/views/OntapStorageSystem.yaml
@@ -71,7 +71,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OntapStorageVolume.yaml
+++ b/product/views/OntapStorageVolume.yaml
@@ -70,7 +70,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OpenscapRuleResult.yaml
+++ b/product/views/OpenscapRuleResult.yaml
@@ -46,7 +46,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- openscap_id
+- name
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/OrchestrationStackOutput.yaml
+++ b/product/views/OrchestrationStackOutput.yaml
@@ -46,7 +46,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- name
+- key
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/SniaLocalFileSystem.yaml
+++ b/product/views/SniaLocalFileSystem.yaml
@@ -61,7 +61,7 @@ order: Ascending
 
 # Columns to sort the report on, in order
 sortby:
-- class_name
+- evm_display_name
 
 # Group rows (y=yes,n=no,c=count)
 group: n


### PR DESCRIPTION
The views sometimes pick a field not on the screen.
The current code can only sort by a field on the screen.

So it ignores the one stated and the first column on the left.

This fixes the reports to pick one on the screen.
