### PR TITLE
[EUWE] workaround BigDecimal not working properly on ruby 2.3.1

### DIFF
--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -50,7 +50,7 @@ class Chargeback
                          when 'derived_memory_available'
                            resource.hardware.try(:memory_mb)
                          when 'derived_vm_allocated_disk_storage'
-                           resource.allocated_disk_storage
+                           resource.allocated_disk_storage.try(:to_f)
                          end
       @value[metric]
     end


### PR DESCRIPTION
This affects euwe only. We shouldn't see this problem on master now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1416001
Fixes https://github.com/ManageIQ/manageiq/issues/13591

@miq-bot add_label chargeback, bug
@miq-bot assign @simaishi 