### PR TITLE
Ensure remote shells generated by SCVMM are closed when finished

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -24,8 +24,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     require 'winrm'
 
     connect_params[:operation_timeout] = 1800
-    winrm = WinRM::Connection.new(connect_params)
-    winrm
+    WinRM::Connection.new(connect_params)
   end
 
   def self.auth_url(hostname, port = nil)


### PR DESCRIPTION
The WinRM shells being created for SCVMM are not being closed properly. It seems we did not completely update the code for WinRM 2.x completely when we upgraded. The result is that sometimes the server will refuse the connection until some of the existing shells eventually time out. This fixes that by ensuring a shell is closed once finished.

It also takes advantage of the `stdout` and `stderr` methods, and removes an unnecessary variable assignment.

Discovered while working towards a solution for https://bugzilla.redhat.com/show_bug.cgi?id=1400583