### PR TITLE
Update querying specs for virtual attribute sort

### DIFF
--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -105,15 +105,15 @@ describe "Querying" do
     it 'supports sql friendly virtual attributes' do
       host_foo =  FactoryGirl.create(:host, :name => 'foo')
       host_bar =  FactoryGirl.create(:host, :name => 'bar')
-      vm_foo = FactoryGirl.create(:vm, :name => 'vm_foo')
-      vm_bar = FactoryGirl.create(:vm, :name => 'vm_bar')
-      host_foo.vms << vm_foo
-      host_bar.vms << vm_bar
+      host_zap =  FactoryGirl.create(:host, :name => 'zap')
+      FactoryGirl.create(:vm, :name => 'vm_foo', :host => host_foo)
+      FactoryGirl.create(:vm, :name => 'vm_bar', :host => host_bar)
+      FactoryGirl.create(:vm, :name => 'vm_zap', :host => host_zap)
 
       run_get vms_url, :sort_by => 'host_name', :sort_order => 'desc', :expand => 'resources'
 
-      expect_query_result(:vms, 2, 2)
-      expect_result_resources_to_match_hash([{'name' => 'vm_foo'}, {'name' => 'vm_bar'}])
+      expect_query_result(:vms, 3, 3)
+      expect_result_resources_to_match_hash([{'name' => 'vm_zap'}, {'name' => 'vm_foo'}, {'name' => 'vm_bar'}])
     end
 
     it 'does not support non sql friendly virtual attributes' do


### PR DESCRIPTION
This is an update to the specs from #13409. It creates 3 VMs out of order to ensure that the sorting is done properly.

cc: @imtayadeway (good catch - thanks for the suggestion 😄 )
@miq-bot add_label enhancement, api, test
@miq-bot assign @abellotti 
