### PR TITLE
[WIP] Add Amazon object storage automation model

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-s3.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-s3.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_S3 < MiqAeServiceManageIQ_Providers_StorageManager
+    expose :parent_manager,                :association => true
+    expose :cloud_object_store_containers, :association => true
+    expose :cloud_object_store_objects,    :association => true
+  end
+end


### PR DESCRIPTION
Similar changes to https://github.com/ManageIQ/manageiq/pull/13458.
Automation service model required for Amazon object storage manager.

Depends on ManageIQ/manageiq-providers-amazon#106.

@miq-bot add_label providers/amazon, automate/model