### PR TITLE
Remove inheritance_column in rename_ems_events migration

### DIFF
--- a/db/migrate/20161101174139_rename_ems_events_purging_settings_keys.rb
+++ b/db/migrate/20161101174139_rename_ems_events_purging_settings_keys.rb
@@ -1,6 +1,5 @@
 class RenameEmsEventsPurgingSettingsKeys < ActiveRecord::Migration[5.0]
   class SettingsChange < ActiveRecord::Base
-    self.inheritance_column = :_type_disabled # disable STI
     serialize :value
   end
 


### PR DESCRIPTION
`self.inheritance_column = :_type_disabled # disable STI`
is used only when we have #type column on the model and there is no SettingChange#type

introduced in https://github.com/ManageIQ/manageiq/pull/12344 

@lfu 

@miq-bot assign @Fryguy 
