### PR TITLE
Decouple API from ApplicationController

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -43,9 +43,9 @@ module Api
 
     def server_info
       {
-        :version   => vmdb_build_info(:version),
-        :build     => vmdb_build_info(:build),
-        :appliance => appliance_name,
+        :version   => Vmdb::Appliance.VERSION,
+        :build     => Vmdb::Appliance.BUILD,
+        :appliance => MiqServer.my_server.name,
       }
     end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,7 +4,7 @@ module Api
   #
   Initializer.new.go
 
-  class BaseController < ActionController::Base
+  class BaseController < ActionController::API
     TAG_NAMESPACE = "/managed".freeze
 
     #
@@ -24,6 +24,7 @@ module Api
     include_concern 'Generic'
     include_concern 'Authentication'
     include CompressedIds
+    include ActionController::HttpAuthentication::Basic::ControllerMethods
     extend ErrorHandler::ClassMethods
 
     before_action :require_api_user_or_token, :except => [:handle_options_request]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -26,9 +26,9 @@ module Api
     include CompressedIds
     extend ErrorHandler::ClassMethods
 
+    before_action :require_api_user_or_token, :except => [:handle_options_request]
     before_action :set_gettext_locale
     before_action :set_access_control_headers
-    prepend_before_action :require_api_user_or_token, :except => [:handle_options_request]
     before_action :parse_api_request, :log_api_request, :validate_api_request
     before_action :validate_api_action, :except => [:options]
     before_action :log_request_initiated, :only => [:handle_options_request]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,7 +4,7 @@ module Api
   #
   Initializer.new.go
 
-  class BaseController < ApplicationController
+  class BaseController < ActionController::Base
     TAG_NAMESPACE = "/managed".freeze
 
     #
@@ -26,21 +26,7 @@ module Api
     include CompressedIds
     extend ErrorHandler::ClassMethods
 
-    #
-    # To skip CSRF token verification as API clients would
-    # not have these. They would instead dealing with the /api/auth
-    # mechanism.
-    #
-    if Vmdb::Application.config.action_controller.allow_forgery_protection
-      skip_before_action :verify_authenticity_token,
-                         :only => [:show, :update, :destroy, :handle_options_request, :options]
-    end
-    skip_before_action :get_global_session_data
-    skip_before_action :reset_toolbar
-    skip_before_action :set_session_tenant
-    skip_before_action :set_user_time_zone
-    skip_before_action :allow_websocket
-    skip_after_action :set_global_session_data
+    before_action :set_gettext_locale
     before_action :set_access_control_headers
     prepend_before_action :require_api_user_or_token, :except => [:handle_options_request]
     before_action :parse_api_request, :log_api_request, :validate_api_request
@@ -53,6 +39,10 @@ module Api
     rescue_from_api_errors
 
     private
+
+    def set_gettext_locale
+      FastGettext.set_locale(LocaleResolver.resolve(User.current_user, headers))
+    end
 
     def validate_response_format
       accept = request.headers["Accept"]

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -23,12 +23,7 @@ module Api
 
       module ClassMethods
         def rescue_from_api_errors
-          ERROR_MAPPING.each do |error, type|
-            rescue_from error do |e|
-              raise e unless ApplicationController.handle_exceptions?
-              api_exception_type(type, e)
-            end
-          end
+          ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_exception_type(type, e) } }
         end
       end
 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -65,8 +65,6 @@ module Spec
         @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
         define_user
-
-        ApplicationController.handle_exceptions = true
       end
 
       def entrypoint_url


### PR DESCRIPTION
Since the base controller is skipping all but one of the callbacks defined in
`ApplicationController`, inheriting instead from the unpolluted
ActionController::Base appears to work fine. I've just updated the base controller to reimplement `set_gettext_locale`. Consequently the surface
area of the API controllers can be greatly reduced.

I've also eliminated the call to (and the deliberate setting of in the specs) `ApplicationController.handle_exceptions?`, since I don't see how that can currently be `false`.

This also seems to me to be just generally a good idea, now that `ApplicationController` lives in another repository.

EDIT: rebasing onto https://github.com/ManageIQ/manageiq/pull/13582 will help eliminate the duplication in this PR

@abellotti is this a good time to revive this work?

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 