### PR TITLE
VMs/Snapshots API CRD

### DIFF
--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -23,6 +23,18 @@ module Api
         action_result(false, e.to_s)
       end
 
+      def delete_resource_snapshots(parent, type, id, _data)
+        validation = parent.validate_remove_snapshot(id)
+        raise validation[:message] unless validation[:available]
+        snapshot = resource_search(id, type, collection_class(type))
+
+        task_id = queue_object_action(parent, "summary", :method_name => "remove_snapshot", :args => [id])
+        action_result(true, "Deleting snapshot #{snapshot.name} for #{snapshot_ident(parent)}", :task_id => task_id)
+      rescue => e
+        action_result(false, e.to_s)
+      end
+      alias snapshots_delete_resource delete_resource_snapshots
+
       private
 
       def snapshot_ident(parent)

--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -4,6 +4,32 @@ module Api
       def snapshots_query_resource(object)
         object.snapshots
       end
+
+      def snapshots_create_resource(parent, _type, _id, data)
+        raise "Must specify a name for the snapshot" unless data["name"].present?
+
+        validation = parent.validate_create_snapshot
+        raise validation[:message] unless validation[:available]
+
+        task_id = queue_object_action(
+          parent,
+          "summary",
+          :method_name => "create_snapshot",
+          :args        => [data["name"], data["description"], data.fetch("memory", false)]
+        )
+
+        action_result(true, "Creating snapshot #{data["name"]} for #{snapshot_ident(parent)}", :task_id => task_id)
+      rescue => e
+        action_result(false, e.to_s)
+      end
+
+      private
+
+      def snapshot_ident(parent)
+        klass = parent.class
+        klass_ident = klass.respond_to?(:base_model) ? klass.base_model.name : klass.name
+        "#{klass_ident} id:#{parent.id} name:'#{parent.name}'"
+      end
     end
   end
 end

--- a/app/controllers/api/subcollections/snapshots.rb
+++ b/app/controllers/api/subcollections/snapshots.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Snapshots
+      def snapshots_query_resource(object)
+        object.snapshots
+      end
+    end
+  end
+end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -6,6 +6,7 @@ module Api
     include Subcollections::Accounts
     include Subcollections::CustomAttributes
     include Subcollections::Software
+    include Subcollections::Snapshots
 
     def start_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id

--- a/config/api.yml
+++ b/config/api.yml
@@ -1593,6 +1593,10 @@
       :get:
       - :name: read
         :identifier: vm_snapshot_view
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: vm_snapshot_view
   :software:
     :description: Software
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -1583,6 +1583,16 @@
       :get:
       - :name: read
         :identifier: ops_settings
+  :snapshots:
+    :description: Snapshots
+    :options:
+    - :subcollection
+    :verbs: *g
+    :klass: Snapshot
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: vm_snapshot_view
   :software:
     :description: Software
     :options:
@@ -1876,6 +1886,7 @@
     - :accounts
     - :custom_attributes
     - :software
+    - :snapshots
     :collection_actions:
       :get:
       - :name: read

--- a/config/api.yml
+++ b/config/api.yml
@@ -1587,12 +1587,15 @@
     :description: Snapshots
     :options:
     - :subcollection
-    :verbs: *g
+    :verbs: *gp
     :klass: Snapshot
     :subcollection_actions:
       :get:
       - :name: read
         :identifier: vm_snapshot_view
+      :post:
+      - :name: create
+        :identifier: vm_snapshot_add
     :subresource_actions:
       :get:
       - :name: read

--- a/config/api.yml
+++ b/config/api.yml
@@ -1587,7 +1587,7 @@
     :description: Snapshots
     :options:
     - :subcollection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: Snapshot
     :subcollection_actions:
       :get:
@@ -1600,6 +1600,12 @@
       :get:
       - :name: read
         :identifier: vm_snapshot_view
+      :post:
+      - :name: delete
+        :identifier: vm_snapshot_delete
+      :delete:
+      - :name: delete
+        :identifier: vm_snapshot_delete
   :software:
     :description: Software
     :options:

--- a/spec/factories/snapshot.rb
+++ b/spec/factories/snapshot.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
   factory :snapshot do
+    vm_or_template { create(:vm_vmware) }
+    create_time { 1.minute.ago }
   end
 end

--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "Snapshots API" do
+  describe "as a subcollection of VMs" do
+    describe "GET /api/vms/:c_id/snapshots" do
+      it "can list the snapshots of a VM" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
+        vm = FactoryGirl.create(:vm_vmware)
+        snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
+        _other_snapshot = FactoryGirl.create(:snapshot)
+
+        run_get("#{vms_url(vm.id)}/snapshots")
+
+        expected = {
+          "count"     => 2,
+          "name"      => "snapshots",
+          "subcount"  => 1,
+          "resources" => [
+            {"href" => a_string_matching("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")}
+          ]
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not list snapshots unless authorized" do
+        api_basic_authorize
+        vm = FactoryGirl.create(:vm_vmware)
+        FactoryGirl.create(:snapshot, :vm_or_template => vm)
+
+        run_get("#{vms_url(vm.id)}/snapshots")
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -32,4 +32,34 @@ RSpec.describe "Snapshots API" do
       end
     end
   end
+
+  describe "GET /api/vms/:c_id/snapshots/:s_id" do
+    it "can show a VM's snapshot" do
+      api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
+      vm = FactoryGirl.create(:vm_vmware)
+      create_time = Time.zone.parse("2017-01-11T00:00:00Z")
+      snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm, :create_time => create_time)
+
+      run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+
+      expected = {
+        "create_time"       => create_time.iso8601,
+        "href"              => a_string_matching("#{vms_url(vm.id)}/snapshots/#{snapshot.id}"),
+        "id"                => snapshot.id,
+        "vm_or_template_id" => vm.id
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not show a snapshot unless authorized" do
+      api_basic_authorize
+      vm = FactoryGirl.create(:vm_vmware)
+      snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
+
+      run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end


### PR DESCRIPTION
~~Here's a naive implementation of the Snapshots API, which I'm submitting for early feedback.~~

~~@abellotti I'll work on making the implementation more nuanced (i.e. error handling, etc...), but would you like to go over the high-level design together?~~

Adds CRD actions for snapshots of VMs

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1399526

@miq-bot add-label api, wip
@miq-bot assign @abellotti 

# Examples

## index

```
GET http://localhost:3000/api/vms/1000000002002/snapshots
Authorization: Basic YWRtaW46c21hcnR2bQ==
```

```
{
  "actions": [
    {
      "href": "http://localhost:3000/api/vms/1000000002002/snapshots",
      "method": "post",
      "name": "create"
    }
  ],
  "resources": [
    {
      "href": "http://localhost:3000/api/vms/1000000002002/snapshots/1000000005471"
    }
  ],
  "subcount": 1,
  "count": 187,
  "name": "snapshots"
}
```

## show

```
GET http://localhost:3000/api/vms/1000000002002/snapshots/1000000005471
Authorization: Basic YWRtaW46c21hcnR2bQ==
```

```
{
  "actions": [
    {
      "href": "http://localhost:3000/api/vms/1000000002002/snapshots/1000000005471",
      "method": "post",
      "name": "delete"
    },
    {
      "href": "http://localhost:3000/api/vms/1000000002002/snapshots/1000000005471",
      "method": "delete",
      "name": "delete"
    }
  ],
  "uid_ems": "00517423-dfb3-411d-915d-79eeaa85df9f",
  "vm_or_template_id": 1000000002002,
  "updated_on": "2014-11-24T12:14:26Z",
  "created_on": "2014-11-19T21:17:51Z",
  "disks": [],
  "create_time": "2014-11-19T21:21:31Z",
  "current": 1,
  "description": "Active VM",
  "name": "Active VM",
  "uid": "00517423-dfb3-411d-915d-79eeaa85df9f",
  "id": 1000000005471,
  "href": "http://localhost:3000/api/vms/1000000002002/snapshots/1000000005471"
}
```

## create

### happy path

```
POST http://localhost:3000/api/vms/1000000002158/snapshots
Authorization: Basic YWRtaW46c21hcnR2bQ==

{
  "name": "Tim's snapshot"
}

```
```
{
  "results": [
    {
      "task_href": "http://localhost:3000/api/tasks/1000000340680",
      "task_id": 1000000340680,
      "message": "Creating snapshot for ManageIQ::Providers::Vmware::InfraManager::Vm id: 1000000002158 name: test-2.demo.inec.as",
      "success": true
    }
  ]
}

```
```
GET http://localhost:3000/api/tasks/1000000340680
Authorization: Basic YWRtaW46c21hcnR2bQ==
```
```
{
  "updated_on": "2017-01-24T21:52:54Z",
  "created_on": "2017-01-24T21:52:53Z",
  "userid": "admin",
  "message": "Task completed successfully",
  "status": "Ok",
  "state": "Finished",
  "name": "summary",
  "id": 1000000340680,
  "href": "http://localhost:3000/api/tasks/1000000340680"
}
```

### unhappy path

```
POST http://localhost:3000/api/vms/1000000002002/snapshots
Authorization: Basic YWRtaW46c21hcnR2bQ==

{
  "name": "Tim's snapshot"
}
```

```
{
  "results": [
    {
      "message": "Create Snapshot operation not supported for Redhat VM",
      "success": false
    }
  ]
}
```

# destroy

## happy path
## unhappy path