### PR TITLE
Normalize Job::StateMachine

### DIFF
--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -1,39 +1,39 @@
-class Job
-  module StateMachine
-    def transitions
-      @transitions ||= load_transitions
+module Job::StateMachine
+  extend ActiveSupport::Concern
+
+  def transitions
+    @transitions ||= load_transitions
+  end
+
+  def state=(next_state)
+    # '*' refers to any state; if next_state is '*', remain in current state.
+    super unless next_state.nil? || next_state == '*'
+  end
+
+  # test whether the transition is allowed; if yes, transit to next state
+  def transit_state(signal)
+    permitted_transitions = transitions[signal.to_sym]
+    unless permitted_transitions.nil?
+      next_state = permitted_transitions[state]
+
+      # if current state is not explicitly permitted, is any state (referred by '*') permitted?
+      next_state = permitted_transitions['*'] unless next_state
+      self.state = next_state
     end
+    !!next_state
+  end
 
-    def state=(next_state)
-      # '*' refers to any state; if next_state is '*', remain in current state.
-      super unless next_state.nil? || next_state == '*'
-    end
+  def signal_abort(*args)
+    signal(:abort, *args)
+  end
 
-    # test whether the transition is allowed; if yes, transit to next state
-    def transit_state(signal)
-      permitted_transitions = transitions[signal.to_sym]
-      unless permitted_transitions.nil?
-        next_state = permitted_transitions[state]
-
-        # if current state is not explicitly permitted, is any state (referred by '*') permitted?
-        next_state = permitted_transitions['*'] unless next_state
-        self.state = next_state
-      end
-      !!next_state
-    end
-
-    def signal_abort(*args)
-      signal(:abort, *args)
-    end
-
-    def signal(signal, *args)
-      signal = :abort_job if signal == :abort
-      if transit_state(signal)
-        save
-        send(signal, *args) if respond_to?(signal)
-      else
-        raise _("%{signal} is not permitted at state %{state}") % {:signal => signal, :state => state}
-      end
+  def signal(signal, *args)
+    signal = :abort_job if signal == :abort
+    if transit_state(signal)
+      save
+      send(signal, *args) if respond_to?(signal)
+    else
+      raise _("%{signal} is not permitted at state %{state}") % {:signal => signal, :state => state}
     end
   end
 end

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -1,6 +1,8 @@
-describe Job::StateMachine do
-  before do
-    module TestStateMachine
+describe Job, "::StateMachine" do
+  subject(:job) do
+    # Job is expected to be subclassed by something
+    # that implements load_transitions
+    Class.new(described_class) {
       def load_transitions
         self.state ||= 'initialize'
         {
@@ -12,51 +14,43 @@ describe Job::StateMachine do
           :error        => {'*'          => '*'}
         }
       end
-    end
-
-    @obj = Class.new(Job) do
-      include TestStateMachine
-    end.new
-  end
-
-  after do
-    Object.send(:remove_const, :TestStateMachine)
+    }.new
   end
 
   it "should transition from one state to another by a signal" do
-    @obj.signal(:initializing)
-    expect(@obj.state).to eq 'waiting'
+    job.signal(:initializing)
+    expect(job.state).to eq 'waiting'
   end
 
   it "should transition to another by a signal according to its current state" do
-    @obj.state = 'waiting'
-    @obj.signal(:start)
-    expect(@obj.state).to eq 'doing'
+    job.state = 'waiting'
+    job.signal(:start)
+    expect(job.state).to eq 'doing'
 
-    @obj.state = 'retrying'
-    @obj.signal(:start)
-    expect(@obj.state).to eq 'working'
+    job.state = 'retrying'
+    job.signal(:start)
+    expect(job.state).to eq 'working'
   end
 
   it "should transition to some selected state from any state" do
-    @obj.signal(:cancel)
-    expect(@obj.state).to eq 'canceling'
+    job.signal(:cancel)
+    expect(job.state).to eq 'canceling'
   end
 
   it "should leave the state unchanged for some selected signal" do
-    @obj.state = 'doing'
-    @obj.signal(:error)
-    expect(@obj.state).to eq 'doing'
+    job.state = 'doing'
+    job.signal(:error)
+    expect(job.state).to eq 'doing'
   end
 
   it "should raise an error if the transition is not allowed" do
-    @obj.state = 'working'
-    expect { @obj.signal(:initializing) }
+    job.state = 'working'
+    expect { job.signal(:initializing) }
       .to raise_error(RuntimeError, /initializing is not permitted at state working/)
   end
 
   it "should raise an error if the signal is not defined" do
-    @obj.state = 'working'
-    expect { @obj.signal(:wrong) }.to raise_error(RuntimeError, /wrong is not permitted at state working/)
+    job.state = 'working'
+    expect { job.signal(:wrong) }.to raise_error(RuntimeError, /wrong is not permitted at state working/)
   end
 end


### PR DESCRIPTION
Collapses namespace and uses ActiveSupport::Concern, which follows convention used widely across the app; Fixes tests to be slightly less intrusive and easier to grok.

This is part of an ongoing attempt to fix errors around the Job namespace on CI (which are seemingly non-deterministic and impossible to find)