### PR TITLE
add full reference to CIDR_OR_ID_MATCHER

### DIFF
--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -85,7 +85,7 @@ module Api
 
       def parse_tag_from_href(data)
         href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/#{CID_OR_ID_MATCHER}$})
+        tag  = if href && href.match(%r{^.*/tags/#{ArRegion::CID_OR_ID_MATCHER}$})
                  klass = collection_class(:tags)
                  klass.find(from_cid(href.split('/').last))
                end


### PR DESCRIPTION
Without the full reference to `CIDR_OR_ID_MATCHER`, tagging API is returning  `uninitialized constant Api::Subcollections::Tags::CID_OR_ID_MATCHER` errors (as was referenced in #13581).

cc: @imtayadeway 
@miq-bot add_label bug, api
@miq-bot assign @abellotti 
