### PR TITLE
remove LiveMetric hardcoded column includes

### DIFF
--- a/app/models/live_metric.rb
+++ b/app/models/live_metric.rb
@@ -3,6 +3,13 @@ class LiveMetric < ActsAsArModel
 
   class LiveMetricError < RuntimeError; end
 
+  # all attributes are virtual
+  # - attributes are dynamically generated and would be too much work to query/declare them all
+  # - returning true gets the column names into the REST query (via :includes)
+  def self.virtual_attribute?(_c)
+    true
+  end
+
   def self.find(*args)
     raw_query = args[1]
     validate_raw_query(raw_query)

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -84,7 +84,7 @@ module MiqReport::Generator
     if klass.nil?
       klass = db_class
       result = {}
-      cols.each { |c| result.merge!(c.to_sym => {}) if klass.virtual_attribute?(c) || klass == LiveMetric } if cols
+      cols.each { |c| result.merge!(c.to_sym => {}) if klass.virtual_attribute?(c) } if cols
     end
 
     if includes.kind_of?(Hash)


### PR DESCRIPTION
reports include virtual columns in includes
this is used by Hawkluar LiveMetrics to send the column list to the
server.

Changed LiveMetric virtual column detection to auto include these
columns without hardcoding the class name

tangentially related to https://www.pivotaltracker.com/story/show/137377249

---

Hola @lucasponce - We introduced this change somewhere around #10570 and I'm pretty sure this follows through in your goals.

I am aiming to reduce a bunch of this reporting code, possibly removing report `includes` field or finding a different way of adding these `includes()`.

I don't want to break Hawkular

Is there an integration test we can introduce that will define a report and ensure that the correct columns get into Hawkular API (either via includes or select mechanism)?
