### PR TITLE
Use find_by instead of dynamic find_by_ems_ref_and_ems_id

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggreg
 
   # if availability zone named in metadata exists, return it
   def availability_zone_obj
-    AvailabilityZone.find_by_ems_ref_and_ems_id(availability_zone, ems_id)
+    AvailabilityZone.find_by(:ems_ref => availability_zone, :ems_id => ems_id)
   end
 
   def self.create_aggregate_queue(userid, ext_management_system, options = {})


### PR DESCRIPTION
Addressed issue detected by CodeClimate.