### PR TITLE
Per-endpoint configurable certificate_authority

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -7,7 +7,7 @@ module Api
     AUTH_TYPE_ATTR    = "auth_type".freeze
     DEFAULT_AUTH_TYPE = "default".freeze
     CONNECTION_ATTRS  = %w(connection_configurations).freeze
-    ENDPOINT_ATTRS    = %w(hostname url ipaddress port security_protocol).freeze
+    ENDPOINT_ATTRS    = %w(hostname url ipaddress port security_protocol certificate_authority).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"].freeze
 
     include Subcollections::Policies

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 class Endpoint < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
@@ -5,6 +7,7 @@ class Endpoint < ApplicationRecord
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
   validates :port, :numericality => {:only_integer => true, :allow_nil => true, :greater_than => 0}
   validates :url, :uniqueness => true, :if => :url
+  validate :validate_certificate_authority
 
   def verify_ssl=(val)
     val = resolve_verify_ssl_value(val)
@@ -15,6 +18,29 @@ class Endpoint < ApplicationRecord
     verify_ssl != OpenSSL::SSL::VERIFY_NONE
   end
 
+  # From endpoint, falling back to Settings, then to system CA bundle
+  def ssl_cert_store
+    certs = parse_certificate_authority
+    if certs.present?
+      store = OpenSSL::X509::Store.new
+      certs.each do |cert|
+        store.add_cert(cert)
+      end
+      return store
+    end
+
+    file = Settings.ssl.ssl_ca_file
+    path = Settings.ssl.ssl_ca_path
+    if file.present? || path.present?
+      store = OpenSSL::X509::Store.new
+      store.add_file(file) if file.present?
+      store.add_path(path) if path.present?
+      return store
+    end
+
+    nil # use system defaults
+  end
+
   private
 
   def resolve_verify_ssl_value(val)
@@ -23,5 +49,19 @@ class Endpoint < ApplicationRecord
     when false then OpenSSL::SSL::VERIFY_NONE
     else            val
     end
+  end
+
+  # Returns a list, to support concatenated PEM certs.
+  def parse_certificate_authority
+    return [] if certificate_authority.blank?
+    certificate_authority.split(/(?=-----BEGIN)/).reject(&:blank?).collect do |pem_fragment|
+      OpenSSL::X509::Certificate.new(pem_fragment)
+    end
+  end
+
+  def validate_certificate_authority
+    parse_certificate_authority
+  rescue OpenSSL::OpenSSLError => err
+    errors.add(:certificate_authority, err.to_s)
   end
 end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -111,6 +111,8 @@ class ExtManagementSystem < ApplicationRecord
            :port=,
            :security_protocol,
            :security_protocol=,
+           :certificate_authority,
+           :certificate_authority=,
            :to => :default_endpoint,
            :allow_nil => true
 

--- a/db/migrate/20170117144629_add_certificate_authority_to_endpoint.rb
+++ b/db/migrate/20170117144629_add_certificate_authority_to_endpoint.rb
@@ -1,0 +1,5 @@
+class AddCertificateAuthorityToEndpoint < ActiveRecord::Migration[5.0]
+  def change
+    add_column :endpoints, :certificate_authority, :text
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1160,6 +1160,7 @@ endpoints:
 - security_protocol
 - api_version
 - path
+- certificate_authority
 entitlements:
 - id
 - miq_group_id

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -57,4 +57,74 @@ describe Endpoint do
       expect { Endpoint.create!(:url => "abc") }.to raise_error("Validation failed: Url has already been taken")
     end
   end
+
+  context "certificate_authority" do
+    # openssl req -x509 -newkey rsa:512 -out cert.pem -nodes, all defaults, twice
+    let(:pem1) do
+      <<-EOPEM.strip_heredoc
+        -----BEGIN CERTIFICATE-----
+        MIIBzTCCAXegAwIBAgIJAOgErvCo3YfDMA0GCSqGSIb3DQEBCwUAMEIxCzAJBgNV
+        BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg
+        Q29tcGFueSBMdGQwHhcNMTcwMTE3MTUzODUxWhcNMTcwMjE2MTUzODUxWjBCMQsw
+        CQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZh
+        dWx0IENvbXBhbnkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKkV4c0cV0oB
+        7e1hMmQygmqEELooktNhMpnqqUyy2Lbi/QI3v9f4jyVrI0Uq3x+FXAlopj2ZE+Zp
+        qiaq6vmlPSECAwEAAaNQME4wHQYDVR0OBBYEFN6XWVKCGYdjnecoVEt7rtNP4d6S
+        MB8GA1UdIwQYMBaAFN6XWVKCGYdjnecoVEt7rtNP4d6SMAwGA1UdEwQFMAMBAf8w
+        DQYJKoZIhvcNAQELBQADQQB1IY8KIHcESeKuS8C1i5/wPuFNP3L2a5XKJ29IQsJy
+        xY9wgnq7LoIesQsiuiXOGa8L8C9CviIV38Wz9ySt3aLZ
+        -----END CERTIFICATE-----
+      EOPEM
+    end
+    let(:pem2) do
+      <<-EOPEM.strip_heredoc
+        -----BEGIN CERTIFICATE-----
+        MIIBzTCCAXegAwIBAgIJAOpKKx6qCHdIMA0GCSqGSIb3DQEBCwUAMEIxCzAJBgNV
+        BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg
+        Q29tcGFueSBMdGQwHhcNMTcwMTE3MTY0ODA3WhcNMTcwMjE2MTY0ODA3WjBCMQsw
+        CQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZh
+        dWx0IENvbXBhbnkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKVRWFRPhp0g
+        XcFcm5sjawbCq8I/segjyEcK/oa547pHJXFeuAi8eq1peVNrXU9mpdvnik1i0aLW
+        OuH/XOoUYtUCAwEAAaNQME4wHQYDVR0OBBYEFNpCOxdZrAeWKl1mZRASn4Ss945x
+        MB8GA1UdIwQYMBaAFNpCOxdZrAeWKl1mZRASn4Ss945xMAwGA1UdEwQFMAMBAf8w
+        DQYJKoZIhvcNAQELBQADQQAuuzLKcHLZDewClpG47ImdMPtupNT0YmOYSnDh/Sge
+        tOowLeEkgFb2Eat+n0Ub5BWMuDp0E/d2kx4wMcOLaeLl
+        -----END CERTIFICATE-----
+      EOPEM
+    end
+
+    it "is not required" do
+      endpoint.certificate_authority = nil
+      expect(endpoint.valid?).to be_truthy
+      expect(endpoint.ssl_cert_store).to eq(nil)
+
+      endpoint.certificate_authority = "\n"
+      expect(endpoint.valid?).to be_truthy
+      expect(endpoint.ssl_cert_store).to eq(nil)
+    end
+
+    it "rejects invalid data" do
+      endpoint.certificate_authority = "NONSENSE"
+      expect(endpoint).not_to be_valid
+
+      endpoint.certificate_authority = <<-EOPEM.strip_heredoc
+        -----BEGIN CERTIFICATE-----
+        ValidBase64InvalidCert==
+        -----END CERTIFICATE-----
+      EOPEM
+      expect(endpoint).not_to be_valid
+    end
+
+    it "ssl_cert_store parses valid cert(s)" do
+      endpoint.certificate_authority = pem1
+      expect(endpoint).to be_valid
+      expect(endpoint.send(:parse_certificate_authority).size).to eq(1)
+      expect(endpoint.ssl_cert_store).to be_a(OpenSSL::X509::Store)
+
+      endpoint.certificate_authority = pem1 + pem2
+      expect(endpoint).to be_valid
+      expect(endpoint.send(:parse_certificate_authority).size).to eq(2)
+      expect(endpoint.ssl_cert_store).to be_a(OpenSSL::X509::Store)
+    end
+  end
 end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -25,6 +25,23 @@ describe "Providers API" do
       "auth_key"  => SecureRandom.hex
     }
   end
+  let(:certificate_authority) do
+    # openssl req -x509 -newkey rsa:512 -out cert.pem -nodes, all defaults, twice
+    <<-EOPEM.strip_heredoc
+      -----BEGIN CERTIFICATE-----
+      MIIBzTCCAXegAwIBAgIJAOgErvCo3YfDMA0GCSqGSIb3DQEBCwUAMEIxCzAJBgNV
+      BAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg
+      Q29tcGFueSBMdGQwHhcNMTcwMTE3MTUzODUxWhcNMTcwMjE2MTUzODUxWjBCMQsw
+      CQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZh
+      dWx0IENvbXBhbnkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKkV4c0cV0oB
+      7e1hMmQygmqEELooktNhMpnqqUyy2Lbi/QI3v9f4jyVrI0Uq3x+FXAlopj2ZE+Zp
+      qiaq6vmlPSECAwEAAaNQME4wHQYDVR0OBBYEFN6XWVKCGYdjnecoVEt7rtNP4d6S
+      MB8GA1UdIwQYMBaAFN6XWVKCGYdjnecoVEt7rtNP4d6SMAwGA1UdEwQFMAMBAf8w
+      DQYJKoZIhvcNAQELBQADQQB1IY8KIHcESeKuS8C1i5/wPuFNP3L2a5XKJ29IQsJy
+      xY9wgnq7LoIesQsiuiXOGa8L8C9CviIV38Wz9ySt3aLZ
+      -----END CERTIFICATE-----
+    EOPEM
+  end
   let(:sample_vmware) do
     {
       "type"      => "ManageIQ::Providers::Vmware::InfraManager",
@@ -40,7 +57,8 @@ describe "Providers API" do
       "port"              => 5000,
       "hostname"          => "sample_rhevm.provider.com",
       "ipaddress"         => "100.200.300.2",
-      'security_protocol' => 'kerberos',
+      "security_protocol" => "kerberos",
+      "certificate_authority" => certificate_authority,
     }
   end
   let(:sample_openshift) do
@@ -50,7 +68,8 @@ describe "Providers API" do
       "port"              => 8443,
       "hostname"          => "sample_openshift.provider.com",
       "ipaddress"         => "100.200.300.3",
-      'security_protocol' => 'kerberos',
+      "security_protocol" => "something",
+      "certificate_authority" => certificate_authority,
     }
   end
   let(:default_connection) do
@@ -58,7 +77,9 @@ describe "Providers API" do
       "endpoint"       => {
         "role"     => "default",
         "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => 8444
+        "port"     => 8444,
+        "security_protocol" => "something",
+        "certificate_authority" => certificate_authority,
       },
       "authentication" => {
         "role"     => "bearer",
@@ -71,7 +92,9 @@ describe "Providers API" do
       "endpoint"       => {
         "role"     => "default",
         "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => "8443"
+        "port"     => "8443",
+        "security_protocol" => "something",
+        "certificate_authority" => certificate_authority,
       },
       "authentication" => {
         "role"     => "bearer",
@@ -84,7 +107,9 @@ describe "Providers API" do
       "endpoint"       => {
         "role"     => "hawkular",
         "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => "443"
+        "port"     => "443",
+        "security_protocol" => "something",
+        "certificate_authority" => certificate_authority,
       },
       "authentication" => {
         "role"     => "hawkular",
@@ -98,6 +123,12 @@ describe "Providers API" do
       "name"                      => "sample openshift with multiple endpoints",
       "connection_configurations" => [default_connection, hawkular_connection]
     }
+  end
+
+  def have_endpoint_attributes(expected_hash)
+    h = expected_hash.slice(*ENDPOINT_ATTRS)
+    h["port"] = h["port"].to_i if h.key?("port")
+    have_attributes(h)
   end
 
   context "Provider custom_attributes" do
@@ -324,7 +355,7 @@ describe "Providers API" do
       provider_id = response.parsed_body["results"].first["id"]
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
-      expect_result_to_match_hash(endpoint.attributes, sample_rhevm.slice(*ENDPOINT_ATTRS))
+      expect(endpoint).to have_endpoint_attributes(sample_rhevm)
     end
 
     it "supports openshift creation with auth_key specified" do
@@ -344,9 +375,7 @@ describe "Providers API" do
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       ems = ExtManagementSystem.find(provider_id)
       expect(ems.authentications.size).to eq(1)
-      ENDPOINT_ATTRS.each do |attr|
-        expect(ems.send(attr)).to eq(sample_openshift[attr]) if sample_openshift.key? attr
-      end
+      expect(ems).to have_endpoint_attributes(sample_openshift)
     end
 
     it "supports single provider creation via action" do
@@ -429,14 +458,6 @@ describe "Providers API" do
     end
 
     it "supports provider with multiple endpoints creation" do
-      def hostname(connection)
-        connection["endpoint"]["hostname"]
-      end
-
-      def port(connection)
-        connection["endpoint"]["port"]
-      end
-
       def token(connection)
         connection["authentication"]["auth_key"]
       end
@@ -456,11 +477,13 @@ describe "Providers API" do
       expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
 
-      expect(provider.hostname).to eq(hostname(default_connection))
+      expect(provider).to have_endpoint_attributes(default_connection["endpoint"])
       expect(provider.authentication_token).to eq(token(default_connection))
-      expect(provider.port).to eq(port(default_connection))
-      expect(provider.connection_configurations.hawkular.endpoint.hostname).to eq(hostname(hawkular_connection))
-      expect(provider.connection_configurations.hawkular.authentication.auth_key).to eq(token(hawkular_connection))
+
+      expect(provider.connection_configurations.hawkular.endpoint).to have_endpoint_attributes(
+        hawkular_connection["endpoint"]
+      )
+      expect(provider.authentication_token(:hawkular)).to eq(token(hawkular_connection))
     end
   end
 
@@ -550,6 +573,9 @@ describe "Providers API" do
       run_post(providers_url(provider.id), gen_request(:edit,
                                                        "connection_configurations" => [updated_connection,
                                                                                        hawkular_connection]))
+
+      provider.reload
+      expect(provider).to have_endpoint_attributes(updated_connection["endpoint"])
 
       queue_jobs = MiqQueue.where(:method_name => "authentication_check_types",
                                   :class_name  => "ExtManagementSystem",

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -52,33 +52,33 @@ describe "Providers API" do
   end
   let(:sample_rhevm) do
     {
-      "type"              => "ManageIQ::Providers::Redhat::InfraManager",
-      "name"              => "sample rhevm",
-      "port"              => 5000,
-      "hostname"          => "sample_rhevm.provider.com",
-      "ipaddress"         => "100.200.300.2",
-      "security_protocol" => "kerberos",
+      "type"                  => "ManageIQ::Providers::Redhat::InfraManager",
+      "name"                  => "sample rhevm",
+      "port"                  => 5000,
+      "hostname"              => "sample_rhevm.provider.com",
+      "ipaddress"             => "100.200.300.2",
+      "security_protocol"     => "kerberos",
       "certificate_authority" => certificate_authority,
     }
   end
   let(:sample_openshift) do
     {
-      "type"              => "ManageIQ::Providers::Openshift::ContainerManager",
-      "name"              => "sample openshift",
-      "port"              => 8443,
-      "hostname"          => "sample_openshift.provider.com",
-      "ipaddress"         => "100.200.300.3",
-      "security_protocol" => "something",
+      "type"                  => "ManageIQ::Providers::Openshift::ContainerManager",
+      "name"                  => "sample openshift",
+      "port"                  => 8443,
+      "hostname"              => "sample_openshift.provider.com",
+      "ipaddress"             => "100.200.300.3",
+      "security_protocol"     => "something",
       "certificate_authority" => certificate_authority,
     }
   end
   let(:default_connection) do
     {
       "endpoint"       => {
-        "role"     => "default",
-        "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => 8444,
-        "security_protocol" => "something",
+        "role"                  => "default",
+        "hostname"              => "sample_openshift_multi_end_point.provider.com",
+        "port"                  => 8444,
+        "security_protocol"     => "something",
         "certificate_authority" => certificate_authority,
       },
       "authentication" => {
@@ -90,10 +90,10 @@ describe "Providers API" do
   let(:updated_connection) do
     {
       "endpoint"       => {
-        "role"     => "default",
-        "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => "8443",
-        "security_protocol" => "something",
+        "role"                  => "default",
+        "hostname"              => "sample_openshift_multi_end_point.provider.com",
+        "port"                  => "8443",
+        "security_protocol"     => "something else",
         "certificate_authority" => certificate_authority,
       },
       "authentication" => {
@@ -105,10 +105,10 @@ describe "Providers API" do
   let(:hawkular_connection) do
     {
       "endpoint"       => {
-        "role"     => "hawkular",
-        "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => "443",
-        "security_protocol" => "something",
+        "role"                  => "hawkular",
+        "hostname"              => "sample_openshift_multi_end_point.provider.com",
+        "port"                  => "443",
+        "security_protocol"     => "something",
         "certificate_authority" => certificate_authority,
       },
       "authentication" => {


### PR DESCRIPTION
# Purpose

To securely connect to providers using self-signed TLS certificates, it should be possible to configure ManageIQ to trust specific CA(s).
Currently this generally requires adding them to the system CA bundle on the MIQ machine; Openstack looks at settings `ssl.ssl_ca_file` and `ssl.ssl_ca_path` but you still have to place the file(s) on the machine first.
This PR adds a way to to store the CA in the DB + a bit of support logic + REST API.
It remains up to specific providers to use it (exact use will vary by network lib but something like passing `:ssl_cert_store => endpoint.ssl_cert_store`).

- There can be a secondary use case of "pinning a CA": my provider has a globally trusted cert from a TopSecureCA™, and I want to trust only them, not the standard bundle of over 150 CAs.
  I'm assuming here that whenever you specify a custom CA, you no longer want to trust the system bundle, so this case is also covered.

## Rationale: Global / Per Provider / Per EMS / Per Endpoint ?

- A global pool of trusted CAs would I think be less secure (I trust Alice to administrate provider A and Bob to administrate provider B, but I don't want Bob to be able to impersonate A) and pragmatically inconvenient to manage — hard to know which certs can be removed when.

- Per Endpoint may be best since different endpoints could have different host, port and maybe certs.  YAGNI?

- Per Provider or EMS can be OK too, especially if we allow multiple certs.

=> I've chosen per-Endpoint because it logically belongs with `verify_ssl` and `security_protocol` columns that `Endpoint` already has.

## Rationale: text column holding PEM cert(s)

A few endpoints might end up storing the same cert, but seemed to me much simpler than doing a new table with 1:many association...
I'm storing certs in PEM format — essentially the ASN-1 binary encoded in base64.  Opaque, but it's what essentially all network libs take.
The parsing logic supports multiple concatenated PEM certs.  There is no strong need, but it's a common thing people do with trust roots, so I figured it's easier to make it work than forbid...

## REST API

Same as other endpoint attributes (see #13454):

- Returned in `endpoints` (when non-nil).
- For default endpoint can be set as a top-level attribute.
- Can be set on endpoints inside `connection_configurations`.

@miq-bot add-label enhancement, providers, sql migration, api

cc @simon3z @blomquisg @Fryguy 
