### PR TITLE
rhv: removed the option to migrate the VMs outside of the cluster.

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -186,7 +186,14 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def unsupported_migration_options
-    [:storage, :respool, :folder, :datacenter, :host_filter]
+    [:storage, :respool, :folder, :datacenter, :host_filter, :cluster]
+  end
+
+  # Migrations are supposed to work only in one cluster. If more VMs are going
+  # to be migrated, all have to live on the same cluster, otherwise they can
+  # not be migrated together.
+  def supports_migrate_for_all?(vms)
+    vms.map(&:ems_cluster).uniq.compact.size == 1
   end
 
   private

--- a/app/models/vm_migrate_workflow.rb
+++ b/app/models/vm_migrate_workflow.rb
@@ -16,13 +16,15 @@ class VmMigrateWorkflow < MiqRequestWorkflow
   def get_source_and_targets(refresh = false)
     return @target_resource if @target_resource && refresh == false
 
-    ems = @values[:src_ids].to_miq_a.collect { |v_id| v = Vm.find_by_id(v_id); v.ext_management_system }.uniq.compact
+    vms = Vm.where(:id => @values[:src_ids])
+
+    emses = ExtManagementSystem.where(:id => vms.pluck(:ems_id)).distinct.compact
 
     # If all the selected VMs share the same EMS we can present a list of CIs.
-    return @target_resource = {} if ems.length != 1
+    return @target_resource = {} if emses.length != 1
 
-    result = {:ems => ci_to_hash_struct(ems.first)}
-    @manager = ems.first
+    result = {:ems => ci_to_hash_struct(emses.first)}
+    @manager = emses.first
 
     add_target(:placement_host_name,    :host,    Host,         result)
     add_target(:placement_ds_name,      :storage, Storage,      result)
@@ -36,6 +38,14 @@ class VmMigrateWorkflow < MiqRequestWorkflow
     else
       add_target(:placement_dc_name, :datacenter, EmsFolder, result)
     end
+
+    unless field_supported(:cluster)
+      # If the user can not pick a cluster there can only be one to select
+      # from => preselect it so the hosts will be filtered accordingly.
+      cluster = vms.first.ems_cluster
+      result[:cluster] = ci_to_hash_struct(cluster)
+    end
+
     rails_logger('get_source_and_targets', 1)
     @target_resource = result
   end

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -38,8 +38,8 @@ describe VmMigrateWorkflow do
         workflow.get_source_and_targets
         target_resource = workflow.instance_variable_get(:@target_resource)
         expect(target_resource).not_to include(:storage_id, :respool_id, :folder_id,
-                                               :datacenter_id)
-        expect(target_resource).to include(:host_id, :cluster_id)
+                                               :datacenter_id, :cluster_id)
+        expect(target_resource).to include(:host_id)
       end
     end
 


### PR DESCRIPTION
The support for cross cluster migrations was added to oVirt only as a
workaround for el6->el7 migrations but should not be exposed. Since the current
code in manageiq anyway did not work properly, removing the support for it
completely - it is a low level functionality, it is obsoleted and discouraged
to be used.

Links
https://bugzilla.redhat.com/show_bug.cgi?id=1398287