### PR TITLE
[WIP] Make OrchestrationTemplate self referential

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -8,6 +8,9 @@ class OrchestrationTemplate < ApplicationRecord
 
   has_many :stacks, :class_name => "OrchestrationStack"
 
+  belongs_to :parent, :class_name => "OrchestrationTemplate"
+  has_many :children, :class_name => "OrchestrationTemplate", :foreign_key => 'parent_id'
+
   default_value_for :draft, false
   default_value_for :orderable, true
 

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -8,8 +8,7 @@ class OrchestrationTemplate < ApplicationRecord
 
   has_many :stacks, :class_name => "OrchestrationStack"
 
-  belongs_to :parent, :class_name => "OrchestrationTemplate"
-  has_many :children, :class_name => "OrchestrationTemplate", :foreign_key => 'parent_id'
+  has_ancestry
 
   default_value_for :draft, false
   default_value_for :orderable, true

--- a/db/migrate/20170116200958_self_referential_orchestration_template.rb
+++ b/db/migrate/20170116200958_self_referential_orchestration_template.rb
@@ -1,8 +1,8 @@
 class SelfReferentialOrchestrationTemplate < ActiveRecord::Migration[5.0]
   def change
     change_table :orchestration_templates do |t|
-      t.references :parent, index: true, comment: "Nested template reference"
-      t.string :url, comment: "URL for nested/child template"
+      t.string :ancestry, :index => true, :comment => "Required field for ancestry gem"
+      t.string :url, :comment => "URL for nested/child template"
     end
   end
 end

--- a/db/migrate/20170116200958_self_referential_orchestration_template.rb
+++ b/db/migrate/20170116200958_self_referential_orchestration_template.rb
@@ -1,0 +1,8 @@
+class SelfReferentialOrchestrationTemplate < ActiveRecord::Migration[5.0]
+  def change
+    change_table :orchestration_templates do |t|
+      t.references :parent, index: true, comment: "Nested template reference"
+      t.string :url, comment: "URL for nested/child template"
+    end
+  end
+end


### PR DESCRIPTION
The idea here is to support the concept of nested (linked) templates, i.e. templates with links to other templates. The "main" template would serve as the parent, with all other templates serving as children, potentially having children of their own.

Each child template would store a URL reference to its location that the parent could obtain, and since the children are using the same table, could store their content as well. How MIQ uses that content or URL is up to the app, but it would be readily available in a logical manner.

The ultimate goal here is to improve support for provisioning from nested templates, initially for AWS, but also for other providers. Currently you cannot access a nested template within ManageIQ, they are only URL's within the parent, which makes them difficult to manage.

With this in place you might have a template like this:

```
...
"name": "MyTemplate"
"resources": [ 
  { 
      "apiVersion": "2015-01-01", 
      "name": "linkedTemplate", 
      "type": "Microsoft.Resources/deployments", 
      "properties": { 
        "mode": "incremental", 
        "templateLink": {
          "uri": "https://www.contoso.com/AzureTemplates/newStorageAccount.json",
          "contentVersion": "1.0.0.0"
        }, 
        "parameters": { 
          "StorageAccountName":{"value": "[parameters('StorageAccountName')]"} 
        } 
      } 
  } 
]
```
Assuming these had been added as two separate records, with the parent_id set for the linked template, you could do:

    parent = OrchestrationTemplate.find_by_name("MyTemplate")
    child = parent.children.first
    child.url # "https://www.contoso.com/AzureTemplates/newStorageAccount.json"
    child.content # Presumably the content of that URL
    child.parent # reference back to the parent.

