### PR TITLE
Fix for lib/miq_ldap.rb initialization

### DIFF
--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -30,7 +30,7 @@ class MiqLdap
   end
 
   def initialize(options = {})
-    @auth = options[:auth] || ::Settings.authentication
+    @auth = options[:auth] || ::Settings.authentication.to_hash
 
     log_auth = Vmdb::Settings.mask_passwords!(@auth.deep_clone)
     _log.info("Server Settings: #{log_auth.inspect}")


### PR DESCRIPTION
This fixes an initialization issue introduced with https://github.com/ManageIQ/manageiq/pull/13047.
Mask_passwords! was getting called with a nil setting since deep_clone does not work with Options class.
updated the @auth initialization to take the hash representation of the Settings like it used to.

Fixes: #13403
