### PR TITLE
Do not store ar object for inventory refresh

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -76,8 +76,8 @@ module ManagerRefresh
         else
           index = stringify_reference(custom_manager_uuid.call(record))
         end
-        self.data_index[index]    = new_inventory_object(record.attributes.symbolize_keys)
-        self.data_index[index].id = record.id
+        data_index[index]    = new_inventory_object(record.attributes.symbolize_keys)
+        data_index[index].id = record.id
       end
     end
 

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -173,9 +173,8 @@ module ManagerRefresh
                          end
       return unless record
 
-      inventory_object = new_inventory_object(record.attributes.symbolize_keys)
-      # TODO(lsmola) get rid of storing objects, they are causing memory bloat
-      inventory_object.object = record
+      inventory_object    = new_inventory_object(record.attributes.symbolize_keys)
+      inventory_object.id = record.id
       inventory_object
     end
 

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -319,8 +319,8 @@ module ManagerRefresh
     end
 
     def dependency?(value)
-      (value.kind_of?(::ManagerRefresh::InventoryObjectLazy) && value.dependency?) ||
-        value.kind_of?(::ManagerRefresh::InventoryObject)
+      (value.kind_of?(::ManagerRefresh::InventoryObjectLazy) || value.kind_of?(::ManagerRefresh::InventoryObject)) &&
+        value.dependency?
     end
 
     def transitive_dependency?(value)

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -76,9 +76,8 @@ module ManagerRefresh
         else
           index = stringify_reference(custom_manager_uuid.call(record))
         end
-        self.data_index[index] = new_inventory_object(record.attributes.symbolize_keys)
-        # TODO(lsmola) get rid of storing objects, they are causing memory bloat
-        self.data_index[index].object = record
+        self.data_index[index]    = new_inventory_object(record.attributes.symbolize_keys)
+        self.data_index[index].id = record.id
       end
     end
 
@@ -261,6 +260,34 @@ module ManagerRefresh
                      # Dependency attributes need to be a hard copy, since those will differ for each
                      # InventoryCollection
                      :dependency_attributes => dependency_attributes.clone)
+    end
+
+    def association_to_foreign_key_mapping
+      @association_to_foreign_key_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
+        obj[x.name] = x.foreign_key
+      end
+    end
+
+    def foreign_key_to_association_mapping
+      @foreign_key_to_association_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
+        obj[x.foreign_key] = x.name
+      end
+    end
+
+    def association_to_foreign_type_mapping
+      @association_to_foreign_type_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
+        obj[x.name] = x.foreign_type if x.polymorphic?
+      end
+    end
+
+    def foreign_type_to_association_mapping
+      @foreign_type_to_association_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
+        obj[x.foreign_type] = x.name if x.polymorphic?
+      end
+    end
+
+    def base_class_name
+      @base_class_name ||= model_class.base_class.name
     end
 
     def to_s

--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -87,6 +87,10 @@ module ManagerRefresh
       inventory_collection.base_class_name
     end
 
+    def dependency?
+      !inventory_collection.saved?
+    end
+
     private
 
     def association?(inventory_collection_scope, key)

--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -1,16 +1,16 @@
 module ManagerRefresh
   class InventoryObject
-    attr_accessor :object
+    attr_accessor :object, :id
     attr_reader :inventory_collection, :data
 
     delegate :manager_ref, :to => :inventory_collection
-    delegate :id, :to => :object, :allow_nil => true
     delegate :[], :[]=, :to => :data
 
     def initialize(inventory_collection, data)
       @inventory_collection     = inventory_collection
       @data                     = data
       @object                   = nil
+      @id                       = nil
       @allowed_attributes_index = nil
     end
 
@@ -19,29 +19,53 @@ module ManagerRefresh
     end
 
     def load
-      object
+      id
     end
 
     def attributes(inventory_collection_scope = nil)
-      # We should explicitly pass a scope, since the inventory_object can be mapped to more InventoryCollections with different blacklist
-      # and whitelist. The generic code always passes a scope.
+      # TODO(lsmola) mark method with !, for performance reasons, this methods can be called only once, the second
+      # call will not return saveable result. We do not want to cache the result, since we want the lowest memory
+      # footprint.
+
+      # We should explicitly pass a scope, since the inventory_object can be mapped to more InventoryCollections with
+      # different blacklist and whitelist. The generic code always passes a scope.
       inventory_collection_scope ||= inventory_collection
 
+      attributes_for_saving = {}
       # First transform the values
       data.each do |key, value|
         if !allowed?(inventory_collection_scope, key)
           next
         elsif loadable?(value)
+          # Lets fill also the original data, so other InventoryObject referring to this attribute gets the right
+          # result
           data[key] = value.load
+          if (foreign_key = inventory_collection_scope.association_to_foreign_key_mapping[key])
+            # We have an association to fill, lets fill also the :key, cause some other InventoryObject can refer to it
+            attributes_for_saving[foreign_key] = data[key]
+
+            if (foreign_type = inventory_collection_scope.association_to_foreign_type_mapping[key])
+              # If we have a polymorphic association, we need to also fill a base class name
+              attributes_for_saving[foreign_type] = value.inventory_collection.base_class_name
+            end
+          else
+            # We have a normal attribute to fill, or not an Activerecord association, like Ancestry, or any custom
+            # attribute used in e.g. after_save hook, we can't process them automatically
+            attributes_for_saving[key] = data[key]
+          end
         elsif value.kind_of?(Array) && value.any? { |x| loadable?(x) }
-          data[key] = value.compact.map(&:load).compact
+          # Lets fill also the original data, so other InventoryObject referring to this attribute gets the right
+          # result
+          data[key]                                            = value.compact.map(&:load).compact
+          # We can use built in _ids methods to assign array of ids into has_many relations. So e.g. the :key_pairs=
+          # relation setter will become :key_pair_ids=
+          attributes_for_saving[key.to_s.singularize + "_ids"] = data[key]
         else
-          next
+          attributes_for_saving[key] = value
         end
       end
 
-      # Then return a new hash containing only the values according to the whitelist and the blacklist
-      data.select { |key, _value| allowed?(inventory_collection_scope, key) }
+      attributes_for_saving
     end
 
     def to_s
@@ -54,11 +78,24 @@ module ManagerRefresh
 
     private
 
-    def allowed?(inventory_collection_scope, key)
-      # TODO(lsmola) can we make this O(1)? This check will be performed for each record in the DB
+    def association?(inventory_collection_scope, key)
+      # Is the key an association on inventory_collection_scope model class?
+      !inventory_collection_scope.association_to_foreign_key_mapping[key].nil?
+    end
 
-      return false if inventory_collection_scope.attributes_blacklist.present? && inventory_collection_scope.attributes_blacklist.include?(key)
-      return false if inventory_collection_scope.attributes_whitelist.present? && !inventory_collection_scope.attributes_whitelist.include?(key)
+    def allowed?(inventory_collection_scope, key)
+      foreign_to_association  = inventory_collection_scope.foreign_key_to_association_mapping[key] ||
+        inventory_collection_scope.foreign_type_to_association_mapping[key]
+
+      # TODO(lsmola) can we make this O(1)? This check will be performed for each record in the DB
+      return false if inventory_collection_scope.attributes_blacklist.present? &&
+        (inventory_collection_scope.attributes_blacklist.include?(key) ||
+          (foreign_to_association && inventory_collection_scope.attributes_blacklist.include?(foreign_to_association)))
+
+      return false if inventory_collection_scope.attributes_whitelist.present? &&
+        (!inventory_collection_scope.attributes_whitelist.include?(key) &&
+          (!foreign_to_association || (foreign_to_association && inventory_collection_scope.attributes_whitelist.include?(foreign_to_association))))
+
       true
     end
 

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -28,7 +28,7 @@ module ManagerRefresh
     def dependency?
       # If key is not set, InventoryObjectLazy is a dependency, cause it points to the record itself. Otherwise
       # InventoryObjectLazy is a dependency only if it points to an attribute which is a dependency or a relation.
-      !!(!key || transitive_dependency?)
+      !!(!key || transitive_dependency?) && !inventory_collection.saved?
     end
 
     def transitive_dependency?

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -56,8 +56,7 @@ module ManagerRefresh
     end
 
     def load_object
-      inventory_collection_member = inventory_collection.find(to_s)
-      inventory_collection_member.respond_to?(:id) ? inventory_collection_member.id : inventory_collection_member
+      inventory_collection.find(to_s)
     end
   end
 end

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -57,7 +57,7 @@ module ManagerRefresh
 
     def load_object
       inventory_collection_member = inventory_collection.find(to_s)
-      inventory_collection_member.respond_to?(:object) ? inventory_collection_member.object : inventory_collection_member
+      inventory_collection_member.respond_to?(:id) ? inventory_collection_member.id : inventory_collection_member
     end
   end
 end

--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -55,8 +55,6 @@ module ManagerRefresh::SaveCollection
         record_index[inventory_collection.object_index_with_keys(unique_index_keys, record)] = record
       end
 
-      entity_builder = get_entity_builder(inventory_collection, association)
-
       inventory_collection_size = inventory_collection.size
       created_counter           = 0
       _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} ***************")
@@ -66,7 +64,7 @@ module ManagerRefresh::SaveCollection
           record = record_index.delete(inventory_object.manager_uuid)
           if record.nil?
             next unless inventory_collection.create_allowed?
-            record          = entity_builder.create!(hash.except(:id))
+            record          = inventory_collection.model_class.create!(hash.except(:id))
             created_counter += 1
           else
             record.assign_attributes(hash.except(:id, :type))
@@ -94,15 +92,6 @@ module ManagerRefresh::SaveCollection
           deletes.map(&inventory_collection.delete_method)
         end
         _log.info("*************** DELETED #{inventory_collection} ***************")
-      end
-    end
-
-    def get_entity_builder(inventory_collection, association)
-      if inventory_collection.parent && !inventory_collection.arel
-        association_meta_info = inventory_collection.parent.class.reflect_on_association(inventory_collection.association)
-        association_meta_info.options[:through].blank? ? association : inventory_collection.model_class
-      else
-        inventory_collection.model_class
       end
     end
   end

--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -62,21 +62,21 @@ module ManagerRefresh::SaveCollection
       _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} ***************")
       ActiveRecord::Base.transaction do
         inventory_collection.each do |inventory_object|
-          hash                    = inventory_object.attributes(inventory_collection)
-          inventory_object.object = record_index.delete(inventory_object.manager_uuid)
-          if inventory_object.object.nil?
+          hash   = inventory_object.attributes(inventory_collection)
+          record = record_index.delete(inventory_object.manager_uuid)
+          if record.nil?
             next unless inventory_collection.create_allowed?
-            inventory_object.object = entity_builder.create!(hash.except(:id))
-            created_counter         += 1
+            record          = entity_builder.create!(hash.except(:id))
+            created_counter += 1
           else
-            inventory_object.object.assign_attributes(hash.except(:id, :type))
+            record.assign_attributes(hash.except(:id, :type))
             if inventory_collection.check_changed?
-              inventory_object.object.save! if inventory_object.object.changed?
+              record.save! if record.changed?
             else
-              inventory_object.object.save!
+              record.save!
             end
           end
-          inventory_object.object.try(:reload)
+          inventory_object.id = record.try(:id)
         end
       end
       _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -11,7 +11,7 @@ describe ManagerRefresh::SaveInventory do
   #
   # Test all settings for ManagerRefresh::SaveInventory
   [{:inventory_object_saving_strategy => nil},
-   {:inventory_object_saving_strategy => :recursive},
+   {:inventory_object_saving_strategy => :recursive}
   ].each do |inventory_object_settings|
     context "with settings #{inventory_object_settings}" do
       before :each do
@@ -402,6 +402,10 @@ describe ManagerRefresh::SaveInventory do
           :strategy            => :local_db_cache_all,
           :custom_manager_uuid => -> (hardware) { [hardware.vm_or_template.try(:ems_ref)] })
 
+        @vm_data_3       = vm_data(3).merge(
+          :genealogy_parent      => @data[:miq_templates].lazy_find(image_data(2)[:ems_ref]),
+          :key_pairs             => [@data[:key_pairs].lazy_find(key_pair_data(2)[:name])],
+          :ext_management_system => @ems)
         @vm_data_5       = vm_data(5).merge(
           :genealogy_parent      => @data[:miq_templates].lazy_find(image_data(2)[:ems_ref]),
           :key_pairs             => [@data[:key_pairs].lazy_find(key_pair_data(2)[:name])],

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -268,10 +268,11 @@ describe ManagerRefresh::SaveInventory do
               ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
-              :attributes_whitelist => [:raw_power_state])
+              :attributes_whitelist => [:raw_power_state, :ext_management_system])
 
             expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent, :ems_ref,
-                                                                              :name, :location, :raw_power_state])
+                                                                              :name, :location, :raw_power_state,
+                                                                              :ext_management_system])
           end
 
           it 'does not blacklist fixed attributes when changing manager_ref' do
@@ -292,10 +293,11 @@ describe ManagerRefresh::SaveInventory do
               :manager_ref          => [:uid_ems],
               :parent               => @ems,
               :association          => :vms,
-              :attributes_whitelist => [:raw_power_state])
+              :attributes_whitelist => [:raw_power_state, :ext_management_system])
 
             expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent, :uid_ems,
-                                                                              :name, :location, :raw_power_state])
+                                                                              :name, :location, :raw_power_state,
+                                                                              :ext_management_system])
           end
 
           it 'saves all attributes with blacklist and whitelist disabled' do
@@ -381,7 +383,7 @@ describe ManagerRefresh::SaveInventory do
               :parent               => @ems,
               :association          => :vms,
               # TODO(lsmola) vendor is not getting caught by fixed attributes
-              :attributes_whitelist => [:uid_ems, :vendor])
+              :attributes_whitelist => [:uid_ems, :vendor, :ext_management_system])
 
             # Fill the InventoryCollections with data, that have a modified name, new VM and a missing VM
             add_data_to_inventory_collection(@data[:vms], *changed_data)
@@ -420,7 +422,7 @@ describe ManagerRefresh::SaveInventory do
               :parent               => @ems,
               :association          => :vms,
               # TODO(lsmola) vendor is not getting caught by fixed attributes
-              :attributes_whitelist => [:uid_ems, :raw_power_state, :vendor],
+              :attributes_whitelist => [:uid_ems, :raw_power_state, :vendor, :ext_management_system],
               :attributes_blacklist => [:name, :ems_ref, :raw_power_state])
 
             # Fill the InventoryCollections with data, that have a modified name, new VM and a missing VM
@@ -495,8 +497,12 @@ describe ManagerRefresh::SaveInventory do
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
-                                             vm_data(1).merge(:name => "vm_changed_name_1", :ext_management_system => @ems),
-                                             vm_data(3).merge(:name => "vm_changed_name_3", :ext_management_system => @ems))
+                                             vm_data(1).merge(:name                  => "vm_changed_name_1",
+                                                              :availability_zone     => availability_zone,
+                                                              :ext_management_system => @ems),
+                                             vm_data(3).merge(:name                  => "vm_changed_name_3",
+                                                              :availability_zone     => availability_zone,
+                                                              :ext_management_system => @ems))
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
@@ -520,8 +526,12 @@ describe ManagerRefresh::SaveInventory do
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
-                                             vm_data(1).merge(:name => "vm_changed_name_1", :ext_management_system => @ems),
-                                             vm_data(3).merge(:name => "vm_changed_name_3", :ext_management_system => @ems))
+                                             vm_data(1).merge(:name                  => "vm_changed_name_1",
+                                                              :cloud_tenant          => cloud_tenant,
+                                                              :ext_management_system => @ems),
+                                             vm_data(3).merge(:name                  => "vm_changed_name_3",
+                                                              :cloud_tenant          => cloud_tenant,
+                                                              :ext_management_system => @ems))
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
@@ -545,8 +555,11 @@ describe ManagerRefresh::SaveInventory do
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
-                                             vm_data(1).merge(:name => "vm_changed_name_1"),
-                                             vm_data(3).merge(:name => "vm_changed_name_3"))
+                                             vm_data(1).merge(:name         => "vm_changed_name_1",
+                                                              :cloud_tenant => cloud_tenant),
+                                             vm_data(3).merge(:name                  => "vm_changed_name_3",
+                                                              :ext_management_system => nil,
+                                                              :cloud_tenant          => cloud_tenant))
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)
@@ -578,8 +591,11 @@ describe ManagerRefresh::SaveInventory do
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
-                                             vm_data(1).merge(:name => "vm_changed_name_1"),
-                                             vm_data(3).merge(:name => "vm_changed_name_3"))
+                                             vm_data(1).merge(:name         => "vm_changed_name_1",
+                                                              :cloud_tenant => cloud_tenant),
+                                             vm_data(3).merge(:name                  => "vm_changed_name_3",
+                                                              :ext_management_system => nil,
+                                                              :cloud_tenant          => cloud_tenant))
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, data.values)

--- a/spec/models/manager_refresh/save_inventory/spec_parsed_data.rb
+++ b/spec/models/manager_refresh/save_inventory/spec_parsed_data.rb
@@ -1,34 +1,37 @@
 module SpecParsedData
   def vm_data(i, data = {})
     {
-      :type            => ManageIQ::Providers::CloudManager::Vm.name,
-      :uid_ems         => "vm_uid_ems_#{i}",
-      :ems_ref         => "vm_ems_ref_#{i}",
-      :name            => "vm_name_#{i}",
-      :vendor          => "amazon",
-      :raw_power_state => "unknown",
-      :location        => "vm_location_#{i}",
+      :type                  => ManageIQ::Providers::CloudManager::Vm.name,
+      :ext_management_system => @ems,
+      :uid_ems               => "vm_uid_ems_#{i}",
+      :ems_ref               => "vm_ems_ref_#{i}",
+      :name                  => "vm_name_#{i}",
+      :vendor                => "amazon",
+      :raw_power_state       => "unknown",
+      :location              => "vm_location_#{i}",
     }.merge(data)
   end
 
   def key_pair_data(i, data = {})
     {
-      :type => ManageIQ::Providers::CloudManager::AuthKeyPair.name,
-      :name => "key_pair_name_#{i}",
+      :type     => ManageIQ::Providers::CloudManager::AuthKeyPair.name,
+      :resource => @ems,
+      :name     => "key_pair_name_#{i}",
     }.merge(data)
   end
 
   def image_data(i, data = {})
     {
-      :type               => ManageIQ::Providers::CloudManager::Template.name,
-      :uid_ems            => "image_uid_ems_#{i}",
-      :ems_ref            => "image_ems_ref_#{i}",
-      :name               => "image_name_#{i}",
-      :location           => "image_location_#{i}",
-      :vendor             => "amazon",
-      :raw_power_state    => "never",
-      :template           => true,
-      :publicly_available => false,
+      :type                  => ManageIQ::Providers::CloudManager::Template.name,
+      :ext_management_system => @ems,
+      :uid_ems               => "image_uid_ems_#{i}",
+      :ems_ref               => "image_ems_ref_#{i}",
+      :name                  => "image_name_#{i}",
+      :location              => "image_location_#{i}",
+      :vendor                => "amazon",
+      :raw_power_state       => "never",
+      :template              => true,
+      :publicly_available    => false,
     }.merge(data)
   end
 
@@ -62,17 +65,19 @@ module SpecParsedData
 
   def flavor_data(i, data = {})
     {
-      :name => "t#{i}.nano",
+      :name                  => "t#{i}.nano",
+      :ext_management_system => @ems,
     }.merge(data)
   end
 
   def orchestration_stack_data(i, data = {})
     {
-      :ems_ref       => "stack_ems_ref_#{i}",
-      :name          => "stack_name_#{i}",
-      :description   => "stack_description_#{i}",
-      :status        => "stack_status_#{i}",
-      :status_reason => "stack_status_reason_#{i}",
+      :ems_ref               => "stack_ems_ref_#{i}",
+      :ext_management_system => @ems,
+      :name                  => "stack_name_#{i}",
+      :description           => "stack_description_#{i}",
+      :status                => "stack_status_#{i}",
+      :status_reason         => "stack_status_reason_#{i}",
     }.merge(data)
   end
 
@@ -87,10 +92,11 @@ module SpecParsedData
 
   def network_port_data(i, data = {})
     {
-      :name        => "network_port_name_#{i}",
-      :ems_ref     => "network_port_ems_ref_#{i}",
-      :status      => "network_port_status#{i}",
-      :mac_address => "network_port_mac_#{i}",
+      :name                  => "network_port_name_#{i}",
+      :ext_management_system => @ems.network_manager,
+      :ems_ref               => "network_port_ems_ref_#{i}",
+      :status                => "network_port_status#{i}",
+      :mac_address           => "network_port_mac_#{i}",
     }.merge(data)
   end
 end


### PR DESCRIPTION
Do not store AR objects when doing refresh. And do not create objects using association, but directly through class. This brings down memory requirements heavily.

Implements:
https://www.pivotaltracker.com/story/show/137741549

Benchmark with refreshing AWS env with 77k AWS public images

New refresh with this patch applied
-------------------------------------------

**1st refresh (doing create of images):**

Memory consumed: ~1250MB
Time processing saving: ~500s

**2nd and other refreshes (doing mostly update of images):**

Memory consumed: ~1476MB
Time processing the saving: ~200s

New refresh without this patch applied
------------------------------------------------

**1st refresh (doing create of images):**

Memory consumed: ~3597MB
Time processing saving: ~1100s

**2nd and other refreshes (doing mostly update of images):**

Memory consumed: 2306~MB
Time processing the saving: ~444s

Old refresh
--------------

(there is O(n^2) bug in rails 5.0.1 I have locally fixed)

**1st refresh (doing create of images):**

Memory consumed: ~3344MB
Time processing saving: ~1238s

**2nd and other refreshes (doing mostly update of images):**

Memory consumed: ~3817MB
Time processing the saving: ~1537s

Result
----------

We see huge improvement both in memory and time. The big memory hog is also in the parser, doing api request to AWS takes about 600MB in memory. I've already filled an issue to aws-sdk, so we might see another decrease here after.
