### PR TITLE
Handle case when `dependencies` is empty.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,9 +155,12 @@ end
 # override_gem 'manageiq-ui-classic', :path => File.expand_path("../manageiq-ui-classic", __dir__))
 #
 def override_gem(name, *args)
-  raise "Trying to override unknown gem #{name}" unless (dependency = dependencies.find { |d| d.name == name })
-  dependencies.delete(dependency)
-  gem name, *args
+  if dependencies.any?
+    raise "Trying to override unknown gem #{name}" unless (dependency = dependencies.find { |d| d.name == name })
+    dependencies.delete(dependency)
+
+    gem name, *args
+  end
 end
 
 # Load developer specific Gemfile


### PR DESCRIPTION
Bundler 1.14 seems to make 2 passes on Gemfiles. During the first `dependencies` is empty which triggers the `raise` which causes Bundler to stop parsing. This change ignores the pass in which `dependencies` is empty. It should have no effect on versions < 1.14.
