### PR TITLE
[DARGA] Fix RBAC Features Tree select behavior

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -117,7 +117,16 @@ class OpsController
 
       node[:children] = kids
       node[:select] = parent_checked || @role_features.include?(feature) || select_by_all_descendents(feature)
+
+      if node[:select] == "undefined"
+        node[:addClass] = "dynatree-partsel"
+      end
+
       node
+    end
+
+    def feature_descendants(feature)
+      @descendant_cache[feature] ||= MiqProductFeature.find_by(:identifier => feature).descendants.pluck(:identifier)
     end
 
     def feature_child_select_states(feature)
@@ -125,15 +134,12 @@ class OpsController
       all_children.map { |c| @role_features.include?(c) }
     end
 
-    def feature_descendants(feature)
-      @descendant_cache[feature] ||= MiqProductFeature.find_by(:identifier => feature).descendants.pluck(:identifier)
-    end
-
     def select_by_all_descendents(feature)
       states = feature_child_select_states(feature)
 
       return false       if states.none?
-      return true        if states.any?
+      return true        if states.all? { |s| s == true } # True not truthy
+      return "undefined" if states.any? # undefined is the partial selection value used upstream
 
       false
     end


### PR DESCRIPTION
Currently hidden descendants are not counted when determining whether a checkbox should be checked. This can lead to the appearance that a role does not have a permission that it in fact does.

This changes this tree to count all feature descendants when necessary to show the correct state.

https://bugzilla.redhat.com/show_bug.cgi?id=1348623

**Before**
![screen shot 2017-01-19 at 12 10 40 pm](https://cloud.githubusercontent.com/assets/39493/22123403/5393c1d2-de40-11e6-93ee-232dfbc46ea5.png)

**After**
![screen shot 2017-01-19 at 12 08 34 pm](https://cloud.githubusercontent.com/assets/39493/22123412/5a904d70-de40-11e6-86aa-5ecbb4d6bab4.png)

Related:
https://github.com/ManageIQ/manageiq-ui-classic/pull/137
https://github.com/ManageIQ/manageiq/pull/13577
