### PR TITLE
Add Amazon EC2 block storage manager EMS

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -20,6 +20,7 @@
 - ems-type:cinder
 - ems-type:ec2
 - ems-type:ec2_network
+- ems-type:ec2_block_storage
 - ems-type:foreman_configuration
 - ems-type:foreman_provisioning
 - ems-type:gce

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -23,6 +23,7 @@ describe ExtManagementSystem do
       "azure_network"               => "Azure Network",
       "ec2"                         => "Amazon EC2",
       "ec2_network"                 => "Amazon EC2 Network",
+      "ec2_block_storage"           => "Amazon EBS",
       "foreman_configuration"       => "Foreman Configuration",
       "foreman_provisioning"        => "Foreman Provisioning",
       "gce"                         => "Google Compute Engine",


### PR DESCRIPTION
Resolves the problem with the new EC2 block storage manager not being registered with the ext management system.

@miq-bot add_label providers/amazon,providers/storage/