### PR TITLE
[EUWE] Chargebacks for SCVMM (rollup-less) [2/2]

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -8,10 +8,12 @@ class Chargeback
       # Why we need this?
       #   1) We cannot charge for hours until the resources existed (vm provisioned in the middle of month)
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
+      #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
                                         consuption_start = [@start_time, resource.try(:created_on)].compact.max
-                                        consumption_end = [Time.current, @end_time].min
-                                        (consumption_end - consuption_start).round / 1.hour
+                                        consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
+                                        consumed = (consumption_end - consuption_start).round / 1.hour
+                                        consumed > 0 ? consumed : 0
                                       end
     end
 

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -4,8 +4,12 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
-    def hours_in_interval
-      @hours_in_interval ||= (@end_time - @start_time).round / 1.hour
+    def past_hours_in_interval
+      # We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
+      @past_hours_in_interval ||= begin
+                                    past = (Time.current - @start_time).round / 1.hour
+                                    [past, hours_in_interval].min
+                                  end
     end
 
     def hours_in_month
@@ -15,6 +19,10 @@ class Chargeback
     end
 
     private
+
+    def hours_in_interval
+      @hours_in_interval ||= (@end_time - @start_time).round / 1.hour
+    end
 
     def monthly?
       # A heuristic. Is the interval lenght about 30 days?

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -4,12 +4,15 @@ class Chargeback
       @start_time, @end_time = start_time, end_time
     end
 
-    def past_hours_in_interval
-      # We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
-      @past_hours_in_interval ||= begin
-                                    past = (Time.current - @start_time).round / 1.hour
-                                    [past, hours_in_interval].min
-                                  end
+    def consumed_hours_in_interval
+      # Why we need this?
+      #   1) We cannot charge for hours until the resources existed (vm provisioned in the middle of month)
+      #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
+      @consumed_hours_in_interval ||= begin
+                                        consuption_start = [@start_time, resource.try(:created_on)].compact.max
+                                        consumption_end = [Time.current, @end_time].min
+                                        (consumption_end - consuption_start).round / 1.hour
+                                      end
     end
 
     def hours_in_month

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -7,5 +7,18 @@ class Chargeback
     def hours_in_interval
       @hours_in_interval ||= (@end_time - @start_time).round / 1.hour
     end
+
+    def hours_in_month
+      # If the interval is monthly, we have use exact number of days in interval (i.e. 28, 29, 30, or 31)
+      # othewise (for weekly and daily intervals) we assume month equals to 30 days
+      monthly? ? hours_in_interval : (1.month / 1.hour)
+    end
+
+    private
+
+    def monthly?
+      # A heuristic. Is the interval lenght about 30 days?
+      (hours_in_interval * 1.hour - 1.month).abs < 3.days
+    end
   end
 end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -10,9 +10,9 @@ class Chargeback
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
       #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
-                                        consuption_start = [@start_time, resource.try(:created_on)].compact.max
+                                        consumption_start = [@start_time, resource.try(:created_on)].compact.max
                                         consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
-                                        consumed = (consumption_end - consuption_start).round / 1.hour
+                                        consumed = (consumption_end - consumption_start).round / 1.hour
                                         consumed > 0 ? consumed : 0
                                       end
     end

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -12,7 +12,8 @@ class Chargeback
       extra_resources = cb_class.try(:extra_resources_without_rollups) || []
       timerange.step_value(interval_duration).each_cons(2) do |query_start_time, query_end_time|
         extra_resources.each do |resource|
-          yield ConsumptionWithoutRollups.new(resource, query_start_time, query_end_time)
+          consumption = ConsumptionWithoutRollups.new(resource, query_start_time, query_end_time)
+          yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end
 
         records = base_rollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => 'hourly')

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -19,7 +19,7 @@ class Chargeback
 
     def avg(metric)
       metric_sum = values(metric).sum
-      metric_sum / hours_in_interval
+      metric_sum / past_hours_in_interval
     end
 
     def none?(metric)

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -19,7 +19,7 @@ class Chargeback
 
     def avg(metric)
       metric_sum = values(metric).sum
-      metric_sum / past_hours_in_interval
+      metric_sum / consumed_hours_in_interval
     end
 
     def none?(metric)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -230,7 +230,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def metric_and_cost_by(consumption)
     metric_value = metric_value_by(consumption)
-    [metric_value, hourly_cost(metric_value, consumption) * consumption.hours_in_interval]
+    [metric_value, hourly_cost(metric_value, consumption) * consumption.past_hours_in_interval]
   end
 
   def first_tier?(tier,tiers)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -230,7 +230,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def metric_and_cost_by(consumption)
     metric_value = metric_value_by(consumption)
-    [metric_value, hourly_cost(metric_value, consumption) * consumption.past_hours_in_interval]
+    [metric_value, hourly_cost(metric_value, consumption) * consumption.consumed_hours_in_interval]
   end
 
   def first_tier?(tier,tiers)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -18,8 +18,6 @@ class ChargebackRateDetail < ApplicationRecord
     'yearly'  => _('Yearly')
   }.freeze
 
-  attr_accessor :hours_in_interval
-
   def charge(relevant_fields, consumption)
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -92,7 +92,7 @@ class ChargebackRateDetail < ApplicationRecord
                   when "hourly"  then rate
                   when "daily"   then rate / 24
                   when "weekly"  then rate / 24 / 7
-                  when "monthly" then rate / consumption.hours_in_interval
+                  when "monthly" then rate / consumption.hours_in_month
                   when "yearly"  then rate / 24 / 365
                   else raise "rate time unit of '#{per_time}' not supported"
                   end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -74,25 +74,25 @@ class ChargebackRateDetail < ApplicationRecord
     :yearly  => "Year"
   }
 
-  def hourly_cost(value)
+  def hourly_cost(value, consumption)
     return 0.0 unless self.enabled?
 
     value = 1.0 if fixed?
 
     (fixed_rate, variable_rate) = find_rate(value)
 
-    hourly_fixed_rate    = hourly(fixed_rate)
-    hourly_variable_rate = hourly(variable_rate)
+    hourly_fixed_rate    = hourly(fixed_rate, consumption)
+    hourly_variable_rate = hourly(variable_rate, consumption)
 
     hourly_fixed_rate + rate_adjustment(hourly_variable_rate) * value
   end
 
-  def hourly(rate)
+  def hourly(rate, consumption)
     hourly_rate = case per_time
                   when "hourly"  then rate
                   when "daily"   then rate / 24
                   when "weekly"  then rate / 24 / 7
-                  when "monthly" then rate / @hours_in_interval
+                  when "monthly" then rate / consumption.hours_in_interval
                   when "yearly"  then rate / 24 / 365
                   else raise "rate time unit of '#{per_time}' not supported"
                   end
@@ -229,9 +229,8 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def metric_and_cost_by(consumption)
-    @hours_in_interval = consumption.hours_in_interval
     metric_value = metric_value_by(consumption)
-    [metric_value, hourly_cost(metric_value) * consumption.hours_in_interval]
+    [metric_value, hourly_cost(metric_value, consumption) * consumption.hours_in_interval]
   end
 
   def first_tier?(tier,tiers)

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,5 +1,5 @@
 describe ChargebackContainerImage do
-  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   let(:hourly_rate)       { 0.01 }
   let(:cpu_usage_rate)    { 50.0 }
   let(:cpu_count)         { 1.0 }
@@ -34,7 +34,7 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(starting_date)
+    Timecop.travel(month_end)
   end
 
   after do

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -10,19 +10,18 @@ describe ChargebackContainerImage do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryGirl.create(:ems_openshift) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_openshift)
-
     @node = FactoryGirl.create(:container_node, :name => "node")
-    @image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+    @image = FactoryGirl.create(:container_image, :ext_management_system => ems)
     @label = FactoryGirl.build(:custom_attribute, :name => "version_label-1", :value => "1.0.0-rc_2", :section => 'docker_labels')
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
-    @group = FactoryGirl.create(:container_group, :ext_management_system => @ems, :container_project => @project,
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
+    @group = FactoryGirl.create(:container_group, :ext_management_system => ems, :container_project => @project,
                                 :container_node => @node)
     @container = FactoryGirl.create(:kubernetes_container, :container_group => @group, :container_image => @image)
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
@@ -55,7 +54,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)
@@ -97,7 +96,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)
@@ -142,7 +141,7 @@ describe ChargebackContainerImage do
                                                         :derived_memory_available => memory_available,
                                                         :derived_memory_used      => memory_used,
                                                         :net_usage_rate_average   => net_usage_rate,
-                                                        :parent_ems_id            => @ems.id,
+                                                        :parent_ems_id            => ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -8,6 +8,7 @@ describe ChargebackContainerImage do
   let(:net_usage_rate)    { 25.0 }
   let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
   let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -34,7 +35,7 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(month_end)
+    Timecop.travel(report_run_time)
   end
 
   after do

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -9,6 +9,7 @@ describe ChargebackContainerImage do
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
 
   before do
     MiqRegion.seed
@@ -88,8 +89,6 @@ describe ChargebackContainerImage do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
@@ -125,7 +124,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
     end
   end
 
@@ -134,8 +133,6 @@ describe ChargebackContainerImage do
     before do
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
-
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_end.year) * 24
 
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
@@ -173,7 +170,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
     end
   end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -110,7 +110,6 @@ describe ChargebackContainerImage do
                                                                 :image_tag_names => "environment/prod")
         time += 12.hours
       end
-      @metric_size = @container.metric_rollups.size
     end
 
     subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
@@ -164,7 +163,6 @@ describe ChargebackContainerImage do
                                                                 :image_tag_names => "")
         time += 12.hours
       end
-      @metric_size = @container.metric_rollups.size
     end
 
     subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,5 +1,12 @@
 describe ChargebackContainerImage do
   let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:hourly_rate)       { 0.01 }
+  let(:cpu_usage_rate)    { 50.0 }
+  let(:cpu_count)         { 1.0 }
+  let(:memory_available)  { 1000.0 }
+  let(:memory_used)       { 100.0 }
+  let(:net_usage_rate)    { 25.0 }
+
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -23,14 +30,6 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    @hourly_rate       = 0.01
-    @count_hourly_rate = 1.00
-    @cpu_usage_rate    = 50.0
-    @cpu_count         = 1.0
-    @memory_available  = 1000.0
-    @memory_used       = 100.0
-    @net_usage_rate    = 25.0
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -47,11 +46,11 @@ describe ChargebackContainerImage do
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => t,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -70,7 +69,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -79,7 +78,7 @@ describe ChargebackContainerImage do
                          :chargeback_tiers   => [cbt])
     }
     it "fixed_compute" do
-      expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * hours_in_day)
+      expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
     end
   end
 
@@ -97,11 +96,11 @@ describe ChargebackContainerImage do
       while time < end_time
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -121,7 +120,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -131,7 +130,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
     end
   end
 
@@ -151,11 +150,11 @@ describe ChargebackContainerImage do
       while time < end_time
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
-                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                        :derived_vm_numvcpus      => @cpu_count,
-                                                        :derived_memory_available => @memory_available,
-                                                        :derived_memory_used      => @memory_used,
-                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :cpu_usage_rate_average   => cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => cpu_count,
+                                                        :derived_memory_available => memory_available,
+                                                        :derived_memory_used      => memory_used,
+                                                        :net_usage_rate_average   => net_usage_rate,
                                                         :parent_ems_id            => @ems.id,
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
@@ -175,7 +174,7 @@ describe ChargebackContainerImage do
                          :start         => 0,
                          :finish        => Float::INFINITY,
                          :fixed_rate    => 0.0,
-                         :variable_rate => @hourly_rate.to_s)
+                         :variable_rate => hourly_rate.to_s)
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
@@ -186,7 +185,7 @@ describe ChargebackContainerImage do
     }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
     end
   end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -6,7 +6,8 @@ describe ChargebackContainerImage do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
-  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -33,7 +34,7 @@ describe ChargebackContainerImage do
     @project.tag_with(@tag.name, :ns => '*')
     @image.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+    Timecop.travel(starting_date)
   end
 
   after do

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackContainerImage do
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -30,11 +31,6 @@ describe ChargebackContainerImage do
     @memory_used       = 100.0
     @net_usage_rate    = 25.0
 
-    @options = {:interval_size       => 1,
-                :end_interval_offset => 0,
-                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-    }
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -44,11 +40,9 @@ describe ChargebackContainerImage do
 
   context "Daily" do
     let(:hours_in_day) { 24 }
+    let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
 
     before do
-      @options[:interval] = "daily"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
 
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
@@ -69,7 +63,7 @@ describe ChargebackContainerImage do
       end
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,
@@ -90,12 +84,10 @@ describe ChargebackContainerImage do
   end
 
   context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
 
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -122,7 +114,7 @@ describe ChargebackContainerImage do
       @metric_size = @container.metric_rollups.size
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,
@@ -144,14 +136,12 @@ describe ChargebackContainerImage do
   end
 
   context "Label" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -178,7 +168,7 @@ describe ChargebackContainerImage do
       @metric_size = @container.metric_rollups.size
     end
 
-    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
     let(:cbt) {
       FactoryGirl.create(:chargeback_tier,

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -6,6 +6,7 @@ describe ChargebackContainerImage do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -86,8 +87,6 @@ describe ChargebackContainerImage do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -139,8 +138,6 @@ describe ChargebackContainerImage do
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -7,6 +7,8 @@ describe ChargebackContainerImage do
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
 
   before do
     MiqRegion.seed
@@ -86,13 +88,9 @@ describe ChargebackContainerImage do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
-
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
                                                         :cpu_usage_rate_average   => cpu_usage_rate,
@@ -107,7 +105,6 @@ describe ChargebackContainerImage do
         @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
                                                                 :timestamp => time,
                                                                 :image_tag_names => "environment/prod")
-        time += 12.hours
       end
     end
 
@@ -138,12 +135,9 @@ describe ChargebackContainerImage do
       @image.docker_labels << @label
       ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :label => [@label, "container_image"] }])
 
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_end.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                         :timestamp                => time,
                                                         :cpu_usage_rate_average   => cpu_usage_rate,
@@ -158,7 +152,6 @@ describe ChargebackContainerImage do
         @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
                                                                 :timestamp => time,
                                                                 :image_tag_names => "")
-        time += 12.hours
       end
     end
 

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -6,7 +6,8 @@ describe ChargebackContainerProject do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
-  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -28,7 +29,7 @@ describe ChargebackContainerProject do
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+    Timecop.travel(starting_date)
   end
 
   after do

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackContainerProject do
+  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -25,11 +26,6 @@ describe ChargebackContainerProject do
     @memory_used       = 100.0
     @net_usage_rate    = 25.0
 
-    @options = {:interval_size       => 1,
-                :end_interval_offset => 0,
-                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-    }
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -43,12 +39,9 @@ describe ChargebackContainerProject do
 
   context "Daily" do
     let(:hours_in_day) { 24 }
+    let(:options) { base_options.merge(:interval => 'daily', :entity_id => @project.id, :tag => nil) }
 
     before do
-      @options[:interval] = "daily"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => t,
@@ -65,7 +58,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -137,12 +130,9 @@ describe ChargebackContainerProject do
   end
 
   context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -167,7 +157,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -240,12 +230,9 @@ describe ChargebackContainerProject do
   end
 
   context "tagged project" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = nil
-      @options[:tag] = "/managed/environment/prod"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -267,7 +254,7 @@ describe ChargebackContainerProject do
       end
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -289,13 +276,9 @@ describe ChargebackContainerProject do
   end
 
   context "group results by tag" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = nil
-      @options[:provider_id] = "all"
-      @options[:groupby_tag] = "environment"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -318,7 +301,7 @@ describe ChargebackContainerProject do
       end
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_cores_used,
@@ -341,12 +324,9 @@ describe ChargebackContainerProject do
   end
 
   context "ignore empty metrics in fixed_compute" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @options[:interval] = "monthly"
-      @options[:entity_id] = @project.id
-      @options[:tag] = nil
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -382,7 +362,7 @@ describe ChargebackContainerProject do
       @metric_size = @project.metric_rollups.size
     end
 
-    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(@options).first.first }
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
                                    :start                     => 0,

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -341,7 +341,7 @@ describe ChargebackContainerProject do
 
         # Empty metric for fixed compute
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
-                                                      :timestamp                => "2012-08-31T07:00:00Z",
+                                                      :timestamp                => time,
                                                       :cpu_usage_rate_average   => 0.0,
                                                       :derived_memory_used      => 0.0,
                                                       :parent_ems_id            => @ems.id,

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -8,6 +8,7 @@ describe ChargebackContainerProject do
   let(:net_usage_rate)    { 25.0 }
   let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
   let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -29,7 +30,7 @@ describe ChargebackContainerProject do
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(month_end)
+    Timecop.travel(report_run_time)
   end
 
   after do

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -9,6 +9,7 @@ describe ChargebackContainerProject do
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
 
   before do
     MiqRegion.seed
@@ -134,8 +135,6 @@ describe ChargebackContainerProject do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
@@ -167,9 +166,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
 
     it "memory" do
@@ -185,9 +184,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      metric_used = used_average_for(:derived_memory_used, @hours_in_month)
+      metric_used = used_average_for(:derived_memory_used, hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
 
     it "net io" do
@@ -203,9 +202,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      metric_used = used_average_for(:net_usage_rate_average, @hours_in_month)
+      metric_used = used_average_for(:net_usage_rate_average, hours_in_month)
       expect(subject.net_io_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
@@ -219,7 +218,7 @@ describe ChargebackContainerProject do
                                     :chargeback_tiers   => [cbt]) }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
     end
   end
@@ -227,8 +226,6 @@ describe ChargebackContainerProject do
   context "tagged project" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
@@ -258,17 +255,15 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
     end
   end
 
   context "group results by tag" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
@@ -298,9 +293,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_month)
       expect(subject.tag_name).to eq('Production')
     end
   end
@@ -308,8 +303,6 @@ describe ChargebackContainerProject do
   context "ignore empty metrics in fixed_compute" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(24.hours).each do |time|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
@@ -351,7 +344,7 @@ describe ChargebackContainerProject do
 
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
       expect(subject.fixed_compute_metric).to eq(@metric_size / 2)
     end
   end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -7,7 +7,7 @@ describe ChargebackContainerProject do
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
   let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
-  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
   let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
@@ -19,7 +19,8 @@ describe ChargebackContainerProject do
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems,
+                                  :created_on => month_beginning)
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
     temp = {:cb_rate => @cbr, :object => ems}

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,5 +1,12 @@
 describe ChargebackContainerProject do
   let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:hourly_rate)       { 0.01 }
+  let(:cpu_usage_rate)    { 50.0 }
+  let(:cpu_count)         { 1.0 }
+  let(:memory_available)  { 1000.0 }
+  let(:memory_used)       { 100.0 }
+  let(:net_usage_rate)    { 25.0 }
+
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -17,14 +24,6 @@ describe ChargebackContainerProject do
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
-
-    @hourly_rate       = 0.01
-    @count_hourly_rate = 1.00
-    @cpu_usage_rate    = 50.0
-    @cpu_count         = 1.0
-    @memory_available  = 1000.0
-    @memory_used       = 100.0
-    @net_usage_rate    = 25.0
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
@@ -45,11 +44,11 @@ describe ChargebackContainerProject do
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => t,
-                                                         :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                         :derived_vm_numvcpus      => @cpu_count,
-                                                         :derived_memory_available => @memory_available,
-                                                         :derived_memory_used      => @memory_used,
-                                                         :net_usage_rate_average   => @net_usage_rate,
+                                                         :cpu_usage_rate_average   => cpu_usage_rate,
+                                                         :derived_vm_numvcpus      => cpu_count,
+                                                         :derived_memory_available => memory_available,
+                                                         :derived_memory_used      => memory_used,
+                                                         :net_usage_rate_average   => net_usage_rate,
                                                          :parent_ems_id            => @ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
@@ -69,13 +68,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day)
       expect(subject.cpu_cores_used_metric).to eq(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
 
     it "memory" do
@@ -87,13 +86,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:derived_memory_used, hours_in_day)
       expect(subject.memory_used_metric).to eq(metric_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
 
     it "net io" do
@@ -105,26 +104,26 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:net_usage_rate_average, hours_in_day)
       expect(subject.net_io_used_metric).to eq(metric_used)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
     end
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
                                    :start                     => 0,
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
-                                   :variable_rate             => @hourly_rate.to_s) }
+                                   :variable_rate             => hourly_rate.to_s) }
     let!(:cbrd) {FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
                                    :chargeback_rate_id => @cbr.id,
                                    :per_time           => "hourly",
                                    :chargeback_tiers   => [cbt]) }
     it "fixed_compute" do
-      expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * hours_in_day)
+      expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
     end
   end
@@ -142,11 +141,11 @@ describe ChargebackContainerProject do
       while time < end_time
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
-                                                         :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                         :derived_vm_numvcpus      => @cpu_count,
-                                                         :derived_memory_available => @memory_available,
-                                                         :derived_memory_used      => @memory_used,
-                                                         :net_usage_rate_average   => @net_usage_rate,
+                                                         :cpu_usage_rate_average   => cpu_usage_rate,
+                                                         :derived_vm_numvcpus      => cpu_count,
+                                                         :derived_memory_available => memory_available,
+                                                         :derived_memory_used      => memory_used,
+                                                         :net_usage_rate_average   => net_usage_rate,
                                                          :parent_ems_id            => @ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
@@ -168,13 +167,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
     end
 
     it "memory" do
@@ -186,13 +185,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:derived_memory_used, @hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
     end
 
     it "net io" do
@@ -204,27 +203,27 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:net_usage_rate_average, @hours_in_month)
       expect(subject.net_io_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
     end
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
                                    :start                     => 0,
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
-                                   :variable_rate             => @hourly_rate.to_s) }
+                                   :variable_rate             => hourly_rate.to_s) }
     let!(:cbrd) {FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
                                     :chargeback_rate_id => @cbr.id,
                                     :per_time           => "hourly",
                                     :chargeback_tiers   => [cbt]) }
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
     end
   end
@@ -242,11 +241,11 @@ describe ChargebackContainerProject do
       while time < end_time
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                          :timestamp                => time,
-                                                         :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                         :derived_vm_numvcpus      => @cpu_count,
-                                                         :derived_memory_available => @memory_available,
-                                                         :derived_memory_used      => @memory_used,
-                                                         :net_usage_rate_average   => @net_usage_rate,
+                                                         :cpu_usage_rate_average   => cpu_usage_rate,
+                                                         :derived_vm_numvcpus      => cpu_count,
+                                                         :derived_memory_available => memory_available,
+                                                         :derived_memory_used      => memory_used,
+                                                         :net_usage_rate_average   => net_usage_rate,
                                                          :parent_ems_id            => @ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
@@ -265,13 +264,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
     end
   end
 
@@ -288,11 +287,11 @@ describe ChargebackContainerProject do
       while time < end_time
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
-                                                      :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                      :derived_vm_numvcpus      => @cpu_count,
-                                                      :derived_memory_available => @memory_available,
-                                                      :derived_memory_used      => @memory_used,
-                                                      :net_usage_rate_average   => @net_usage_rate,
+                                                      :cpu_usage_rate_average   => cpu_usage_rate,
+                                                      :derived_vm_numvcpus      => cpu_count,
+                                                      :derived_memory_available => memory_available,
+                                                      :derived_memory_used      => memory_used,
+                                                      :net_usage_rate_average   => net_usage_rate,
                                                       :parent_ems_id            => @ems.id,
                                                       :tag_names                => "environment/prod",
                                                       :resource_name            => @project.name)
@@ -312,13 +311,13 @@ describe ChargebackContainerProject do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
       expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * @hours_in_month)
       expect(subject.tag_name).to eq('Production')
     end
   end
@@ -336,11 +335,11 @@ describe ChargebackContainerProject do
       while time < end_time
         @project.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                       :timestamp                => time,
-                                                      :cpu_usage_rate_average   => @cpu_usage_rate,
-                                                      :derived_vm_numvcpus      => @cpu_count,
-                                                      :derived_memory_available => @memory_available,
-                                                      :derived_memory_used      => @memory_used,
-                                                      :net_usage_rate_average   => @net_usage_rate,
+                                                      :cpu_usage_rate_average   => cpu_usage_rate,
+                                                      :derived_vm_numvcpus      => cpu_count,
+                                                      :derived_memory_available => memory_available,
+                                                      :derived_memory_used      => memory_used,
+                                                      :net_usage_rate_average   => net_usage_rate,
                                                       :parent_ems_id            => @ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
@@ -368,7 +367,7 @@ describe ChargebackContainerProject do
                                    :start                     => 0,
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
-                                   :variable_rate             => @hourly_rate.to_s) }
+                                   :variable_rate             => hourly_rate.to_s) }
     let!(:cbrd) do
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
                          :chargeback_rate_id => @cbr.id,
@@ -379,7 +378,7 @@ describe ChargebackContainerProject do
 
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
-      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * @hours_in_month)
       expect(subject.fixed_compute_metric).to eq(@metric_size / 2)
     end
   end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,5 +1,5 @@
 describe ChargebackContainerProject do
-  let(:base_options) { {:interval_size => 1, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
+  let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'Pacific Time (US & Canada)'} } }
   let(:hourly_rate)       { 0.01 }
   let(:cpu_usage_rate)    { 50.0 }
   let(:cpu_count)         { 1.0 }
@@ -29,7 +29,7 @@ describe ChargebackContainerProject do
     @tag = c.tag
     @project.tag_with(@tag.name, :ns => '*')
 
-    Timecop.travel(starting_date)
+    Timecop.travel(month_end)
   end
 
   after do

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -10,18 +10,17 @@ describe ChargebackContainerProject do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) {FactoryGirl.create(:ems_openshift) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_openshift)
-
-    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
-    temp = {:cb_rate => @cbr, :object => @ems}
+    temp = {:cb_rate => @cbr, :object => ems}
     ChargebackRate.set_assignments(:compute, [temp])
 
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
@@ -53,7 +52,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -143,7 +142,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -234,7 +233,7 @@ describe ChargebackContainerProject do
                                                          :derived_memory_available => memory_available,
                                                          :derived_memory_used      => memory_used,
                                                          :net_usage_rate_average   => net_usage_rate,
-                                                         :parent_ems_id            => @ems.id,
+                                                         :parent_ems_id            => ems.id,
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name)
       end
@@ -272,7 +271,7 @@ describe ChargebackContainerProject do
                                                       :derived_memory_available => memory_available,
                                                       :derived_memory_used      => memory_used,
                                                       :net_usage_rate_average   => net_usage_rate,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "environment/prod",
                                                       :resource_name            => @project.name)
       end
@@ -311,7 +310,7 @@ describe ChargebackContainerProject do
                                                       :derived_memory_available => memory_available,
                                                       :derived_memory_used      => memory_used,
                                                       :net_usage_rate_average   => net_usage_rate,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
         # Empty metric for fixed compute
@@ -319,7 +318,7 @@ describe ChargebackContainerProject do
                                                       :timestamp                => time + 12.hours,
                                                       :cpu_usage_rate_average   => 0.0,
                                                       :derived_memory_used      => 0.0,
-                                                      :parent_ems_id            => @ems.id,
+                                                      :parent_ems_id            => ems.id,
                                                       :tag_names                => "",
                                                       :resource_name            => @project.name)
       end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -6,6 +6,7 @@ describe ChargebackContainerProject do
   let(:memory_available)  { 1000.0 }
   let(:memory_used)       { 100.0 }
   let(:net_usage_rate)    { 25.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -131,8 +132,6 @@ describe ChargebackContainerProject do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -231,8 +230,6 @@ describe ChargebackContainerProject do
   context "tagged project" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :tag => '/managed/environment/prod') }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -277,8 +274,6 @@ describe ChargebackContainerProject do
   context "group results by tag" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => nil, :provider_id => 'all', :groupby_tag => 'environment') }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -325,8 +320,6 @@ describe ChargebackContainerProject do
   context "ignore empty metrics in fixed_compute" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
     before do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -90,6 +90,12 @@ describe ChargebackRateDetail do
       expect { annual_rate.hourly(rate, consumption) }.to raise_error(RuntimeError,
                                                                       "rate time unit of 'annually' not supported")
     end
+
+    let(:monthly_rate) { FactoryGirl.build(:chargeback_rate_detail, :per_time => 'monthly') }
+    let(:weekly_consumption) { Chargeback::ConsumptionWithRollups.new([], Time.current - 1.week, Time.current) }
+    it 'monhtly rate returns correct hourly(_rate) when consumption slice is weekly' do
+      expect(monthly_rate.hourly(rate, weekly_consumption)).to eq(rate / (1.month / 1.hour))
+    end
   end
 
   it "#rate_adjustment" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -24,8 +24,7 @@ describe ChargebackRateDetail do
     end
   end
 
-  let(:hours_in_month) { 720 }
-  let(:consumption) { instance_double('Consumption', :hours_in_interval => hours_in_month) }
+  let(:consumption) { instance_double('Consumption', :hours_in_month => (1.month / 1.hour)) }
 
   it '#hourly_cost' do
     cvalue   = 42.0

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -54,34 +54,42 @@ describe ChargebackRateDetail do
     expect(cbd.hourly_cost(cvalue, consumption)).to eq(0.0)
   end
 
-  it "#hourly" do
-    [
-      0,
-      0.0,
-      0.00
-    ].each do |rate|
-      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'hourly')
+  describe '#hourly (rate)' do
+    let(:rate) { 8.26 }
+    it 'returns 0 when the rate was 0' do
+      [
+        0,
+        0.0,
+        0.00
+      ].each do |zero|
+        cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'hourly')
+        expect(cbd.hourly(zero, consumption)).to eq(0.0)
+      end
+    end
 
-      expect(cbd.hourly(rate, consumption)).to eq(0.0)
+    it 'calculates hourly rate for given rate' do
+      cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
+      [
+        'hourly',   'megabytes',  rate,
+        'daily',    'megabytes',  rate / 24,
+        'weekly',   'megabytes',  rate / 24 / 7,
+        'monthly',  'megabytes',  rate / 24 / 30,
+        'yearly',   'megabytes',  rate / 24 / 365
+      ].each_slice(3) do |per_time, per_unit, hourly_rate|
+        cbd = FactoryGirl.build(:chargeback_rate_detail,
+                                :per_time                          => per_time,
+                                :per_unit                          => per_unit,
+                                :metric                            => 'derived_memory_available',
+                                :chargeback_rate_detail_measure_id => cbdm.id)
+        expect(cbd.hourly(rate, consumption)).to eq(hourly_rate)
+      end
     end
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
-    rate = 8.26
-    [
-      'hourly',   'megabytes',  rate,
-      'daily',    'megabytes',  rate / 24,
-      'weekly',   'megabytes',  rate / 24 / 7,
-      'monthly',  'megabytes',  rate / 24 / 30,
-      'yearly',   'megabytes',  rate / 24 / 365
-    ].each_slice(3) do |per_time, per_unit, hourly_rate|
-      cbd = FactoryGirl.build(:chargeback_rate_detail,
-                              :per_time                          => per_time,
-                              :per_unit                          => per_unit,
-                              :metric                            => 'derived_memory_available',
-                              :chargeback_rate_detail_measure_id => cbdm.id)
-      expect(cbd.hourly(rate, consumption)).to eq(hourly_rate)
+
+    let(:annual_rate) { FactoryGirl.build(:chargeback_rate_detail, :per_time => 'annually') }
+    it 'cannot calculate for unknown time interval' do
+      expect { annual_rate.hourly(rate, consumption) }.to raise_error(RuntimeError,
+                                                                      "rate time unit of 'annually' not supported")
     end
-    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'annually')
-    expect  { cbd.hourly(rate, consumption) }.to raise_error(RuntimeError, "rate time unit of 'annually' not supported")
   end
 
   it "#rate_adjustment" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -35,10 +35,10 @@ describe ChargebackRateDetail do
     per_time = 'monthly'
     per_unit = 'megabytes'
     cbd = FactoryGirl.build(:chargeback_rate_detail,
-                            :per_time          => per_time,
-                            :per_unit          => per_unit,
-                            :enabled           => true,
-                            :hours_in_interval => hours_in_month)
+                            :per_time => per_time,
+                            :per_unit => per_unit,
+                            :enabled  => true)
+    cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbt = FactoryGirl.create(:chargeback_tier,
                              :chargeback_rate_detail_id => cbd.id,
                              :start                     => tier_start,
@@ -75,12 +75,11 @@ describe ChargebackRateDetail do
       'yearly',   'megabytes',  rate / 24 / 365
     ].each_slice(3) do |per_time, per_unit, hourly_rate|
       cbd = FactoryGirl.build(:chargeback_rate_detail,
-                               :per_time                          => per_time,
-                               :per_unit                          => per_unit,
-                               :metric                            => 'derived_memory_available',
-                               :chargeback_rate_detail_measure_id => cbdm.id,
-                               :hours_in_interval                 => hours_in_month
-                              )
+                              :per_time                          => per_time,
+                              :per_unit                          => per_unit,
+                              :metric                            => 'derived_memory_available',
+                              :chargeback_rate_detail_measure_id => cbdm.id)
+      cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
       expect(cbd.hourly(rate)).to eq(hourly_rate)
     end
     cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'annually')
@@ -186,14 +185,14 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
                                   :per_unit                          => 'bytes',
                                   :metric                            => 'derived_memory_available',
                                   :per_time                          => 'monthly',
-                                  :chargeback_rate_detail_measure_id => cbdm.id,
-                                  :hours_in_interval                 => hours_in_month)
+                                  :chargeback_rate_detail_measure_id => cbdm.id)
+    cbd_bytes.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbd_gigabytes = FactoryGirl.build(:chargeback_rate_detail,
                                       :per_unit                          => 'gigabytes',
                                       :metric                            => 'derived_memory_available',
                                       :per_time                          => 'monthly',
-                                      :chargeback_rate_detail_measure_id => cbdm.id,
-                                      :hours_in_interval                 => hours_in_month)
+                                      :chargeback_rate_detail_measure_id => cbdm.id)
+    cbd_gigabytes.instance_variable_set(:@hours_in_interval, hours_in_month)
     expect(cbd_bytes.hourly_cost(100)).to eq(cbd_gigabytes.hourly_cost(100))
   end
 

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -25,6 +25,7 @@ describe ChargebackRateDetail do
   end
 
   let(:hours_in_month) { 720 }
+  let(:consumption) { instance_double('Consumption', :hours_in_interval => hours_in_month) }
 
   it '#hourly_cost' do
     cvalue   = 42.0
@@ -38,7 +39,6 @@ describe ChargebackRateDetail do
                             :per_time => per_time,
                             :per_unit => per_unit,
                             :enabled  => true)
-    cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbt = FactoryGirl.create(:chargeback_tier,
                              :chargeback_rate_detail_id => cbd.id,
                              :start                     => tier_start,
@@ -46,13 +46,13 @@ describe ChargebackRateDetail do
                              :fixed_rate                => fixed_rate,
                              :variable_rate             => variable_rate)
     cbd.update(:chargeback_tiers => [cbt])
-    expect(cbd.hourly_cost(cvalue)).to eq(cvalue * cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
+    expect(cbd.hourly_cost(cvalue, consumption)).to eq(cvalue * cbd.hourly(variable_rate, consumption) + cbd.hourly(fixed_rate, consumption))
 
     cbd.group = 'fixed'
-    expect(cbd.hourly_cost(cvalue)).to eq(cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
+    expect(cbd.hourly_cost(cvalue, consumption)).to eq(cbd.hourly(variable_rate, consumption) + cbd.hourly(fixed_rate, consumption))
 
     cbd.enabled = false
-    expect(cbd.hourly_cost(cvalue)).to eq(0.0)
+    expect(cbd.hourly_cost(cvalue, consumption)).to eq(0.0)
   end
 
   it "#hourly" do
@@ -63,7 +63,7 @@ describe ChargebackRateDetail do
     ].each do |rate|
       cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'hourly')
 
-      expect(cbd.hourly(rate)).to eq(0.0)
+      expect(cbd.hourly(rate, consumption)).to eq(0.0)
     end
     cbdm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
     rate = 8.26
@@ -79,11 +79,10 @@ describe ChargebackRateDetail do
                               :per_unit                          => per_unit,
                               :metric                            => 'derived_memory_available',
                               :chargeback_rate_detail_measure_id => cbdm.id)
-      cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
-      expect(cbd.hourly(rate)).to eq(hourly_rate)
+      expect(cbd.hourly(rate, consumption)).to eq(hourly_rate)
     end
     cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'annually')
-    expect  { cbd.hourly(rate) }.to raise_error(RuntimeError, "rate time unit of 'annually' not supported")
+    expect  { cbd.hourly(rate, consumption) }.to raise_error(RuntimeError, "rate time unit of 'annually' not supported")
   end
 
   it "#rate_adjustment" do
@@ -186,14 +185,12 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
                                   :metric                            => 'derived_memory_available',
                                   :per_time                          => 'monthly',
                                   :chargeback_rate_detail_measure_id => cbdm.id)
-    cbd_bytes.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbd_gigabytes = FactoryGirl.build(:chargeback_rate_detail,
                                       :per_unit                          => 'gigabytes',
                                       :metric                            => 'derived_memory_available',
                                       :per_time                          => 'monthly',
                                       :chargeback_rate_detail_measure_id => cbdm.id)
-    cbd_gigabytes.instance_variable_set(:@hours_in_interval, hours_in_month)
-    expect(cbd_bytes.hourly_cost(100)).to eq(cbd_gigabytes.hourly_cost(100))
+    expect(cbd_bytes.hourly_cost(100, consumption)).to eq(cbd_gigabytes.hourly_cost(100, consumption))
   end
 
   it "#show_rates" do

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -16,7 +16,8 @@ describe ChargebackVm do
   let(:tag) { Tag.find_by_name('/managed/environment/prod') }
   let(:vm) do
     ems = FactoryGirl.create(:ems_vmware)
-    vm = FactoryGirl.create(:vm_vmware, :name => 'test_vm', :evm_owner => admin, :ems_ref => 'ems_ref')
+    vm = FactoryGirl.create(:vm_vmware, :name => 'test_vm', :evm_owner => admin, :ems_ref => 'ems_ref',
+                            :created_on => start_of_all_intervals)
     vm.tag_with(tag.name, :ns => '*')
     host = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware,
                                                                      :memory_mb => 8124, :cpu_total_cores => 1,

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -1,0 +1,93 @@
+describe ChargebackVm do
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:start_of_all_intervals) { Time.parse('2007-01-01 00:00:00Z').utc } # 0hours, Monday, 1st of month
+  let(:consumed_hours) { 17 }
+  let(:midle_of_the_first_day) { start_of_all_intervals + consumed_hours.hours } # it is a Monday
+  let(:ts) { midle_of_the_first_day.in_time_zone(Metric::Helper.get_time_zone(opt[:ext_options])) }
+  let(:report_run_time) { midle_of_the_first_day }
+
+  let(:opt) do
+    {:interval_size       => 1,
+     :end_interval_offset => 0,
+     :tag                 => '/managed/environment/prod',
+     :ext_options         => {:tz => 'UTC'},
+     :userid              => admin.userid}
+  end
+  let(:tag) { Tag.find_by_name('/managed/environment/prod') }
+  let(:vm) do
+    ems = FactoryGirl.create(:ems_vmware)
+    vm = FactoryGirl.create(:vm_vmware, :name => 'test_vm', :evm_owner => admin, :ems_ref => 'ems_ref')
+    vm.tag_with(tag.name, :ns => '*')
+    host = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware,
+                                                                     :memory_mb => 8124, :cpu_total_cores => 1,
+                                                                     :cpu_speed => 9576), :vms => [vm])
+    ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => ems)
+    ems_cluster.hosts << host
+    storage = FactoryGirl.create(:storage_target_vmware)
+
+    Range.new(start_of_all_intervals, midle_of_the_first_day, true).step_value(1.hour).each do |time|
+      vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
+                                              :derived_vm_numvcpus       => number_of_cpus,
+                                              :cpu_usagemhz_rate_average => cpu_usagemhz,
+                                              :timestamp                 => time,
+                                              :tag_names                 => 'environment/prod',
+                                              :parent_host_id            => host.id,
+                                              :parent_ems_cluster_id     => ems_cluster.id,
+                                              :parent_ems_id             => ems.id,
+                                              :parent_storage_id         => storage.id,
+                                              :resource_name             => vm.name,
+                                             )
+    end
+    vm
+  end
+  let(:hourly_rate)               { 0.01 }
+  let(:count_hourly_rate)         { 1.2 }
+  let!(:chargeback_rate) do
+    cat = FactoryGirl.create(:classification, :description => 'Environment', :name => 'environment',
+                             :single_value => true, :show => true)
+    c = FactoryGirl.create(:classification, :name => 'prod', :description => 'Production', :parent_id => cat.id)
+    chargeback_rate = FactoryGirl.create(:chargeback_rate)
+    cbrd1 = FactoryGirl.create(:chargeback_rate_detail_cpu_used, :chargeback_rate_id => chargeback_rate.id, :per_time => 'hourly')
+    cbt1 = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => cbrd1.id, :start => 0,
+                              :finish => Float::INFINITY, :fixed_rate => 0.0, :variable_rate => hourly_rate.to_s)
+    cbrd2 = FactoryGirl.create(:chargeback_rate_detail_cpu_allocated, :chargeback_rate_id => chargeback_rate.id, :per_time => 'hourly')
+    cbt2 = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => cbrd2.id, :start => 0,
+                              :finish => Float::INFINITY, :fixed_rate => 0.0, :variable_rate => count_hourly_rate.to_s)
+    temp = { :cb_rate => chargeback_rate, :tag => [c, 'vm'] }
+    ChargebackRate.set_assignments(:compute, [temp])
+  end
+
+  before do
+    MiqRegion.seed
+    ChargebackRate.seed
+    EvmSpecHelper.create_guid_miq_server_zone
+    Timecop.travel(report_run_time)
+    vm
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:daily_cb)   { ChargebackVm.build_results_for_report_ChargebackVm(opt.merge(:interval => 'daily')).first.first }
+  let(:weekly_cb)  { ChargebackVm.build_results_for_report_ChargebackVm(opt.merge(:interval => 'weekly')).first.first }
+  let(:monthly_cb) { ChargebackVm.build_results_for_report_ChargebackVm(opt.merge(:interval => 'monthly')).first.first }
+
+  let(:number_of_cpus) { 1 }
+  let(:cpu_allocated_cost) { number_of_cpus * consumed_hours * count_hourly_rate }
+  let(:cpu_usagemhz) { 50 }
+  let(:cpu_usage_cost) { cpu_usagemhz * consumed_hours * hourly_rate }
+
+  it 'should calculate the same -- no matter the time range (daily/weekly/monthly)' do
+    [daily_cb, weekly_cb, monthly_cb].each do |cb|
+      expect(cb.start_date).to eq(report_run_time.beginning_of_month)
+      expect(cb.fixed_compute_metric).to eq(consumed_hours)
+      expect(cb.cpu_allocated_metric).to eq(number_of_cpus)
+      expect(cb.cpu_allocated_cost).to eq(cpu_allocated_cost)
+      expect(cb.cpu_used_metric).to eq(cpu_usagemhz)
+      expect(cb.cpu_used_cost).to eq(cpu_usage_cost)
+      expect(cb.total_cost).to eq(cpu_allocated_cost + cpu_usage_cost)
+      expect(cb.total_cost).to eq(28.9) # hardcoded value here keeps us honest
+    end
+  end
+end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -17,6 +17,7 @@ describe ChargebackVm do
   let(:net_usage_rate)            { 25.0 }
   let(:vm_used_disk_storage)      { 1.0 }
   let(:vm_allocated_disk_storage) { 4.0 }
+  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
 
   before do
     MiqRegion.seed
@@ -67,8 +68,6 @@ describe ChargebackVm do
       @service << @vm1
       @service.save
 
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -474,8 +473,6 @@ describe ChargebackVm do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly') }
     before  do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
@@ -852,8 +849,6 @@ describe ChargebackVm do
   context "Group by tags" do
     let(:options) { base_options.merge(:interval => 'monthly', :groupby_tag => 'environment') }
     before  do
-      tz = Metric::Helper.get_time_zone(options[:ext_options])
-      ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -20,6 +20,7 @@ describe ChargebackVm do
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
 
   before do
     MiqRegion.seed
@@ -470,8 +471,6 @@ describe ChargebackVm do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly') }
     before  do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
@@ -524,10 +523,10 @@ describe ChargebackVm do
       cbrd.save
 
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
-      expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * @hours_in_month)
+      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
+      expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
     end
 
     let(:fixed_rate) { 10.0 }
@@ -562,15 +561,15 @@ describe ChargebackVm do
       cbrd.save
 
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
 
-      fixed = fixed_rate * @hours_in_month
-      variable = cpu_count * count_hourly_rate * @hours_in_month
+      fixed = fixed_rate * hours_in_month
+      variable = cpu_count * count_hourly_rate * hours_in_month
       expect(subject.cpu_allocated_cost).to be_within(0.01).of(fixed + variable)
 
-      fixed = fixed_rate * @hours_in_month
-      variable = used_metric * hourly_rate * @hours_in_month
+      fixed = fixed_rate * hours_in_month
+      variable = used_metric * hourly_rate * hours_in_month
       expect(subject.cpu_used_cost).to be_within(0.01).of(fixed + variable)
     end
 
@@ -602,13 +601,13 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
       expect(subject.memory_allocated_metric).to eq(memory_available)
-      used_metric = used_average_for(:derived_memory_used, @hours_in_month)
+      used_metric = used_average_for(:derived_memory_used, hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      memory_allocated_cost = memory_available * hourly_rate * @hours_in_month
+      memory_allocated_cost = memory_available * hourly_rate * hours_in_month
       expect(subject.memory_allocated_cost).to be_within(0.01).of(memory_allocated_cost)
-      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
+      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
       expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
@@ -627,10 +626,10 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      used_metric = used_average_for(:disk_usage_rate_average, @hours_in_month)
+      used_metric = used_average_for(:disk_usage_rate_average, hours_in_month)
       expect(subject.disk_io_used_metric).to be_within(0.01).of(used_metric)
 
-      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
+      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
       expect(subject.disk_io_cost).to eq(subject.disk_io_used_cost)
     end
 
@@ -648,9 +647,9 @@ describe ChargebackVm do
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      used_metric = used_average_for(:net_usage_rate_average, @hours_in_month)
+      used_metric = used_average_for(:net_usage_rate_average, hours_in_month)
       expect(subject.net_io_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
       expect(subject.net_io_cost).to eq(subject.net_io_used_cost)
     end
 
@@ -688,14 +687,14 @@ describe ChargebackVm do
       cbrd.save
 
       expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
-      used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
+      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expected_value = hourly_fixed_rate * @hours_in_month
+      expected_value = hourly_fixed_rate * hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
 
-      expected_value = hourly_fixed_rate * @hours_in_month
+      expected_value = hourly_fixed_rate * hours_in_month
       expect(subject.storage_used_cost).to be_within(0.01).of(expected_value)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
@@ -731,13 +730,13 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
       expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
-      used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
+      used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expected_value = vm_allocated_disk_storage * count_hourly_rate * @hours_in_month
+      expected_value = vm_allocated_disk_storage * count_hourly_rate * hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
-      expected_value = used_metric / 1.gigabytes * count_hourly_rate * @hours_in_month
+      expected_value = used_metric / 1.gigabytes * count_hourly_rate * hours_in_month
       expect(subject.storage_used_cost).to be_within(0.01).of(expected_value)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
@@ -842,8 +841,6 @@ describe ChargebackVm do
   context "Group by tags" do
     let(:options) { base_options.merge(:interval => 'monthly', :groupby_tag => 'environment') }
     before  do
-      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
-
       Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
@@ -896,7 +893,7 @@ describe ChargebackVm do
       cbrd.save
 
       expect(subject.cpu_allocated_metric).to eq(cpu_count)
-      used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
+      used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.tag_name).to eq('Production')
     end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,7 +1,7 @@
 describe ChargebackVm do
   let(:admin) { FactoryGirl.create(:user_admin) }
   let(:base_options) do
-    {:interval_size       => 1,
+    {:interval_size       => 2,
      :end_interval_offset => 0,
      :tag                 => '/managed/environment/prod',
      :ext_options         => {:tz => 'Pacific Time (US & Canada)'},
@@ -18,7 +18,7 @@ describe ChargebackVm do
   let(:vm_used_disk_storage)      { 1.0 }
   let(:vm_allocated_disk_storage) { 4.0 }
   let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
-  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -47,7 +47,7 @@ describe ChargebackVm do
     temp = {:cb_rate => @cbr, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
 
-    Timecop.travel(starting_date)
+    Timecop.travel(month_end)
   end
 
   after do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -34,7 +34,8 @@ describe ChargebackVm do
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
 
-    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref")
+    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref",
+                              :created_on => month_beginning)
     @vm1.tag_with(@tag.name, :ns => '*')
 
     @host1   = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -908,7 +909,7 @@ describe ChargebackVm do
        :ext_options => {:tz => 'UTC'}, :userid => admin.userid}
     end
     let!(:vm1) do
-      vm = FactoryGirl.create(:vm_microsoft)
+      vm = FactoryGirl.create(:vm_microsoft, :created_on => report_run_time - 1.day)
       vm.tag_with(@tag.name, :ns => '*')
       vm
     end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -18,6 +18,8 @@ describe ChargebackVm do
   let(:vm_used_disk_storage)      { 1.0 }
   let(:vm_allocated_disk_storage) { 4.0 }
   let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
 
   before do
     MiqRegion.seed
@@ -68,12 +70,9 @@ describe ChargebackVm do
       @service << @vm1
       @service.save
 
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
-
       @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => admin)
 
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         [@vm1, @vm2].each do |vm|
           vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
@@ -93,8 +92,6 @@ describe ChargebackVm do
                                                   :resource_name                     => @vm1.name,
                                                  )
         end
-
-        time += 12.hours
       end
 
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
@@ -473,12 +470,9 @@ describe ChargebackVm do
   context "Monthly" do
     let(:options) { base_options.merge(:interval => 'monthly') }
     before  do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
                                                   :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
@@ -496,7 +490,6 @@ describe ChargebackVm do
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
-        time += 12.hour
       end
     end
 
@@ -849,12 +842,9 @@ describe ChargebackVm do
   context "Group by tags" do
     let(:options) { base_options.merge(:interval => 'monthly', :groupby_tag => 'environment') }
     before  do
-      time     = ts.beginning_of_month.utc
-      end_time = ts.end_of_month.utc
+      @hours_in_month = Time.days_in_month(month_beginning.month, month_beginning.year) * 24
 
-      @hours_in_month = Time.days_in_month(time.month, time.year) * 24
-
-      while time < end_time
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
                                                   :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
@@ -872,7 +862,6 @@ describe ChargebackVm do
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
         )
-        time += 12.hour
       end
     end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -902,7 +902,7 @@ describe ChargebackVm do
 
   context 'for SCVMM (hyper-v)' do
     let(:base_options) do
-      {:interval_size => 1, :end_interval_offset => 0, :tag => '/managed/environment/prod',
+      {:interval_size => 2, :end_interval_offset => 0, :tag => '/managed/environment/prod',
        :ext_options => {:tz => 'UTC'}, :userid => admin.userid}
     end
     let!(:vm1) do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -17,7 +17,8 @@ describe ChargebackVm do
   let(:net_usage_rate)            { 25.0 }
   let(:vm_used_disk_storage)      { 1.0 }
   let(:vm_allocated_disk_storage) { 4.0 }
-  let(:ts) { Time.now.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -46,7 +47,7 @@ describe ChargebackVm do
     temp = {:cb_rate => @cbr, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
 
-    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+    Timecop.travel(starting_date)
   end
 
   after do

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,5 +1,13 @@
 describe ChargebackVm do
   let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:base_options) do
+    {:interval_size       => 1,
+     :end_interval_offset => 0,
+     :tag                 => '/managed/environment/prod',
+     :ext_options         => {:tz => 'Pacific Time (US & Canada)'},
+     :userid              => admin.userid}
+  end
+
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -35,13 +43,6 @@ describe ChargebackVm do
     @vm_used_disk_storage      = 1.0
     @vm_allocated_disk_storage = 4.0
 
-    @options = {:interval_size       => 1,
-                :end_interval_offset => 0,
-                :tag                 => "/managed/environment/prod",
-                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-                :userid              => admin.userid
-                }
-
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
 
@@ -56,15 +57,18 @@ describe ChargebackVm do
   end
 
   it "succeeds without a userid" do
-    @options.delete(:userid)
-    expect { ChargebackVm.build_results_for_report_ChargebackVm(@options) }.not_to raise_error
+    options = base_options.except(:userid)
+    expect { ChargebackVm.build_results_for_report_ChargebackVm(options) }.not_to raise_error
   end
 
   context "by service" do
+    let(:options) { base_options.merge(:interval => 'monthly', :interval_size => 4, :service_id => @service.id) }
     before(:each) do
-      @options[:interval] = "monthly"
+      @service = FactoryGirl.create(:service)
+      @service << @vm1
+      @service.save
 
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -95,10 +99,6 @@ describe ChargebackVm do
         time += 12.hours
       end
 
-      @service = FactoryGirl.create(:service)
-      @service << @vm1
-      @service.save
-
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
                                :chargeback_rate_id => @cbr.id,
                                :per_time           => "hourly"
@@ -125,15 +125,10 @@ describe ChargebackVm do
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-
-      @options.merge!(:interval_size => 4,
-                      :ext_options   => {:tz => "Eastern Time (US & Canada)"},
-                      :service_id    => @service.id
-                     )
     end
 
     it "only includes VMs belonging to service in results" do
-      result = described_class.build_results_for_report_ChargebackVm(@options)
+      result = described_class.build_results_for_report_ChargebackVm(options)
       expect(result).not_to be_nil
       expect(result.first.all? { |r| r.vm_name == "test_vm" })
     end
@@ -145,10 +140,9 @@ describe ChargebackVm do
 
   context "Daily" do
     let(:hours_in_day) { 24 }
+    let(:options) { base_options.merge(:interval => 'daily') }
 
     before  do
-      @options[:interval] = "daily"
-
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => t,
@@ -170,7 +164,7 @@ describe ChargebackVm do
       end
     end
 
-    subject { ChargebackVm.build_results_for_report_ChargebackVm(@options).first.first }
+    subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
@@ -439,6 +433,7 @@ describe ChargebackVm do
   end
 
   context "Report a chargeback of a tenant" do
+    let(:options_tenant) { base_options.merge(:tenant_id => @tenant.id) }
     before do
       @tenant = FactoryGirl.create(:tenant)
       @tenant_child = FactoryGirl.create(:tenant, :ancestry => @tenant.id)
@@ -463,15 +458,9 @@ describe ChargebackVm do
                              :resource_name                     => @vm_tenant.name,
                             )
       end
-      @options_tenant = {:interval_size       => 1,
-                         :end_interval_offset => 0,
-                         :tag                 => "/managed/environment/prod",
-                         :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-                         :tenant_id           => @tenant.id
-                        }
     end
 
-    subject { ChargebackVm.build_results_for_report_ChargebackVm(@options_tenant).first.first }
+    subject { ChargebackVm.build_results_for_report_ChargebackVm(options_tenant).first.first }
 
     it "report a chargeback of a subtenant" do
       tier = FactoryGirl.create(:chargeback_tier)
@@ -484,10 +473,9 @@ describe ChargebackVm do
     end
   end
   context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly') }
     before  do
-      @options[:interval] = "monthly"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -516,7 +504,7 @@ describe ChargebackVm do
       end
     end
 
-    subject { ChargebackVm.build_results_for_report_ChargebackVm(@options).first.first }
+    subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,
@@ -767,13 +755,9 @@ describe ChargebackVm do
 
     context "by owner" do
       let(:user) { FactoryGirl.create(:user, :name => 'Test VM Owner', :userid => 'test_user') }
+      let(:options) { {:interval_size => 4, :owner => user.userid, :ext_options => {:tz => 'Eastern Time (US & Canada)'} } }
       before do
         @vm1.update_attribute(:evm_owner, user)
-
-        @options = {:interval_size => 4,
-                    :owner         => user.userid,
-                    :ext_options   => {:tz => "Eastern Time (US & Canada)"},
-                   }
       end
 
       it "valid" do
@@ -867,11 +851,9 @@ describe ChargebackVm do
   end
 
   context "Group by tags" do
+    let(:options) { base_options.merge(:interval => 'monthly', :groupby_tag => 'environment') }
     before  do
-      @options[:interval] = "monthly"
-      @options[:groupby_tag] = "environment"
-
-      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      tz = Metric::Helper.get_time_zone(options[:ext_options])
       ts = Time.now.in_time_zone(tz)
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
@@ -900,7 +882,7 @@ describe ChargebackVm do
       end
     end
 
-    subject { ChargebackVm.build_results_for_report_ChargebackVm(@options).first.first }
+    subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
     it "cpu" do
       cbrd = FactoryGirl.build(:chargeback_rate_detail_cpu_used,

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -21,13 +21,13 @@ describe ChargebackVm do
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
 
   before do
     MiqRegion.seed
     ChargebackRate.seed
 
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_vmware)
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
@@ -39,7 +39,7 @@ describe ChargebackVm do
     @storage = FactoryGirl.create(:storage_target_vmware)
     @host1.storages << @storage
 
-    @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => @ems)
+    @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => ems)
     @ems_cluster.hosts << @host1
 
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
@@ -88,7 +88,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -153,7 +153,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -449,7 +449,7 @@ describe ChargebackVm do
                              :tag_names                         => "environment/prod",
                              :parent_host_id                    => @host1.id,
                              :parent_ems_cluster_id             => @ems_cluster.id,
-                             :parent_ems_id                     => @ems.id,
+                             :parent_ems_id                     => ems.id,
                              :parent_storage_id                 => @storage.id,
                              :resource_name                     => @vm_tenant.name,
                             )
@@ -485,7 +485,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
                                                  )
@@ -766,7 +766,7 @@ describe ChargebackVm do
     let(:metric_rollup) do
       FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z", :tag_names => "environment/prod",
                                                :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                                               :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                                               :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                                                :resource => @vm1)
     end
     let(:consumption) { Chargeback::ConsumptionWithRollups.new([metric_rollup], nil, nil) }
@@ -815,12 +815,12 @@ describe ChargebackVm do
       let(:metric_rollup) do
         FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
                           :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
-                          :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                          :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                           :resource => @vm1, :resource_name => @vm1.name)
       end
 
       it 'sets extra fields' do
-        is_expected.to include(shared_extra_fields.merge('provider_name' => @ems.name, 'provider_uid' => @ems.guid))
+        is_expected.to include(shared_extra_fields.merge('provider_name' => ems.name, 'provider_uid' => ems.guid))
       end
     end
 
@@ -855,7 +855,7 @@ describe ChargebackVm do
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
-                                                  :parent_ems_id                     => @ems.id,
+                                                  :parent_ems_id                     => ems.id,
                                                   :parent_storage_id                 => @storage.id,
                                                   :resource_name                     => @vm1.name,
         )

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -766,23 +766,23 @@ describe ChargebackVm do
     end
 
     context "by owner" do
+      let(:user) { FactoryGirl.create(:user, :name => 'Test VM Owner', :userid => 'test_user') }
       before do
-        @user = FactoryGirl.create(:user, :name => 'Test VM Owner', :userid => 'test_user')
-        @vm1.update_attribute(:evm_owner, @user)
+        @vm1.update_attribute(:evm_owner, user)
 
         @options = {:interval_size => 4,
-                    :owner         => @user.userid,
+                    :owner         => user.userid,
                     :ext_options   => {:tz => "Eastern Time (US & Canada)"},
                    }
       end
 
       it "valid" do
-        expect(subject.owner_name).to eq(@user.name)
+        expect(subject.owner_name).to eq(user.name)
       end
 
       it "not exist" do
-        @user.delete
-        expect { subject }.to raise_error(MiqException::Error, "Unable to find user '#{@user.userid}'")
+        user.delete
+        expect { subject }.to raise_error(MiqException::Error, "Unable to find user '#{user.userid}'")
       end
     end
   end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -19,6 +19,7 @@ describe ChargebackVm do
   let(:vm_allocated_disk_storage) { 4.0 }
   let(:starting_date) { Time.zone.parse('2012-09-01 00:00:00 UTC') }
   let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
+  let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
   let(:month_end) { ts.end_of_month.utc }
   let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
@@ -47,7 +48,7 @@ describe ChargebackVm do
     temp = {:cb_rate => @cbr, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
 
-    Timecop.travel(month_end)
+    Timecop.travel(report_run_time)
   end
 
   after do
@@ -765,7 +766,8 @@ describe ChargebackVm do
     let(:chargeback_vm)           { FactoryGirl.build(:chargeback_vm) }
     let(:rate_assignment_options) { {:cb_rate => @cbr, :object => Tenant.root_tenant} }
     let(:metric_rollup) do
-      FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z", :tag_names => "environment/prod",
+      FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => report_run_time - 1.day - 17.hours,
+                                               :tag_names => "environment/prod",
                                                :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
                                                :parent_ems_id => ems.id, :parent_storage_id => @storage.id,
                                                :resource => @vm1)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -7,6 +7,16 @@ describe ChargebackVm do
      :ext_options         => {:tz => 'Pacific Time (US & Canada)'},
      :userid              => admin.userid}
   end
+  let(:hourly_rate)               { 0.01 }
+  let(:count_hourly_rate)         { 1.00 }
+  let(:cpu_usagemhz_rate)         { 50.0 }
+  let(:cpu_count)                 { 1.0 }
+  let(:memory_available)          { 1000.0 }
+  let(:memory_used)               { 100.0 }
+  let(:disk_usage_rate)           { 100.0 }
+  let(:net_usage_rate)            { 25.0 }
+  let(:vm_used_disk_storage)      { 1.0 }
+  let(:vm_allocated_disk_storage) { 4.0 }
 
   before do
     MiqRegion.seed
@@ -31,17 +41,6 @@ describe ChargebackVm do
     @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
     temp = {:cb_rate => @cbr, :tag => [c, "vm"]}
     ChargebackRate.set_assignments(:compute, [temp])
-
-    @hourly_rate               = 0.01
-    @count_hourly_rate         = 1.00
-    @cpu_usagemhz_rate         = 50.0
-    @cpu_count                 = 1.0
-    @memory_available          = 1000.0
-    @memory_used               = 100.0
-    @disk_usage_rate           = 100.0
-    @net_usage_rate            = 25.0
-    @vm_used_disk_storage      = 1.0
-    @vm_allocated_disk_storage = 4.0
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
   end
@@ -79,14 +78,14 @@ describe ChargebackVm do
         [@vm1, @vm2].each do |vm|
           vm.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -108,7 +107,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -121,7 +120,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -146,14 +145,14 @@ describe ChargebackVm do
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => t,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -176,7 +175,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -189,17 +188,17 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
-      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * hours_in_day)
-      expect(subject.cpu_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+      expect(subject.cpu_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
@@ -217,7 +216,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -230,7 +229,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -243,16 +242,16 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 1.0,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day)
       expect(subject.cpu_used_metric).to eq(used_metric)
 
-      expect(subject.cpu_allocated_cost).to eq(@cpu_count * @count_hourly_rate * hours_in_day)
-      expect(subject.cpu_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+      expect(subject.cpu_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
     end
 
@@ -266,7 +265,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -279,18 +278,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_allocated_metric).to eq(@memory_available)
+      expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, hours_in_day)
       expect(subject.memory_used_metric).to eq(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      expect(subject.memory_allocated_cost).to eq(@memory_available * @hourly_rate * hours_in_day)
-      expect(subject.memory_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.memory_allocated_cost).to eq(memory_available * hourly_rate * hours_in_day)
+      expect(subject.memory_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
@@ -304,7 +303,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -312,7 +311,7 @@ describe ChargebackVm do
       used_metric = used_average_for(:disk_usage_rate_average, hours_in_day)
       expect(subject.disk_io_used_metric).to eq(used_metric)
       expect(subject.disk_io_metric).to eq(subject.disk_io_metric)
-      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_day)
       expect(subject.disk_io_cost).to eq(subject.disk_io_used_cost)
     end
 
@@ -326,14 +325,14 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       used_metric = used_average_for(:net_usage_rate_average, hours_in_day)
       expect(subject.net_io_used_metric).to eq(used_metric)
-      expect(subject.net_io_used_cost).to eq(used_metric * @hourly_rate * hours_in_day)
+      expect(subject.net_io_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
       expect(subject.net_io_cost).to eq(subject.net_io_used_cost)
     end
 
@@ -351,7 +350,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -367,17 +366,17 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
       expect(subject.storage_used_metric).to eq(used_metric)
-      expect(subject.storage_used_cost).to eq(used_metric / 1.gigabyte * @count_hourly_rate * hours_in_day)
+      expect(subject.storage_used_cost).to eq(used_metric / 1.gigabyte * count_hourly_rate * hours_in_day)
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
-      storage_allocated_cost = @vm_allocated_disk_storage * @count_hourly_rate * hours_in_day
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
+      storage_allocated_cost = vm_allocated_disk_storage * count_hourly_rate * hours_in_day
       expect(subject.storage_allocated_cost).to eq(storage_allocated_cost)
 
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
@@ -417,7 +416,7 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
 
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
       expect(subject.storage_used_metric).to eq(used_metric)
@@ -442,14 +441,14 @@ describe ChargebackVm do
         @vm_tenant.metric_rollups <<
           FactoryGirl.create(:metric_rollup_vm_hr,
                              :timestamp                         => t,
-                             :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                             :derived_vm_numvcpus               => @cpu_count,
-                             :derived_memory_available          => @memory_available,
-                             :derived_memory_used               => @memory_used,
-                             :disk_usage_rate_average           => @disk_usage_rate,
-                             :net_usage_rate_average            => @net_usage_rate,
-                             :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                             :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                             :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                             :derived_vm_numvcpus               => cpu_count,
+                             :derived_memory_available          => memory_available,
+                             :derived_memory_used               => memory_used,
+                             :disk_usage_rate_average           => disk_usage_rate,
+                             :net_usage_rate_average            => net_usage_rate,
+                             :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                             :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                              :tag_names                         => "environment/prod",
                              :parent_host_id                    => @host1.id,
                              :parent_ems_cluster_id             => @ems_cluster.id,
@@ -485,14 +484,14 @@ describe ChargebackVm do
       while time < end_time
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -516,7 +515,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -529,16 +528,16 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
-      expect(subject.cpu_allocated_cost).to be_within(0.01).of(@cpu_count * @count_hourly_rate * @hours_in_month)
+      expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
+      expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * @hours_in_month)
     end
 
     let(:fixed_rate) { 10.0 }
@@ -553,7 +552,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => fixed_rate,
-                               :variable_rate             => @hourly_rate.to_s)
+                               :variable_rate             => hourly_rate.to_s)
 
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -567,21 +566,21 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => fixed_rate,
-                               :variable_rate             => @count_hourly_rate.to_s)
+                               :variable_rate             => count_hourly_rate.to_s)
 
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
 
       fixed = fixed_rate * @hours_in_month
-      variable = @cpu_count * @count_hourly_rate * @hours_in_month
+      variable = cpu_count * count_hourly_rate * @hours_in_month
       expect(subject.cpu_allocated_cost).to be_within(0.01).of(fixed + variable)
 
       fixed = fixed_rate * @hours_in_month
-      variable = used_metric * @hourly_rate * @hours_in_month
+      variable = used_metric * hourly_rate * @hours_in_month
       expect(subject.cpu_used_cost).to be_within(0.01).of(fixed + variable)
     end
 
@@ -595,7 +594,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -608,18 +607,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.memory_allocated_metric).to eq(@memory_available)
+      expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, @hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
-      memory_allocated_cost = @memory_available * @hourly_rate * @hours_in_month
+      memory_allocated_cost = memory_available * hourly_rate * @hours_in_month
       expect(subject.memory_allocated_cost).to be_within(0.01).of(memory_allocated_cost)
-      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.memory_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
       expect(subject.memory_cost).to eq(subject.memory_allocated_cost + subject.memory_used_cost)
     end
 
@@ -633,7 +632,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -641,7 +640,7 @@ describe ChargebackVm do
       used_metric = used_average_for(:disk_usage_rate_average, @hours_in_month)
       expect(subject.disk_io_used_metric).to be_within(0.01).of(used_metric)
 
-      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.disk_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
       expect(subject.disk_io_cost).to eq(subject.disk_io_used_cost)
     end
 
@@ -655,13 +654,13 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
       used_metric = used_average_for(:net_usage_rate_average, @hours_in_month)
       expect(subject.net_io_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * @hourly_rate * @hours_in_month)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(used_metric * hourly_rate * @hours_in_month)
       expect(subject.net_io_cost).to eq(subject.net_io_used_cost)
     end
 
@@ -698,7 +697,7 @@ describe ChargebackVm do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
@@ -723,7 +722,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -737,18 +736,18 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
                               )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
-      expect(subject.storage_allocated_metric).to eq(@vm_allocated_disk_storage.gigabytes)
+      expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, @hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expected_value = @vm_allocated_disk_storage * @count_hourly_rate * @hours_in_month
+      expected_value = vm_allocated_disk_storage * count_hourly_rate * @hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
-      expected_value = used_metric / 1.gigabytes * @count_hourly_rate * @hours_in_month
+      expected_value = used_metric / 1.gigabytes * count_hourly_rate * @hours_in_month
       expect(subject.storage_used_cost).to be_within(0.01).of(expected_value)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
@@ -863,14 +862,14 @@ describe ChargebackVm do
       while time < end_time
         @vm1.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                   :timestamp                         => time,
-                                                  :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
-                                                  :derived_vm_numvcpus               => @cpu_count,
-                                                  :derived_memory_available          => @memory_available,
-                                                  :derived_memory_used               => @memory_used,
-                                                  :disk_usage_rate_average           => @disk_usage_rate,
-                                                  :net_usage_rate_average            => @net_usage_rate,
-                                                  :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
-                                                  :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                                                  :cpu_usagemhz_rate_average         => cpu_usagemhz_rate,
+                                                  :derived_vm_numvcpus               => cpu_count,
+                                                  :derived_memory_available          => memory_available,
+                                                  :derived_memory_used               => memory_used,
+                                                  :disk_usage_rate_average           => disk_usage_rate,
+                                                  :net_usage_rate_average            => net_usage_rate,
+                                                  :derived_vm_used_disk_storage      => vm_used_disk_storage.gigabytes,
+                                                  :derived_vm_allocated_disk_storage => vm_allocated_disk_storage.gigabytes,
                                                   :tag_names                         => "environment/prod",
                                                   :parent_host_id                    => @host1.id,
                                                   :parent_ems_cluster_id             => @ems_cluster.id,
@@ -894,7 +893,7 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @hourly_rate.to_s
+                               :variable_rate             => hourly_rate.to_s
       )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
@@ -907,12 +906,12 @@ describe ChargebackVm do
                                :start                     => 0,
                                :finish                    => Float::INFINITY,
                                :fixed_rate                => 0.0,
-                               :variable_rate             => @count_hourly_rate.to_s
+                               :variable_rate             => count_hourly_rate.to_s
       )
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_allocated_metric).to eq(@cpu_count)
+      expect(subject.cpu_allocated_metric).to eq(cpu_count)
       used_metric = used_average_for(:cpu_usagemhz_rate_average, @hours_in_month)
       expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
       expect(subject.tag_name).to eq('Production')
@@ -933,7 +932,7 @@ describe ChargebackVm do
     let(:tier) do
       FactoryGirl.create(:chargeback_tier, :start         => 0,
                                            :finish        => Float::INFINITY,
-                                           :fixed_rate    => @hourly_rate.to_s,
+                                           :fixed_rate    => hourly_rate.to_s,
                                            :variable_rate => 0.0)
     end
     let!(:rate_detail) do
@@ -948,8 +947,8 @@ describe ChargebackVm do
     it 'works' do
       expect(subject.chargeback_rates).to eq(@cbr.description)
       expect(subject.fixed_compute_metric).to eq(1) # One day of fixed compute metric
-      expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * 24)
-      expect(subject.total_cost).to eq(@hourly_rate * 24)
+      expect(subject.fixed_compute_1_cost).to eq(hourly_rate * 24)
+      expect(subject.total_cost).to eq(hourly_rate * 24)
     end
   end
 end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,4 +1,5 @@
 describe ChargebackVm do
+  let(:admin) { FactoryGirl.create(:user_admin) }
   before do
     MiqRegion.seed
     ChargebackRate.seed
@@ -9,9 +10,7 @@ describe ChargebackVm do
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
     @tag = Tag.find_by_name("/managed/environment/prod")
 
-    @admin = FactoryGirl.create(:user_admin)
-
-    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => @admin, :ems_ref => "ems_ref")
+    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref")
     @vm1.tag_with(@tag.name, :ns => '*')
 
     @host1   = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -40,7 +39,7 @@ describe ChargebackVm do
                 :end_interval_offset => 0,
                 :tag                 => "/managed/environment/prod",
                 :ext_options         => {:tz => "Pacific Time (US & Canada)"},
-                :userid              => @admin.userid
+                :userid              => admin.userid
                 }
 
     Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
@@ -70,7 +69,7 @@ describe ChargebackVm do
       time     = ts.beginning_of_month.utc
       end_time = ts.end_of_month.utc
 
-      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => @admin)
+      @vm2 = FactoryGirl.create(:vm_vmware, :name => "test_vm 2", :evm_owner => admin)
 
       while time < end_time
         [@vm1, @vm2].each do |vm|
@@ -831,7 +830,7 @@ describe ChargebackVm do
     let(:vm_owners)     { {@vm1.id => @vm1.evm_owner_name} }
     let(:consumption) { Chargeback::ConsumptionWithRollups.new([metric_rollup], nil, nil) }
     let(:shared_extra_fields) do
-      {'vm_name' => @vm1.name, 'owner_name' => @admin.name, 'vm_uid' => 'ems_ref', 'vm_guid' => @vm1.guid,
+      {'vm_name' => @vm1.name, 'owner_name' => admin.name, 'vm_uid' => 'ems_ref', 'vm_guid' => @vm1.guid,
        'vm_id' => @vm1.id}
     end
     subject { ChargebackVm.new(report_options, consumption).attributes }
@@ -941,7 +940,7 @@ describe ChargebackVm do
   context 'for SCVMM (hyper-v)' do
     let(:base_options) do
       {:interval_size => 1, :end_interval_offset => 0, :tag => '/managed/environment/prod',
-       :ext_options => {:tz => 'UTC'}, :userid => @admin.userid}
+       :ext_options => {:tz => 'UTC'}, :userid => admin.userid}
     end
     let!(:vm1) do
       vm = FactoryGirl.create(:vm_microsoft)


### PR DESCRIPTION
## What?
This is continuation of #13419. However, much smaller. **Most of the commits here just amend specs.** Specs needed to be amended in order to fix time handling issues we had in CB.

## Related PRs
This is equivalent of backporting the following prs and resolving conflicts.
https://github.com/ManageIQ/manageiq/pull/12807
https://github.com/ManageIQ/manageiq/pull/13144
https://github.com/ManageIQ/manageiq/pull/13134
https://github.com/ManageIQ/manageiq/pull/13373
https://github.com/ManageIQ/manageiq/pull/13451

## Related BZs
- This backports bug https://bugzilla.redhat.com/show_bug.cgi?id=1412221 to euwe.
- This fixes minor issues we had in handling time during chargeback calculations. (most of them was not found by users, however with SCVMM chargebacks, they would become much more visible). Thus, I conclude this pr somewhat relates to the new feature of scvmm (that is https://bugzilla.redhat.com/show_bug.cgi?id=1411941).
 - This is hopefully last pr we need in euwe for Chargebacks.

@miq-bot add_label chargebacks
