### PR TITLE
[EUWE] Display Advanced Search in Configuration management

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -776,7 +776,7 @@ module ApplicationController::Filter
     if ["delete", "saveit"].include?(params[:button])
       if @edit[:in_explorer]
         if "cs_filter_tree" == x_active_tree.to_s
-          build_configuration_mananger_tree(:cs_filter, x_active_tree)
+          build_configuration_manager_tree(:cs_filter, x_active_tree)
         else
           tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
           builder = TreeBuilder.class_for_type(tree_type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -800,7 +800,7 @@ module ApplicationHelper
        ems_container vm miq_template offline retired templates
        host service storage ems_cloud ems_cluster flavor
        ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
-       load_balancer
+       load_balancer provider_foreman
        ems_storage cloud_volume cloud_object_store_container
        resource_pool ems_infra ontap_storage_system ontap_storage_volume
        ontap_file_share snia_local_file_system ontap_logical_disk
@@ -1196,7 +1196,7 @@ module ApplicationHelper
                      ems_cloud ems_cluster ems_container ems_infra flavor host host_aggregate miq_template offline
                      ontap_file_share ontap_logical_disk ontap_storage_system ontap_storage_volume
                      ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
-                     ems_storage load_balancer
+                     ems_storage load_balancer provider_foreman
                      orchestration_stack resource_pool retired service configuration_job configuration_scripts
                      snia_local_file_system storage_manager templates vm)
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1393438

Display Advanced Search when clicking on the button
when reaching Configuration -> Configuration Management
and selecting Configured Systems or Ansible Tower Job Templates.

This PR resolves conflicts of backporting https://github.com/ManageIQ/manageiq/pull/11797 to Euwe