### PR TITLE
[api] Add OPTIONS method to Clusters and Hosts

### DIFF
--- a/app/controllers/api/clusters_controller.rb
+++ b/app/controllers/api/clusters_controller.rb
@@ -3,5 +3,9 @@ module Api
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags
+
+    def options
+      render_options(:clusters, :node_types => EmsCluster.node_types)
+    end
   end
 end

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -20,5 +20,9 @@ module Api
         host.update_authentication(all_credentials) if all_credentials.present?
       end
     end
+
+    def options
+      render_options(:hosts, :node_types => Host.node_types)
+    end
   end
 end

--- a/spec/requests/api/clusters_spec.rb
+++ b/spec/requests/api/clusters_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe 'Clusters API' do
+  context 'OPTIONS /api/clusters' do
+    it 'returns clusters node_types' do
+      api_basic_authorize
+
+      expected = a_hash_including("data" => {"node_types" => EmsCluster.node_types.to_s})
+
+      run_options(clusters_url)
+      expect(response.parsed_body).to match(expected)
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+    end
+  end
+end

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -77,5 +77,17 @@ RSpec.describe "hosts API" do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context 'OPTIONS /api/hosts' do
+      it 'returns hosts node_types' do
+        api_basic_authorize
+
+        expected = a_hash_including("data" => {"node_types" => Host.node_types.to_s})
+
+        run_options(hosts_url)
+        expect(response.parsed_body).to match(expected)
+        expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      end
+    end
   end
 end


### PR DESCRIPTION
The `OPTIONS` method was added to `Clusters` and `Hosts` in order to retrieve the metadata `node_types` on those collections