### PR TITLE
Provider generator enhancements

### DIFF
--- a/lib/generators/provider/templates/.travis.yml
+++ b/lib/generators/provider/templates/.travis.yml
@@ -10,7 +10,5 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
-before_install: bin/setup
-script:
-- bundle exec bin/rails app:test:providers:<%= provider_name %>:setup app:test:providers:<%= provider_name %>
+install: bin/setup
 after_script: bundle exec codeclimate-test-reporter

--- a/lib/generators/provider/templates/Rakefile
+++ b/lib/generators/provider/templates/Rakefile
@@ -1,8 +1,20 @@
+require 'bundler/setup'
+require 'bundler/gem_tasks'
+
 begin
-  require 'bundler/setup'
+  require 'rspec/core/rake_task'
+
+  APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
+  load 'rails/tasks/engine.rake'
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
 
-APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
-load 'rails/tasks/engine.rake'
+namespace :spec do
+  desc "Setup environment for specs"
+  task :setup => 'app:test:providers:<%= provider_name %>:setup'
+end
+
+desc "Run all amazon specs"
+task :spec => 'app:test:providers:<%= provider_name %>'
+
+task :default => :spec

--- a/lib/generators/provider/templates/lib/manageiq-providers-%provider_name%.rb
+++ b/lib/generators/provider/templates/lib/manageiq-providers-%provider_name%.rb
@@ -1,0 +1,2 @@
+require "manageiq/providers/<%= provider_name %>/engine"
+require "manageiq/providers/<%= provider_name %>/version"


### PR DESCRIPTION
### dont run bundle twice on travis 
without an install script travis defaults to bundle install because there is a Gemfile in the project root.
This effectively runs bundle twice, because we also run it from bin/setup
see  https://github.com/ManageIQ/manageiq-providers-amazon/pull/108

### default rake task to run specs
makes `bundle exec rake` work
still keeps the specs in lib/tasks/spec.rake
see my (debatable) rationale in 
https://github.com/ManageIQ/manageiq-providers-amazon/pull/92

###  manageiq-provider-name.rb for easy require
add common gem file to be able to `require 'manageiq-providers-name'`

@miq-bot add_label enhancement, pluggable providers
@miq-bot assign @bdunne 
