### PR TITLE
Add description to miq_alert_statuses

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -198,15 +198,16 @@ class MiqAlert < ApplicationRecord
     # If we are alerting, invoke the alert actions, then add a status so we can limit how often to alert
     # Otherwise, destroy this alert's statuses for our target
     invoke_actions(target, inputs) if result
-    add_status_post_evaluate(target, result)
+    add_status_post_evaluate(target, result, inputs[:description])
 
     result
   end
 
-  def add_status_post_evaluate(target, result)
+  def add_status_post_evaluate(target, result, status_description)
     status = miq_alert_statuses.find_or_initialize_by(:resource => target)
     status.result = result
     status.ems_id = target.try(:ems_id)
+    status.description = status_description || description
     status.evaluated_on = Time.now.utc
     status.save
     miq_alert_statuses << status

--- a/db/migrate/20170125141153_add_message_to_alert_statuses.rb
+++ b/db/migrate/20170125141153_add_message_to_alert_statuses.rb
@@ -1,0 +1,5 @@
+class AddMessageToAlertStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :description, :string
+  end
+end

--- a/db/migrate/20170125141953_update_description_in_miq_alert_status.rb
+++ b/db/migrate/20170125141953_update_description_in_miq_alert_status.rb
@@ -1,0 +1,19 @@
+class UpdateDescriptionInMiqAlertStatus < ActiveRecord::Migration[5.0]
+  class MiqAlertStatus < ActiveRecord::Base
+    belongs_to :miq_alert, :class_name => "UpdateDescriptionInMiqAlertStatus::MiqAlert"
+  end
+
+  class MiqAlert < ActiveRecord::Base
+    has_many :miq_alert_statuses, :dependent => :destroy, :class_name => "UpdateDescriptionInMiqAlertStatus::MiqAlertStatus"
+  end
+
+  def up
+    say_with_time("update description in miq alert statuses") do
+      miq_alerts = Arel::Table.new('miq_alerts')
+      miq_alert_statuses = Arel::Table.new('miq_alert_statuses')
+      join_sql = miq_alerts.project(miq_alerts[:description])
+                           .where(miq_alerts[:id].eq(miq_alert_statuses[:miq_alert_id])).to_sql
+      MiqAlertStatus.update_all("description = (#{join_sql})")
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4838,6 +4838,7 @@ miq_alert_statuses:
 - ancestry
 - acknowledged
 - ems_id
+- description
 miq_alerts:
 - id
 - guid

--- a/spec/migrations/20170125141953_update_description_in_miq_alert_status_spec.rb
+++ b/spec/migrations/20170125141953_update_description_in_miq_alert_status_spec.rb
@@ -1,0 +1,18 @@
+require_migration
+
+describe UpdateDescriptionInMiqAlertStatus do
+  let(:miq_alert_stub) { migration_stub(:MiqAlert) }
+  let(:miq_alert_status_stub) { migration_stub(:MiqAlertStatus) }
+
+  migration_context :up do
+    it 'it sets miq_alert_status.description using miq_alert.description' do
+      ma = miq_alert_stub.create(:description => 'all your base are belong to us!')
+      mas = miq_alert_status_stub.create
+      ma.miq_alert_statuses = [mas]
+      expect(mas.description).to be_nil
+      migrate
+      mas.reload
+      expect(mas.description).to eq('all your base are belong to us!')
+    end
+  end
+end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -107,6 +107,11 @@ describe MiqAlert do
         expect(@alert.miq_alert_statuses.find_by(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).result).to be_truthy
       end
 
+      it "cookie stamps the description on the alert" do
+        mas = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).first
+        expect(mas.description).to eq("VM Unregistered")
+      end
+
       it "should have a link from the Vm to the miq alert status" do
         expect(@vm.miq_alert_statuses.where(:miq_alert_id => @alert.id).count).to eq(1)
       end


### PR DESCRIPTION
Why cookie description from miq_alert to miq_alert_statuses?
We want to support generic alerting from external systems (hawkular). 
What we get from it is only instances of an alert (==miq_alert_status) containing a description and there is no entity parallel to miq_alert.

The purpose of this change is to take the description from the MAS when it is available (container alerts from hawkular) or from the MA otherwise (all other providers including middleware alerts)

The piece adding the external description on mas will come in the event collection patch #12773 