### PR TITLE
[EUWE] Fix RBAC Features Tree select behavior

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -2,145 +2,250 @@ class OpsController
   class RbacTree
     include CompressedIds
 
-    def self.build(role, role_features, edit)
-      new(role, role_features, edit).build
+    def self.build(role, role_features, editable)
+      new(role, role_features, editable).build
     end
 
-    def initialize(role, role_features, edit)
+    attr_reader :role, :role_features, :editable
+
+    def initialize(role, role_features, editable)
       @role = role
       @role_features = role_features
-      @edit = edit
+      @editable = editable
+
+      @descendant_cache = {}
+    end
+
+    def build
+      root_node[:children] = recurse_menu_objects(filtered_menus, root_select)
+
+      select_if_kids_selected(root_node, root_node[:children])
+
+      root_node[:children] << all_vm_node
+
+      root_node
+    end
+
+    def filtered_menus
+      menus = []
+
+      Menu::Manager.each do |section|
+        next if section.id == :cons && !Settings.product.consumption
+        next if section.name.nil?
+        next unless Vmdb::PermissionStores.instance.can?(section.id)
+
+        menus.push(section)
+      end
+
+      menus
+    end
+
+    def recurse_menu_objects(items, checked = false)
+      items.map do |item|
+        case item
+        when Menu::Section
+          build_section(item)
+        when Menu::Item
+          if item.feature.nil? || !MiqProductFeature.feature_exists?(item.feature)
+            next
+          end
+          build_item(item, checked)
+        when String
+          build_feature(item, checked)
+        else
+          item
+        end
+      end
+    end
+
+    def build_section(section)
+      node = default_node.merge(
+        :key      => "#{node_id}___tab_#{section.id}",
+        :title    => _(section.name),
+        :tooltip  => _("%{title} Main Tab") % {:title => section.name},
+        :children => {}
+      )
+
+      node[:children] = recurse_menu_objects(section.items).compact
+      select_if_kids_selected(node, node[:children])
+
+      node
+    end
+
+    def build_item(item, checked = false)
+      details = MiqProductFeature.feature_details(item.feature)
+
+      node = default_node.merge(
+        :key      => "#{node_id}__#{item.feature}",
+        :title    => _(details[:name]),
+        :tooltip  => _(details[:description]) || _(details[:name]),
+        :select   => checked,
+        :children => {}
+      )
+
+      # selected by parent or self
+      node[:select] ||= role_features.include?(item.feature)
+
+      # selected by children (including hidden)
+      node[:select] ||= select_by_child_states(feature_child_select_states(item.feature))
+
+      # add visible children to tree
+      kids = MiqProductFeature.feature_children(item.feature)
+      node[:children] = recurse_menu_objects(kids, node[:select])
+
+      node
+    end
+
+    def build_feature(feature, checked = false)
+      details = MiqProductFeature.feature_details(feature)
+
+      node = default_node.merge(
+        :key      => "#{node_id}__#{feature}",
+        :icon     => img("100/feature_#{details[:feature_type]}"),
+        :title    => _(details[:name]),
+        :tooltip  => _(details[:description]) || _(details[:name]),
+        :children => {}
+      )
+
+      # Select if parent is true or role has feature
+      # don't care if parent is 'undefined'
+      if checked == true || role_features.include?(remove_accords_suffix(feature))
+        node[:select] = true
+      end
+
+      # Select by children
+      # Count hidden children but keep them out of the tree
+      node[:select] ||= select_by_child_states(feature_child_select_states(feature))
+
+      visible_children = MiqProductFeature.feature_children(feature).map do |child|
+        name = remove_accords_suffix(child)
+        name if MiqProductFeature.feature_exists?(name)
+      end
+
+      node[:children] = recurse_menu_objects(visible_children, node[:select])
+
+      node unless details[:hidden]
+    end
+
+    def all_vm_node
+      @all_vm_node ||= begin
+        text = _("Access Rules for all Virtual Machines")
+        feat_kids = MiqProductFeature.feature_children("all_vm_rules")
+        checked = root_select || role_features.include?("all_vm_rules")
+
+        node = default_node.merge(
+          :key      => "#{node_id}___tab_all_vm_rules",
+          :title    => text,
+          :tooltip  => text,
+          :select   => checked,
+          :children => recurse_menu_objects(feat_kids, checked)
+        )
+
+        select_if_kids_selected(node, node[:children])
+
+        node
+      end
+    end
+
+    def feature_child_select_states(feature)
+      all_children = feature_descendants(feature)
+      all_children.map { |c| role_features.include?(c) }
+    end
+
+    def feature_descendants(feature)
+      @descendant_cache[feature] ||= MiqProductFeature.find_by(:identifier => feature).descendants.pluck(:identifier)
+    end
+
+    def select_if_kids_selected(node, kids)
+      # Do nothing if no kids
+      return if kids.none?
+
+      if all_checked?(kids)
+        node[:select] = true
+        return
+      end
+
+      if any_checked?(kids)
+        node[:select] = 'undefined'
+      end
+    end
+
+    def select_by_child_states(states)
+      return false       if states.none?
+      return true        if states.all? { |s| s == true } # True not just truthy
+      return 'undefined' if states.any?
+
+      false
+    end
+
+    def root_node
+      @root_node ||= {
+        :key         => root_key,
+        :title       => root_title,
+        :tooltip     => root_tooltip,
+        :icon        => img("100/feature_node.png"),
+        :expand      => true,
+        :cfmeNoClick => true,
+        :select      => root_select,
+        :checkable   => editable
+      }
+    end
+
+    def root_tooltip
+      _(root[:description]) || _(root[:name])
+    end
+
+    def root_title
+      _(root[:name])
+    end
+
+    def root_key
+      "#{node_id}__#{root_feature}"
+    end
+
+    def root_select
+      role_features.include?(root_feature)
+    end
+
+    def node_id
+      role.id ? to_cid(role.id) : "new"
     end
 
     def remove_accords_suffix(name)
       name.sub(/_accords$/, '')
     end
 
-    def all_checked(kids)
+    def root_feature
+      @root_feature ||= MiqProductFeature.feature_root
+    end
+
+    def root
+      @root ||= MiqProductFeature.feature_details(root_feature)
+    end
+
+    def default_node
+      {
+        :key         => node_id,
+        :icon        => img("100/feature_node.png"),
+        :title       => "",
+        :cfmeNoClick => true,
+        :select      => false,
+        :checkable   => editable
+      }
+    end
+
+    def all_checked?(kids)
       return false if kids.empty? # empty list is considered not checked
-      kids.length == kids.collect { |k| k if k[:select] }.compact.length
+      kids.length == kids.collect { |k| k if k[:select] == true }.compact.length
     end
 
-    def build_section(section, parent_checked)
-      kids = []
-      node = {
-        :key         => "#{@role.id ? to_cid(@role.id) : "new"}___tab_#{section.id}",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
-        :title       => _(section.name),
-        :tooltip     => _("%{title} Main Tab") % {:title => section.name},
-        :checkable   => @edit,
-        :cfmeNoClick => true
-      }
-
-      section.items.each do |item|
-        if item.kind_of?(Menu::Section) # recurse for sections
-          next unless Vmdb::PermissionStores.instance.can?(item.id)
-          feature = build_section(item, parent_checked)
-          kids.push(feature)
-        else # kind_of?(Menu::Item) # add item features
-          next if item.feature.nil?
-          feature_name = remove_accords_suffix(item.feature)
-          next unless MiqProductFeature.feature_exists?(feature_name) # FIXME: feature name? or :feature for items
-          feature = rbac_features_tree_add_node(feature_name, node[:key], parent_checked)
-          kids.push(feature) unless feature.nil?
-        end
-      end
-
-      node[:select] = parent_checked || all_checked(kids)
-      node[:children] = kids
-
-      checked = kids.count { |kid| kid[:select] }
-      if checked == kids.length
-        node[:select] = true
-      elsif checked == 0
-        node[:select] = false
-      else
-        node[:select] = 'undefined'
-      end
-
-      node
+    def any_checked?(kids)
+      return false if kids.empty?
+      kids.any? { |k| k[:select] }
     end
 
-    def build
-      root_feature = MiqProductFeature.feature_root
-      root = MiqProductFeature.feature_details(root_feature)
-      root_node = {
-        :key         => "#{@role.id ? to_cid(@role.id) : "new"}__#{root_feature}",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
-        :title       => _(root[:name]),
-        :tooltip     => _(root[:description]) || _(root[:name]),
-        :expand      => true,
-        :cfmeNoClick => true,
-        :select      => @role_features.include?(root_feature),
-        :checkable   => @edit
-      }
-
-      top_nodes = []
-      @all_vm_node = {
-        :key         => "#{@role.id ? to_cid(@role.id) : "new"}___tab_all_vm_rules",
-        :icon        => ActionController::Base.helpers.image_path('100/feature_node.png'),
-        :title       => t = _("Access Rules for all Virtual Machines"),
-        :tooltip     => t,
-        :children    => [],
-        :cfmeNoClick => true,
-        :select      => root_node[:select],
-        :checkable   => @edit
-      }
-      rbac_features_tree_add_node("all_vm_rules", root_node[:key], @all_vm_node[:select])
-
-      Menu::Manager.each do |section|
-        next if section.id == :cons && !Settings.product.consumption
-        next unless Vmdb::PermissionStores.instance.can?(section.id)
-
-        top_nodes.push(build_section(section, root_node[:select]))
-      end
-      top_nodes << @all_vm_node
-
-      checked = top_nodes.count { |kid| kid[:select] }
-      if checked == top_nodes.length
-        root_node[:select] = true
-      elsif checked == 0
-        root_node[:select] = false
-      else
-        root_node[:select] = 'undefined'
-      end
-
-      root_node[:children] = top_nodes
-      root_node
-    end
-
-    def rbac_features_tree_add_node(feature, _pid, parent_checked = false)
-      details = MiqProductFeature.feature_details(feature)
-      return if details[:hidden]
-
-      kids = []
-      node = {
-        :key         => "#{@role.id ? to_cid(@role.id) : "new"}__#{feature}",
-        :icon        => ActionController::Base.helpers.image_path("100/feature_#{details[:feature_type]}.png"),
-        :title       => _(details[:name]),
-        :tooltip     => _(details[:description]) || _(details[:name]),
-        :checkable   => @edit,
-        :cfmeNoClick => true
-      }
-      node[:hideCheckbox] = true if details[:protected]
-
-      MiqProductFeature.feature_children(feature).each do |f|
-        feat = rbac_features_tree_add_node(f,
-                                           node[:key],
-                                           parent_checked || @role_features.include?(feature)) if f
-        next unless feat
-
-        # exceptional handling for named features
-        if %w(image instance miq_template vm).index(f)
-          @all_vm_node[:children].push(feat)
-        else
-          kids.push(feat)
-        end
-      end
-
-      node[:children] = kids
-      node[:select] = parent_checked || @role_features.include?(feature) || all_checked(kids)
-      node
+    def img(name)
+      ActionController::Base.helpers.image_path(name)
     end
   end
 end

--- a/spec/controllers/ops_controller/rbac_tree_spec.rb
+++ b/spec/controllers/ops_controller/rbac_tree_spec.rb
@@ -1,14 +1,46 @@
 describe OpsController::RbacTree do
-  let(:role) do
-    # Pick a small subset of the product features tree to allow the spec to
-    #   exercise building more than a single node
-    FactoryGirl.create(:miq_user_role, :features =>
-      %w(all_vm_rules instance instance_view instance_show_list instance_control instance_scan)
-    )
+  before(:all) do
+    MiqProductFeature.seed_features
   end
 
-  it ".build" do
-    features_tree = described_class.build(role, role.feature_identifiers.sort, false).to_json
-    expect(features_tree).to include("Access Rules for all Virtual Machines")
+  let(:role) do
+    roles = YAML.load_file(MiqUserRole::FIXTURE_YAML)
+    role = roles.detect { |r| r[:name] == "EvmRole-approver" }
+
+    FactoryGirl.create(:miq_user_role, :role => "approver", :features => role[:miq_product_feature_identifiers])
+  end
+
+  let(:features) { role.miq_product_features.order(:identifier).pluck(:identifier) }
+
+  subject { described_class.new(role, features, false).build }
+
+  it 'builds a hash tree' do
+    expect(subject[:children].first[:title]).to eq "Cloud Intel"
+  end
+
+  it 'bubbles select states from child to parent' do
+    expect(subject[:select]).to eq "undefined"
+
+    control = subject[:children].detect { |c| c[:title] == "Control" }
+    explore = control[:children].detect { |c| c[:title] == "Explorer" }
+    imp_exp = control[:children].detect { |c| c[:title] == "Import/Export" }
+
+    expect(control[:select]).to eq "undefined"
+    expect(explore[:select]).to eq "undefined"
+    expect(imp_exp[:select]).to be false
+  end
+
+  context "when read-only" do
+    it 'sets the checkable key to false' do
+      expect(subject[:children].first[:checkable]).to be false
+    end
+  end
+
+  context "when editable" do
+    subject { described_class.new(role, features, true).build }
+
+    it 'sets the checkable key to true' do
+      expect(subject[:children].first[:checkable]).to be true
+    end
   end
 end


### PR DESCRIPTION
Currently selected boxes deeper in the tree do not “bubble up” the select state to their ancestors. This changes that by counting all descendants including hidden features, also taking into account 3 possible select states.

**Before**
![rbac-tree-before](https://cloud.githubusercontent.com/assets/39493/22090039/0a7eb0b6-dda4-11e6-8624-e7b5015febf4.png)

**After**
![rbac-tree-after](https://cloud.githubusercontent.com/assets/39493/22090042/10b40e9a-dda4-11e6-9eb0-d30c0be3a78a.png)

Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1348623
https://bugzilla.redhat.com/show_bug.cgi?id=1411831

Related:
https://github.com/ManageIQ/manageiq-ui-classic/pull/137
https://github.com/ManageIQ/manageiq/pull/13592

/cc @dclarizio 
