### PR TITLE
Add Amazon S3 manager EMS

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -21,6 +21,7 @@
 - ems-type:ec2
 - ems-type:ec2_network
 - ems-type:ec2_block_storage
+- ems-type:s3
 - ems-type:foreman_configuration
 - ems-type:foreman_provisioning
 - ems-type:gce

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -24,6 +24,7 @@ describe ExtManagementSystem do
       "ec2"                         => "Amazon EC2",
       "ec2_network"                 => "Amazon EC2 Network",
       "ec2_block_storage"           => "Amazon EBS",
+      "s3"                          => "Amazon S3",
       "foreman_configuration"       => "Foreman Configuration",
       "foreman_provisioning"        => "Foreman Provisioning",
       "gce"                         => "Google Compute Engine",


### PR DESCRIPTION
Register S3 with the ext management system.
Similar to https://github.com/ManageIQ/manageiq/pull/13539.

Depends on ManageIQ/manageiq-providers-amazon#106.

Reqiured to CI tests pass.

@miq-bot add_label providers/amazon,providers/storage