### PR TITLE
Add hide & show alert status actions

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -9,6 +9,7 @@ class MiqAlertStatus < ApplicationRecord
   belongs_to :ext_management_system
   has_many :miq_alert_status_actions, -> { order "created_at" }, :dependent => :destroy
   virtual_column :assignee, :type => :string
+  virtual_column :hidden, :type => :boolean
 
   validates :severity, :acceptance => { :accept => SEVERITY_LEVELS }
 
@@ -18,5 +19,9 @@ class MiqAlertStatus < ApplicationRecord
 
   def assigned?
     assignee.present?
+  end
+
+  def hidden?
+    miq_alert_status_actions.where(:action_type => %w(hide show)).last.try(:action_type) == 'hide'
   end
 end

--- a/app/models/miq_alert_status_action.rb
+++ b/app/models/miq_alert_status_action.rb
@@ -1,5 +1,5 @@
 class MiqAlertStatusAction < ApplicationRecord
-  ACTION_TYPES = %w(assign acknowledge comment unassign unacknowledge).freeze
+  ACTION_TYPES = %w(assign acknowledge comment unassign unacknowledge hide show).freeze
 
   belongs_to :miq_alert_status
   belongs_to :assignee, :class_name => 'User'
@@ -15,8 +15,9 @@ class MiqAlertStatusAction < ApplicationRecord
   after_save :update_status_acknowledgement
 
   def only_assignee_can_acknowledge
-    if action_type == 'acknowledge' && miq_alert_status.assignee.try(:id) != user.id
-      errors.add(:user, "that is not assigned cannot acknowledge")
+    if ['acknowledge', 'unacknowledge', 'hide', 'show'].include?(action_type) &&
+        miq_alert_status.assignee.try(:id) != user.id
+      errors.add(:user, "that is not assigned cannot #{action_type}")
     end
   end
 

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -12,6 +12,12 @@ describe MiqAlertStatus do
     FactoryGirl.create(:miq_alert_status_action, :action_type => 'assign', :user => user1, :assignee => user1,
                        :miq_alert_status => alert)
   end
+  let(:hide_action) do
+    FactoryGirl.create(:miq_alert_status_action, :action_type => 'hide', :user => user1, :miq_alert_status => alert)
+  end
+  let(:show_action) do
+    FactoryGirl.create(:miq_alert_status_action, :action_type => 'show', :user => user1, :miq_alert_status => alert)
+  end
 
   describe "Validation" do
     it "should reject unexpected severities" do
@@ -104,6 +110,22 @@ describe MiqAlertStatus do
       end
       alert.reload
       expect(alert.assignee).to be_nil
+    end
+  end
+
+  describe "#hidden?" do
+    it "returns false for new" do
+      expect(alert.hidden?).to be_falsey
+    end
+
+    it "returns true after hide action" do
+      alert.miq_alert_status_actions = [assignment_action, hide_action]
+      expect(alert.hidden?).to be_truthy
+    end
+
+    it "returns false after show action" do
+      alert.miq_alert_status_actions = [assignment_action, hide_action, show_action]
+      expect(alert.hidden?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
This should provide all the backend support needed to support hiding alert statuses for the alert screen.
Implemented using a new `hide` action_type

The api can be used to filter based on visibility:
```
localhost:3000/api/alerts?filter[]=hidden?=true&expand=resources
```
We also support making them visible again with a `show` action_type.
