### PR TITLE
Add methods for configuring and starting ansible inside

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -8,6 +8,7 @@ class MiqDatabase < ApplicationRecord
 
   include AuthenticationMixin
   include PasswordMixin
+  include AnsibleAuthentications
 
   virtual_has_many  :vmdb_tables
 
@@ -86,76 +87,5 @@ class MiqDatabase < ApplicationRecord
 
   def registration_organization_name
     registration_organization_display_name || registration_organization
-  end
-
-  def ansible_secret_key
-    auth = authentication_type("ansible_secret_key")
-    auth.nil? ? nil : auth.auth_key
-  end
-
-  def ansible_secret_key=(key)
-    auth = authentication_type("ansible_secret_key")
-    auth ||= AuthToken.new(
-      :name     => "Ansible Secret Key",
-      :resource => self,
-      :authtype => "ansible_secret_key"
-    )
-
-    auth.auth_key = key
-    auth.save!
-  end
-
-  def ansible_rabbitmq_password
-    auth = authentication_type("ansible_rabbitmq_auth")
-    auth.nil? ? nil : auth.password
-  end
-
-  def ansible_rabbitmq_password=(password)
-    auth = authentication_type("ansible_rabbitmq_auth")
-    auth ||= AuthUseridPassword.new(
-      :userid   => "tower",
-      :name     => "Ansible Rabbitmq Auth",
-      :resource => self,
-      :authtype => "ansible_rabbitmq_auth"
-    )
-
-    auth.password = password
-    auth.save!
-  end
-
-  def ansible_admin_password
-    auth = authentication_type("ansible_admin_password")
-    auth.nil? ? nil : auth.password
-  end
-
-  def ansible_admin_password=(password)
-    auth = authentication_type("ansible_admin_password")
-    auth ||= AuthUseridPassword.new(
-      :userid   => "admin",
-      :name     => "Ansible Admin Password",
-      :resource => self,
-      :authtype => "ansible_admin_password"
-    )
-
-    auth.password = password
-    auth.save!
-  end
-
-  def ansible_database_password
-    auth = authentication_type("ansible_database_password")
-    auth.nil? ? nil : auth.password
-  end
-
-  def ansible_database_password=(password)
-    auth = authentication_type("ansible_database_password")
-    auth ||= AuthUseridPassword.new(
-      :userid   => "awx",
-      :name     => "Ansible Database Password",
-      :resource => self,
-      :authtype => "ansible_database_password"
-    )
-
-    auth.password = password
-    auth.save!
   end
 end

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -87,4 +87,57 @@ class MiqDatabase < ApplicationRecord
   def registration_organization_name
     registration_organization_display_name || registration_organization
   end
+
+  def ansible_secret_key
+    auth = authentication_type("ansible_secret_key")
+    auth.nil? ? nil : auth.auth_key
+  end
+
+  def ansible_secret_key=(key)
+    auth = authentication_type("ansible_secret_key")
+    auth ||= AuthToken.new(
+      :name     => "Ansible Secret Key",
+      :resource => self,
+      :authtype => "ansible_secret_key"
+    )
+
+    auth.auth_key = key
+    auth.save!
+  end
+
+  def ansible_rabbitmq_password
+    auth = authentication_type("ansible_rabbitmq_auth")
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_rabbitmq_password=(password)
+    auth = authentication_type("ansible_rabbitmq_auth")
+    auth ||= AuthUseridPassword.new(
+      :userid   => "tower",
+      :name     => "Ansible Rabbitmq Auth",
+      :resource => self,
+      :authtype => "ansible_rabbitmq_auth"
+    )
+
+    auth.password = password
+    auth.save!
+  end
+
+  def ansible_admin_password
+    auth = authentication_type("ansible_admin_password")
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_admin_password=(password)
+    auth = authentication_type("ansible_admin_password")
+    auth ||= AuthUseridPassword.new(
+      :userid   => "admin",
+      :name     => "Ansible Admin Password",
+      :resource => self,
+      :authtype => "ansible_admin_password"
+    )
+
+    auth.password = password
+    auth.save!
+  end
 end

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -140,4 +140,22 @@ class MiqDatabase < ApplicationRecord
     auth.password = password
     auth.save!
   end
+
+  def ansible_database_password
+    auth = authentication_type("ansible_database_password")
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_database_password=(password)
+    auth = authentication_type("ansible_database_password")
+    auth ||= AuthUseridPassword.new(
+      :userid   => "awx",
+      :name     => "Ansible Database Password",
+      :resource => self,
+      :authtype => "ansible_database_password"
+    )
+
+    auth.password = password
+    auth.save!
+  end
 end

--- a/app/models/mixins/ansible_authentications.rb
+++ b/app/models/mixins/ansible_authentications.rb
@@ -1,0 +1,83 @@
+module AnsibleAuthentications
+  ANSIBLE_SECRET_KEY_TYPE = "ansible_secret_key".freeze
+  ANSIBLE_RABBITMQ_TYPE   = "ansible_rabbitmq_auth".freeze
+  ANSIBLE_ADMIN_TYPE      = "ansible_admin_password".freeze
+  ANSIBLE_DATABASE_TYPE   = "ansible_database_password".freeze
+
+  def self.included(base)
+    base.class_eval do
+      include AuthenticationMixin
+    end
+  end
+
+  def ansible_secret_key
+    auth = authentication_type(ANSIBLE_SECRET_KEY_TYPE)
+    auth.nil? ? nil : auth.auth_key
+  end
+
+  def ansible_secret_key=(key)
+    auth = authentication_type(ANSIBLE_SECRET_KEY_TYPE)
+    auth ||= AuthToken.new(
+      :name     => "Ansible Secret Key",
+      :resource => self,
+      :authtype => ANSIBLE_SECRET_KEY_TYPE
+    )
+
+    auth.auth_key = key
+    auth.save!
+  end
+
+  def ansible_rabbitmq_password
+    auth = authentication_type(ANSIBLE_RABBITMQ_TYPE)
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_rabbitmq_password=(password)
+    auth = authentication_type(ANSIBLE_RABBITMQ_TYPE)
+    auth ||= AuthUseridPassword.new(
+      :userid   => "tower",
+      :name     => "Ansible Rabbitmq Auth",
+      :resource => self,
+      :authtype => ANSIBLE_RABBITMQ_TYPE
+    )
+
+    auth.password = password
+    auth.save!
+  end
+
+  def ansible_admin_password
+    auth = authentication_type(ANSIBLE_ADMIN_TYPE)
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_admin_password=(password)
+    auth = authentication_type(ANSIBLE_ADMIN_TYPE)
+    auth ||= AuthUseridPassword.new(
+      :userid   => "admin",
+      :name     => "Ansible Admin Password",
+      :resource => self,
+      :authtype => ANSIBLE_ADMIN_TYPE
+    )
+
+    auth.password = password
+    auth.save!
+  end
+
+  def ansible_database_password
+    auth = authentication_type(ANSIBLE_DATABASE_TYPE)
+    auth.nil? ? nil : auth.password
+  end
+
+  def ansible_database_password=(password)
+    auth = authentication_type(ANSIBLE_DATABASE_TYPE)
+    auth ||= AuthUseridPassword.new(
+      :userid   => "awx",
+      :name     => "Ansible Database Password",
+      :resource => self,
+      :authtype => ANSIBLE_DATABASE_TYPE
+    )
+
+    auth.password = password
+    auth.save!
+  end
+end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -41,6 +41,10 @@ class EmbeddedAnsible
   end
 
   def self.stop
+    services.each { |service| LinuxAdmin::Service.new(service).stop }
+  end
+
+  def self.disable
     services.each { |service| LinuxAdmin::Service.new(service).stop.disable }
   end
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -1,6 +1,10 @@
+require "awesome_spawn"
+require "linux_admin"
+
 class EmbeddedAnsible
   APPLIANCE_ANSIBLE_DIRECTORY = "/opt/ansible-installer".freeze
   ANSIBLE_ROLE                = "embedded_ansible".freeze
+  SETUP_SCRIPT                = "#{APPLIANCE_ANSIBLE_DIRECTORY}/setup.sh".freeze
 
   def self.available?
     path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
@@ -12,7 +16,30 @@ class EmbeddedAnsible
   end
 
   def self.running?
-    # TODO
-    false
+    services.all? { |service| LinuxAdmin::Service.new(service).running? }
+  end
+
+  def self.configure
+    setup_params = {
+      :e => "minimum_var_space=0",
+      :k => "packages,migrations,supervisor"
+    }
+    AwesomeSpawn.run!(SETUP_SCRIPT, :params => setup_params)
+  end
+
+  def self.start
+    setup_params = {
+      :e => "minimum_var_space=0",
+      :k => "packages,migrations"
+    }
+    AwesomeSpawn.run!(SETUP_SCRIPT, :params => setup_params)
+  end
+
+  def self.stop
+    services.each { |service| LinuxAdmin::Service.new(service).stop.disable }
+  end
+
+  def self.services
+    AwesomeSpawn.run!("source /etc/sysconfig/ansible-tower; echo $TOWER_SERVICES").output.split
   end
 end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -89,12 +89,12 @@ class EmbeddedAnsible
   private_class_method :configure_secret_key
 
   def self.generate_admin_password
-    miq_database.ansible_admin_password = SecureRandom.base64
+    miq_database.ansible_admin_password = SecureRandom.hex
   end
   private_class_method :generate_admin_password
 
   def self.generate_rabbitmq_password
-    miq_database.ansible_rabbitmq_password = SecureRandom.base64
+    miq_database.ansible_rabbitmq_password = SecureRandom.hex
   end
   private_class_method :generate_rabbitmq_password
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -3,7 +3,8 @@ class EmbeddedAnsible
   ANSIBLE_ROLE                = "embedded_ansible".freeze
 
   def self.available?
-    installed?
+    path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
+    Dir.exist?(File.expand_path(path.to_s))
   end
 
   def self.enabled?
@@ -14,10 +15,4 @@ class EmbeddedAnsible
     # TODO
     false
   end
-
-  def self.installed?
-    path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
-    Dir.exist?(File.expand_path(path.to_s))
-  end
-  private_class_method :installed?
 end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -23,6 +23,11 @@ class EmbeddedAnsible
     services.all? { |service| LinuxAdmin::Service.new(service).running? }
   end
 
+  def self.configured?
+    key = miq_database.ansible_secret_key
+    key.present? && key == File.read(SECRET_KEY_FILE)
+  end
+
   def self.configure
     configure_secret_key
     run_setup_script(:e => "minimum_var_space=0", :k => CONFIGURE_EXCLUDE_TAGS)

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -7,8 +7,8 @@ class EmbeddedAnsible
   ANSIBLE_ROLE                = "embedded_ansible".freeze
   SETUP_SCRIPT                = "#{APPLIANCE_ANSIBLE_DIRECTORY}/setup.sh".freeze
   SECRET_KEY_FILE             = "/etc/tower/SECRET_KEY".freeze
-  CONFIGURE_EXCLUDE_TAGS      = "packages,migrations,supervisor".freeze
-  START_EXCLUDE_TAGS          = "packages,migrations".freeze
+  CONFIGURE_EXCLUDE_TAGS      = "packages,migrations,firewall,supervisor".freeze
+  START_EXCLUDE_TAGS          = "packages,migrations,firewall".freeze
   NGINX_HTTP_PORT             = "54321".freeze
   NGINX_HTTPS_PORT            = "54322".freeze
 

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -1,3 +1,6 @@
+require "linux_admin"
+require "awesome_spawn"
+
 describe EmbeddedAnsible do
   before do
     ENV["APPLIANCE_ANSIBLE_DIRECTORY"] = nil
@@ -22,6 +25,52 @@ describe EmbeddedAnsible do
       allow(Dir).to receive(:exist?).with("/opt/ansible-installer").and_return(false)
 
       expect(described_class.available?).to be_falsey
+    end
+  end
+
+  context "with services" do
+    let(:nginx_service)       { double("nginx service") }
+    let(:supervisord_service) { double("supervisord service") }
+    let(:rabbitmq_service)    { double("rabbitmq service") }
+
+    before do
+      expect(AwesomeSpawn).to receive(:run!)
+        .with("source /etc/sysconfig/ansible-tower; echo $TOWER_SERVICES")
+        .and_return(double(:output => "nginx supervisord rabbitmq"))
+      allow(LinuxAdmin::Service).to receive(:new).with("nginx").and_return(nginx_service)
+      allow(LinuxAdmin::Service).to receive(:new).with("supervisord").and_return(supervisord_service)
+      allow(LinuxAdmin::Service).to receive(:new).with("rabbitmq").and_return(rabbitmq_service)
+    end
+
+    describe ".running?" do
+      it "returns true when all services are running" do
+        expect(nginx_service).to receive(:running?).and_return(true)
+        expect(supervisord_service).to receive(:running?).and_return(true)
+        expect(rabbitmq_service).to receive(:running?).and_return(true)
+
+        expect(described_class.running?).to be true
+      end
+
+      it "returns false when a service is not running" do
+        expect(nginx_service).to receive(:running?).and_return(true)
+        expect(supervisord_service).to receive(:running?).and_return(false)
+
+        expect(described_class.running?).to be false
+      end
+    end
+
+    describe ".stop" do
+      it "stops all the services" do
+        expect(nginx_service).to receive(:stop).and_return(nginx_service)
+        expect(supervisord_service).to receive(:stop).and_return(supervisord_service)
+        expect(rabbitmq_service).to receive(:stop).and_return(rabbitmq_service)
+
+        expect(nginx_service).to receive(:disable).and_return(nginx_service)
+        expect(supervisord_service).to receive(:disable).and_return(supervisord_service)
+        expect(rabbitmq_service).to receive(:disable).and_return(rabbitmq_service)
+
+        described_class.stop
+      end
     end
   end
 end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -76,6 +76,13 @@ describe EmbeddedAnsible do
 
   context "with an miq_databases row" do
     let(:miq_database) { MiqDatabase.first }
+    let(:extra_vars) do
+      {
+        :minimum_var_space => 0,
+        :nginx_http_port   => described_class::NGINX_HTTP_PORT,
+        :nginx_https_port   => described_class::NGINX_HTTPS_PORT
+      }.to_json
+    end
 
     before do
       FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
@@ -150,7 +157,7 @@ describe EmbeddedAnsible do
           inventory_file_contents = File.read(params[:i])
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
-          expect(params[:e]).to eq("minimum_var_space=0")
+          expect(params[:e]).to eq(extra_vars)
           expect(params[:k]).to eq("packages,migrations,supervisor")
 
           new_admin_password  = miq_database.ansible_admin_password
@@ -173,7 +180,7 @@ describe EmbeddedAnsible do
           inventory_file_contents = File.read(params[:i])
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
-          expect(params[:e]).to eq("minimum_var_space=0")
+          expect(params[:e]).to eq(extra_vars)
           expect(params[:k]).to eq("packages,migrations,supervisor")
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")
@@ -194,7 +201,7 @@ describe EmbeddedAnsible do
           inventory_file_contents = File.read(params[:i])
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
-          expect(params[:e]).to eq("minimum_var_space=0")
+          expect(params[:e]).to eq(extra_vars)
           expect(params[:k]).to eq("packages,migrations")
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -80,7 +80,7 @@ describe EmbeddedAnsible do
       {
         :minimum_var_space => 0,
         :nginx_http_port   => described_class::NGINX_HTTP_PORT,
-        :nginx_https_port   => described_class::NGINX_HTTPS_PORT
+        :nginx_https_port  => described_class::NGINX_HTTPS_PORT
       }.to_json
     end
 
@@ -152,6 +152,7 @@ describe EmbeddedAnsible do
       end
 
       it "generates new passwords with no passwords set" do
+        expect(described_class).to receive(:generate_database_password).and_return("databasepassword")
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
           inventory_file_contents = File.read(params[:i])
@@ -166,6 +167,7 @@ describe EmbeddedAnsible do
           expect(new_rabbit_password).not_to be_nil
           expect(inventory_file_contents).to include("admin_password='#{new_admin_password}'")
           expect(inventory_file_contents).to include("rabbitmq_password='#{new_rabbit_password}'")
+          expect(inventory_file_contents).to include("pg_password='databasepassword'")
         end
 
         described_class.configure
@@ -174,6 +176,7 @@ describe EmbeddedAnsible do
       it "uses the existing passwords when they are set in the database" do
         miq_database.ansible_admin_password    = "adminpassword"
         miq_database.ansible_rabbitmq_password = "rabbitpassword"
+        miq_database.ansible_database_password = "databasepassword"
 
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
@@ -185,6 +188,7 @@ describe EmbeddedAnsible do
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")
           expect(inventory_file_contents).to include("rabbitmq_password='rabbitpassword'")
+          expect(inventory_file_contents).to include("pg_password='databasepassword'")
         end
 
         described_class.configure
@@ -195,6 +199,7 @@ describe EmbeddedAnsible do
       it "runs the setup script with the correct args" do
         miq_database.ansible_admin_password    = "adminpassword"
         miq_database.ansible_rabbitmq_password = "rabbitpassword"
+        miq_database.ansible_database_password = "databasepassword"
 
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
@@ -206,6 +211,7 @@ describe EmbeddedAnsible do
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")
           expect(inventory_file_contents).to include("rabbitmq_password='rabbitpassword'")
+          expect(inventory_file_contents).to include("pg_password='databasepassword'")
         end
 
         described_class.start

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -65,11 +65,21 @@ describe EmbeddedAnsible do
         expect(supervisord_service).to receive(:stop).and_return(supervisord_service)
         expect(rabbitmq_service).to receive(:stop).and_return(rabbitmq_service)
 
+        described_class.stop
+      end
+    end
+
+    describe ".disable" do
+      it "stops and disables all the services" do
+        expect(nginx_service).to receive(:stop).and_return(nginx_service)
+        expect(supervisord_service).to receive(:stop).and_return(supervisord_service)
+        expect(rabbitmq_service).to receive(:stop).and_return(rabbitmq_service)
+
         expect(nginx_service).to receive(:disable).and_return(nginx_service)
         expect(supervisord_service).to receive(:disable).and_return(supervisord_service)
         expect(rabbitmq_service).to receive(:disable).and_return(rabbitmq_service)
 
-        described_class.stop
+        described_class.disable
       end
     end
   end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -158,7 +158,7 @@ describe EmbeddedAnsible do
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
           expect(params[:e]).to eq(extra_vars)
-          expect(params[:k]).to eq("packages,migrations,supervisor")
+          expect(params[:k]).to eq("packages,migrations,firewall,supervisor")
 
           new_admin_password  = miq_database.ansible_admin_password
           new_rabbit_password = miq_database.ansible_rabbitmq_password
@@ -181,7 +181,7 @@ describe EmbeddedAnsible do
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
           expect(params[:e]).to eq(extra_vars)
-          expect(params[:k]).to eq("packages,migrations,supervisor")
+          expect(params[:k]).to eq("packages,migrations,firewall,supervisor")
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")
           expect(inventory_file_contents).to include("rabbitmq_password='rabbitpassword'")
@@ -202,7 +202,7 @@ describe EmbeddedAnsible do
 
           expect(script_path).to eq("/opt/ansible-installer/setup.sh")
           expect(params[:e]).to eq(extra_vars)
-          expect(params[:k]).to eq("packages,migrations")
+          expect(params[:k]).to eq("packages,migrations,firewall")
 
           expect(inventory_file_contents).to include("admin_password='adminpassword'")
           expect(inventory_file_contents).to include("rabbitmq_password='rabbitpassword'")


### PR DESCRIPTION
This PR mainly fleshes out the `EmbeddedAnsible` class created in https://github.com/ManageIQ/manageiq/pull/13435

This adds things like configuring the appliance to run the ansible service and methods for managing that service.

Also added here is a way to share the keys and passwords needed by the embedded ansible service across servers in case of role failover.

This is the general shape of the API that will be used by the worker being created in https://github.com/ManageIQ/manageiq/issues/13551

https://www.pivotaltracker.com/story/show/137048481