### PR TITLE
[EUWE] Make created filters in Datastores visible and fix commiting filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -659,7 +659,7 @@ module ApplicationController::Filter
           adv_search_build_lists
           # Save the last search loaded (saved)
           @edit[@expkey][:exp_last_loaded] = {:id => s.id, :name => s.name, :description => s.description, :typ => s.search_type}
-          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description]
+          @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded][:description] unless @edit[@expkey][:exp_last_loaded].nil?
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -24,8 +24,13 @@ class TreeBuilderStorage < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    return count_only ? 0 : [] if object[:id] != "global"
-    objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
+    objects = MiqSearch.where(:db => options[:leaf])
+    objects = case object[:id]
+              when "global" # Global filters
+                objects.visible_to_all
+              when "my"     # My filters
+                objects.where(:search_type => "user", :search_key => User.current_user.userid)
+              end
     count_only_or_objects(count_only, objects, "description")
   end
 end

--- a/app/views/layouts/exp_atom/_editor.html.haml
+++ b/app/views/layouts/exp_atom/_editor.html.haml
@@ -21,25 +21,20 @@
       - exptypes -= [[_(EXP_FIND_TYPE[0]), EXP_FIND_TYPE[1]]]
   #exp_atom_editor_div
     %fieldset{:style => "width:auto; padding-left: 6px; padding-top: 6px;"}
-      %ul.searchtoolbar
-        %li
-          - t = _('Commit expression element changes')
-          = link_to(image_tag(image_path('toolbars/commit.png'), :alt => t),
-            {:action => 'exp_button', :pressed => 'commit'},
-            "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            :remote                => true,
-            "data-method"          => :post,
-            :title                 => t)
-        %li
-          - t = _("Discard expression element changes")
-          = link_to(image_tag(image_path('toolbars/discard.png'), :alt => t),
-            {:action => 'exp_button', :pressed  => 'discard'},
-            "data-miq_sparkle_on"  => true,
-            "data-miq_sparkle_off" => true,
-            :remote                => true,
-            "data-method"          => :post,
-            :title                 => t)
+      - t = _('Commit expression element changes')
+      %button.btn.btn-default{"data-method" => :post,
+      "data-miq_sparkle_on" => true,
+      :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'commit')}');",
+      :remote               => true,
+      :title                => t}
+        %i.fa.fa-lg.fa-check
+      - t = _("Discard expression element changes")
+      %button.btn.btn-default{"data-method" => :post,
+      "data-miq_sparkle_on" => true,
+      :onclick              => "miqAjaxButton('#{url_for(:action => 'exp_button', :pressed => 'discard')}');",
+      :remote               => true,
+      :title                => t}
+        %i.fa-lg.pficon.pficon-close
       %div{:style => "padding: 10px;"}
         - if @edit[@expkey][:exp_key] == "NOT"
           %font{:color => "black"}


### PR DESCRIPTION
fixing 
https://bugzilla.redhat.com/show_bug.cgi?id=1414876
https://bugzilla.redhat.com/show_bug.cgi?id=1414870

Make created filters (not global) in Compute -> Infrastructure -> Datastores
visible under My Filters in accordion, no need to refresh the page
after creating a new filter.
Fix commiting a new filter which is related to its creating and saving.

this PR resolves conflicts of backporting 
https://github.com/ManageIQ/manageiq-ui-classic/pull/98
and https://github.com/ManageIQ/manageiq-ui-classic/pull/142
to euwe