### PR TITLE
Remove some obsolete rubocop config from routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,4 @@ Vmdb::Application.routes.draw do
   if Rails.env.development? && defined?(Rails::Server)
     mount WebsocketServer.new(:logger => Logger.new(STDOUT)) => '/ws'
   end
-  # rubocop:enable MultilineOperationIndentation
-  # rubocop:enable AlignHash
 end


### PR DESCRIPTION
These rules were previously disabled elsewhere in this file, but that
was removed in 4be21c7669ad.

@miq-bot add-label technical debt
@miq-bot assign @jrafanie 

