### PR TITLE
Rename EC2 block storage to EC2 EBS storage

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -20,7 +20,7 @@
 - ems-type:cinder
 - ems-type:ec2
 - ems-type:ec2_network
-- ems-type:ec2_block_storage
+- ems-type:ec2_ebs_storage
 - ems-type:foreman_configuration
 - ems-type:foreman_provisioning
 - ems-type:gce

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -23,7 +23,7 @@ describe ExtManagementSystem do
       "azure_network"               => "Azure Network",
       "ec2"                         => "Amazon EC2",
       "ec2_network"                 => "Amazon EC2 Network",
-      "ec2_block_storage"           => "Amazon EBS",
+      "ec2_ebs_storage"             => "Amazon EBS",
       "foreman_configuration"       => "Foreman Configuration",
       "foreman_provisioning"        => "Foreman Provisioning",
       "gce"                         => "Google Compute Engine",


### PR DESCRIPTION
The initial version of the Amazon block storage manager used the name
`ec2_block_storage` which has now been replaced with `ec2_ebs_storage`
to make it more explicit. This patch fixes the `ext_management_system`
spec and the corresponding tamplate to use the new name.

@miq-bot add_label providers/amazon,providers/storage,wip