### PR TITLE
Parse and expose CFN orchestration template resources

### DIFF
--- a/app/models/orchestration_template/orchestration_resource.rb
+++ b/app/models/orchestration_template/orchestration_resource.rb
@@ -1,0 +1,10 @@
+class OrchestrationTemplate
+  class OrchestrationResource
+    attr_accessor :name
+    attr_accessor :type
+
+    def initialize(hash = {})
+      hash.each { |key, value| public_send("#{key}=", value) }
+    end
+  end
+end

--- a/app/models/orchestration_template_cfn.rb
+++ b/app/models/orchestration_template_cfn.rb
@@ -31,8 +31,7 @@ class OrchestrationTemplateCfn < OrchestrationTemplate
   end
 
   def resources
-    raw_resources = JSON.parse(content)["Resources"]
-    (raw_resources || {}).collect do |key, val|
+    @resources ||= (JSON.parse(content)["Resources"] || {}).collect do |key, val|
       OrchestrationTemplate::OrchestrationResource.new(
         :name => key,
         :type => val['Type']

--- a/app/models/orchestration_template_cfn.rb
+++ b/app/models/orchestration_template_cfn.rb
@@ -30,6 +30,16 @@ class OrchestrationTemplateCfn < OrchestrationTemplate
     end
   end
 
+  def resources
+    raw_resources = JSON.parse(content)["Resources"]
+    (raw_resources || {}).collect do |key, val|
+      OrchestrationTemplate::OrchestrationResource.new(
+        :name => key,
+        :type => val['Type']
+      )
+    end
+  end
+
   def self.register_eligible_manager(cloud_manager_class)
     eligible_manager_types << cloud_manager_class
   end

--- a/spec/fixtures/orchestration_templates/cfn_parameters.json
+++ b/spec/fixtures/orchestration_templates/cfn_parameters.json
@@ -58,6 +58,39 @@
       "Properties" : {
         "ImageId" : "ami-2f726546"
       }
+    },
+
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable SSH access via port 22",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "22",
+          "ToPort" : "22",
+          "CidrIp" : { "Ref" : "SSHLocation"}
+        } ]
+      }
+    },
+
+    "WebServerScaleUpPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "WebServerGroup" },
+        "Cooldown" : "60",
+        "ScalingAdjustment" : "1"
+      }
+    },
+
+    "WebServerScaleDownPolicy" : {
+      "Type" : "AWS::AutoScaling::ScalingPolicy",
+      "Properties" : {
+        "AdjustmentType" : "ChangeInCapacity",
+        "AutoScalingGroupName" : { "Ref" : "WebServerGroup" },
+        "Cooldown" : "60",
+        "ScalingAdjustment" : "-1"
+      }
     }
   }
 }

--- a/spec/models/orchestration_template_cfn_spec.rb
+++ b/spec/models/orchestration_template_cfn_spec.rb
@@ -24,6 +24,17 @@ describe OrchestrationTemplateCfn do
       assert_min_max_value(param_hash["SecondaryIPAddressCount"])
       assert_hidden_length_pattern(param_hash["MasterUserPassword"])
     end
+
+    it "parses resources from a template" do
+      resource_types = valid_template.resources.collect(&:type).sort!
+
+      expect(resource_types).to eq(
+        ["AWS::AutoScaling::ScalingPolicy",
+         "AWS::AutoScaling::ScalingPolicy",
+         "AWS::EC2::Instance",
+         "AWS::EC2::SecurityGroup"]
+      )
+    end
   end
 
   def assert_aws_type(parameter)


### PR DESCRIPTION
This change parses and exposes the resource content of CloudFormation orchestration templates. This will enable a preview of what will be instantiated if the orchestration template is deployed to a stack.
Orchestration templates can be gathered from 2 places:
1) The AWS provider
2) Manually built in the service catalog.

Implementing this code change to the ```OrchestrationTemplateCfn``` class will ensure we parse templates that come from both sources.

### Steps to test

There is currently no way to test this change using the UI but it can be tested on the rails console:
i) Get an instance of the OrchestrationStackCfn class
```o = OrchestrationTemplateCfn.first```

ii) Get the resources:
```o.resources```

iii) Examine one of the resources. The name and the type properties should be set correctly, for example:
```irb(main):010:0> o.resources.first```
```=> #<OrchestrationTemplate::OrchestrationResource:0x007f971a423048 @name="WebServer", @type="AWS::EC2::Instance">```

https://www.pivotaltracker.com/story/show/138045737

