### PR TITLE
Report both includes

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -80,7 +80,11 @@ module MiqReport::Generator
     @table2class[table]
   end
 
-  def get_include_for_find(includes, klass = nil)
+  def get_include_for_find
+    (include_as_hash || {}).deep_merge(include_for_find || {}).presence
+  end
+
+  def include_as_hash(includes = include, klass = nil)
     if klass.nil?
       klass = db_class
       result = {}
@@ -100,7 +104,7 @@ module MiqReport::Generator
           if v.nil? || v["include"].blank?
             result.merge!(k => {})
           else
-            result.merge!(k => get_include_for_find(v["include"], assoc_klass)) if assoc_klass
+            result.merge!(k => include_as_hash(v["include"], assoc_klass)) if assoc_klass
           end
 
           v["columns"].each { |c| result[k].merge!(c.to_sym => {}) if assoc_klass.virtual_attribute?(c) } if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]
@@ -177,7 +181,7 @@ module MiqReport::Generator
     interval = db_options.present? && db_options[:interval]
     custom_results_method = (db_options && db_options[:rpt_type]) ? "build_results_for_report_#{db_options[:rpt_type]}" : nil
 
-    includes = get_include_for_find(include)
+    includes = get_include_for_find
 
     load_custom_attributes
 

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -102,17 +102,21 @@ module MiqReport::Generator
           assoc_klass = assoc_reflection.nil? ? nil : (assoc_reflection.options[:polymorphic] ? k : assoc_reflection.klass)
 
           if v.nil? || v["include"].blank?
-            result.merge!(k => {})
-          else
-            result.merge!(k => include_as_hash(v["include"], assoc_klass)) if assoc_klass
+            result[k] = {}
+          elsif assoc_klass
+            result[k] = include_as_hash(v["include"], assoc_klass)
           end
 
-          v["columns"].each { |c| result[k].merge!(c.to_sym => {}) if assoc_klass.virtual_attribute?(c) } if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]
+          if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]
+            v["columns"].each do |c|
+              result[k][c.to_sym] = {} if assoc_klass.virtual_attribute?(c)
+            end
+          end
         end
       end
     elsif includes.kind_of?(Array)
       result ||= {}
-      includes.each { |i| result.merge!(i.to_sym => {}) }
+      includes.each { |i| result[i.to_sym] = {} }
     end
 
     result

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -82,9 +82,7 @@ module MiqReport::Search
     self.display_filter = options.delete(:display_filter_hash)  if options[:display_filter_hash]
     self.display_filter = options.delete(:display_filter_block) if options[:display_filter_block]
 
-    includes1 = get_include_for_find(include)
-    includes = MiqExpression.merge_includes(includes1, include_for_find)
-
+    includes = get_include_for_find
     self.extras ||= {}
     if extras[:target_ids_for_paging] && db_class.column_names.include?('id')
       return get_cached_page(limited_ids(limit, offset), includes, options)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -30,8 +30,8 @@ module MiqReport::Search
     end
   end
 
-  def get_cached_page(ids, includes, includes2, options)
-    data         = db_class.where(:id => ids).includes(includes).includes(includes2).to_a
+  def get_cached_page(ids, includes, options)
+    data         = db_class.where(:id => ids).includes(includes).to_a
     targets_hash = data.index_by(&:id) if options[:targets_hash]
     build_table(data, db, options)
     return table, extras[:attrs_for_paging].merge(:paged_read_from_cache => true, :targets_hash => targets_hash)
@@ -87,7 +87,7 @@ module MiqReport::Search
 
     self.extras ||= {}
     if extras[:target_ids_for_paging] && db_class.column_names.include?('id')
-      return get_cached_page(limited_ids(limit, offset), includes1, include_for_find, options)
+      return get_cached_page(limited_ids(limit, offset), includes, options)
     end
 
     order = get_order_info

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -720,11 +720,6 @@ class MiqExpression
     end
   end
 
-  def self.merge_includes(*incl_list)
-    return nil if incl_list.blank?
-    incl_list.compact.each_with_object({}) { |i, result| result.deep_merge!(i) }
-  end
-
   def self.get_cols_from_expression(exp, options = {})
     result = {}
     if exp.kind_of?(Hash)


### PR DESCRIPTION
`MiqReport` (definitions in `product/*/*.yaml`) are used for our table views and reports.

In reports we define associated tables using the `:includes` value.
In table views, we define associated tables with both `:includes` and `:includes_for_find`.

This PR removes that distinction. So both reports and views use both fields.

https://www.pivotaltracker.com/story/show/137377249