### PR TITLE
API Enhancement to support filtering on id attributes by compressed id's

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -1,6 +1,8 @@
 module Api
   class BaseController
     module Parameters
+      include CompressedIds
+
       def paginate_params?
         params['offset'] || params['limit']
       end
@@ -99,6 +101,8 @@ module Api
                           [filter_value, methods[:default]]
                         end
                       end
+
+        filter_value = from_cid(filter_value) if filter_attr =~ /[_]?id$/ && cid?(filter_value)
 
         if filter_value =~ /%|\*/
           filter_value = "/\\A#{Regexp.escape(filter_value)}\\z/"

--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -1,8 +1,6 @@
 module Api
   class BaseController
     module Parameters
-      include CompressedIds
-
       def paginate_params?
         params['offset'] || params['limit']
       end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -484,8 +484,14 @@ describe "Querying" do
       ems2 = FactoryGirl.create(:ems_vmware, :zone => zone)
       host = FactoryGirl.create(:host)
 
-      _vm = FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems1.id, :raw_power_state => "poweredOn")
-      vm2 = FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems2.id, :raw_power_state => "poweredOff")
+      _vm = FactoryGirl.create(:vm_vmware,
+                               :host                  => host,
+                               :ext_management_system => ems1,
+                               :raw_power_state       => "poweredOn")
+      vm2 = FactoryGirl.create(:vm_vmware,
+                               :host                  => host,
+                               :ext_management_system => ems2,
+                               :raw_power_state       => "poweredOff")
 
       run_get vms_url, :expand => "resources",
                        :filter => ["ems_id = #{ApplicationRecord.compress_id(ems2.id)}"]

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -457,6 +457,42 @@ describe "Querying" do
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
+
+    it "supports filtering by compressed id" do
+      vm1, _vm2 = create_vms_by_name(%w(aa bb))
+
+      run_get vms_url, :expand => "resources",
+                       :filter => ["id = #{ApplicationRecord.compress_id(vm1.id)}"]
+
+      expect_query_result(:vms, 1, 2)
+      expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid}])
+    end
+
+    it "supports filtering by compressed id as string" do
+      _vm1, vm2 = create_vms_by_name(%w(aa bb))
+
+      run_get vms_url, :expand => "resources",
+                       :filter => ["id = '#{ApplicationRecord.compress_id(vm2.id)}'"]
+
+      expect_query_result(:vms, 1, 2)
+      expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid}])
+    end
+
+    it "supports filtering by compressed id on *_id named attributes" do
+      zone = FactoryGirl.create(:zone, :name => "api_zone")
+      ems1 = FactoryGirl.create(:ems_vmware, :zone => zone)
+      ems2 = FactoryGirl.create(:ems_vmware, :zone => zone)
+      host = FactoryGirl.create(:host)
+
+      _vm = FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems1.id, :raw_power_state => "poweredOn")
+      vm2 = FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems2.id, :raw_power_state => "poweredOff")
+
+      run_get vms_url, :expand => "resources",
+                       :filter => ["ems_id = #{ApplicationRecord.compress_id(ems2.id)}"]
+
+      expect_query_result(:vms, 1, 2)
+      expect_result_resources_to_match_hash([{"name" => vm2.name, "guid" => vm2.guid}])
+    end
   end
 
   describe "Querying vm attributes" do


### PR DESCRIPTION
- This enhancement allows filtering on id attributes or any of the *_id
named attributes, i.e. storage_id, ems_id, etc. by compressed id,

  i.e.
    GET /api/vms?expand=resources&attributes=name,vendor&filter=id='2r77'
    GET /api/instances?expand=resources&attributes=name,storage_id&filter[]=storage_id=1r32

- Added specs

Fixes: #11636

