### PR TITLE
add create_catalog_item to ServiceTemplateAnsibleTower 

### DIFF
--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -9,10 +9,12 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
       create(options.except(:config_info)) do |service_template|
-        config_info = options[:config_info]
+        config_info = validate_config_info(options)
 
         service_template.job_template = if config_info[:configuration_script_id]
                                           ConfigurationScript.find(config_info[:configuration_script_id])
+                                        else
+                                          config_info[:configuration]
                                         end
 
         service_template.create_resource_actions(config_info)
@@ -41,4 +43,13 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
   def self.default_retirement_entry_point
     nil
   end
+
+  def self.validate_config_info(options)
+    config_info = options[:config_info]
+    unless config_info[:configuration_script_id] || config_info[:configuration]
+      raise _('Must provide configuration_script_id or configuration')
+    end
+    config_info
+  end
+  private_class_method :validate_config_info
 end

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -1,0 +1,38 @@
+describe ServiceTemplateAnsibleTower do
+  describe "#create_catalog_item" do
+    let(:ra1) { FactoryGirl.create(:resource_action, :action => 'Provision') }
+    let(:ra2) { FactoryGirl.create(:resource_action, :action => 'Retirement') }
+    let(:service_dialog) { FactoryGirl.create(:dialog) }
+    let(:configuration_script) { FactoryGirl.create(:configuration_script) }
+    let(:catalog_item_options) do
+      {
+        :name         => 'Ansible Tower',
+        :service_type => 'generic_ansible_tower',
+        :prov_type    => 'amazon',
+        :display      => 'false',
+        :description  => 'a description',
+        :config_info  => {
+          :configuration_script_id => configuration_script.id,
+          :provision               => {
+            :fqname            => ra1.fqname,
+            :service_dialog_id => service_dialog.id
+          },
+          :retirement              => {
+            :fqname            => ra2.fqname,
+            :service_dialog_id => service_dialog.id
+          }
+        }
+      }
+    end
+
+    it 'creates and returns a catalog item' do
+      service_template = ServiceTemplateAnsibleTower.create_catalog_item(catalog_item_options)
+
+      expect(service_template.name).to eq('Ansible Tower')
+      expect(service_template.service_resources.count).to eq(1)
+      expect(service_template.dialogs.first).to eq(service_dialog)
+      expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
+      expect(service_template.job_template).to eq(configuration_script)
+    end
+  end
+end

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -14,24 +14,40 @@ describe ServiceTemplateAnsibleTower do
         :config_info  => {
           :configuration_script_id => configuration_script.id,
           :provision               => {
-            :fqname            => ra1.fqname,
-            :service_dialog_id => service_dialog.id
+            :fqname    => ra1.fqname,
+            :dialog_id => service_dialog.id
           },
           :retirement              => {
-            :fqname            => ra2.fqname,
-            :service_dialog_id => service_dialog.id
+            :fqname    => ra2.fqname,
+            :dialog_id => service_dialog.id
           }
         }
       }
     end
 
-    it 'creates and returns a catalog item' do
+    it 'creates and returns an ansible tower catalog item' do
       service_template = ServiceTemplateAnsibleTower.create_catalog_item(catalog_item_options)
+      service_template.reload
 
       expect(service_template.name).to eq('Ansible Tower')
       expect(service_template.service_resources.count).to eq(1)
       expect(service_template.dialogs.first).to eq(service_dialog)
       expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
+      expect(service_template.job_template).to eq(configuration_script)
+    end
+
+    it 'validates the presence of a configuration_script_id or configuration' do
+      catalog_item_options[:config_info].delete(:configuration_script_id)
+
+      expect do
+        ServiceTemplateAnsibleTower.create_catalog_item(catalog_item_options)
+      end.to raise_error(StandardError, 'Must provide configuration_script_id or configuration')
+    end
+
+    it 'accepts a configuration' do
+      catalog_item_options[:config_info] = { :configuration => configuration_script }
+      service_template = ServiceTemplateAnsibleTower.create_catalog_item(catalog_item_options)
+
       expect(service_template.job_template).to eq(configuration_script)
     end
   end


### PR DESCRIPTION
This adds class method `create_catalog_item` to `ServiceTemplateAnsibleTower` and takes in the following:

```
      {
        :name         => 'Ansible Tower',
        :service_type => 'generic_ansible_tower',
        :prov_type    => 'amazon',
        :display      => 'false',
        :description  => 'a description',
        :config_info  => {
          :configuration_script_id => configuration_script.id,
          :provision               => {
            :fqname            => ra1.fqname,
            :dialog_id => service_dialog.id
          },
          :retirement              => {
            :fqname            => ra2.fqname,
            :dialog_id => service_dialog.id
          }
        }
      }
```

@miq-bot add_label wip, enhancement, orchestration, services, euwe/no
@miq-bot assign @bzwei 
