### PR TITLE
[WIP][DARGA] Backport PR 13101 to DARGA:  Allow cpu_usagemhz_rate_average_max_over_time_period and derived_memory_used_max_over_time_period to be used in reports as SQL

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -423,6 +423,7 @@ module Rbac
 
     if targets.nil?
       scope = apply_scope(klass, scope)
+      scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
     elsif targets.kind_of?(Array)
       if targets.first.kind_of?(Numeric)
         target_ids = targets
@@ -432,6 +433,7 @@ module Rbac
         results_format ||= :objects
       end
       scope = apply_scope(klass, scope)
+      scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
 
       ids_clause = ["#{klass.table_name}.id IN (?)", target_ids] if klass.respond_to?(:table_name)
     else # targets is a scope, class, or AASM class (VimPerformanceDaily in particular)
@@ -440,6 +442,7 @@ module Rbac
 
       results_format ||= :objects
       scope = apply_scope(targets, scope)
+      scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
 
       unless klass.respond_to?(:find)
         klass = targets
@@ -519,6 +522,10 @@ module Rbac
       end
       klass.send(*scope)
     end
+  end
+
+  def self.apply_select(klass, scope, extra_cols)
+    scope.select(scope.select_values.blank? ? klass.arel_table[Arel.star] : nil).select(extra_cols)
   end
 
   def self.get_belongsto_matches(blist, klass)

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -165,21 +165,29 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    opts = {
-      :end_date => Time.now.utc,
-      :days     => Metric::LongTermAverages::AVG_DAYS
-    }
-    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                          .maximum(:cpu_usagemhz_rate_average)
+    if has_attribute?("cpu_usagemhz_rate_average_max_over_time_period")
+      self["cpu_usagemhz_rate_average_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:cpu_usagemhz_rate_average)
+    end
   end
 
   def derived_memory_used_max_over_time_period
-    opts = {
-      :end_date => Time.now.utc,
-      :days     => Metric::LongTermAverages::AVG_DAYS
-    }
-    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                          .maximum(:derived_memory_used)
+    if has_attribute?("derived_memory_used_max_over_time_period")
+      self["derived_memory_used_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:derived_memory_used)
+    end
   end
 
   private

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -137,13 +137,21 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:cpu_usagemhz_rate_average).compact.max
+    opts = {
+      :end_date => Time.now.utc,
+      :days     => Metric::LongTermAverages::AVG_DAYS
+    }
+    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                          .maximum(:cpu_usagemhz_rate_average)
   end
 
   def derived_memory_used_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:derived_memory_used).compact.max
+    opts = {
+      :end_date => Time.now.utc,
+      :days     => Metric::LongTermAverages::AVG_DAYS
+    }
+    VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                          .maximum(:derived_memory_used)
   end
 
   private

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -31,11 +31,39 @@ module VmOrTemplate::RightSizing
 
     virtual_column :max_cpu_usage_rate_average_max_over_time_period,     :type => :float
     virtual_column :max_mem_usage_absolute_average_max_over_time_period, :type => :float
-    virtual_column :cpu_usagemhz_rate_average_max_over_time_period,      :type => :float
-    virtual_column :derived_memory_used_max_over_time_period,            :type => :float
+
+    virtual_attribute :cpu_usagemhz_rate_average_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:cpu_usagemhz_rate_average)
+    virtual_attribute :derived_memory_used_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:derived_memory_used)
   end
 
   module ClassMethods
+    def metric_rollup_vattr_arel(col)
+      lambda do |t|
+        metric_rollup_table = MetricRollup.arel_table
+        select_clause = metric_rollup_table[col].maximum
+
+        now       = Time.now.utc
+        timestamp = (now - 30.days).utc..now
+        tp_ids    = TimeProfile.default_time_profile(nil)
+                               .profile_for_each_region
+                               .pluck(:id)
+
+        where_clause =
+          metric_rollup_table[:time_profile_id].in(tp_ids)
+            .and(metric_rollup_table[:capture_interval_name].eq("daily"))
+            .and(metric_rollup_table[:timestamp].between(timestamp))
+            .and(metric_rollup_table[:resource_type].eq("VmOrTemplate"))
+            .and(metric_rollup_table[:resource_id].eq(t[:id]))
+
+        t.grouping(
+          metric_rollup_table.project(select_clause)
+                             .where(where_clause)
+        )
+      end
+    end
+
     DEFAULT_CPU_RECOMMENDATION_MINIMUM = 1
     def cpu_recommendation_minimum
       VMDB::Config.new("vmdb").config.fetch_path(:recommendations, :cpu_minimum) || DEFAULT_CPU_RECOMMENDATION_MINIMUM

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -511,6 +511,94 @@ module ActiveRecord
         end
       }
     end
+
+    # FIXME: Hopefully we can get this into Rails core so this is no longer
+    # required in our codebase, but the rule that are broken here are mostly
+    # due to the style of the Rails codebase conflicting with our own.
+    # Ignoring them to avoid noise in RuboCop, but allow us to keep the same
+    # syntax from the original codebase.
+    #
+    # rubocop:disable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+    # rubocop:disable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    class JoinDependency
+      def instantiate(result_set, aliases)
+        primary_key = aliases.column_alias(join_root, join_root.primary_key)
+
+        seen = Hash.new { |i, object_id|
+          i[object_id] = Hash.new { |j, child_class|
+            j[child_class] = {}
+          }
+        }
+
+        model_cache = Hash.new { |h,klass| h[klass] = {} }
+        parents = model_cache[join_root]
+        column_aliases = aliases.column_aliases join_root
+
+        # New Code
+        #
+        # This monkey patches the ActiveRecord::Associations::JoinDependency to
+        # include columns into the main record that might have been added
+        # through a `select` clause.
+        #
+        # This can be seen with the following:
+        #
+        #   Vm.select(Vm.arel_table[Arel.star]).select(:some_vm_virtual_col)
+        #     .includes(:tags => {}).references(:tags => {})
+        #
+        # Which will produce a SQL SELECT statement kind of like this:
+        #
+        #   SELECT "vms".*,
+        #          (<virtual_attribute_arel>) AS some_vm_virtual_col,
+        #          "vms"."id"      AS t0_r0
+        #          "vms"."vendor"  AS t0_r1
+        #          "vms"."format"  AS t0_r1
+        #          "vms"."version" AS t0_r1
+        #          ...
+        #          "tags"."id"     AS t1_r0
+        #          "tags"."name"   AS t1_r1
+        #
+        # This is because rails is trying to reduce the number of queries
+        # needed to fetch all of the records in the include, so it grabs the
+        # columns for both of the tables together to do it.  Unfortuantely (or
+        # fortunately... depending on how you look at it), it does not remove
+        # any `.select` columns from the query that is run in the process, so
+        # that is brought along for the ride, but never used when this method
+        # instanciates the objects.
+        #
+        # The "New Code" here simply also instanciates any extra rows that
+        # might have been included in the select (virtual_columns) as well and
+        # brought back with the result set.
+        unless result_set.empty?
+          join_dep_keys         = aliases.columns.map(&:right)
+          join_root_aliases     = column_aliases.map(&:first)
+          additional_attributes = result_set.first.keys
+                                            .reject { |k| join_dep_keys.include?(k) }
+                                            .reject { |k| join_root_aliases.include?(k) }
+                                            .map    { |k| [k, k] }
+          column_aliases += additional_attributes
+        end
+        # End of New Code
+
+        message_bus = ActiveSupport::Notifications.instrumenter
+
+        payload = {
+          record_count: result_set.length,
+          class_name: join_root.base_klass.name
+        }
+
+        message_bus.instrument('instantiation.active_record', payload) do
+          result_set.each { |row_hash|
+            parent_key = primary_key ? row_hash[primary_key] : row_hash
+            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
+            construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
+          }
+        end
+
+        parents.values
+      end
+      # rubocop:enable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+      # rubocop:enable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    end
   end
 
   class Relation

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -498,6 +498,19 @@ describe VirtualFields do
       end
     end
 
+    describe ".select" do
+      it "supports #includes with #references" do
+        vm           = FactoryGirl.create :vm_vmware
+        table        = Vm.arel_table
+        dash         = Arel::Nodes::SqlLiteral.new("'-'")
+        name_dash_id = Arel::Nodes::NamedFunction.new("CONCAT", [table[:name], dash, table[:id]])
+                                                 .as("name_dash_id")
+        result       = Vm.select(name_dash_id).includes(:tags => {}).references(:tags => {})
+
+        expect(result.first.attributes["name_dash_id"]).to eq("#{vm.name}-#{vm.id}")
+      end
+    end
+
     describe ".virtual_delegate" do
       # double purposing col1. It has an actual value in the child class
       let(:parent) { TestClass.create(:id => 1, :col1 => 4) }

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -74,6 +74,12 @@ describe Rbac do
         expect(results).to match_array [owned_vm]
       end
 
+      it "with :extra_cols finds Service" do
+        FactoryGirl.create :service, :evm_owner => owner_user
+        results = described_class.search(:class => "Service", :extra_cols => [:owned_by_current_user]).first
+        expect(results.first.attributes["owned_by_current_user"]).to be false
+      end
+
       it "leaving tenant doesnt find Vm" do
         owner_user.update_attributes(:miq_groups => [other_user.current_group])
         User.with_user(owner_user) do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -572,6 +572,78 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".cpu_usagemhz_rate_average_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 10.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 100.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.cpu_usagemhz_rate_average_max_over_time_period).to eq(100.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "cpu_usagemhz_rate_average_max_over_time_period"
+        )
+      ).to eq(100.0)
+    end
+  end
+
+  describe ".derived_memory_used_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 10.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 1000.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.derived_memory_used_max_over_time_period).to eq(1000.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "derived_memory_used_max_over_time_period"
+        )
+      ).to eq(1000.0)
+    end
+  end
+
   describe ".host_name" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }


### PR DESCRIPTION
Backports code from https://github.com/ManageIQ/manageiq/pull/13101 to darga.  Some commits could be a straight cherry pick, while others were required to be manually backported.  Some other dependencies might be required as well (support for `.select` with virtual attributes for example).

A more indepth description can be found in the original PR.

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1395743
* https://github.com/ManageIQ/manageiq/pull/13101