### PR TITLE
Add Amazon object storage refresh worker class

### DIFF
--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -38,6 +38,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker
     ManageIQ::Providers::Vmware::CloudManager::RefreshWorker
     ManageIQ::Providers::Vmware::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
@@ -95,6 +96,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
     ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/manageiq/pull/13457.

The new Amazon object storage refresh worker should be listed in monitored class names.

Depends on ManageIQ/manageiq-providers-amazon#106.

@miq-bot add_label providers/amazon, providers/storage, enhancement