### PR TITLE
Avoid unnecessary queries in Api::BaseController#add_resource

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -47,7 +47,7 @@ module Api
         resource = klass.new(data)
         if resource.save
           add_subcollection_data_to_resource(resource, type, subcollection_data)
-          klass.find(resource.id)
+          resource
         else
           raise BadRequestError, "Failed to add a new #{type} resource - #{resource.errors.full_messages.join(', ')}"
         end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -44,13 +44,13 @@ module Api
             data.delete(sc.to_s)
           end
         end
-        rsc = klass.create(data)
-        if rsc.id.nil?
-          raise BadRequestError, "Failed to add a new #{type} resource - #{rsc.errors.full_messages.join(', ')}"
+        resource = klass.create(data)
+        if resource.id.nil?
+          raise BadRequestError, "Failed to add a new #{type} resource - #{resource.errors.full_messages.join(', ')}"
         end
-        rsc.save
-        add_subcollection_data_to_resource(rsc, type, subcollection_data)
-        klass.find(rsc.id)
+        resource.save
+        add_subcollection_data_to_resource(resource, type, subcollection_data)
+        klass.find(resource.id)
       end
 
       alias_method :create_resource, :add_resource

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -44,13 +44,13 @@ module Api
             data.delete(sc.to_s)
           end
         end
-        resource = klass.create(data)
-        if resource.id.nil?
+        resource = klass.new(data)
+        if resource.save
+          add_subcollection_data_to_resource(resource, type, subcollection_data)
+          klass.find(resource.id)
+        else
           raise BadRequestError, "Failed to add a new #{type} resource - #{resource.errors.full_messages.join(', ')}"
         end
-        resource.save
-        add_subcollection_data_to_resource(resource, type, subcollection_data)
-        klass.find(resource.id)
       end
 
       alias_method :create_resource, :add_resource


### PR DESCRIPTION
Some refactoring here to avoid some unnecessary work:

* don't save the created resource twice
* don't load the already loaded resource again

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
