### PR TITLE
Remove availability zone from extra_keys in SaveInventoryBlockStorage

### DIFF
--- a/app/models/ems_refresh/save_inventory_block_storage.rb
+++ b/app/models/ems_refresh/save_inventory_block_storage.rb
@@ -60,7 +60,7 @@ module EmsRefresh::SaveInventoryBlockStorage
     end
 
     save_inventory_multi(ems.cloud_volumes, hashes, deletes, [:ems_ref],
-                         nil, [:tenant, :availability_zone, :base_snapshot])
+                         nil, [:tenant, :base_snapshot])
     store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 


### PR DESCRIPTION
While working with Amazon EBS provider block storage save inventory
failed to save the availability zone. This was due to the fact that
`:availability_zone` is given in the `extra_keys` list that defines the
set of hash keys that are removed from the hash we are trying to save.

For Cinder provider, a cross-linker is used to set the
availability_zone_id from the parent provider. With this patch, both EBS
and Cinder providers properly save the availability zone reference.

@miq-bot add_label providers/storage