### PR TITLE
Reports: Remove unused cols

### DIFF
--- a/product/views/Condition.yaml
+++ b/product/views/Condition.yaml
@@ -19,13 +19,7 @@ db: Condition
 
 # Columns to fetch from the main table
 cols:
-- name
 - description
-- modifier
-- expression
-- towhat
-- created_on
-- updated_on
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -33,12 +27,10 @@ include:
 # Order of columns (from all tables)
 col_order: 
 - description
-#- name
 
 # Column titles, in order
 headers:
 - Description
-#- Name
 
 # Condition(s) string for the SQL query
 conditions: 

--- a/product/views/ConditionSet.yaml
+++ b/product/views/ConditionSet.yaml
@@ -21,8 +21,6 @@ db: ConditionSet
 cols:
 - name
 - description
-- created_on
-- updated_on
 
 # Included tables (joined, has_one, has_many) and columns
 include:

--- a/product/views/MiqAction.yaml
+++ b/product/views/MiqAction.yaml
@@ -19,7 +19,6 @@ db: MiqAction
 
 # Columns to fetch from the main table
 cols:
-- name
 - description
 - action_type_description
 

--- a/product/views/MiqActionSet.yaml
+++ b/product/views/MiqActionSet.yaml
@@ -21,8 +21,6 @@ db: MiqActionSet
 cols:
 - name
 - description
-- created_on
-- updated_on
 
 # Included tables (joined, has_one, has_many) and columns
 include:

--- a/product/views/MiqEvent-actions.yaml
+++ b/product/views/MiqEvent-actions.yaml
@@ -19,7 +19,6 @@ db: MiqAction
 
 # Columns to fetch from the main table
 cols:
-- name
 - description
 - v_synchronicity
 - action_type

--- a/product/views/MiqPolicy.yaml
+++ b/product/views/MiqPolicy.yaml
@@ -19,7 +19,6 @@ db: MiqPolicy
 
 # Columns to fetch from the main table
 cols:
-- name
 - description
 - active
 

--- a/product/views/MiqProvision.yaml
+++ b/product/views/MiqProvision.yaml
@@ -46,7 +46,7 @@ order: Descending
 
 # Columns to sort the report on, in order
 sortby:
-- updated_on
+- status
 
 # Group rows (y=yes,n=no,c=count)
 group: n

--- a/product/views/MiqReportResult.yaml
+++ b/product/views/MiqReportResult.yaml
@@ -20,7 +20,6 @@ db: MiqReportResult
 # Columns to fetch from the main table
 cols:
 - created_on
-- name
 - last_run_on
 - report_source
 - userid

--- a/product/views/Patch.yaml
+++ b/product/views/Patch.yaml
@@ -26,8 +26,6 @@ cols:
 - v_install_date
 - is_valid
 - installed
-- created_on
-- updated_on
 
 # Included tables (joined, has_one, has_many) and columns
 include:

--- a/product/views/ScanItemSet.yaml
+++ b/product/views/ScanItemSet.yaml
@@ -22,8 +22,6 @@ cols:
 - name
 - description
 - mode
-- created_on
-- updated_on
 
 
 # Included tables (joined, has_one, has_many) and columns


### PR DESCRIPTION
`col_order` and `Header` define which fields are displayed in the ui.
`cols` defines which fields are brought back from the database.

This PR removes the columns that are not displayed
Other reports bring back `name` or `updated_at`/`created_at` but don't display them.

`product/views/Condition.yaml` brings back a number of columns, but only displays `description` I'm questioning whether it is even used.

Please let me know if I've misunderstood the fields in reports.

https://www.pivotaltracker.com/story/show/137377399