### PR TITLE
[EUWE] Fix incorrect use of PostponedTranslation

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -447,8 +447,8 @@ module UiConstants
   # This set of assignments was created for miq_alerts
   ASSIGN_TOS["ExtManagementSystem"] = {
     "enterprise"                 => N_("The Enterprise"),
-    "ext_management_system"      => PostponedTranslation.new(N_("Selected Providers")),
-    "ext_management_system-tags" => PostponedTranslation.new(N_("Tagged Providers"))
+    "ext_management_system"      => N_("Selected Providers"),
+    "ext_management_system-tags" => N_("Tagged Providers")
   }
   ASSIGN_TOS["EmsCluster"] = {
     "ems_cluster"      => PostponedTranslation.new(N_("Selected %{tables}")) do


### PR DESCRIPTION
`PostponedTranslation` needs to be passed a block, which in this case is not really needed
(no string expansion is being done here).

https://bugzilla.redhat.com/show_bug.cgi?id=1416311

This fix is euwe only, things on master were already fixed in a different way in https://github.com/ManageIQ/manageiq-ui-classic/pull/241