### PR TITLE
Add base_model to modified ConfigurationScript classes.

### DIFF
--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -1,2 +1,5 @@
 class ConfigurationScript < ConfigurationScriptBase
+  def self.base_model
+    ConfigurationScript
+  end
 end

--- a/app/models/configuration_script_payload.rb
+++ b/app/models/configuration_script_payload.rb
@@ -1,3 +1,7 @@
 class ConfigurationScriptPayload < ConfigurationScriptBase
   belongs_to :configuration_script_source
+
+  def self.base_model
+    ConfigurationScriptPayload
+  end
 end


### PR DESCRIPTION
This fixes the UI where it's expecting ConfigurationScript.base_model to
return ConfigurationScript

@bdunne @jameswnl Please review.