### PR TITLE
Introduces CloudTenancyMixin to fix RBAC for cloud_tenant based models

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -6,6 +6,7 @@ class CloudVolume < ApplicationRecord
   include AsyncDeleteMixin
   include AvailabilityMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :availability_zone

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -69,10 +69,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   after_save :save_on_other_managers
 
   def save_on_other_managers
-    storage_managers.each do |manager|
-      manager.tenant_mapping_enabled = tenant_mapping_enabled
-      manager.save!
-    end
+    storage_managers.update_all(:tenant_mapping_enabled => tenant_mapping_enabled)
   end
 
   def supports_cloud_tenants?

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -66,6 +66,15 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     true
   end
 
+  after_save :save_on_other_managers
+
+  def save_on_other_managers
+    storage_managers.each do |manager|
+      manager.tenant_mapping_enabled = tenant_mapping_enabled
+      manager.save!
+    end
+  end
+
   def supports_cloud_tenants?
     true
   end

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -1,0 +1,19 @@
+module CloudTenancyMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    include TenancyCommonMixin
+
+    def tenant_id_clause_format(tenant_ids)
+      ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE", tenant_ids]
+    end
+
+    def tenant_joins_clause(scope)
+      scope.joins(:cloud_tenant => "source_tenant").joins(:ext_management_system)
+    end
+  end
+
+  def tenant
+    cloud_tenant
+  end
+end

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -5,7 +5,7 @@ module CloudTenancyMixin
     include TenancyCommonMixin
 
     def tenant_id_clause_format(tenant_ids)
-      ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE", tenant_ids]
+      ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", tenant_ids]
     end
 
     def tenant_joins_clause(scope)

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -9,7 +9,7 @@ module CloudTenancyMixin
     end
 
     def tenant_joins_clause(scope)
-      scope.joins(:cloud_tenant => "source_tenant").joins(:ext_management_system)
+      scope.includes(:cloud_tenant => "source_tenant").includes(:ext_management_system)
     end
   end
 

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -12,8 +12,4 @@ module CloudTenancyMixin
       scope.includes(:cloud_tenant => "source_tenant").includes(:ext_management_system)
     end
   end
-
-  def tenant
-    cloud_tenant
-  end
 end

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -4,6 +4,10 @@ module CloudTenancyMixin
   module ClassMethods
     include TenancyCommonMixin
 
+    def scope_by_cloud_tenant?
+      true
+    end
+
     def tenant_id_clause_format(tenant_ids)
       ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", tenant_ids]
     end

--- a/app/models/mixins/tenancy_common_mixin.rb
+++ b/app/models/mixins/tenancy_common_mixin.rb
@@ -1,0 +1,23 @@
+module TenancyCommonMixin
+  def scope_by_tenant?
+    true
+  end
+
+  def accessible_tenant_ids(user_or_group, strategy)
+    tenant = user_or_group.try(:current_tenant)
+    return [] if tenant.nil? || tenant.root?
+
+    tenant.accessible_tenant_ids(strategy)
+  end
+
+  def tenant_id_clause(user_or_group)
+    tenant_ids = accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(self))
+    return if tenant_ids.empty?
+
+    tenant_id_clause_format(tenant_ids)
+  end
+
+  def tenant_id_clause_format(tenant_ids)
+    {table_name => {:tenant_id => tenant_ids}}
+  end
+end

--- a/app/models/mixins/tenancy_common_mixin.rb
+++ b/app/models/mixins/tenancy_common_mixin.rb
@@ -1,8 +1,4 @@
 module TenancyCommonMixin
-  def scope_by_tenant?
-    true
-  end
-
   def accessible_tenant_ids(user_or_group, strategy)
     tenant = user_or_group.try(:current_tenant)
     return [] if tenant.nil? || tenant.root?

--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -6,23 +6,7 @@ module TenancyMixin
   end
 
   module ClassMethods
-    def scope_by_tenant?
-      true
-    end
-
-    def accessible_tenant_ids(user_or_group, strategy)
-      tenant = user_or_group.try(:current_tenant)
-      return [] if tenant.nil? || tenant.root?
-
-      tenant.accessible_tenant_ids(strategy)
-    end
-
-    def tenant_id_clause(user_or_group)
-      tenant_ids = accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(self))
-      return if tenant_ids.empty?
-
-      {table_name => {:tenant_id => tenant_ids}}
-    end
+    include TenancyCommonMixin
   end
 
   def set_tenant

--- a/app/models/mixins/tenancy_mixin.rb
+++ b/app/models/mixins/tenancy_mixin.rb
@@ -7,6 +7,10 @@ module TenancyMixin
 
   module ClassMethods
     include TenancyCommonMixin
+
+    def scope_by_tenant?
+      true
+    end
   end
 
   def set_tenant

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -428,6 +428,10 @@ module Rbac
       user_or_group = user || miq_group
       tenant_id_clause = klass.tenant_id_clause(user_or_group)
 
+      if klass.respond_to?(:tenant_joins_clause)
+        scope = klass.tenant_joins_clause(scope)
+      end
+
       tenant_id_clause ? scope.where(tenant_id_clause) : scope
     end
 

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -427,12 +427,14 @@ module Rbac
       klass = scope.respond_to?(:klass) ? scope.klass : scope
       user_or_group = user || miq_group
       tenant_id_clause = klass.tenant_id_clause(user_or_group)
-
-      if klass.respond_to?(:tenant_joins_clause)
-        scope = klass.tenant_joins_clause(scope)
-      end
-
       tenant_id_clause ? scope.where(tenant_id_clause) : scope
+    end
+
+    def scope_to_cloud_tenant(scope, user, miq_group)
+      klass = scope.respond_to?(:klass) ? scope.klass : scope
+      user_or_group = user || miq_group
+      tenant_id_clause = klass.tenant_id_clause(user_or_group)
+      klass.tenant_joins_clause(scope).where(tenant_id_clause)
     end
 
     ##
@@ -444,6 +446,8 @@ module Rbac
       # TENANT_ACCESS_STRATEGY are a consolidated list of them.
       if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
         scope = scope_to_tenant(scope, user, miq_group)
+      elsif klass.respond_to?(:scope_by_cloud_tenant?) && klass.scope_by_cloud_tenant?
+        scope = scope_to_cloud_tenant(scope, user, miq_group)
       end
 
       if apply_rbac_directly?(klass)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1404,33 +1404,31 @@ describe Rbac::Filterer do
     let(:project2_volume)       { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_openstack, :cloud_tenant => project2_cloud_tenant) }
     let(:ems_other)             { FactoryGirl.create(:ems_cloud, :name => 'ems_other', :tenant_mapping_enabled => false) }
     let(:volume_other)          { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_other) }
-    let(:all_volumes)           { [project1_volume, project2_volume, volume_other] }
+    let!(:all_volumes)          { [project1_volume, project2_volume, volume_other] }
 
-    it "cloud_tenant should see its own cloud volumes and other volumes where tenant_mapping is not enabled" do
-      all_volumes
+    it "lists its own cloud volumes and other volumes where tenant_mapping is not enabled" do
       ems_openstack.tenant_mapping_enabled = true
       ems_openstack.save!
-      results = described_class.search(:class => "CloudVolume", :user => project1_user).first
+      results = described_class.search(:class => CloudVolume, :user => project1_user).first
       expect(results).to match_array [project1_volume, volume_other]
 
-      results = described_class.search(:class => "CloudVolume", :user => project2_user).first
+      results = described_class.search(:class => CloudVolume, :user => project2_user).first
       expect(results).to match_array [project2_volume, volume_other]
 
-      results = described_class.search(:class => "CloudVolume", :user => owner_user).first
+      results = described_class.search(:class => CloudVolume, :user => owner_user).first
       expect(results).to match_array [volume_other]
     end
 
-    it "all cloud volumes should be visible to all users when tenant_mapping is not enabled" do
-      all_volumes
+    it "all cloud volumes are visible to all users when tenant_mapping is not enabled" do
       ems_openstack.tenant_mapping_enabled = false
       ems_openstack.save!
-      results = described_class.search(:class => "CloudVolume", :user => project1_user).first
+      results = described_class.search(:class => CloudVolume, :user => project1_user).first
       expect(results).to match_array [project1_volume, project2_volume, volume_other]
 
-      results = described_class.search(:class => "CloudVolume", :user => project2_user).first
+      results = described_class.search(:class => CloudVolume, :user => project2_user).first
       expect(results).to match_array [project1_volume, project2_volume, volume_other]
 
-      results = described_class.search(:class => "CloudVolume", :user => owner_user).first
+      results = described_class.search(:class => CloudVolume, :user => owner_user).first
       expect(results).to match_array [project1_volume, project2_volume, volume_other]
     end
   end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1390,6 +1390,50 @@ describe Rbac::Filterer do
     end
   end
 
+  describe "cloud_tenant based search" do
+    let(:ems_openstack)         { FactoryGirl.create(:ems_cloud) }
+    let(:project1_tenant)       { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }
+    let(:project1_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project1_tenant) }
+    let(:project1_group)        { FactoryGirl.create(:miq_group, :tenant => project1_tenant) }
+    let(:project1_user)         { FactoryGirl.create(:user, :miq_groups => [project1_group]) }
+    let(:project1_volume)       { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_openstack, :cloud_tenant => project1_cloud_tenant) }
+    let(:project2_tenant)       { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }
+    let(:project2_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project2_tenant) }
+    let(:project2_group)        { FactoryGirl.create(:miq_group, :tenant => project2_tenant) }
+    let(:project2_user)         { FactoryGirl.create(:user, :miq_groups => [project2_group]) }
+    let(:project2_volume)       { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_openstack, :cloud_tenant => project2_cloud_tenant) }
+    let(:ems_other)             { FactoryGirl.create(:ems_cloud, :name => 'ems_other', :tenant_mapping_enabled => false) }
+    let(:volume_other)          { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_other) }
+    let(:all_volumes)           { [project1_volume, project2_volume, volume_other] }
+
+    it "cloud_tenant should see its own cloud volumes and other volumes where tenant_mapping is not enabled" do
+      all_volumes
+      ems_openstack.tenant_mapping_enabled = true
+      ems_openstack.save!
+      results = described_class.search(:class => "CloudVolume", :user => project1_user).first
+      expect(results).to match_array [project1_volume, volume_other]
+
+      results = described_class.search(:class => "CloudVolume", :user => project2_user).first
+      expect(results).to match_array [project2_volume, volume_other]
+
+      results = described_class.search(:class => "CloudVolume", :user => owner_user).first
+      expect(results).to match_array [volume_other]
+    end
+
+    it "all cloud volumes should be visible to all users when tenant_mapping is not enabled" do
+      all_volumes
+      ems_openstack.tenant_mapping_enabled = false
+      ems_openstack.save!
+      results = described_class.search(:class => "CloudVolume", :user => project1_user).first
+      expect(results).to match_array [project1_volume, project2_volume, volume_other]
+
+      results = described_class.search(:class => "CloudVolume", :user => project2_user).first
+      expect(results).to match_array [project1_volume, project2_volume, volume_other]
+
+      results = described_class.search(:class => "CloudVolume", :user => owner_user).first
+      expect(results).to match_array [project1_volume, project2_volume, volume_other]
+    end
+  end
 
   private
 

--- a/spec/models/mixins/cloud_tenancy_mixin_spec.rb
+++ b/spec/models/mixins/cloud_tenancy_mixin_spec.rb
@@ -1,0 +1,25 @@
+describe CloudTenancyMixin do
+  let(:root_tenant) do
+    Tenant.seed
+  end
+
+  let(:default_tenant) do
+    root_tenant
+    Tenant.default_tenant
+  end
+
+  describe "miq_group" do
+    let(:user)         { FactoryGirl.create(:user, :userid => 'user', :miq_groups => [tenant_group]) }
+    let(:tenant)       { FactoryGirl.build(:tenant, :parent => default_tenant) }
+    let(:tenant_users) { FactoryGirl.create(:miq_user_role, :name => "tenant-users") }
+    let(:tenant_group) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_users, :tenant => tenant) }
+
+    it "finds correct tenant id clause for regular tenants" do
+      expect(VmOrTemplate.tenant_id_clause(user)).to eql ["(vms.template = true AND vms.tenant_id IN (?)) OR (vms.template = false AND vms.tenant_id IN (?))", [default_tenant.id, tenant.id], [tenant.id]]
+    end
+
+    it "finds correct tenant id clause for cloud tenants" do
+      expect(CloudVolume.tenant_id_clause(user)).to eql ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE", [tenant.id]]
+    end
+  end
+end

--- a/spec/models/mixins/cloud_tenancy_mixin_spec.rb
+++ b/spec/models/mixins/cloud_tenancy_mixin_spec.rb
@@ -19,7 +19,7 @@ describe CloudTenancyMixin do
     end
 
     it "finds correct tenant id clause for cloud tenants" do
-      expect(CloudVolume.tenant_id_clause(user)).to eql ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE", [tenant.id]]
+      expect(CloudVolume.tenant_id_clause(user)).to eql ["(tenants.id IN (?) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", [tenant.id]]
     end
   end
 end


### PR DESCRIPTION
RBAC is broken for models based on cloud_tenant instead of tenant.
Currently a cloud tenant user can see all cloud_tenant based
objects. This patches introduces a CloudTenancyMixin that a
cloud_tenant model can include for RBAC to work correctly.

CloudTenancyMixin is similar to TenancyMixin in that it defines
methods used by Rbac.Filterer.scope_targets to filter results
so that users only sees objects that belong to their tenant
groups.

CloudVolume now includes CloudTenancyMixin which fixes issue

Additional models using cloud_tenant will be updated in subsequent
patches.

Fixes 
----------------

* https://github.com/ManageIQ/manageiq/issues/13343#issuecomment-270410029

Steps for Testing/QA [Optional]
-------------------------------

In OpenStack Dashboard,
* create two projects, project1 and project2, add the admin user as a admin to both projects (otherwise you won't be able to setup the groups users in ManageIQ as the admin user)
* create one volume in project1
* create one volume in project2

Verify you have Tenant Mapping Enabled set to True for your OpenStack Cloud Provider. If not recreate it.

Under Configuration > Access Control > Groups
* create an admin group for project/tenant project1 and has role EvmRole-super_administrator
* create an admin group for project/tenant project2 and has role EvmRole-super_administrator

Under Configuration > Access Control > Users
* create a user project1-admin who belongs to project1 admin group and has EvmRole-super_administrator role
* create a user project2-admin who belongs to project2 admin group and has EvmRole-super_administrator role

Login as project1-admin, navigate to Storage > Block Storage > Volumes, and verify you only see volumes belonging to project1
Login as project2-admin, navigate to Storage > Block Storage > Volumes, and verify you only see volumes belonging to project2

