### PR TITLE
Add 'delete' to generic object configuration dropdown

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2343,6 +2343,10 @@
       :description: Generic Object Definition Edit
       :feature_type: node
       :identifier: generic_object_definition_edit
+    - :name: Generic Object Definition Delete
+      :description: Generic Object Definition Delete
+      :feature_type: node
+      :identifier: generic_object_definition_delete
 
 # Automate Import/Export
 - :name: Import/Export


### PR DESCRIPTION
This is a re-submit of https://github.com/ManageIQ/manageiq/pull/12102, but without the UI pieces, only the `db/fixtures` file to add the corresponding 'delete' button to the configuration drop-down.

Before deletion:
![screen shot 2016-10-21 at 9 03 14 am](https://cloud.githubusercontent.com/assets/164557/19605133/47d8535e-976d-11e6-93b2-8d7961510e45.png)

After deletion:
![screen shot 2016-10-21 at 9 01 15 am](https://cloud.githubusercontent.com/assets/164557/19605086/1b7c5792-976d-11e6-905f-42d171443540.png)

https://www.pivotaltracker.com/story/show/129980083

@miq-bot assign @gmcculloug 