### PR TITLE
GraphRefresh: allow an array to branch into GraphRefresh

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -1,8 +1,12 @@
 module EmsRefresh::SaveInventory
   def save_ems_inventory(ems, hashes, target = nil)
+    if hashes.kind_of?(Array)
+      ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
+      return
+    end
     if hashes && hashes[:_inventory_collection]
       hashes.delete(:_inventory_collection)
-      ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
+      ManagerRefresh::SaveInventory.save_inventory(ems, hashes.values)
       return
     end
     case ems

--- a/app/models/manager_refresh/save_collection/recursive.rb
+++ b/app/models/manager_refresh/save_collection/recursive.rb
@@ -4,7 +4,7 @@ module ManagerRefresh::SaveCollection
 
     class << self
       def save_collections(ems, inventory_collections)
-        graph = ManagerRefresh::InventoryCollection::Graph.new(inventory_collections.values)
+        graph = ManagerRefresh::InventoryCollection::Graph.new(inventory_collections)
         graph.build_directed_acyclic_graph!
 
         graph.nodes.each do |inventory_collection|

--- a/app/models/manager_refresh/save_collection/topological_sort.rb
+++ b/app/models/manager_refresh/save_collection/topological_sort.rb
@@ -4,7 +4,7 @@ module ManagerRefresh::SaveCollection
 
     class << self
       def save_collections(ems, inventory_collections)
-        graph = ManagerRefresh::InventoryCollection::Graph.new(inventory_collections.values)
+        graph = ManagerRefresh::InventoryCollection::Graph.new(inventory_collections)
         graph.build_directed_acyclic_graph!
 
         layers = ManagerRefresh::Graph::TopologicalSort.new(graph).topological_sort

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -93,7 +93,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -132,7 +132,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert that saved data have the updated values, checking id to make sure the original records are updated
           assert_full_inventory_collections_graph
@@ -182,7 +182,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -269,7 +269,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -376,7 +376,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:hardwares], @hardware_data_1)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")
@@ -395,7 +395,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:hardwares], @hardware_data_1)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")
@@ -414,7 +414,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(@data[:hardwares], @hardware_data_1)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
@@ -319,7 +319,7 @@ describe ManagerRefresh::SaveInventory do
                                              @orchestration_stack_resource_data_12_23)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert saved data
             assert_full_inventory_collections_graph
@@ -351,7 +351,7 @@ describe ManagerRefresh::SaveInventory do
                                              @orchestration_stack_resource_data_12_23)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert saved data
             assert_full_inventory_collections_graph
@@ -389,7 +389,7 @@ describe ManagerRefresh::SaveInventory do
                                              @orchestration_stack_resource_data_12_23)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert saved data
             assert_full_inventory_collections_graph
@@ -421,7 +421,7 @@ describe ManagerRefresh::SaveInventory do
                                              @orchestration_stack_resource_data_12_23)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert saved data
             assert_full_inventory_collections_graph
@@ -483,7 +483,7 @@ describe ManagerRefresh::SaveInventory do
                                            @network_port_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -553,7 +553,7 @@ describe ManagerRefresh::SaveInventory do
                                            @network_port_3)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
           # Assert saved data
           assert_full_inventory_collections_graph
 
@@ -593,7 +593,7 @@ describe ManagerRefresh::SaveInventory do
 
           # Invoke the InventoryCollections saving and check we raise an exception that a cycle was found, after we
           # attempted to remove the cycles.
-          expect { ManagerRefresh::SaveInventory.save_inventory(@ems, @data) }.to raise_error(/^Cycle from /)
+          expect { ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values) }.to raise_error(/^Cycle from /)
         end
 
         it 'test network_port -> network_port -> stack -> resource -> stack' do
@@ -680,7 +680,7 @@ describe ManagerRefresh::SaveInventory do
           # Invoke the InventoryCollections saving and check we raise an exception that a cycle was found, after we
           # attempted to remove the cycles.
           # TODO(lsmola) make this spec pass, by enhancing the logic around transitive edges
-          expect { ManagerRefresh::SaveInventory.save_inventory(@ems, @data) }.to raise_error(/^Cycle from /)
+          expect { ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values) }.to raise_error(/^Cycle from /)
         end
 
         it 'test network_port -> stack -> resource -> stack and network_port -> resource -> stack -> resource -> stack ' do
@@ -740,7 +740,7 @@ describe ManagerRefresh::SaveInventory do
                                            @network_port_4)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -794,7 +794,7 @@ describe ManagerRefresh::SaveInventory do
                                            @orchestration_stack_resource_data_12_23)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph
@@ -870,7 +870,7 @@ describe ManagerRefresh::SaveInventory do
                                            @orchestration_stack_resource_data_12_23)
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
           assert_full_inventory_collections_graph

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -28,7 +28,7 @@ describe ManagerRefresh::SaveInventory do
         initialize_inventory_collection_data
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -41,7 +41,7 @@ describe ManagerRefresh::SaveInventory do
         initialize_inventory_collection_data
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -70,7 +70,7 @@ describe ManagerRefresh::SaveInventory do
         add_data_to_inventory_collection(@data[:disks], @disk_data_3, @disk_data_31)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         load_records
         @vm3          = Vm.find_by(:ems_ref => "vm_ems_ref_3")
@@ -122,7 +122,7 @@ describe ManagerRefresh::SaveInventory do
         initialize_inventory_collection_data
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -146,7 +146,7 @@ describe ManagerRefresh::SaveInventory do
                                          @hardware_data_3)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         ### Third refresh ###
         # Initialize the InventoryCollections and data for the disks with new disk under a vm
@@ -169,7 +169,7 @@ describe ManagerRefresh::SaveInventory do
         add_data_to_inventory_collection(@data[:disks], @disk_data_3, @disk_data_31)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -234,7 +234,7 @@ describe ManagerRefresh::SaveInventory do
         add_data_to_inventory_collection(@data[:disks], @disk_data_3, @disk_data_32)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -288,7 +288,7 @@ describe ManagerRefresh::SaveInventory do
         initialize_inventory_collection_data
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -332,7 +332,7 @@ describe ManagerRefresh::SaveInventory do
         add_data_to_inventory_collection(@data[:disks], @disk_data_3, @disk_data_31)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records
@@ -422,7 +422,7 @@ describe ManagerRefresh::SaveInventory do
                                          @disk_data_5)
 
         # Invoke the InventoryCollections saving
-        ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+        ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
         # Assert all data were filled
         load_records

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -38,7 +38,7 @@ describe ManagerRefresh::SaveInventory do
           add_data_to_inventory_collection(data[:vms], vm_data(1), vm_data(2))
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
           # Assert saved data
           assert_all_records_match_hashes(
@@ -59,7 +59,7 @@ describe ManagerRefresh::SaveInventory do
                                            vm_data(2))
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
           # Assert that saved data have the updated values, checking id to make sure the original records are updated
           assert_all_records_match_hashes(
@@ -83,7 +83,7 @@ describe ManagerRefresh::SaveInventory do
                                            vm_data(2).merge(:name => "vm_changed_name_2"))
 
           # Invoke the InventoryCollections saving
-          ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+          ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
           # Assert that saved data have the updated values, checking id to make sure the original records are updated
           assert_all_records_match_hashes(
@@ -123,7 +123,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(2).merge(:name => "vm_changed_name_2"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data have the updated values, checking id to make sure the original records are updated
             assert_all_records_match_hashes(
@@ -140,7 +140,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data contain the new VM
             assert_all_records_match_hashes(
@@ -156,7 +156,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(1).merge(:name => "vm_changed_name_1"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data do miss the deleted VM
             assert_all_records_match_hashes(
@@ -171,7 +171,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
@@ -199,7 +199,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that DB still contains the disconnected VMs
             assert_all_records_match_hashes(
@@ -310,7 +310,7 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:vms], *changed_data)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data don;t have the blacklisted attributes updated nor filled
             assert_all_records_match_hashes(
@@ -348,7 +348,7 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:vms], *changed_data)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data don;t have the blacklisted attributes updated nor filled
             assert_all_records_match_hashes(
@@ -387,7 +387,7 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:vms], *changed_data)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data don;t have the blacklisted attributes updated nor filled
             assert_all_records_match_hashes(
@@ -427,7 +427,7 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:vms], *changed_data)
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data don;t have the blacklisted attributes updated nor filled
             assert_all_records_match_hashes(
@@ -471,7 +471,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, @data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
             # Assert that saved data contain the new VM, but no VM was deleted
             assert_all_records_match_hashes(
@@ -499,7 +499,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3", :ext_management_system => @ems))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
@@ -524,7 +524,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3", :ext_management_system => @ems))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
@@ -549,7 +549,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
@@ -582,7 +582,7 @@ describe ManagerRefresh::SaveInventory do
                                              vm_data(3).merge(:name => "vm_changed_name_3"))
 
             # Invoke the InventoryCollections saving
-            ManagerRefresh::SaveInventory.save_inventory(@ems, data)
+            ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(


### PR DESCRIPTION
remove the need to pass an hash to `save_ems_inventory`
In case its an Array, assume its a GraphRefresh

No need to build up a hash if we only use values


@Ladas please review