### PR TITLE
Fix specs after manageiq-ui-classic#14.

### DIFF
--- a/spec/routing/vm_routing_spec.rb
+++ b/spec/routing/vm_routing_spec.rb
@@ -41,7 +41,7 @@ describe VmOrTemplateController do
     right_size
     set_checked_items
     show_list
-    vmtree_selected
+    genealogy_tree_selected
   ).each do |path|
     describe "##{path}" do
       it "routes with POST" do


### PR DESCRIPTION
Healing cross repo dependencies (caused by https://github.com/ManageIQ/manageiq-ui-classic/pull/14)

Failure was:
```
  1) VmOrTemplateController#vmtree_selected routes with POST

     Failure/Error: expect(post("/#{controller_name}/#{path}")).to route_to("#{controller_name}##{path}")

       No route matches "/vm/vmtree_selected"

     # ./spec/routing/vm_routing_spec.rb:48:in `block (4 levels) in <top (required)>'
```

Perhaps we can move some of the routing specs to manageiq-ui-classic?