### PR TITLE
remove unneeded include_for_find

### DIFF
--- a/product/views/AvailabilityZone.yaml
+++ b/product/views/AvailabilityZone.yaml
@@ -30,7 +30,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/CloudNetwork.yaml
+++ b/product/views/CloudNetwork.yaml
@@ -31,7 +31,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/CloudSubnet.yaml
+++ b/product/views/CloudSubnet.yaml
@@ -34,7 +34,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/CloudTenant.yaml
+++ b/product/views/CloudTenant.yaml
@@ -30,7 +30,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -33,8 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :container_group: {}
-  :container_image: {}
 
 # Order of columns (from all tables)
 col_order: 

--- a/product/views/ContainerGroup.yaml
+++ b/product/views/ContainerGroup.yaml
@@ -37,7 +37,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :container_project: {}
 
 # Order of columns (from all tables)
 col_order: 

--- a/product/views/Flavor.yaml
+++ b/product/views/Flavor.yaml
@@ -39,7 +39,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
   
 # Order of columns (from all tables)
 col_order: 

--- a/product/views/FloatingIp.yaml
+++ b/product/views/FloatingIp.yaml
@@ -33,8 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
-  :vm: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/HostAggregate.yaml
+++ b/product/views/HostAggregate.yaml
@@ -30,7 +30,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/InstanceOrImage.yaml
+++ b/product/views/InstanceOrImage.yaml
@@ -37,8 +37,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/LoadBalancer.yaml
+++ b/product/views/LoadBalancer.yaml
@@ -31,7 +31,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
@@ -40,8 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
-  :provider: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ManageIQ_Providers_CloudManager.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager.yaml
@@ -36,7 +36,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
@@ -35,7 +35,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
@@ -35,7 +35,6 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
-  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_CloudManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Template.yaml
@@ -40,7 +40,6 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
-  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
@@ -41,7 +41,6 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
-  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
@@ -41,7 +41,6 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
-  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm.yaml
@@ -46,7 +46,6 @@ include:
 include_for_find:
   :compliances: {}
   :operating_system: {}
-  :hardware: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -40,8 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
-  :provider: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ManageIQ_Providers_ContainerManager.yaml
+++ b/product/views/ManageIQ_Providers_ContainerManager.yaml
@@ -33,7 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
+++ b/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
@@ -33,7 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -41,8 +41,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
-  :provider: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -40,7 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_InfraManager_Template.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Template.yaml
@@ -41,8 +41,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager_Vm.yaml
@@ -41,8 +41,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/ManageIQ_Providers_MiddlewareManager.yaml
+++ b/product/views/ManageIQ_Providers_MiddlewareManager.yaml
@@ -33,7 +33,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_NetworkManager.yaml
+++ b/product/views/ManageIQ_Providers_NetworkManager.yaml
@@ -34,7 +34,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ManageIQ_Providers_StorageManager.yaml
+++ b/product/views/ManageIQ_Providers_StorageManager.yaml
@@ -32,7 +32,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/MiqTemplate-all_miq_templates.yaml
+++ b/product/views/MiqTemplate-all_miq_templates.yaml
@@ -36,8 +36,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/NetworkPort.yaml
+++ b/product/views/NetworkPort.yaml
@@ -35,8 +35,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
-#  :device: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/NetworkRouter.yaml
+++ b/product/views/NetworkRouter.yaml
@@ -31,7 +31,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/OrchestrationStack.yaml
+++ b/product/views/OrchestrationStack.yaml
@@ -35,7 +35,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/SecurityGroup.yaml
+++ b/product/views/SecurityGroup.yaml
@@ -31,7 +31,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :ext_management_system: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -40,7 +40,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :service_template_catalog: {}
 
 # Order of columns (from all tables)
 col_order:

--- a/product/views/StorageManager.yaml
+++ b/product/views/StorageManager.yaml
@@ -36,7 +36,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
 #  :hosts:
 #    :storages: {}
 #  :vms: {}

--- a/product/views/Vm-VmReconfigureRequest.yaml
+++ b/product/views/Vm-VmReconfigureRequest.yaml
@@ -34,7 +34,6 @@ include:
 include_for_find:
   :hardware:
    :disks: {}
-  :host: {}
   
 # Order of columns (from all tables)
 col_order: 

--- a/product/views/Vm-all_vms.yaml
+++ b/product/views/Vm-all_vms.yaml
@@ -36,8 +36,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/VmOrTemplate-all_archived.yaml
+++ b/product/views/VmOrTemplate-all_archived.yaml
@@ -37,8 +37,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/VmOrTemplate-all_orphaned.yaml
+++ b/product/views/VmOrTemplate-all_orphaned.yaml
@@ -37,8 +37,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/VmOrTemplate-all_vms_and_templates.yaml
+++ b/product/views/VmOrTemplate-all_vms_and_templates.yaml
@@ -38,8 +38,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/VmOrTemplate.yaml
+++ b/product/views/VmOrTemplate.yaml
@@ -42,8 +42,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :host: {}
-  :storage: {}
   :snapshots: {}
   :compliances: {}
   :operating_system: {}

--- a/product/views/ems_block_storage.yaml
+++ b/product/views/ems_block_storage.yaml
@@ -32,7 +32,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)

--- a/product/views/ems_object_storage.yaml
+++ b/product/views/ems_object_storage.yaml
@@ -32,7 +32,6 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :zone: {}
   :tags: {}
 
 # Order of columns (from all tables)


### PR DESCRIPTION
update reports

these reports have values for `include_for_find`
but since these values are already in `includes` (and the primary query) they do nothing.
