### PR TITLE
Move methods to ChargeableField

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -8,9 +8,18 @@ class ChargeableField < ApplicationRecord
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
 
+  def measure(consumption)
+    return 1.0 if fixed?
+    return 0 if consumption.none?(metric)
+    return consumption.max(metric) if allocated?
+    return consumption.avg(metric) if used?
+  end
+
   def fixed?
     group == 'fixed'
   end
+
+  private
 
   def used?
     source == 'used'

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -35,6 +35,17 @@ class ChargeableField < ApplicationRecord
     UNITS[metric] ? detail_measure.adjust(target_unit, UNITS[metric]) : 1
   end
 
+  def metric_keys
+    ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
+     "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
+  end
+
+  def cost_keys
+    ["#{rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
+     "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
+     'total_cost']
+  end
+
   def rate_name
     "#{group}_#{source}"
   end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -35,6 +35,10 @@ class ChargeableField < ApplicationRecord
     UNITS[metric] ? detail_measure.adjust(target_unit, UNITS[metric]) : 1
   end
 
+  def rate_name
+    "#{group}_#{source}"
+  end
+
   private
 
   def used?

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -46,11 +46,11 @@ class ChargeableField < ApplicationRecord
      'total_cost']
   end
 
+  private
+
   def rate_name
     "#{group}_#{source}"
   end
-
-  private
 
   def used?
     source == 'used'

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -8,6 +8,10 @@ class ChargeableField < ApplicationRecord
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
 
+  def fixed?
+    group == 'fixed'
+  end
+
   def used?
     source == 'used'
   end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -3,7 +3,18 @@ class ChargeableField < ApplicationRecord
     'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
   }.freeze
 
-  belongs_to :measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
+  # The following chargeable fields are stored in following units
+  UNITS = {
+    'cpu_usagemhz_rate_average'         => 'megahertz',
+    'derived_memory_used'               => 'megabytes',
+    'derived_memory_available'          => 'megabytes',
+    'net_usage_rate_average'            => 'kbps',
+    'disk_usage_rate_average'           => 'kbps',
+    'derived_vm_allocated_disk_storage' => 'bytes',
+    'derived_vm_used_disk_storage'      => 'bytes'
+  }.freeze
+
+  belongs_to :detail_measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
 
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
@@ -17,6 +28,11 @@ class ChargeableField < ApplicationRecord
 
   def fixed?
     group == 'fixed'
+  end
+
+  def adjustment_to(target_unit)
+    # return multiplicator, that would bring UNITS[metric] to target_unit
+    UNITS[metric] ? detail_measure.adjust(target_unit, UNITS[metric]) : 1
   end
 
   private

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -8,6 +8,14 @@ class ChargeableField < ApplicationRecord
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
 
+  def used?
+    source == 'used'
+  end
+
+  def allocated?
+    source == 'allocated'
+  end
+
   def self.seed
     seed_data.each do |f|
       rec = ChargeableField.find_by(:metric => f[:metric])

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,6 +12,8 @@ class ChargebackRateDetail < ApplicationRecord
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true
 
+  delegate :metric_keys, :cost_keys, :to => :chargeable_field
+
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id).freeze
   PER_TIME_TYPES = {
     "hourly"  => _("Hourly"),
@@ -159,17 +161,6 @@ class ChargebackRateDetail < ApplicationRecord
 
   def gratis?
     chargeback_tiers.all?(&:gratis?)
-  end
-
-  def metric_keys
-    ["#{chargeable_field.rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
-     "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
-  end
-
-  def cost_keys
-    ["#{chargeable_field.rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
-     "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
-     'total_cost']
   end
 
   def metric_and_cost_by(consumption)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -88,10 +88,6 @@ class ChargebackRateDetail < ApplicationRecord
     (metric_keys.to_set & report_cols).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
   end
 
-  def rate_name
-    "#{group}_#{source}"
-  end
-
   def friendly_rate
     (fixed_rate, variable_rate) = find_rate(0.0)
     value = read_attribute(:friendly_rate)
@@ -166,12 +162,12 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def metric_keys
-    ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
+    ["#{chargeable_field.rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
      "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
   end
 
   def cost_keys
-    ["#{rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
+    ["#{chargeable_field.rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
      "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
      'total_cost']
   end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -38,16 +38,8 @@ class ChargebackRateDetail < ApplicationRecord
     return 1.0 if fixed?
 
     return 0 if consumption.none?(metric)
-    return consumption.max(metric) if allocated?
-    return consumption.avg(metric) if used?
-  end
-
-  def used?
-    source == "used"
-  end
-
-  def allocated?
-    source == "allocated"
+    return consumption.max(metric) if chargeable_field.allocated?
+    return consumption.avg(metric) if chargeable_field.used?
   end
 
   def fixed?

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -108,7 +108,8 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def per_unit_display
-    detail_measure.nil? ? per_unit.to_s.capitalize : detail_measure.measures.key(per_unit)
+    measure = chargeable_field.detail_measure
+    measure.nil? ? per_unit.to_s.capitalize : measure.measures.key(per_unit)
   end
 
   # New method created in order to show the rates in a easier to understand way

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -34,14 +34,6 @@ class ChargebackRateDetail < ApplicationRecord
     result
   end
 
-  def metric_value_by(consumption)
-    return 1.0 if chargeable_field.fixed?
-
-    return 0 if consumption.none?(metric)
-    return consumption.max(metric) if chargeable_field.allocated?
-    return consumption.avg(metric) if chargeable_field.used?
-  end
-
   # Set the rates according to the tiers
   def find_rate(value)
     fixed_rate = 0.0
@@ -200,7 +192,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def metric_and_cost_by(consumption)
-    metric_value = metric_value_by(consumption)
+    metric_value = chargeable_field.measure(consumption)
     [metric_value, hourly_cost(metric_value, consumption) * consumption.consumed_hours_in_interval]
   end
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -80,23 +80,8 @@ class ChargebackRateDetail < ApplicationRecord
     hourly_rate
   end
 
-  # Scale the rate in the unit defined by user -> to the default unit of the metric
-  METRIC_UNITS = {
-    'cpu_usagemhz_rate_average'         => 'megahertz',
-    'derived_memory_used'               => 'megabytes',
-    'derived_memory_available'          => 'megabytes',
-    'net_usage_rate_average'            => 'kbps',
-    'disk_usage_rate_average'           => 'kbps',
-    'derived_vm_allocated_disk_storage' => 'bytes',
-    'derived_vm_used_disk_storage'      => 'bytes'
-  }.freeze
-
   def rate_adjustment
-    @rate_adjustment ||= if METRIC_UNITS[metric]
-                           detail_measure.adjust(per_unit, METRIC_UNITS[metric])
-                         else
-                           1
-                         end
+    @rate_adjustment ||= chargeable_field.adjustment_to(per_unit)
   end
 
   def affects_report_fields(report_cols)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -59,8 +59,6 @@ class ChargebackRateDetail < ApplicationRecord
   def hourly_cost(value, consumption)
     return 0.0 unless self.enabled?
 
-    value = 1.0 if chargeable_field.fixed?
-
     (fixed_rate, variable_rate) = find_rate(value)
 
     hourly_fixed_rate    = hourly(fixed_rate, consumption)

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
     metric      'cpu_usagemhz_rate_average'
     group       'cpu'
     source      'used'
+    detail_measure { FactoryGirl.build(:chargeback_measure_hz) }
   end
 
   factory :chargeable_field_cpu_allocated, :parent => :chargeable_field do
@@ -32,6 +33,7 @@ FactoryGirl.define do
     metric      'derived_memory_available'
     group       'memory'
     source      'allocated'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_storage_allocated, :parent => :chargeable_field do
@@ -39,6 +41,7 @@ FactoryGirl.define do
     metric      'derived_vm_allocated_disk_storage'
     group       'storage'
     source      'allocated'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_cpu_cores_used, :parent => :chargeable_field do
@@ -53,6 +56,7 @@ FactoryGirl.define do
     metric      'derived_memory_used'
     group       'memory'
     source      'used'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_net_io_used, :parent => :chargeable_field do
@@ -60,6 +64,7 @@ FactoryGirl.define do
     metric      'net_usage_rate_average'
     group       'net_io'
     source      'used'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bps) }
   end
 
   factory :chargeable_field_disk_io_used, :parent => :chargeable_field do
@@ -67,6 +72,7 @@ FactoryGirl.define do
     metric      'disk_usage_rate_average'
     group       'disk_io'
     source      'used'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bps) }
   end
 
   factory :chargeable_field_storage_used, :parent => :chargeable_field do
@@ -74,5 +80,6 @@ FactoryGirl.define do
     metric      'derived_vm_used_disk_storage'
     group       'storage'
     source      'used'
+    detail_measure { FactoryGirl.build(:chargeback_measure_bytes) }
   end
 end

--- a/spec/factories/chargeback_rate_detail_measure.rb
+++ b/spec/factories/chargeback_rate_detail_measure.rb
@@ -5,4 +5,20 @@ FactoryGirl.define do
     units_display %w(B KB MB GB TB)
     units %w(bytes kilobytes megabytes gigabytes terabytes)
   end
+
+  factory :chargeback_measure_bytes, :parent => :chargeback_rate_detail_measure
+
+  factory :chargeback_measure_hz, :parent => :chargeback_rate_detail_measure do
+    name 'Hz Units'
+    step '1000'
+    units_display %w(Hz KHz MHz GHz THz)
+    units %w(hertz kilohertz megahertz gigahertz teraherts)
+  end
+
+  factory :chargeback_measure_bps, :parent => :chargeback_rate_detail_measure do
+    name 'Bytes per Second Units'
+    step '1000'
+    units_display %w(Bps KBps MBps GBps)
+    units %w(bps kbps mbps gbps)
+  end
 end

--- a/spec/models/chargeable_field_spec.rb
+++ b/spec/models/chargeable_field_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ChargeableField, :type => :model do
     let(:source) { 'used' }
     let(:group) { 'cpu' }
     let(:field) { FactoryGirl.build(:chargeable_field, :source => source, :group => group) }
-    subject { field.rate_name }
+    subject { field.send :rate_name }
     it { is_expected.to eq("#{group}_#{source}") }
   end
 end

--- a/spec/models/chargeable_field_spec.rb
+++ b/spec/models/chargeable_field_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ChargeableField, :type => :model do
+  describe '#rate_name' do
+    let(:source) { 'used' }
+    let(:group) { 'cpu' }
+    let(:field) { FactoryGirl.build(:chargeable_field, :source => source, :group => group) }
+    subject { field.rate_name }
+    it { is_expected.to eq("#{group}_#{source}") }
+  end
+end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -16,7 +16,10 @@ describe ChargebackRateDetail do
     let(:cbt1) { FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 10, :fixed_rate => 3.0, :variable_rate => 0.3) }
     let(:cbt2) { FactoryGirl.build(:chargeback_tier, :start => 10, :finish => 50, :fixed_rate => 2.0, :variable_rate => 0.2) }
     let(:cbt3) { FactoryGirl.build(:chargeback_tier, :start => 50, :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 0.1) }
-    let(:cbd) { FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt3, cbt2, cbt1]) }
+    let(:cbd) do
+      FactoryGirl.build(:chargeback_rate_detail, :chargeback_tiers => [cbt3, cbt2, cbt1],
+                                                 :chargeable_field => field)
+    end
 
     it "finds proper rate according the value" do
       expect(cbd.find_rate(cvalue["val1"])).to eq([cbt1.fixed_rate, cbt1.variable_rate])
@@ -31,13 +34,13 @@ describe ChargebackRateDetail do
                           :units_display => %w(B KB MB GB TB),
                           :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
       end
+      let(:field) { FactoryGirl.create(:chargeable_field_storage_allocated, :detail_measure => measure) }
       let(:cbd) do
         # This charges per gigabyte, tiers are per gigabytes
         FactoryGirl.build(:chargeback_rate_detail,
                           :chargeback_tiers => [cbt1, cbt2, cbt3],
-                          :detail_measure   => measure,
-                          :per_unit         => 'gigabytes',
-                          :metric           => 'derived_vm_allocated_disk_storage')
+                          :chargeable_field => field,
+                          :per_unit         => 'gigabytes')
       end
       it 'finds proper tier for the value' do
         expect(cbd.find_rate(0.0)).to                   eq([cbt1.fixed_rate, cbt1.variable_rate])
@@ -126,15 +129,13 @@ describe ChargebackRateDetail do
 
   it "#rate_adjustment" do
     value = 10.gigabytes
-    cbdm = FactoryGirl.create(:chargeback_rate_detail_measure,
-                              :units_display => %w(B KB MB GB TB),
-                              :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
+    field = FactoryGirl.build(:chargeable_field_memory_allocated) # the core metric is in megabytes
     [
       'megabytes', value,
       'gigabytes', value / 1024,
     ].each_slice(2) do |per_unit, rate_adjustment|
       cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :metric => 'derived_memory_available',
-       :chargeback_rate_detail_measure_id => cbdm.id)
+                                                       :chargeable_field => field)
       expect(cbd.rate_adjustment * value).to eq(rate_adjustment)
     end
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -77,7 +77,7 @@ describe ChargebackRateDetail do
     expect(cbd.hourly_cost(cvalue, consumption)).to eq(cvalue * cbd.hourly(variable_rate, consumption) + cbd.hourly(fixed_rate, consumption))
 
     cbd.chargeable_field = FactoryGirl.build(:chargeable_field_fixed_compute_1)
-    expect(cbd.hourly_cost(cvalue, consumption)).to eq(cbd.hourly(variable_rate, consumption) + cbd.hourly(fixed_rate, consumption))
+    expect(cbd.hourly_cost(1, consumption)).to eq(cbd.hourly(variable_rate, consumption) + cbd.hourly(fixed_rate, consumption))
 
     cbd.enabled = false
     expect(cbd.hourly_cost(cvalue, consumption)).to eq(0.0)

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -140,13 +140,6 @@ describe ChargebackRateDetail do
     end
   end
 
-  it "#rate_name" do
-    source = 'used'
-    group  = 'cpu'
-    cbd = FactoryGirl.build(:chargeback_rate_detail, :source => source, :group => group)
-    expect(cbd.rate_name).to eq("#{group}_#{source}")
-  end
-
   it "#friendly_rate" do
     friendly_rate = "My Rate"
     cbd = FactoryGirl.build(:chargeback_rate_detail, :friendly_rate => friendly_rate)

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -172,11 +172,12 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "#per_unit_display_without_measurements" do
+    expect(field.detail_measure).to be_nil
     [
       'cpu',       'Cpu',
       'ohms',      'Ohms'
     ].each_slice(2) do |per_unit, per_unit_display|
-      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :detail_measure => nil)
+      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :chargeable_field => field)
       expect(cbd.per_unit_display).to eq(per_unit_display)
     end
   end
@@ -185,10 +186,8 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbdm = FactoryGirl.create(:chargeback_rate_detail_measure,
                               :units_display => %w(B KB MB GB TB),
                               :units         => %w(bytes kilobytes megabytes gigabytes terabytes))
-
-    cbd  = FactoryGirl.build(:chargeback_rate_detail,
-                             :per_unit                          => 'megabytes',
-                             :chargeback_rate_detail_measure_id => cbdm.id)
+    field = FactoryGirl.create(:chargeable_field, :detail_measure => cbdm)
+    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => 'megabytes', :chargeable_field => field)
     expect(cbd.per_unit_display).to eq('MB')
   end
 


### PR DESCRIPTION
## What
 - This removes backend methods from `ChargebackRateDetail`.
 - These method are then added to `ChargeableField` where they belong.

## Motivation
 - That way we decouple charging from measurement.
 -  -> That will make rate editor (about charging) less complex
 -  -> That will make new chargeable items (that's about measurement) possible .

Continuation of #13375.


@miq-bot add_label chargeback, technical debt, euwe/no, wip
@miq-bot assign @gtanzillo 