### PR TITLE
[DARGA] Handle duplicate purge events

### DIFF
--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -284,19 +284,6 @@ describe EmsEvent do
           :args        => [purge_time]
         )
       end
-
-      it "with item already in the queue" do
-        new_purge_time = (Time.now + 20).round
-        described_class.purge_queue(new_purge_time)
-
-        q = MiqQueue.all
-        expect(q.length).to eq(1)
-        expect(q.first).to have_attributes(
-          :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [new_purge_time]
-        )
-      end
     end
 
     context ".purge" do


### PR DESCRIPTION
We no longer only insert unique purge events.

This PR updates the specs to match what is on master [[ref]](https://github.com/ManageIQ/manageiq/blob/master/spec/models/event_stream/purging_spec.rb)

This fixes a breaking spec from the back port of #11813

(cherry picked from commit a9497c3d792341e1c81113a7a071e634a92bdc03)

 https://bugzilla.redhat.com/show_bug.cgi?id=1412448

