### PR TITLE
add create_catalog_item to ServiceTemplateOrchestration

### DIFF
--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -3,6 +3,24 @@ class ServiceTemplateOrchestration < ServiceTemplate
 
   before_save :remove_invalid_resource
 
+  def self.create_catalog_item(options, _auth_user = nil)
+    transaction do
+      create(options.except(:config_info)).tap do |service_template|
+        config_info = options[:config_info]
+
+        service_template.orchestration_template = if config_info[:template_id]
+                                                    OrchestrationTemplate.find(config_info[:template_id])
+                                                  end
+
+        service_template.orchestration_manager = if config_info[:manager_id]
+                                                   ExtManagementSystem.find(config_info[:manager_id])
+                                                 end
+
+        service_template.create_resource_actions(config_info)
+      end
+    end
+  end
+
   def remove_invalid_resource
     # remove the resource from both memory and table
     service_resources.to_a.delete_if { |r| r.destroy unless r.resource }

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -6,14 +6,17 @@ class ServiceTemplateOrchestration < ServiceTemplate
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
       create(options.except(:config_info)).tap do |service_template|
-        config_info = options[:config_info]
+        config_info = validate_config_info(options)
 
         service_template.orchestration_template = if config_info[:template_id]
                                                     OrchestrationTemplate.find(config_info[:template_id])
+                                                  else
+                                                    config_info[:template]
                                                   end
-
         service_template.orchestration_manager = if config_info[:manager_id]
                                                    ExtManagementSystem.find(config_info[:manager_id])
+                                                 else
+                                                   config_info[:manager]
                                                  end
 
         service_template.create_resource_actions(config_info)
@@ -42,4 +45,13 @@ class ServiceTemplateOrchestration < ServiceTemplate
   def my_zone
     orchestration_manager.try(:my_zone) || MiqServer.my_zone
   end
+
+  def self.validate_config_info(options)
+    config_info = options[:config_info]
+    unless (config_info[:template_id] && config_info[:manager_id]) || (config_info[:template] && config_info[:manager])
+      raise _('Must provide both template_id and manager_id or manager and template')
+    end
+    config_info
+  end
+  private_class_method :validate_config_info
 end

--- a/spec/models/service_template_orchestration_spec.rb
+++ b/spec/models/service_template_orchestration_spec.rb
@@ -100,4 +100,43 @@ describe ServiceTemplateOrchestration do
       end
     end
   end
+
+  describe '#create_catalog_item' do
+    let(:ra1) { FactoryGirl.create(:resource_action, :action => 'Provision') }
+    let(:ra2) { FactoryGirl.create(:resource_action, :action => 'Retirement') }
+    let(:service_dialog) { FactoryGirl.create(:dialog) }
+    let(:template) { FactoryGirl.create(:orchestration_template) }
+    let(:manager) { FactoryGirl.create(:ext_management_system) }
+    let(:catalog_item_options) do
+      {
+        :name         => 'Orchestration Template',
+        :service_type => 'atomic',
+        :prov_type    => 'generic_orchestration',
+        :display      => 'false',
+        :description  => 'a description',
+        :config_info  => {
+          :template_id => template.id,
+          :manager_id  => manager.id,
+          :provision   => {
+            :fqname            => ra1.fqname,
+            :service_dialog_id => service_dialog.id
+          },
+          :retirement  => {
+            :fqname            => ra2.fqname,
+            :service_dialog_id => service_dialog.id
+          }
+        }
+      }
+    end
+
+    it 'creates and returns an orchestration service template' do
+      service_template = ServiceTemplateOrchestration.create_catalog_item(catalog_item_options)
+
+      expect(service_template.name).to eq('Orchestration Template')
+      expect(service_template.dialogs.first).to eq(service_dialog)
+      expect(service_template.orchestration_template).to eq(template)
+      expect(service_template.orchestration_manager).to eq(manager)
+      expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
+    end
+  end
 end


### PR DESCRIPTION
This adds class method `create_catalog_item` to ServiceTemplateOrchestration and takes in the following:
```
{
        :name         => 'Orchestration Template',
        :service_type => 'atomic',
        :prov_type    => 'generic_orchestration',
        :display      => 'false',
        :description  => 'a description',
        :config_info  => {
          :template_id => template.id,
          :manager_id  => manager.id,
          :provision   => {
            :fqname            => ra1.fqname,
            :dialog_id => service_dialog.id
          },
          :retirement  => {
            :fqname            => ra2.fqname,
            :dialog_id => service_dialog.id
          }
        }
      }
```

@miq-bot enhancement, euwe/no, services, wip
@miq-bot assign @bzwei 