### PR TITLE
Reports: Remove extra cols from provider manager views

### DIFF
--- a/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
@@ -20,9 +20,7 @@ db: ManageIQ::Providers::AnsibleTower::AutomationManager
 # Columns to fetch from the main table
 cols:
 - name
-- url
 - type
-- zone.name
 - last_refresh_date
 - region_description
 - authentication_status
@@ -35,7 +33,6 @@ include:
     - name
   provider:
     columns:
-    - name
     - url
 
 # Included tables and columns for query performance

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -20,9 +20,7 @@ db: ManageIQ::Providers::ConfigurationManager
 # Columns to fetch from the main table
 cols:
 - name
-- url
 - type
-- zone.name
 - last_refresh_date
 - region_description
 - authentication_status
@@ -35,7 +33,6 @@ include:
     - name
   provider:
     columns:
-    - name
     - url
 
 # Included tables and columns for query performance

--- a/product/views/ManageIQ_Providers_ContainerManager.yaml
+++ b/product/views/ManageIQ_Providers_ContainerManager.yaml
@@ -27,9 +27,6 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-  zone:
-    columns:
-    - name
 
 # Included tables and columns for query performance
 include_for_find:

--- a/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
+++ b/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
@@ -27,9 +27,6 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-  zone:
-    columns:
-    - name
 
 # Included tables and columns for query performance
 include_for_find:

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -20,9 +20,7 @@ db: ManageIQ::Providers::Foreman::ConfigurationManager
 # Columns to fetch from the main table
 cols:
 - name
-- url
 - type
-- zone.name
 - last_refresh_date
 - region_description
 - authentication_status
@@ -36,7 +34,6 @@ include:
     - name
   provider:
     columns:
-    - name
     - url
 
 # Included tables and columns for query performance

--- a/product/views/ManageIQ_Providers_MiddlewareManager.yaml
+++ b/product/views/ManageIQ_Providers_MiddlewareManager.yaml
@@ -27,9 +27,6 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-  zone:
-    columns:
-    - name
 
 # Included tables and columns for query performance
 include_for_find:


### PR DESCRIPTION
High level: we state includes that are not necessary.
Which is not the end of the world.
But it is not good if the includes are no longer valid.

So the goal is to trim down the columns in the `product/views`.

1. there is no need to bring back `zone.name` and `zone`/`name` in `includes`. trimmed to just one.
2. there is no need to bring back `url` when `provider.url` is used. (only need 1 url)
3. remove `zone.name` when it is not included in display.
