### PR TITLE
Miq expression column type deux

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1626,9 +1626,10 @@ class MiqExpression
 
       if (val = expression["field"] || expression["count"] || expression["tag"])
         ret = []
-        ret << Field.parse(val) if Field.is_field?(val)
-        val = expression["value"]
-        ret << Field.parse(val) if Field.is_field?(val)
+        tg = self.class.parse_field_or_tag(val)
+        ret << tg if tg
+        tg = self.class.parse_field_or_tag(expression["value"])
+        ret << tg if tg
         ret
       else
         fields(expression.values)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -45,6 +45,10 @@ class MiqExpression::Field
     column_type == :string
   end
 
+  def numeric?
+    [:fixnum, :integer, :float].include?(column_type)
+  end
+
   def attribute_supported_by_sql?
     !custom_attribute_column? && target.attribute_supported_by_sql?(column)
   end
@@ -108,6 +112,10 @@ class MiqExpression::Field
 
   def virtual_attribute?
     target.virtual_attribute?(column)
+  end
+
+  def sub_type
+    MiqReport::Formats.sub_type(column.to_sym) || column_type
   end
 
   def arel_attribute

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -106,6 +106,10 @@ class MiqExpression::Field
     end
   end
 
+  def virtual_attribute?
+    target.virtual_attribute?(column)
+  end
+
   def arel_attribute
     target.arel_attribute(column)
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -31,6 +31,10 @@ class MiqExpression::Tag
     column_type
   end
 
+  def attribute_supported_by_sql?
+    false
+  end
+
   def eql?(other)
     other.try(:model) == model && other.try(:namespace) == namespace
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -23,8 +23,8 @@ class MiqExpression::Tag
     :string
   end
 
-  def equ?(other)
+  def eql?(other)
     other.try(:model) == model && other.try(:namespace) == namespace
   end
-  alias == equ?
+  alias == eql?
 end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -19,8 +19,16 @@ class MiqExpression::Tag
     model.arel_attribute(:id).in(ids)
   end
 
+  def numeric?
+    false
+  end
+
   def column_type
     :string
+  end
+
+  def sub_type
+    column_type
   end
 
   def eql?(other)

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -185,6 +185,24 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#virtual_attribute?" do
+    it "detects non-virtual" do
+      expect(MiqExpression::Field.parse("Vm-name")).not_to be_virtual_attribute
+    end
+
+    it "detects virtual" do
+      expect(MiqExpression::Field.parse("Vm-host_name")).to be_virtual_attribute
+    end
+
+    it "detects non-virtual through a relation" do
+      expect(MiqExpression::Field.parse("Host.vms-name")).not_to be_virtual_attribute
+    end
+
+    it "detects virtual through a relation" do
+      expect(MiqExpression::Field.parse("Host.vms-host_name")).to be_virtual_attribute
+    end
+  end
+
   describe "#is_field?" do
     it "detects a valid field" do
       expect(MiqExpression::Field.is_field?("Vm-name")).to be_truthy

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -203,6 +203,28 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#sub_type" do
+    it "detects :string" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.sub_type).to eq(:string)
+    end
+
+    it "detects :integer" do
+      field = described_class.new(Vm, [], "id")
+      expect(field.sub_type).to eq(:integer)
+    end
+  end
+
+  describe "#numeric?" do
+    it "detects integer as numeric" do
+      expect(MiqExpression::Field.parse("Vm-id")).to be_numeric
+    end
+
+    it "detects string as non-numeric" do
+      expect(MiqExpression::Field.parse("Vm-name")).not_to be_numeric
+    end
+  end
+
   describe "#is_field?" do
     it "detects a valid field" do
       expect(MiqExpression::Field.is_field?("Vm-name")).to be_truthy

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe MiqExpression::Tag do
       expect(described_class.new(Vm, "/host").column_type).to eq(:string)
     end
   end
+
+  describe "#numeric?" do
+    it "is never numeric" do
+      expect(described_class.new(Vm, "/host")).not_to be_numeric
+    end
+  end
+
+  describe "#sub_type" do
+    it "is always a string" do
+      expect(described_class.new(Vm, "/host").sub_type).to eq(:string)
+    end
+  end
 end

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -35,4 +35,10 @@ RSpec.describe MiqExpression::Tag do
       expect(described_class.new(Vm, "/host").sub_type).to eq(:string)
     end
   end
+
+  describe "#attribute_supported_by_sql?" do
+    it "is always false" do
+      expect(described_class.new(Vm, "/host")).not_to be_attribute_supported_by_sql
+    end
+  end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2628,5 +2628,19 @@ describe MiqExpression do
         an_object_having_attributes(:model => Vm, :column => "name")
       )
     end
+
+    it "extracts tags" do
+      expression = {
+        "AND" => [
+          {">=" => {"field" => "EmsClusterPerformance-cpu_usagemhz_rate_average", "value" => "0"}},
+          {"<"  => {"field" => "Vm.managed-favorite_color", "value" => "5"}}
+        ]
+      }
+      actual = described_class.new(expression).fields
+      expect(actual).to contain_exactly(
+        an_object_having_attributes(:model => EmsClusterPerformance, :column => "cpu_usagemhz_rate_average"),
+        an_object_having_attributes(:model => Vm, :namespace => "/managed/favorite_color")
+      )
+    end
   end
 end


### PR DESCRIPTION
**High level goal:**

We need to add enhancements and improve performance in `MiqExpression`, but unfortunatly it is too big and complicated.

The goal of this set of PRs is to move the functionality of `MiqExpression#get_col_info` to `MiqExpression::Field` and `MiqExpression::Tag`.

---
**This PR:**

Taken from https://github.com/ManageIQ/manageiq/pull/13446

Add methods to `Tag` and `Field`:

- `numeric?`
- `sub_type`
- `virtual_attribute?`
- `attribute_supported_by_sql?`.
