### PR TITLE
Ensure that Field.new receives model (and not string)

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1604,6 +1604,7 @@ class MiqExpression
   end
 
   def self.create_field(model, associations, field_name)
+    model = model_class(model)
     Field.new(model, associations, field_name)
   end
 


### PR DESCRIPTION
introduced in https://github.com/ManageIQ/manageiq/pull/13243

var [`model`](https://github.com/ManageIQ/manageiq/commit/e7ab375928640822c1303d6adc62fc59ff709c60) can be string because we are calling with string it in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller.rb#L844

we was using  `model_class` method for the model, it returns always `Class`

cc @kbrock @martinpovolny @gtanzillo 