### PR TITLE
Added missing parameter when requesting OpenStack remote console

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/remote_console.rb
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => 'ems_operations',
         :zone        => my_zone,
-        :args        => [userid, protocol]
+        :args        => [userid, MiqServer.my_server.id, protocol]
       }
 
       MiqTask.generic_action_with_callback(task_opts, queue_opts)


### PR DESCRIPTION
Fixes the 'wrong number of arguments' error
https://bugzilla.redhat.com/show_bug.cgi?id=1414377