### PR TITLE
Fix broken MiqRequest specs

### DIFF
--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -315,7 +315,12 @@ describe MiqRequest do
   end
 
   context '#workflow' do
-    let(:provision_request) { FactoryGirl.create(:miq_provision_request, :requester => fred, :src_vm_id => template.id) }
+    let(:provision_request) do
+      FactoryGirl.create(:miq_provision_request,
+                         :requester => fred,
+                         :src_vm_id => template.id,
+                         :options => {:src_vm_id => template.id})
+    end
     let(:ems)          { FactoryGirl.create(:ems_vmware) }
     let(:template)     { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
     let(:host) { double('Host', :id => 1, :name => 'my_host') }

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "Requests API" do
       request = FactoryGirl.create(:miq_provision_request,
                                    :requester => @user,
                                    :src_vm_id => vm_template.id,
-                                   :options   => {:owner_email => 'tester@example.com'})
+                                   :options   => {:owner_email => 'tester@example.com', :src_vm_id => vm_template.id})
       FactoryGirl.create(:miq_dialog,
                          :name        => "miq_provision_dialogs",
                          :dialog_type => MiqProvisionWorkflow)


### PR DESCRIPTION
Fixes two specs that were broken with the merging of https://github.com/ManageIQ/manageiq/pull/13045. It appears
that in order for the provision workflow to populate `allowed_tags` now, it
must find the source vm/template, which needs to be supplied in the
options when you create the provision request.

@miq-bot add-label bug, test
@miq-bot assign @gmcculloug 