### PR TITLE
Override ActiveSupport Inflection for "bases"

### DIFF
--- a/config/initializers/as_inflections.rb
+++ b/config/initializers/as_inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.singular(/(base)s$/i, '\1') # Override rails default: "bases".singularize => "base" not "basis"
+end

--- a/spec/initializers/as_inflections_spec.rb
+++ b/spec/initializers/as_inflections_spec.rb
@@ -1,0 +1,8 @@
+describe String, "inflections" do
+  {
+    "base" => "bases",
+  }.each do |singular, plural|
+    example("#pluralize")   { expect(singular.pluralize).to eq(plural) }
+    example("#singularize") { expect(plural.singularize).to eq(singular) }
+  end
+end


### PR DESCRIPTION
Rails singularizes "bases" to "basis"
We want "bases".singularize to be "base"

See usage in https://github.com/ManageIQ/manageiq/pull/13523/files#diff-5915b4f8bc244828cd9b675fe145ee74R20