### PR TITLE
Refactor chargeback seeds

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -8,7 +8,7 @@ class ChargeableField < ApplicationRecord
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
 
-  def self.seed_fields
+  def self.seed
     seed_data.each do |f|
       rec = ChargeableField.find_by(:metric => f[:metric])
       measure = f.delete(:measure)

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -65,33 +65,11 @@ class ChargebackRate < ApplicationRecord
 
   def self.seed
     # seeding the measure fixture before seed the chargeback rates fixtures
-    seed_chargeback_rate_measure
+    ChargebackRateDetailMeasure.seed_measures
     ChargeableField.seed_fields # Cannot use seed order until we refactor seed_chargeback_rate_measure
     # seeding the currencies
     seed_chargeback_rate_detail_currency
     seed_chargeback_rate
-  end
-
-  def self.seed_chargeback_rate_measure
-    fixture_file_measure = File.join(FIXTURE_DIR, "chargeback_rates_measures.yml")
-    if File.exist?(fixture_file_measure)
-      fixture = YAML.load_file(fixture_file_measure)
-      fixture.each do |cbr|
-        rec = ChargebackRateDetailMeasure.find_by(:name => cbr[:name])
-        if rec.nil?
-          _log.info("Creating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
-          rec = ChargebackRateDetailMeasure.create(cbr)
-        else
-          fixture_mtime = File.mtime(fixture_file_measure).utc
-          if fixture_mtime > rec.created_at
-            _log.info("Updating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
-            rec.update_attributes(cbr)
-            rec.created_at = fixture_mtime
-            rec.save
-          end
-        end
-      end
-    end
   end
 
   def self.seed_chargeback_rate_detail_currency

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -67,33 +67,8 @@ class ChargebackRate < ApplicationRecord
     # seeding the measure fixture before seed the chargeback rates fixtures
     ChargebackRateDetailMeasure.seed_measures
     ChargeableField.seed_fields # Cannot use seed order until we refactor seed_chargeback_rate_measure
-    # seeding the currencies
-    seed_chargeback_rate_detail_currency
+    ChargebackRateDetailCurrency.seed_currencies
     seed_chargeback_rate
-  end
-
-  def self.seed_chargeback_rate_detail_currency
-    # seeding the chargeback_rate_detail_currencies
-    # Modified seed method. Now updates chargeback_rate_detail_currencies too
-    fixture_file_currency = File.join(FIXTURE_DIR, "chargeback_rate_detail_currencies.yml")
-    if File.exist?(fixture_file_currency)
-      fixture = YAML.load_file(fixture_file_currency)
-      fixture_mtime_currency = File.mtime(fixture_file_currency).utc
-      fixture.each do |cbr|
-        rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
-        if rec.nil?
-          _log.info("Creating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]!!!!")
-          rec = ChargebackRateDetailCurrency.create(cbr)
-        else
-          if fixture_mtime_currency > rec.created_at
-            _log.info("Updating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
-            rec.update_attributes(cbr)
-            rec.created_at = fixture_mtime_currency
-            rec.save
-          end
-        end
-      end
-    end
   end
 
   def self.seed_chargeback_rate

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -64,15 +64,6 @@ class ChargebackRate < ApplicationRecord
   end
 
   def self.seed
-    # seeding the measure fixture before seed the chargeback rates fixtures
-    ChargebackRateDetailMeasure.seed_measures
-    ChargeableField.seed_fields # Cannot use seed order until we refactor seed_chargeback_rate_measure
-    ChargebackRateDetailCurrency.seed_currencies
-    seed_chargeback_rate
-  end
-
-  def self.seed_chargeback_rate
-    # seeding the rates fixtures
     fixture_file = File.join(FIXTURE_DIR, "chargeback_rates.yml")
     if File.exist?(fixture_file)
       fixture = YAML.load_file(fixture_file)

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -18,7 +18,7 @@ class ChargebackRateDetailCurrency < ApplicationRecord
     end
   end
 
-  def self.seed_currencies
+  def self.seed
     fixture_file_currency = File.join(FIXTURE_DIR, 'chargeback_rate_detail_currencies.yml')
     if File.exist?(fixture_file_currency)
       fixture = YAML.load_file(fixture_file_currency)

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -17,4 +17,24 @@ class ChargebackRateDetailCurrency < ApplicationRecord
       hsh[currency_code] = currency.id
     end
   end
+
+  def self.seed_currencies
+    fixture_file_currency = File.join(FIXTURE_DIR, 'chargeback_rate_detail_currencies.yml')
+    if File.exist?(fixture_file_currency)
+      fixture = YAML.load_file(fixture_file_currency)
+      fixture_mtime_currency = File.mtime(fixture_file_currency).utc
+      fixture.each do |cbr|
+        rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
+        if rec.nil?
+          _log.info("Creating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]!!!!")
+          rec = ChargebackRateDetailCurrency.create(cbr)
+        elsif fixture_mtime_currency > rec.created_at
+          _log.info("Updating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
+          rec.update_attributes(cbr)
+          rec.created_at = fixture_mtime_currency
+          rec.save
+        end
+      end
+    end
+  end
 end

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -25,7 +25,7 @@ class ChargebackRateDetailMeasure < ApplicationRecord
     end
   end
 
-  def self.seed_measures
+  def self.seed
     fixture_file_measure = File.join(FIXTURE_DIR, "chargeback_rates_measures.yml")
     if File.exist?(fixture_file_measure)
       fixture = YAML.load_file(fixture_file_measure)

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -24,4 +24,26 @@ class ChargebackRateDetailMeasure < ApplicationRecord
       errors.add("Units Problem", "Units_display length diferent that the units length")
     end
   end
+
+  def self.seed_measures
+    fixture_file_measure = File.join(FIXTURE_DIR, "chargeback_rates_measures.yml")
+    if File.exist?(fixture_file_measure)
+      fixture = YAML.load_file(fixture_file_measure)
+      fixture.each do |cbr|
+        rec = ChargebackRateDetailMeasure.find_by(:name => cbr[:name])
+        if rec.nil?
+          _log.info("Creating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
+          rec = ChargebackRateDetailMeasure.create(cbr)
+        else
+          fixture_mtime = File.mtime(fixture_file_measure).utc
+          if fixture_mtime > rec.created_at
+            _log.info("Updating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
+            rec.update_attributes(cbr)
+            rec.created_at = fixture_mtime
+            rec.save
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -25,7 +25,11 @@ class EvmDatabase
     MiqAction
     MiqEventDefinition
     MiqPolicySet
-  )
+    ChargebackRateDetailMeasure
+    ChargeableField
+    ChargebackRateDetailCurrency
+    ChargebackRate
+  ).freeze
 
   RAILS_ENGINE_MODEL_CLASS_NAMES = %w(MiqAeDatastore)
 

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -26,6 +26,8 @@ describe ChargebackContainerImage do
 
   before do
     MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -31,6 +31,8 @@ describe ChargebackContainerProject do
 
   before do
     MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -63,6 +63,8 @@ describe ChargebackVm do
 
   before do
     MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
     ChargebackRate.seed
     EvmSpecHelper.create_guid_miq_server_zone
     Timecop.travel(report_run_time)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -56,6 +56,8 @@ describe ChargebackVm do
 
   before do
     MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
     ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
## What
Refactor seed methods to its appropriate classes.

## Why
1) Seems more clean.
2) Potential savings in specs (Most of the specs do not need to seed all tables, but they do) (seeding is run many times per test run, each `context` runs the seed again.
3) Possibly dropping default rates in the long run (the code and ui is now structured in a way, we need default rates, that however may not be necessary in future).

@miq-bot add_label chargeback, technical debt, wip, euwe/no
@miq-bot assign @gtanzillo 
