### PR TITLE
Rename Amazon storage manager AE models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolume < MiqAeServiceCloudVolume
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager < MiqAeServiceManageIQ_Providers_StorageManager
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolume < MiqAeServiceCloudVolume
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume_snapshot.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs < MiqAeServiceManageIQ_Providers_StorageManager
+  end
+end


### PR DESCRIPTION
This patch accompanies the renaiming of Amazon `BlockStorageManager`
into `StorageManager::Ebs`. It merely renames the corresponding
automation models.

@miq-bot label providers/amazon,providers/storage,automate/model,wip