### PR TITLE
Remove factory girl from migration script

### DIFF
--- a/spec/migrations/20170115140217_update_ems_in_miq_alert_status_spec.rb
+++ b/spec/migrations/20170115140217_update_ems_in_miq_alert_status_spec.rb
@@ -1,12 +1,24 @@
 require_migration
 
+class UpdateEmsInMiqAlertStatus < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+  class Vm < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+    belongs_to :ext_management_system, :foreign_key => :ems_id
+  end
+end
+
 describe UpdateEmsInMiqAlertStatus do
   let(:miq_alert_status_stub) { migration_stub(:MiqAlertStatus) }
+  let(:vm_cloud_stub) { migration_stub(:Vm) }
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
 
   migration_context :up do
     it 'it sets ems_id for vms' do
-      ext = FactoryGirl.create(:ext_management_system)
-      vm = FactoryGirl.create(:vm_cloud, :ext_management_system => ext)
+      ext = ext_management_system_stub.create
+      vm = vm_cloud_stub.create(:ext_management_system => ext)
       miq_alert_status = miq_alert_status_stub.create!(:resource_type => "VmOrTemplate", :resource_id => vm.id)
       expect(miq_alert_status.ems_id).to be_nil
       migrate


### PR DESCRIPTION
A migration spec using factory girl can fail future PRs.
Example validations on columns added in a later migration

Seen in https://github.com/ManageIQ/manageiq/pull/13567#issuecomment-273807344