### PR TITLE
This default_scope is not needed or used in any way

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -5,8 +5,6 @@ class ChargebackRateDetail < ApplicationRecord
   belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
   has_many :chargeback_tiers, :dependent => :destroy, :autosave => true
 
-  default_scope { order(:group => :asc, :description => :asc) }
-
   validates :group, :source, :chargeback_rate, :presence => true
   validate :contiguous_tiers?
 


### PR DESCRIPTION
Playing with the ui. It seems this default_scope affects nothing.

@miq-bot add_label techical debt, chargeback, euwe/no
@miq-bot assign @gtanzillo 