### PR TITLE
Extract LocaleResolver service

### DIFF
--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -1,11 +1,12 @@
 class LocaleResolver
-  def self.resolve(headers = {})
-    new(headers).resolve
+  def self.resolve(user, headers = {})
+    new(user, headers).resolve
   end
 
-  attr_reader :headers
+  attr_reader :user, :headers
 
-  def initialize(headers = {})
+  def initialize(user, headers = {})
+    @user = user
     @headers = headers
   end
 
@@ -18,7 +19,7 @@ class LocaleResolver
   private
 
   def user_locale
-    @user_locale ||= (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
+    @user_locale ||= (user.try(:settings) || {}).fetch_path(:display, :locale)
   end
 
   def server_locale

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -1,5 +1,15 @@
 class LocaleResolver
   def self.resolve(headers = {})
+    new(headers).resolve
+  end
+
+  attr_reader :headers
+
+  def initialize(headers = {})
+    @headers = headers
+  end
+
+  def resolve
     user_locale = (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
     if user_locale == 'default' || user_locale.nil?
       server_locale = ::Settings.server.locale

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -3,14 +3,13 @@ class LocaleResolver
     user_locale = (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
     if user_locale == 'default' || user_locale.nil?
       server_locale = ::Settings.server.locale
-      locale = if server_locale == "default" || server_locale.nil?
-                 headers['Accept-Language']
-               else
-                 server_locale
-               end
+      if server_locale == "default" || server_locale.nil?
+        headers['Accept-Language']
+      else
+        server_locale
+      end
     else
-      locale = user_locale
+      user_locale
     end
-    locale
   end
 end

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -11,7 +11,6 @@ class LocaleResolver
 
   def resolve
     if user_locale == 'default' || user_locale.nil?
-      server_locale = ::Settings.server.locale
       if server_locale == "default" || server_locale.nil?
         headers['Accept-Language']
       else
@@ -26,5 +25,9 @@ class LocaleResolver
 
   def user_locale
     @user_locale ||= (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
+  end
+
+  def server_locale
+    @server_locale ||= ::Settings.server.locale
   end
 end

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -10,8 +10,8 @@ class LocaleResolver
   end
 
   def resolve
-    if user_locale == 'default' || user_locale.nil?
-      if server_locale == "default" || server_locale.nil?
+    if !set?(user_locale)
+      if !set?(server_locale)
         headers['Accept-Language']
       else
         server_locale
@@ -29,5 +29,9 @@ class LocaleResolver
 
   def server_locale
     @server_locale ||= ::Settings.server.locale
+  end
+
+  def set?(locale)
+    locale && locale != "default"
   end
 end

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -1,0 +1,22 @@
+class LocaleResolver
+  def self.resolve(headers = {})
+    user_settings = User.current_user.try(:settings)
+    user_locale = user_settings[:display][:locale] if user_settings &&
+                                                      user_settings.key?(:display) &&
+                                                      user_settings[:display].key?(:locale)
+    if user_locale == 'default' || user_locale.nil?
+      server_locale = ::Settings.server.locale
+      # user settings && server settings == 'default'
+      # OR not defined
+      # use HTTP_ACCEPT_LANGUAGE
+      locale = if server_locale == "default" || server_locale.nil?
+                 headers['Accept-Language']
+               else
+                 server_locale
+               end
+    else
+      locale = user_locale
+    end
+    locale
+  end
+end

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -10,15 +10,9 @@ class LocaleResolver
   end
 
   def resolve
-    if set?(user_locale)
-      user_locale
-    else
-      if set?(server_locale)
-        server_locale
-      else
-        headers['Accept-Language']
-      end
-    end
+    return user_locale if set?(user_locale)
+    return server_locale if set?(server_locale)
+    headers["Accept-Language"]
   end
 
   private

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -6,9 +6,6 @@ class LocaleResolver
                                                       user_settings[:display].key?(:locale)
     if user_locale == 'default' || user_locale.nil?
       server_locale = ::Settings.server.locale
-      # user settings && server settings == 'default'
-      # OR not defined
-      # use HTTP_ACCEPT_LANGUAGE
       locale = if server_locale == "default" || server_locale.nil?
                  headers['Accept-Language']
                else

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -1,9 +1,6 @@
 class LocaleResolver
   def self.resolve(headers = {})
-    user_settings = User.current_user.try(:settings)
-    user_locale = user_settings[:display][:locale] if user_settings &&
-                                                      user_settings.key?(:display) &&
-                                                      user_settings[:display].key?(:locale)
+    user_locale = (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
     if user_locale == 'default' || user_locale.nil?
       server_locale = ::Settings.server.locale
       locale = if server_locale == "default" || server_locale.nil?

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -10,7 +10,6 @@ class LocaleResolver
   end
 
   def resolve
-    user_locale = (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
     if user_locale == 'default' || user_locale.nil?
       server_locale = ::Settings.server.locale
       if server_locale == "default" || server_locale.nil?
@@ -21,5 +20,11 @@ class LocaleResolver
     else
       user_locale
     end
+  end
+
+  private
+
+  def user_locale
+    @user_locale ||= (User.current_user.try(:settings) || {}).fetch_path(:display, :locale)
   end
 end

--- a/lib/services/locale_resolver.rb
+++ b/lib/services/locale_resolver.rb
@@ -10,14 +10,14 @@ class LocaleResolver
   end
 
   def resolve
-    if !set?(user_locale)
-      if !set?(server_locale)
-        headers['Accept-Language']
-      else
-        server_locale
-      end
-    else
+    if set?(user_locale)
       user_locale
+    else
+      if set?(server_locale)
+        server_locale
+      else
+        headers['Accept-Language']
+      end
     end
   end
 

--- a/spec/lib/services/locale_resolver_spec.rb
+++ b/spec/lib/services/locale_resolver_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe LocaleResolver do
+  context "when the user's locale is set" do
+    before { stub_current_user_with_locale("en-US") }
+
+    it "returns the user's locale" do
+      expect(described_class.resolve).to eq("en-US")
+    end
+  end
+
+  context "when the user's locale is 'default'" do
+    before { stub_current_user_with_locale("default") }
+
+    context "and the server's locale is set" do
+      before { stub_server_settings_with_locale("en-US") }
+
+      it "returns the server's locale" do
+        expect(described_class.resolve).to eq("en-US")
+      end
+    end
+
+    context "and the server's locale is 'default'" do
+      before { stub_server_settings_with_locale("default") }
+
+      it "returns the locale from the headers" do
+        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+      end
+    end
+
+    context "and the server's locale is not set" do
+      before { stub_server_settings_with_locale(nil) }
+
+      it "returns the locale from the headers" do
+        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+      end
+    end
+  end
+
+  context "when the user's locale is not set" do
+    before { stub_current_user_with_locale(nil) }
+
+    context "and the server's locale is set" do
+      before { stub_server_settings_with_locale("en-US") }
+
+      it "returns the server's locale" do
+        expect(described_class.resolve).to eq("en-US")
+      end
+    end
+
+    context "and the server's locale is 'default'" do
+      before { stub_server_settings_with_locale("default") }
+
+      it "returns the locale from the headers" do
+        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+      end
+    end
+
+    context "and the server's locale is not set" do
+      before { stub_server_settings_with_locale(nil) }
+
+      it "returns the locale from the headers" do
+        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+      end
+    end
+  end
+
+  def stub_current_user_with_locale(locale)
+    user = instance_double(User, :settings => {:display => {:locale => locale}})
+    allow(User).to receive(:current_user).and_return(user)
+  end
+
+  def stub_server_settings_with_locale(locale)
+    allow(Settings.server).to receive(:locale).and_return(locale)
+  end
+end

--- a/spec/lib/services/locale_resolver_spec.rb
+++ b/spec/lib/services/locale_resolver_spec.rb
@@ -1,20 +1,18 @@
 RSpec.describe LocaleResolver do
   context "when the user's locale is set" do
-    before { stub_current_user_with_locale("en-US") }
-
     it "returns the user's locale" do
-      expect(described_class.resolve).to eq("en-US")
+      user = instance_double(User, :settings => {:display => {:locale => "en-US"}})
+      expect(described_class.resolve(user)).to eq("en-US")
     end
   end
 
   context "when the user's locale is 'default'" do
-    before { stub_current_user_with_locale("default") }
-
     context "and the server's locale is set" do
       before { stub_server_settings_with_locale("en-US") }
 
       it "returns the server's locale" do
-        expect(described_class.resolve).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => "default"}})
+        expect(described_class.resolve(user)).to eq("en-US")
       end
     end
 
@@ -22,7 +20,8 @@ RSpec.describe LocaleResolver do
       before { stub_server_settings_with_locale("default") }
 
       it "returns the locale from the headers" do
-        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => "default"}})
+        expect(described_class.resolve(user, "Accept-Language" => "en-US")).to eq("en-US")
       end
     end
 
@@ -30,19 +29,19 @@ RSpec.describe LocaleResolver do
       before { stub_server_settings_with_locale(nil) }
 
       it "returns the locale from the headers" do
-        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => "default"}})
+        expect(described_class.resolve(user, "Accept-Language" => "en-US")).to eq("en-US")
       end
     end
   end
 
   context "when the user's locale is not set" do
-    before { stub_current_user_with_locale(nil) }
-
     context "and the server's locale is set" do
       before { stub_server_settings_with_locale("en-US") }
 
       it "returns the server's locale" do
-        expect(described_class.resolve).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => nil}})
+        expect(described_class.resolve(user)).to eq("en-US")
       end
     end
 
@@ -50,7 +49,8 @@ RSpec.describe LocaleResolver do
       before { stub_server_settings_with_locale("default") }
 
       it "returns the locale from the headers" do
-        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => nil}})
+        expect(described_class.resolve(user, "Accept-Language" => "en-US")).to eq("en-US")
       end
     end
 
@@ -58,14 +58,10 @@ RSpec.describe LocaleResolver do
       before { stub_server_settings_with_locale(nil) }
 
       it "returns the locale from the headers" do
-        expect(described_class.resolve("Accept-Language" => "en-US")).to eq("en-US")
+        user = instance_double(User, :settings => {:display => {:locale => nil}})
+        expect(described_class.resolve(user, "Accept-Language" => "en-US")).to eq("en-US")
       end
     end
-  end
-
-  def stub_current_user_with_locale(locale)
-    user = instance_double(User, :settings => {:display => {:locale => locale}})
-    allow(User).to receive(:current_user).and_return(user)
   end
 
   def stub_server_settings_with_locale(locale)


### PR DESCRIPTION
This code is currently borrowed from `ApplicationController`, which will
delegate to this service when (if) this gets merged. Then, the API controller
can be decoupled from `ApplicationController` - this function is its
only dependency.

EDIT: also, I added isolated tests for this :tada:

@miq-bot add-label core, api, refactoring
@miq-bot assign @abellotti 