### PR TITLE
Use task queue for CRUD operations on Cloud Volume

### DIFF
--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -5,8 +5,48 @@ module CloudVolume::Operations
   end
 
   module InstanceMethods
+    def attach_volume_queue(userid, server_ems_ref, device = nil)
+      task_opts = {
+        :action => "attaching Cloud Volume for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'attach_volume',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :zone        => ext_management_system.my_zone,
+        :args        => [server_ems_ref, device]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def attach_volume(server_ems_ref, device = nil)
+      raw_attach_volume(server_ems_ref, device)
+    end
+
     def validate_attach_volume
       validate_unsupported(_("Attach Volume Operation"))
+    end
+
+    def detach_volume_queue(userid, server_ems_ref)
+      task_opts = {
+        :action => "detaching Cloud Volume for user #{userid}",
+        :userid => userid
+      }
+      queue_opts = {
+        :class_name  => self.class.name,
+        :method_name => 'detach_volume',
+        :instance_id => id,
+        :role        => 'ems_operations',
+        :zone        => ext_management_system.my_zone,
+        :args        => [server_ems_ref]
+      }
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def detach_volume(server_ems_ref)
+      raw_detach_volume(server_ems_ref)
     end
 
     def validate_detach_volume

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -78,7 +78,6 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
       :class_name  => self.class.name,
       :method_name => 'backup_create',
       :instance_id => id,
-      :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
       :args        => [options]
@@ -105,7 +104,6 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
       :class_name  => self.class.name,
       :method_name => 'backup_restore',
       :instance_id => id,
-      :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
       :args        => [backup_id]

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -22,6 +22,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
     double.tap do |volumes|
       handle = double
       allow(handle).to receive(:volumes).and_return(volumes)
+      allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
       allow(ems).to receive(:connect).with(hash_including(:service     => 'Volume',
                                                           :tenant_name => tenant.name)).and_return(handle)
       allow(volumes).to receive(:get).with(cloud_volume.ems_ref).and_return(the_raw_volume)
@@ -46,7 +47,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
         allow(the_new_volume).to receive("status").and_return('creating')
         expect(the_new_volume).to receive(:save).and_return(the_new_volume)
 
-        volume = CloudVolume.create_volume(ems, volume_options)
+        volume = CloudVolume.create_volume(ems.id, volume_options)
         expect(volume.class).to        eq described_class
         expect(volume.name).to         eq 'new_name'
         expect(volume.ems_ref).to      eq 'new_id'
@@ -71,7 +72,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
       it 'catches errors from provider' do
         expect(the_new_volume).to receive(:save).and_raise('bad request')
 
-        expect { CloudVolume.create_volume(ems, volume_options) }.to raise_error(MiqException::MiqVolumeCreateError)
+        expect { CloudVolume.create_volume(ems.id, volume_options) }.to raise_error(MiqException::MiqVolumeCreateError)
       end
     end
 


### PR DESCRIPTION
Uses task queue instead of making direct provider API calls from the UI. This PR contains the necessary model changes.