### PR TITLE
Introduce Generic Service and ServiceTemplate

### DIFF
--- a/app/models/service_generic.rb
+++ b/app/models/service_generic.rb
@@ -1,0 +1,31 @@
+class ServiceGeneric < Service
+  # A chance for taking options from automate script to override options from a service dialog
+  def preprovision(_options = {})
+  end
+
+  # Interact with external provider to act on this service item
+  # The result is called stack, normally a vmdb object. It can map to an object in the provider,
+  # or even be a virtual object
+  def provision
+    raise NotImplementedError, _("provision must be implemented in a subclass")
+  end
+
+  # Check the provider provision status. It should return [true/false, status_message]
+  def check_provisioned?
+    raise NotImplementedError, _("check_provisioned must be implemented in a subclass")
+  end
+
+  # Start a provider refresh
+  def refresh_provider
+    raise NotImplementedError, _("refresh_provider must be implemented in a subclass")
+  end
+
+  # Check the refresh status. It should return [true/false, status_message]
+  def check_refreshed
+    raise NotImplementedError, _("check_refreshed must be implemented in a subclass")
+  end
+
+  # Execute after refresh is done. Do cleaning up or update linkage here
+  def post_provision(_options = {})
+  end
+end

--- a/app/models/service_template_generic.rb
+++ b/app/models/service_template_generic.rb
@@ -1,0 +1,13 @@
+class ServiceTemplateGeneric < ServiceTemplate
+  before_save :remove_invalid_resource
+
+  def remove_invalid_resource
+    # remove the resource from both memory and table
+    service_resources.to_a.delete_if { |r| r.destroy unless r.resource }
+  end
+
+  def create_subtasks(_parent_service_task, _parent_service)
+    # no sub task is needed for this service
+    []
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceGeneric < MiqAeServiceService
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_generic.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_generic.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceTemplateGeneric < MiqAeServiceServiceTemplate
+  end
+end


### PR DESCRIPTION
Introduce `ServiceTemplateGeneric` and `ServiceGeneric` classes. They are the base class for all future services based on generic types. 

The `ServiceGeneric` defines a set of interfaces corresponds to the generic automate state machine introduce in https://github.com/ManageIQ/manageiq-content/pull/24. Currently only the methods needed for provisioning. More methods can be added for retirement and reconfigure.

@miq-bot assign @gmcculloug 
@tinaafitz please review