### PR TITLE
Make ChargeableField compulsory in ChargebackRateDetail

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -7,7 +7,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   default_scope { order(:group => :asc, :description => :asc) }
 
-  validates :group, :source, :chargeback_rate, :presence => true
+  validates :group, :source, :chargeback_rate, :chargeable_field, :presence => true
   validate :contiguous_tiers?
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -1,0 +1,75 @@
+FactoryGirl.define do
+  factory :chargeable_field do
+    initialize_with { ChargeableField.find_or_create_by!(:metric => metric, :group => group, :source => source) }
+  end
+
+  factory :chargeable_field_fixed_compute_1, :parent => :chargeable_field do
+    description 'Fixed Compute Cost 1'
+    source      'compute_1'
+    group       'fixed'
+    metric      'fixed_compute_1'
+  end
+
+  factory :chargeable_field_cpu_used, :parent => :chargeable_field do
+    description 'Used CPU in MHz'
+    metric      'cpu_usagemhz_rate_average'
+    group       'cpu'
+    source      'used'
+  end
+
+  factory :chargeable_field_cpu_allocated, :parent => :chargeable_field do
+    description 'Allocated CPU Count'
+    metric      'derived_vm_numvcpus'
+    group       'cpu'
+    source      'allocated'
+  end
+
+  factory :chargeable_field_memory_allocated, :parent => :chargeable_field do
+    description 'Allocated Memory in MB'
+    metric      'derived_memory_available'
+    group       'memory'
+    source      'allocated'
+  end
+
+  factory :chargeable_field_storage_allocated, :parent => :chargeable_field do
+    description 'Allocated Disk Storage in Bytes'
+    metric      'derived_vm_allocated_disk_storage'
+    group       'storage'
+    source      'allocated'
+  end
+
+  factory :chargeable_field_cpu_cores_used, :parent => :chargeable_field do
+    description 'Used CPU in Cores'
+    metric      'cpu_usage_rate_average'
+    group       'cpu_cores'
+    source      'used'
+  end
+
+  factory :chargeable_field_memory_used, :parent => :chargeable_field do
+    description 'Used Memory in MB'
+    metric      'derived_memory_used'
+    group       'memory'
+    source      'used'
+  end
+
+  factory :chargeable_field_net_io_used, :parent => :chargeable_field do
+    description 'Used Network I/O in KBps'
+    metric      'net_usage_rate_average'
+    group       'net_io'
+    source      'used'
+  end
+
+  factory :chargeable_field_disk_io_used, :parent => :chargeable_field do
+    description 'Used disk I/O in KBps'
+    metric      'disk_usage_rate_average'
+    group       'disk_io'
+    source      'used'
+  end
+
+  factory :chargeable_field_storage_used, :parent => :chargeable_field do
+    description 'Used Disk Storage in Bytes'
+    metric      'derived_vm_used_disk_storage'
+    group       'storage'
+    source      'used'
+  end
+end

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
   factory :chargeable_field do
+    metric 'unknown'
+    group  'unknown'
+    source 'unknown'
     initialize_with { ChargeableField.find_or_create_by!(:metric => metric, :group => group, :source => source) }
   end
 

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -81,6 +81,7 @@ FactoryGirl.define do
     description "Used CPU in MHz"
     metric      "cpu_usagemhz_rate_average"
     per_unit    "megahertz"
+    chargeable_field { FactoryGirl.build(:chargeable_field_cpu_used) }
   end
 
   factory :chargeback_rate_detail_cpu_cores_used, :traits => [:used], :parent => :chargeback_rate_detail do
@@ -88,6 +89,7 @@ FactoryGirl.define do
     metric      "cpu_usage_rate_average"
     group       "cpu_cores"
     per_unit    "cores"
+    chargeable_field { FactoryGirl.build(:chargeable_field_cpu_cores_used) }
   end
 
   factory :chargeback_rate_detail_cpu_allocated, :traits => [:allocated, :cpu, :daily],
@@ -95,47 +97,55 @@ FactoryGirl.define do
     description "Allocated CPU Count"
     metric      "derived_vm_numvcpus"
     per_unit    "cpu"
+    chargeable_field { FactoryGirl.build(:chargeable_field_cpu_allocated) }
   end
 
   factory :chargeback_rate_detail_memory_allocated, :traits => [:allocated, :memory, :megabytes, :daily],
                                                     :parent => :chargeback_rate_detail do
     description "Allocated Memory in MB"
     metric      "derived_memory_available"
+    chargeable_field { FactoryGirl.build(:chargeable_field_memory_allocated) }
   end
 
   factory :chargeback_rate_detail_memory_used, :traits => [:used, :memory, :megabytes, :hourly],
                                                :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
     metric      "derived_memory_used"
+    chargeable_field { FactoryGirl.build(:chargeable_field_memory_used) }
   end
 
   factory :chargeback_rate_detail_disk_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
     description "Used Disk I/O in KBps"
     group       "disk_io"
     metric      "disk_usage_rate_average"
+    chargeable_field { FactoryGirl.build(:chargeable_field_disk_io_used) }
   end
 
   factory :chargeback_rate_detail_net_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
     description "Used Network I/O in KBps"
     group       "net_io"
     metric      "net_usage_rate_average"
+    chargeable_field { FactoryGirl.build(:chargeable_field_net_io_used) }
   end
 
   factory :chargeback_rate_detail_storage_used, :traits => [:used, :storage_group, :gigabytes],
                                                 :parent => :chargeback_rate_detail do
     description "Used Disk Storage in Bytes"
     metric      "derived_vm_used_disk_storage"
+    chargeable_field { FactoryGirl.build(:chargeable_field_storage_used) }
   end
 
   factory :chargeback_rate_detail_storage_allocated, :traits => [:allocated, :storage_group, :gigabytes],
                                                      :parent => :chargeback_rate_detail do
     description "Allocated Disk Storage in Bytes"
     metric      "derived_vm_allocated_disk_storage"
+    chargeable_field { FactoryGirl.build(:chargeable_field_storage_allocated) }
   end
 
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
     sequence(:description) { |n| "Fixed Compute Cost #{n}" }
     sequence(:source)      { |n| "compute_#{n}" }
+    chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
 
   factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -1,8 +1,10 @@
 describe ChargebackRateDetail do
+  let(:field) { FactoryGirl.build(:chargeable_field) }
   describe "#chargeback_rate" do
     it "is invalid without a valid chargeback_rate" do
       invalid_chargeback_rate_id = (ChargebackRate.maximum(:id) || -1) + 1
       chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail,
+                                                 :chargeable_field   => field,
                                                  :chargeback_rate_id => invalid_chargeback_rate_id)
       expect(chargeback_rate_detail).to be_invalid
       expect(chargeback_rate_detail.errors.messages).to include(:chargeback_rate => [/can't be blank/])
@@ -182,6 +184,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       nil   nil                   nil)
       .each_slice(3) do |per_unit, metric, chargeback_rate_detail_measure_id|
         cbd = FactoryGirl.build(:chargeback_rate_detail,
+                                :chargeable_field                  => field,
                                 :per_unit                          => per_unit,
                                 :metric                            => metric,
                                 :chargeback_rate_detail_measure_id => chargeback_rate_detail_measure_id)
@@ -245,14 +248,14 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
 
     it "add an initial valid tier" do
       cbt1 = FactoryGirl.build(:chargeback_tier, :start => 0, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
+      cbd  = FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt1], :chargeable_field => field)
 
       expect(cbd.contiguous_tiers?).to be true
     end
 
     it "add an invalid tier to an existing tier set" do
       cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
+      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1], :chargeable_field => field)
 
       cbt2 = FactoryGirl.build(:chargeback_tier, :start => 6, :finish => Float::INFINITY)
       cbt1.finish = 5
@@ -263,7 +266,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
 
     it "add a valid tier to an existing tier set" do
       cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
+      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1], :chargeable_field => field)
 
       cbt2 = FactoryGirl.build(:chargeback_tier, :start => 5, :finish => Float::INFINITY)
       cbt1.finish = 5
@@ -275,7 +278,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     it "remove a tier from an existing tier set, leaving the set invalid" do
       cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0, :finish => 5)
       cbt2 = FactoryGirl.create(:chargeback_tier, :start => 5, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1, cbt2])
+      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1, cbt2], :chargeable_field => field)
 
       cbd.chargeback_tiers = [cbt1]
 
@@ -285,7 +288,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     it "remove a tier from an existing set of tiers" do
       cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0, :finish => 5)
       cbt2 = FactoryGirl.create(:chargeback_tier, :start => 5, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1, cbt2])
+      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1, cbt2], :chargeable_field => field)
 
       cbt1.finish = Float::INFINITY
       cbd.chargeback_tiers = [cbt1]
@@ -295,7 +298,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
 
     it "remove last tier" do
       cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0, :finish => Float::INFINITY)
-      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1])
+      cbd  = FactoryGirl.create(:chargeback_rate_detail, :chargeback_tiers => [cbt1], :chargeable_field => field)
       cbd.chargeback_tiers = []
 
       expect(cbd.contiguous_tiers?).to be true

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -76,7 +76,8 @@ describe ChargebackRate do
     context 'when there are valid rate details' do
       let(:symbol) { '฿' }
       let(:currency) { FactoryGirl.create(:chargeback_rate_detail_currency, :symbol => symbol) }
-      let(:details) { [FactoryGirl.create(:chargeback_rate_detail, :detail_currency => currency)] }
+      let(:field) { FactoryGirl.create(:chargeable_field) }
+      let(:details) { [FactoryGirl.create(:chargeback_rate_detail, :detail_currency => currency, :chargeable_field => field)] }
       it { is_expected.to eq(symbol) }
     end
   end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "chargebacks API" do
+  let(:field) { FactoryGirl.create(:chargeable_field) }
+
   it "can fetch the list of all chargeback rates" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
@@ -29,7 +31,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can fetch chargeback rate details" do
-    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :chargeable_field => field)
     chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                          :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                          :variable_rate => 0.0)
@@ -48,7 +50,7 @@ RSpec.describe "chargebacks API" do
   end
 
   it "can fetch an individual chargeback rate detail" do
-    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
+    chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1", :chargeable_field => field)
     chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                          :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                          :variable_rate => 0.0)
@@ -202,11 +204,12 @@ RSpec.describe "chargebacks API" do
 
       expect do
         run_post rates_url,
-                 :description        => "rate_0",
-                 :group              => "fixed",
-                 :chargeback_rate_id => chargeback_rate.id,
-                 :source             => "used",
-                 :enabled            => true
+                 :description         => "rate_0",
+                 :group               => "fixed",
+                 :chargeback_rate_id  => chargeback_rate.id,
+                 :chargeable_field_id => field.id,
+                 :source              => "used",
+                 :enabled             => true
       end.to change(ChargebackRateDetail, :count).by(1)
       expect_result_to_match_hash(response.parsed_body["results"].first, "description" => "rate_0", "enabled" => true)
       expect(response).to have_http_status(:ok)
@@ -225,7 +228,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can edit a chargeback rate detail through POST" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0", :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
@@ -241,7 +244,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can edit a chargeback rate detail through PATCH" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_0", :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
@@ -257,7 +260,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can delete a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
@@ -273,7 +276,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can delete a chargeback rate detail through POST" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
@@ -329,7 +332,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "cannot edit a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1")
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :description => "rate_1", :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)
@@ -345,7 +348,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "cannot delete a chargeback rate detail" do
-      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail)
+      chargeback_rate_detail = FactoryGirl.build(:chargeback_rate_detail, :chargeable_field => field)
       chargeback_tier = FactoryGirl.create(:chargeback_tier, :chargeback_rate_detail_id => chargeback_rate_detail.id,
                                            :start => 0, :finish => Float::INFINITY, :fixed_rate => 0.0,
                                            :variable_rate => 0.0)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -429,7 +429,7 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Rates" do
-      FactoryGirl.create(:chargeback_rate_detail)
+      FactoryGirl.create(:chargeback_rate_detail, :chargeable_field => FactoryGirl.build(:chargeable_field))
       test_collection_bulk_query(:rates, rates_url, ChargebackRateDetail)
     end
 


### PR DESCRIPTION
## What
Next step is to make chargeable_field mandatory. And fix all the code that does break the mandatory requirement.

That is continuation of #13375.

Once the chargeable_field is mandatory we can rely on it and we can start cleaning-up chargeback_rate_detail.

@miq-bot add_label chargeback, technical debt, euwe/no, wip
@miq-bot assign @gtanzillo 