### PR TITLE
Fix tier selection when using different units.

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -58,7 +58,7 @@ class ChargebackRateDetail < ApplicationRecord
   def find_rate(value)
     fixed_rate = 0.0
     variable_rate = 0.0
-    tier_found = chargeback_tiers.detect { |tier| tier.includes?(value / rate_adjustment) }
+    tier_found = chargeback_tiers.detect { |tier| tier.includes?(value * rate_adjustment) }
     unless tier_found.nil?
       fixed_rate = tier_found.fixed_rate
       variable_rate = tier_found.variable_rate


### PR DESCRIPTION
## The problem was
Rates are tiered. Tier is selected based on the metrics' value.

When metric value and tier boundaries were in different units (metric in bytes, tiers in gigabytes), the tier selection was broken. We used `/` operator instead of `*`.

## Cause
This problem existed since the day 0. It became just more visible after recent refactoring in #13331. I noticed that on one ocasion we had `value * rate_adjustment` and on another occasion we had `value / rate_adjustment`. That begged for investigation.

@miq-bot add_label chargeback, wip, bug
@miq-bot assign @gtanzillo 