### PR TITLE
Add note for shared example groups

### DIFF
--- a/spec/shared/README.md
+++ b/spec/shared/README.md
@@ -1,0 +1,5 @@
+# Shared Example Groups
+
+Note that these shared example groups may be utilized outside of the core
+project; for example, provider gems utilize and run `:floating_ip` for their
+specific provider. Edit and remove these files with caution.


### PR DESCRIPTION
This adds a little README that shows up nicely in Github, cautioning that these
are utilized outside of the core project. It's easy to overlook that without
seeing previous history.

Followup to https://github.com/ManageIQ/manageiq/pull/11414