### PR TITLE
Add configuration_template column to resource actions

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -1,5 +1,6 @@
 class ResourceAction < ApplicationRecord
   belongs_to :resource, :polymorphic => true
+  belongs_to :configuration_template, :polymorphic => true
   belongs_to :dialog
 
   serialize  :ae_attributes, Hash

--- a/app/models/resource_action_serializer.rb
+++ b/app/models/resource_action_serializer.rb
@@ -1,5 +1,6 @@
 class ResourceActionSerializer < Serializer
-  EXCLUDED_ATTRIBUTES = %w(created_at updated_at id dialog_id resource_id)
+  EXCLUDED_ATTRIBUTES = %w(created_at updated_at id dialog_id resource_id
+                           configuration_template_id configuration_template_type).freeze
 
   def serialize(resource_action)
     included_attributes(resource_action.attributes)

--- a/db/migrate/20170118140522_add_configuration_template_to_resource_actions.rb
+++ b/db/migrate/20170118140522_add_configuration_template_to_resource_actions.rb
@@ -1,0 +1,6 @@
+class AddConfigurationTemplateToResourceActions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :resource_actions, :configuration_template_id,   :bigint
+    add_column :resource_actions, :configuration_template_type, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6221,6 +6221,8 @@ resource_actions:
 - ae_instance
 - ae_message
 - ae_attributes
+- configuration_template_id
+- configuration_template_type
 resource_groups:
 - id
 - name

--- a/spec/models/resource_action_serializer_spec.rb
+++ b/spec/models/resource_action_serializer_spec.rb
@@ -2,33 +2,22 @@ describe ResourceActionSerializer do
   let(:resource_action_serializer) { described_class.new }
 
   describe "#serialize" do
-    let(:resource_action) do
-      ResourceAction.new(
-        :dialog_id     => 123,
-        :resource_id   => 321,
-        :created_at    => Time.now,
-        :updated_at    => Time.now,
-        :resource_type => "DialogField",
-        :ae_namespace  => "Customer/Sample",
-        :ae_class      => "Methods",
-        :ae_instance   => "Testing"
-      )
-    end
+    let(:resource_action) { ResourceAction.new(expected_serialized_values) }
 
     let(:expected_serialized_values) do
       {
-        "action"        => nil,
         "resource_type" => "DialogField",
         "ae_namespace"  => "Customer/Sample",
         "ae_class"      => "Methods",
         "ae_instance"   => "Testing",
-        "ae_message"    => nil,
-        "ae_attributes" => {}
       }
     end
 
     it "serializes the resource_action" do
-      expect(resource_action_serializer.serialize(resource_action)).to eq(expected_serialized_values)
+      serialized = resource_action_serializer.serialize(resource_action)
+      expect(serialized).to have_attributes(expected_serialized_values)
+      expect(serialized.keys).to include("action", "ae_attributes", "ae_message")
+      expect(serialized.keys).not_to include(*described_class::EXCLUDED_ATTRIBUTES)
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/137305047

Add polymorphic configure_template column to `ResourceAction`. This is needed to support the Ansible Insight project. Each entry point (Provisioning/Retirement/Reconfigurate) may have different playbook, so the playbook should tie to each `ResourceAction`.

We make it polymorphic so that the action is not limit to playbook, but other types such as container template or orchestration template.