### PR TITLE
add create_catalog_item class method to ServiceTemplate

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -45,16 +45,18 @@ class ServiceTemplate < ApplicationRecord
   virtual_has_one :custom_actions, :class_name => "Hash"
   virtual_has_one :custom_action_buttons, :class_name => "Array"
 
-  # This method creates
   def self.create_catalog_item(options, auth_user)
-    create(options.except(:config_info)).tap do |service_template|
-      config_info = options[:config_info].except(:ae_endpoints)
-      workflow_class = MiqProvisionWorkflow.class_for_source(config_info[:src_vm_id])
-      raise 'Could not find Provision Workflow class for source VM' unless workflow_class
-      request = workflow_class.new(config_info, auth_user).make_request(nil, config_info)
-      service_template.add_resource(request)
-      dialog = Dialog.find(config_info[:service_dialog_id]) if config_info[:service_dialog_id]
-      service_template.set_resource_actions(options[:config_info][:ae_endpoints], dialog)
+    transaction do
+      create(options.except(:config_info)).tap do |service_template|
+        config_info = options[:config_info].except(:provision, :retirement, :reconfigure)
+
+        workflow_class = MiqProvisionWorkflow.class_for_source(config_info[:src_vm_id])
+        if workflow_class
+          request = workflow_class.new(config_info, auth_user).make_request(nil, config_info)
+          service_template.add_resource(request)
+        end
+        service_template.create_resource_actions(options[:config_info])
+      end
     end
   end
 
@@ -193,9 +195,9 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def create_tasks_for_service(service_task, parent_svc)
-    return [] unless parent_svc || self.class.include_service_template?(service_task,
-                                                                        service_task.source_id,
-                                                                        parent_svc)
+    return [] unless self.class.include_service_template?(service_task,
+                                                          service_task.source_id,
+                                                          parent_svc) unless parent_svc
     svc = create_service(service_task, parent_svc)
 
     set_ownership(svc, service_task.get_user)
@@ -274,7 +276,7 @@ class ServiceTemplate < ApplicationRecord
   def template_valid?
     validate_template[:valid]
   end
-  alias template_valid template_valid?
+  alias_method :template_valid, :template_valid?
 
   def template_valid_error_message
     validate_template[:message]
@@ -304,28 +306,37 @@ class ServiceTemplate < ApplicationRecord
     resource_actions.find_by(:action => "Provision")
   end
 
-  def set_resource_actions(ae_endpoints, dialog)
+  def create_resource_actions(ae_endpoints)
     ae_endpoints ||= {}
     [
       {:name      => 'Provision',
-       :param_key => 'provisioning',
+       :param_key => :provision,
        :method    => 'default_provisioning_entry_point',
        :args      => [service_type]},
       {:name      => 'Reconfigure',
-       :param_key => 'reconfigure',
+       :param_key => :reconfigure,
        :method    => 'default_reconfiguration_entry_point',
        :args      => []},
       {:name      => 'Retirement',
-       :param_key => 'retirement',
+       :param_key => :retirement,
        :method    => 'default_retirement_entry_point',
        :args      => []}
     ].each do |action|
-      fqname = if ae_endpoints[action[:param_key]].nil?
+      ae_endpoint = ae_endpoints[action[:param_key]]
+      next unless ae_endpoint
+      fqname = if ae_endpoint.empty?
                  self.class.send(action[:method], *action[:args]) || ""
                else
-                 ae_endpoints[action[:param_key]]
+                 ae_endpoint[:fqname]
                end
-      resource_actions.build(:action => action[:name], :fqname => fqname, :dialog => dialog)
+
+      build_options = {:action => action[:name], :fqname => fqname}
+      build_options.merge!(ae_endpoint.slice(:dialog,
+                                             :dialog_id,
+                                             :configuration_template,
+                                             :configuration_template_id,
+                                             :configuration_template_type))
+      resource_actions.build(build_options)
     end
     save!
   end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -437,6 +437,59 @@ describe ServiceTemplate do
       expect(service_template.provision_action).to eq(provision_action)
     end
   end
+
+  describe '#create_catalog_item' do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:ra1) { FactoryGirl.create(:resource_action, :action => 'Provision') }
+    let(:ra2) { FactoryGirl.create(:resource_action, :action => 'Retirement') }
+    let(:ems) { FactoryGirl.create(:ems_amazon) }
+    let(:vm) { FactoryGirl.create(:vm_amazon, :ext_management_system => ems) }
+    let(:flavor) { FactoryGirl.create(:flavor_amazon) }
+    let(:request_dialog) { FactoryGirl.create(:miq_dialog_provision) }
+    let(:service_dialog) { FactoryGirl.create(:dialog) }
+    let(:catalog_item_options) do
+      {
+        :name         => 'Atomic Service Template',
+        :service_type => 'atomic',
+        :prov_type    => 'amazon',
+        :display      => 'false',
+        :description  => 'a description',
+        :config_info  => {
+          :miq_request_dialog_name => request_dialog.name,
+          :service_dialog_id       => service_dialog.id,
+          :placement_auto          => [true, 1],
+          :number_of_vms           => [1, '1'],
+          :src_vm_id               => [vm.id, vm.name],
+          :vm_name                 => vm.name,
+          :schedule_type           => ['immediately', 'Immediately on Approval'],
+          :instance_type           => [flavor.id, flavor.name],
+          :src_ems_id              => [ems.id, ems.name],
+          :ae_endpoints            => {
+            :provisioning => ra1.fqname,
+            :retirement   => ra2.fqname
+          }
+        }
+      }
+    end
+
+    it 'creates and returns a catalog item' do
+      service_template = ServiceTemplate.create_catalog_item(catalog_item_options, user)
+
+      expect(service_template.name).to eq('Atomic Service Template')
+      expect(service_template.service_resources.count).to eq(1)
+      expect(service_template.service_resources.first.resource_type).to eq('MiqRequest')
+      expect(service_template.dialogs.first).to eq(service_dialog)
+      expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Reconfigure', 'Retirement')
+    end
+
+    it 'will raise an error if it cannot find a Provision Workflow class for source VM' do
+      catalog_item_options[:config_info][:src_vm_id] = []
+
+      expect do
+        ServiceTemplate.create_catalog_item(catalog_item_options, user)
+      end.to raise_error(StandardError, 'Could not find Provision Workflow class for source VM')
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
This is a class method on `ServiceTemplate` to `create_catalog_item`. 
The format for the options passed in are as follows:
```
      {
        :name         => 'Atomic Service Template',
        :service_type => 'atomic',
        :prov_type    => 'amazon',
        :display      => 'false',
        :description  => 'a description',
        :config_info  => {
          :miq_request_dialog_name => request_dialog.name,
          :placement_auto          => [true, 1],
          :number_of_vms           => [1, '1'],
          :src_vm_id               => [vm.id, vm.name],
          :vm_name                 => vm.name,
          :schedule_type           => ['immediately', 'Immediately on Approval'],
          :instance_type           => [flavor.id, flavor.name],
          :src_ems_id              => [ems.id, ems.name],
          :provision               => {
            :fqname            => ra1.fqname,
            :service_dialog_id => service_dialog.id
          },
          :retirement              => {
            :fqname            => ra2.fqname,
            :service_dialog_id => service_dialog.id
          }
        }
      }
```

Much of this is based off of #12594. By creating these class methods, it will simplify the process of creating catalog items. Once these class methods are completed, #12594 will be updated to account for these changes with a much simpler API

@miq-bot assign @bzwei 
@miq-bot add_label enhancement, euwe/no, services 
cc: @h-kataria 
