### PR TITLE
Rename Amazon EBS storage manager

### DIFF
--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -19,6 +19,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
     ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker
@@ -95,6 +96,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
     ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::ConfigurationManager::RefreshWorker

--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -20,7 +20,7 @@
 - ems-type:cinder
 - ems-type:ec2
 - ems-type:ec2_network
-- ems-type:ec2_block_storage
+- ems-type:ec2_ebs_storage
 - ems-type:foreman_configuration
 - ems-type:foreman_provisioning
 - ems-type:gce

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolume < MiqAeServiceCloudVolume
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager-cloud_volume_snapshot.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-block_storage_manager.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_BlockStorageManager < MiqAeServiceManageIQ_Providers_StorageManager
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolume < MiqAeServiceCloudVolume
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs-cloud_volume_snapshot.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-ebs.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_Ebs < MiqAeServiceManageIQ_Providers_StorageManager
+  end
+end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -23,7 +23,7 @@ describe ExtManagementSystem do
       "azure_network"               => "Azure Network",
       "ec2"                         => "Amazon EC2",
       "ec2_network"                 => "Amazon EC2 Network",
-      "ec2_block_storage"           => "Amazon EBS",
+      "ec2_ebs_storage"             => "Amazon EBS",
       "foreman_configuration"       => "Foreman Configuration",
       "foreman_provisioning"        => "Foreman Provisioning",
       "gce"                         => "Google Compute Engine",


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-amazon/pull/107 renames the Amazon block storage manager from `ManageIQ::Providers::Amazon::BlockStorageManager` to `ManageIQ::Providers::Amazon::StorageManager::Ebs`. This patch fixes the dependencies in the main repository that were broken by this change.

It replaces these PRs:
 * ext management system: https://github.com/ManageIQ/manageiq/pull/13549
 * automation: https://github.com/ManageIQ/manageiq/pull/13550
 * refresh worker: https://github.com/ManageIQ/manageiq/pull/13457

@miq-bot providers/amazon,providers/storage

@miq-bot assign @roliveri 