### PR TITLE
Set folder vm folders only

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -842,9 +842,13 @@ class MiqRequestWorkflow
   end
 
   def get_ems_folders(folder, dh = {}, full_path = "")
-    if folder.evm_object_class == :EmsFolder && !folder.hidden
-      full_path += full_path.blank? ? folder.name.to_s : " / #{folder.name}"
-      dh[folder.id] = full_path unless folder.type == "Datacenter"
+    if folder.evm_object_class == :EmsFolder
+      if folder.hidden
+        return dh if folder.name != 'vm'
+      else
+        full_path += full_path.blank? ? folder.name.to_s : " / #{folder.name}"
+        dh[folder.id] = full_path unless folder.type == "Datacenter"
+      end
     end
 
     # Process child folders


### PR DESCRIPTION
VMware providers contain folders for both "Hosts & Clusters" and "Vms & Templates" which can have duplicate names.  During VM provisioning only vm/template folders should be available for selection as the target folder.

This change limits the drop-down in the provisioning dialog to only the VM folders.  In addition the `set_folder` method available to automate has been updated to use the same code path as the UI drop-down to ensure the same folder section is available to the caller.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1414136

Steps for Testing/QA [Optional]
-------------------------------
In the VMware provider create a folder in 'Hosts and Clusters" with a different name from any folders listed for vms/templates.  Load the VM provisioning dialog and verify the host folder is not available in the list.

cc @syncrou @agrare 