### PR TITLE
use consistent time generation for testing retirement

### DIFF
--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -65,7 +65,7 @@ describe "Service Retirement Management" do
   it "#retire date" do
     expect(AuditEvent).to receive(:success).once
     options = {}
-    options[:date] = Date.today
+    options[:date] = Time.zone.today
     @stack.retire(options)
     @stack.reload
     expect(@stack.retires_on).to eq(options[:date])
@@ -102,26 +102,26 @@ describe "Service Retirement Management" do
 
   it "#retires_on - today" do
     expect(@stack.retirement_due?).to be_falsey
-    @stack.retires_on = Date.today
+    @stack.retires_on = Time.zone.today
     expect(@stack.retirement_due?).to be_truthy
   end
 
   it "#retires_on - tomorrow" do
     expect(@stack.retirement_due?).to be_falsey
-    @stack.retires_on = Date.today + 1
+    @stack.retires_on = Time.zone.today + 1
     expect(@stack.retirement_due?).to be_falsey
   end
 
   it "#retirement_due?" do
     expect(@stack.retirement_due?).to be_falsey
 
-    @stack.update_attributes(:retires_on => Date.today + 1.day)
+    @stack.update_attributes(:retires_on => Time.zone.today + 1.day)
     expect(@stack.retirement_due?).to be_falsey
 
-    @stack.update_attributes(:retires_on => Date.today)
+    @stack.update_attributes(:retires_on => Time.zone.today)
     expect(@stack.retirement_due?).to be_truthy
 
-    @stack.update_attributes(:retires_on => Date.today - 1.day)
+    @stack.update_attributes(:retires_on => Time.zone.today - 1.day)
     expect(@stack.retirement_due?).to be_truthy
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -65,7 +65,7 @@ describe "Service Retirement Management" do
   it "#retire date" do
     expect(AuditEvent).to receive(:success).once
     options = {}
-    options[:date] = Date.today
+    options[:date] = Time.zone.today
     @service.retire(options)
     @service.reload
     expect(@service.retires_on).to eq(options[:date])
@@ -131,19 +131,19 @@ describe "Service Retirement Management" do
 
   it "#retires_on - today" do
     expect(@service.retirement_due?).to be_falsey
-    @service.retires_on = Date.today
+    @service.retires_on = Time.zone.today
     expect(@service.retirement_due?).to be_truthy
   end
 
   it "#retires_on - tomorrow" do
     expect(@service.retirement_due?).to be_falsey
-    @service.retires_on = Date.today + 1
+    @service.retires_on = Time.zone.today + 1
     expect(@service.retirement_due?).to be_falsey
   end
 
   # it "#retirement_warn" do
   #  expect(@service.retirement_warn).to be_nil
-  #   @service.update_attributes(:retirement_last_warn => Date.today)
+  #   @service.update_attributes(:retirement_last_warn => Time.zone.today)
   #   @service.retirement_warn = 60
   #  expect(@service.retirement_warn).to eq(60)
   #  expect(@service.retirement_last_warn).to be_nil
@@ -152,13 +152,13 @@ describe "Service Retirement Management" do
   it "#retirement_due?" do
     expect(@service.retirement_due?).to be_falsey
 
-    @service.update_attributes(:retires_on => Date.today + 1.day)
+    @service.update_attributes(:retires_on => Time.zone.today + 1.day)
     expect(@service.retirement_due?).to be_falsey
 
-    @service.update_attributes(:retires_on => Date.today)
+    @service.update_attributes(:retires_on => Time.zone.today)
     expect(@service.retirement_due?).to be_truthy
 
-    @service.update_attributes(:retires_on => Date.today - 1.day)
+    @service.update_attributes(:retires_on => Time.zone.today - 1.day)
     expect(@service.retirement_due?).to be_truthy
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -62,7 +62,7 @@ describe "VM Retirement Management" do
   it "#retire date" do
     expect(AuditEvent).to receive(:success).once
     options = {}
-    options[:date] = Date.today
+    options[:date] = Time.zone.today
     @vm.retire(options)
     @vm.reload
     expect(@vm.retires_on).to eq(options[:date])
@@ -102,21 +102,21 @@ describe "VM Retirement Management" do
 
   it "#retires_on - today" do
     expect(@vm.retirement_due?).to be_falsey
-    @vm.retires_on = Date.today
+    @vm.retires_on = Time.zone.today
 
     expect(@vm.retirement_due?).to be_truthy
   end
 
   it "#retires_on - tomorrow" do
     expect(@vm.retirement_due?).to be_falsey
-    @vm.retires_on = Date.today + 1
+    @vm.retires_on = Time.zone.today + 1
 
     expect(@vm.retirement_due?).to be_falsey
   end
 
   # it "#retirement_warn" do
   #   expect(@vm.retirement_warn).to be_nil
-  #   @vm.update_attributes(:retirement_last_warn => Date.today)
+  #   @vm.update_attributes(:retirement_last_warn => Time.zone.today)
   #   @vm.retirement_warn = 60
 
   #   expect(@vm.retirement_warn).to eq(60)
@@ -126,15 +126,15 @@ describe "VM Retirement Management" do
   it "#retirement_due?" do
     vm = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
     expect(vm.retirement_due?).to be_falsey
-    vm.update_attributes(:retires_on => Date.today + 1.day)
+    vm.update_attributes(:retires_on => Time.zone.today + 1.day)
     expect(vm.retirement_due?).to be_falsey
 
-    vm.retires_on = Date.today
+    vm.retires_on = Time.zone.today
 
-    vm.update_attributes(:retires_on => Date.today)
+    vm.update_attributes(:retires_on => Time.zone.today)
     expect(vm.retirement_due?).to be_truthy
 
-    vm.update_attributes(:retires_on => Date.today - 1.day)
+    vm.update_attributes(:retires_on => Time.zone.today - 1.day)
     expect(vm.retirement_due?).to be_truthy
   end
 


### PR DESCRIPTION
retirement_mixin uses Time.zone.now for testing retirement_due?
The tests were creating test data with Date.today (with +/- days too)
As a result, if local time and UTC time don't have the same date
component, the comparisons will return the wrong results. This commit
changes the tests to generate "today" with Time.zone.today instead --
this guarantees that comparisons in the model class are generated using
the same notion of time zone, etc.
