### PR TITLE
[DARGA] Accept option to delete all associated resources

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_stack.rb
@@ -41,9 +41,10 @@ class ManageIQ::Providers::Azure::CloudManager::OrchestrationStack < ManageIQ::P
     raise MiqException::MiqOrchestrationUpdateError, err.to_s, err.backtrace
   end
 
-  def raw_delete_stack
+  def raw_delete_stack(delete_all = false)
     ext_management_system.with_provider_connection do |configure|
-      Azure::Armrest::TemplateDeploymentService.new(configure).delete(name, resource_group)
+      tds = Azure::Armrest::TemplateDeploymentService.new(configure)
+      delete_all ? tds.delete_associated_resources(name, resource_group) : tds.delete(name, resource_group)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"


### PR DESCRIPTION
Upstream https://github.com/ManageIQ/manageiq-providers-azure/pull/24 commit 71e9ea4a549450dda09c34a95a8911d566821046

There is a difference from the upstream where by default all resources are deleted
with the stack. For Darga we will only delete resources when the flag is on.

https://bugzilla.redhat.com/show_bug.cgi?id=1414005