### PR TITLE
Stop using (soon-to-be-removed-)cols from chargeback_rate_detail

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -7,7 +7,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   default_scope { order(:group => :asc, :description => :asc) }
 
-  validates :group, :source, :chargeback_rate, :chargeable_field, :presence => true
+  validates :chargeback_rate, :chargeable_field, :presence => true
   validate :contiguous_tiers?
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -5,7 +5,7 @@ class ChargebackRateDetail < ApplicationRecord
   belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
   has_many :chargeback_tiers, :dependent => :destroy, :autosave => true
 
-  default_scope { order(:group => :asc, :description => :asc) }
+  default_scope { joins(:chargeable_field).merge(ChargeableField.order(:group => :asc, :description => :asc)) }
 
   validates :chargeback_rate, :chargeable_field, :presence => true
   validate :contiguous_tiers?

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -7,8 +7,6 @@ class ChargebackRateDetailMeasure < ApplicationRecord
   validates :units_display, :presence => true, :length => {:minimum => 2}
   validate :units_same_length
 
-  has_many :chargeback_rate_detail, :foreign_key => "chargeback_rate_detail_measure_id"
-
   def measures
     Hash[units_display.zip(units)]
   end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -78,14 +78,12 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_cpu_used, :traits => [:used, :cpu], :parent => :chargeback_rate_detail do
     description "Used CPU in MHz"
-    metric      "cpu_usagemhz_rate_average"
     per_unit    "megahertz"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_used) }
   end
 
   factory :chargeback_rate_detail_cpu_cores_used, :traits => [:used], :parent => :chargeback_rate_detail do
     description "Used CPU in Cores"
-    metric      "cpu_usage_rate_average"
     group       "cpu_cores"
     per_unit    "cores"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_cores_used) }
@@ -94,7 +92,6 @@ FactoryGirl.define do
   factory :chargeback_rate_detail_cpu_allocated, :traits => [:allocated, :cpu, :daily],
                                                  :parent => :chargeback_rate_detail do
     description "Allocated CPU Count"
-    metric      "derived_vm_numvcpus"
     per_unit    "cpu"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_allocated) }
   end
@@ -102,42 +99,36 @@ FactoryGirl.define do
   factory :chargeback_rate_detail_memory_allocated, :traits => [:allocated, :memory, :megabytes, :daily],
                                                     :parent => :chargeback_rate_detail do
     description "Allocated Memory in MB"
-    metric      "derived_memory_available"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_allocated) }
   end
 
   factory :chargeback_rate_detail_memory_used, :traits => [:used, :memory, :megabytes, :hourly],
                                                :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
-    metric      "derived_memory_used"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_used) }
   end
 
   factory :chargeback_rate_detail_disk_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
     description "Used Disk I/O in KBps"
     group       "disk_io"
-    metric      "disk_usage_rate_average"
     chargeable_field { FactoryGirl.build(:chargeable_field_disk_io_used) }
   end
 
   factory :chargeback_rate_detail_net_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
     description "Used Network I/O in KBps"
     group       "net_io"
-    metric      "net_usage_rate_average"
     chargeable_field { FactoryGirl.build(:chargeable_field_net_io_used) }
   end
 
   factory :chargeback_rate_detail_storage_used, :traits => [:used, :storage_group, :gigabytes],
                                                 :parent => :chargeback_rate_detail do
     description "Used Disk Storage in Bytes"
-    metric      "derived_vm_used_disk_storage"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_used) }
   end
 
   factory :chargeback_rate_detail_storage_allocated, :traits => [:allocated, :storage_group, :gigabytes],
                                                      :parent => :chargeback_rate_detail do
     description "Allocated Disk Storage in Bytes"
-    metric      "derived_vm_allocated_disk_storage"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_allocated) }
   end
 

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -51,64 +51,53 @@ FactoryGirl.define do
   end
 
   factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do
-    description "Used CPU in MHz"
     per_unit    "megahertz"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_used) }
   end
 
   factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
-    description "Used CPU in Cores"
     per_unit    "cores"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_cores_used) }
   end
 
   factory :chargeback_rate_detail_cpu_allocated, :traits => [:daily],
                                                  :parent => :chargeback_rate_detail do
-    description "Allocated CPU Count"
     per_unit    "cpu"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_allocated) }
   end
 
   factory :chargeback_rate_detail_memory_allocated, :traits => [:megabytes, :daily],
                                                     :parent => :chargeback_rate_detail do
-    description "Allocated Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_allocated) }
   end
 
   factory :chargeback_rate_detail_memory_used, :traits => [:megabytes, :hourly],
                                                :parent => :chargeback_rate_detail do
-    description "Used Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_used) }
   end
 
   factory :chargeback_rate_detail_disk_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
-    description "Used Disk I/O in KBps"
     chargeable_field { FactoryGirl.build(:chargeable_field_disk_io_used) }
   end
 
   factory :chargeback_rate_detail_net_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
-    description "Used Network I/O in KBps"
     chargeable_field { FactoryGirl.build(:chargeable_field_net_io_used) }
   end
 
   factory :chargeback_rate_detail_storage_used, :traits => [:gigabytes],
                                                 :parent => :chargeback_rate_detail do
-    description "Used Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_used) }
   end
 
   factory :chargeback_rate_detail_storage_allocated, :traits => [:gigabytes],
                                                      :parent => :chargeback_rate_detail do
-    description "Allocated Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_allocated) }
   end
 
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
-    sequence(:description) { |n| "Fixed Compute Cost #{n}" }
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
 
   factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
-    sequence(:description) { |n| "Fixed Storage Cost #{n}" }
   end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -97,7 +97,4 @@ FactoryGirl.define do
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
-
-  factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
-  end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail do
     group   "unknown"
-    source  "unknown"
     chargeback_rate
     detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency) }
 
@@ -32,16 +31,8 @@ FactoryGirl.define do
     end
   end
 
-  trait :used do
-    source "used"
-  end
-
   trait :fixed do
     group "fixed"
-  end
-
-  trait :allocated do
-    source "allocated"
   end
 
   trait :cpu do
@@ -76,57 +67,57 @@ FactoryGirl.define do
     per_time "hourly"
   end
 
-  factory :chargeback_rate_detail_cpu_used, :traits => [:used, :cpu], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_cpu_used, :traits => [:cpu], :parent => :chargeback_rate_detail do
     description "Used CPU in MHz"
     per_unit    "megahertz"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_used) }
   end
 
-  factory :chargeback_rate_detail_cpu_cores_used, :traits => [:used], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
     description "Used CPU in Cores"
     group       "cpu_cores"
     per_unit    "cores"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_cores_used) }
   end
 
-  factory :chargeback_rate_detail_cpu_allocated, :traits => [:allocated, :cpu, :daily],
+  factory :chargeback_rate_detail_cpu_allocated, :traits => [:cpu, :daily],
                                                  :parent => :chargeback_rate_detail do
     description "Allocated CPU Count"
     per_unit    "cpu"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_allocated) }
   end
 
-  factory :chargeback_rate_detail_memory_allocated, :traits => [:allocated, :memory, :megabytes, :daily],
+  factory :chargeback_rate_detail_memory_allocated, :traits => [:memory, :megabytes, :daily],
                                                     :parent => :chargeback_rate_detail do
     description "Allocated Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_allocated) }
   end
 
-  factory :chargeback_rate_detail_memory_used, :traits => [:used, :memory, :megabytes, :hourly],
+  factory :chargeback_rate_detail_memory_used, :traits => [:memory, :megabytes, :hourly],
                                                :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_used) }
   end
 
-  factory :chargeback_rate_detail_disk_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_disk_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
     description "Used Disk I/O in KBps"
     group       "disk_io"
     chargeable_field { FactoryGirl.build(:chargeable_field_disk_io_used) }
   end
 
-  factory :chargeback_rate_detail_net_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_net_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
     description "Used Network I/O in KBps"
     group       "net_io"
     chargeable_field { FactoryGirl.build(:chargeable_field_net_io_used) }
   end
 
-  factory :chargeback_rate_detail_storage_used, :traits => [:used, :storage_group, :gigabytes],
+  factory :chargeback_rate_detail_storage_used, :traits => [:storage_group, :gigabytes],
                                                 :parent => :chargeback_rate_detail do
     description "Used Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_used) }
   end
 
-  factory :chargeback_rate_detail_storage_allocated, :traits => [:allocated, :storage_group, :gigabytes],
+  factory :chargeback_rate_detail_storage_allocated, :traits => [:storage_group, :gigabytes],
                                                      :parent => :chargeback_rate_detail do
     description "Allocated Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_allocated) }
@@ -134,12 +125,10 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
     sequence(:description) { |n| "Fixed Compute Cost #{n}" }
-    sequence(:source)      { |n| "compute_#{n}" }
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
 
   factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
     sequence(:description) { |n| "Fixed Storage Cost #{n}" }
-    sequence(:source)      { |n| "storage_#{n}" }
   end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     source  "unknown"
     chargeback_rate
     detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency) }
-    detail_measure { FactoryGirl.create(:chargeback_rate_detail_measure) }
 
     transient do
       tiers_params nil

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :chargeback_rate_detail do
-    group   "unknown"
     chargeback_rate
     detail_currency { FactoryGirl.create(:chargeback_rate_detail_currency) }
 
@@ -31,22 +30,6 @@ FactoryGirl.define do
     end
   end
 
-  trait :fixed do
-    group "fixed"
-  end
-
-  trait :cpu do
-    group "cpu"
-  end
-
-  trait :storage_group do
-    group "storage"
-  end
-
-  trait :memory do
-    group "memory"
-  end
-
   trait :megabytes do
     per_unit "megabytes"
   end
@@ -67,7 +50,7 @@ FactoryGirl.define do
     per_time "hourly"
   end
 
-  factory :chargeback_rate_detail_cpu_used, :traits => [:cpu], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do
     description "Used CPU in MHz"
     per_unit    "megahertz"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_used) }
@@ -75,25 +58,24 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
     description "Used CPU in Cores"
-    group       "cpu_cores"
     per_unit    "cores"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_cores_used) }
   end
 
-  factory :chargeback_rate_detail_cpu_allocated, :traits => [:cpu, :daily],
+  factory :chargeback_rate_detail_cpu_allocated, :traits => [:daily],
                                                  :parent => :chargeback_rate_detail do
     description "Allocated CPU Count"
     per_unit    "cpu"
     chargeable_field { FactoryGirl.build(:chargeable_field_cpu_allocated) }
   end
 
-  factory :chargeback_rate_detail_memory_allocated, :traits => [:memory, :megabytes, :daily],
+  factory :chargeback_rate_detail_memory_allocated, :traits => [:megabytes, :daily],
                                                     :parent => :chargeback_rate_detail do
     description "Allocated Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_allocated) }
   end
 
-  factory :chargeback_rate_detail_memory_used, :traits => [:memory, :megabytes, :hourly],
+  factory :chargeback_rate_detail_memory_used, :traits => [:megabytes, :hourly],
                                                :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
     chargeable_field { FactoryGirl.build(:chargeable_field_memory_used) }
@@ -101,34 +83,32 @@ FactoryGirl.define do
 
   factory :chargeback_rate_detail_disk_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
     description "Used Disk I/O in KBps"
-    group       "disk_io"
     chargeable_field { FactoryGirl.build(:chargeable_field_disk_io_used) }
   end
 
   factory :chargeback_rate_detail_net_io_used, :traits => [:kbps], :parent => :chargeback_rate_detail do
     description "Used Network I/O in KBps"
-    group       "net_io"
     chargeable_field { FactoryGirl.build(:chargeable_field_net_io_used) }
   end
 
-  factory :chargeback_rate_detail_storage_used, :traits => [:storage_group, :gigabytes],
+  factory :chargeback_rate_detail_storage_used, :traits => [:gigabytes],
                                                 :parent => :chargeback_rate_detail do
     description "Used Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_used) }
   end
 
-  factory :chargeback_rate_detail_storage_allocated, :traits => [:storage_group, :gigabytes],
+  factory :chargeback_rate_detail_storage_allocated, :traits => [:gigabytes],
                                                      :parent => :chargeback_rate_detail do
     description "Allocated Disk Storage in Bytes"
     chargeable_field { FactoryGirl.build(:chargeable_field_storage_allocated) }
   end
 
-  factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
     sequence(:description) { |n| "Fixed Compute Cost #{n}" }
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
 
-  factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
+  factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
     sequence(:description) { |n| "Fixed Storage Cost #{n}" }
   end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -13,10 +13,7 @@ describe ChargebackContainerImage do
 
   let(:hourly_variable_tier_rate) { {:variable_rate => hourly_rate.to_s} }
 
-  let(:detail_params) do
-    {:chargeback_rate_detail_fixed_compute_cost => { :tiers  => [hourly_variable_tier_rate],
-                                                     :detail => { :source => "compute_1"} } }
-  end
+  let(:detail_params) { {:chargeback_rate_detail_fixed_compute_cost => { :tiers => [hourly_variable_tier_rate] } } }
 
   let!(:chargeback_rate) do
     FactoryGirl.create(:chargeback_rate, :detail_params => detail_params)

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -15,8 +15,7 @@ describe ChargebackContainerProject do
 
   let(:detail_params) do
     {
-      :chargeback_rate_detail_fixed_compute_cost => {:tiers  => [hourly_variable_tier_rate],
-                                                     :detail => { :source => 'compute_1'} },
+      :chargeback_rate_detail_fixed_compute_cost => {:tiers => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_cpu_cores_used     => {:tiers => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_net_io_used        => {:tiers => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]}

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -104,10 +104,7 @@ describe ChargebackRateDetail do
         'monthly',  'megabytes',  rate / 24 / 30,
         'yearly',   'megabytes',  rate / 24 / 365
       ].each_slice(3) do |per_time, per_unit, hourly_rate|
-        cbd = FactoryGirl.build(:chargeback_rate_detail,
-                                :per_time => per_time,
-                                :per_unit => per_unit,
-                                :metric   => 'derived_memory_available')
+        cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => per_time, :per_unit => per_unit)
         expect(cbd.hourly(rate, consumption)).to eq(hourly_rate)
       end
     end
@@ -132,8 +129,7 @@ describe ChargebackRateDetail do
       'megabytes', value,
       'gigabytes', value / 1024,
     ].each_slice(2) do |per_unit, rate_adjustment|
-      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :metric => 'derived_memory_available',
-                                                       :chargeable_field => field)
+      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :chargeable_field => field)
       expect(cbd.rate_adjustment * value).to eq(rate_adjustment)
     end
   end
@@ -195,24 +191,20 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     expect(cbd.rate_type).to eq(rate_type)
   end
 
-  it 'is valid without per_unit and metric' do
-    %w(
-      'cpu' 'derived_vm_numvcpus',
-      nil   nil                  )
-      .each_slice(3) do |per_unit, metric|
-        cbd = FactoryGirl.build(:chargeback_rate_detail,
-                                :chargeable_field => field,
-                                :per_unit         => per_unit,
-                                :metric           => metric)
-        cbt = FactoryGirl.create(:chargeback_tier,
-                                 :chargeback_rate_detail_id => cbd.id,
-                                 :start                     => 0,
-                                 :finish                    => Float::INFINITY,
-                                 :fixed_rate                => 0.0,
-                                 :variable_rate             => 0.0)
-        cbd.update(:chargeback_tiers => [cbt])
-        expect(cbd).to be_valid
-      end
+  it 'is valid without per_unit' do
+    ['cpu', nil].each do |per_unit|
+      cbd = FactoryGirl.build(:chargeback_rate_detail,
+                              :chargeable_field => field,
+                              :per_unit         => per_unit)
+      cbt = FactoryGirl.create(:chargeback_tier,
+                               :chargeback_rate_detail_id => cbd.id,
+                               :start                     => 0,
+                               :finish                    => Float::INFINITY,
+                               :fixed_rate                => 0.0,
+                               :variable_rate             => 0.0)
+      cbd.update(:chargeback_tiers => [cbt])
+      expect(cbd).to be_valid
+    end
   end
 
   it "diferents_per_units_rates_should_have_the_same_cost" do
@@ -220,12 +212,10 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbd_bytes = FactoryGirl.build(:chargeback_rate_detail,
                                   :chargeable_field => field,
                                   :per_unit         => 'bytes',
-                                  :metric           => 'derived_memory_available',
                                   :per_time         => 'monthly')
     cbd_gigabytes = FactoryGirl.build(:chargeback_rate_detail,
                                       :chargeable_field => field,
                                       :per_unit         => 'gigabytes',
-                                      :metric           => 'derived_memory_available',
                                       :per_time         => 'monthly')
     expect(cbd_bytes.hourly_cost(100, consumption)).to eq(cbd_gigabytes.hourly_cost(100, consumption))
   end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -35,8 +35,7 @@ describe ChargebackVm do
       :chargeback_rate_detail_net_io_used        => {:tiers  => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_storage_used       => {:tiers  => [count_hourly_variable_tier_rate]},
       :chargeback_rate_detail_storage_allocated  => {:tiers  => [count_hourly_variable_tier_rate]},
-      :chargeback_rate_detail_fixed_compute_cost => {:tiers  => [hourly_variable_tier_rate],
-                                                     :detail => { :source => 'compute_1'} }
+      :chargeback_rate_detail_fixed_compute_cost => {:tiers  => [hourly_variable_tier_rate]}
     }
   end
 

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -223,8 +223,8 @@ RSpec.describe "chargebacks API" do
                  :description => "rate_0",
                  :enabled     => true
       end.not_to change(ChargebackRateDetail, :count)
-      expect_bad_request(/group can't be blank/i)
-      expect_bad_request(/source can't be blank/i)
+      expect_bad_request(/Chargeback rate can't be blank/i)
+      expect_bad_request(/Chargeable field can't be blank/i)
     end
 
     it "can edit a chargeback rate detail through POST" do

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -2,7 +2,8 @@ module Spec
   module Support
     module ChargebackHelper
       def set_tier_param_for(metric, param, value, num_of_tier = 0)
-        tier = chargeback_rate.chargeback_rate_details.where(:metric => metric).first.chargeback_tiers[num_of_tier]
+        detail = chargeback_rate.chargeback_rate_details.joins(:chargeable_field).where(:chargeable_fields => { :metric => metric }).first
+        tier = detail.chargeback_tiers[num_of_tier]
         tier.send("#{param}=", value)
         tier.save
       end


### PR DESCRIPTION
## What
Part of refactoring: #13375. 

Before we drop cols in chargeback_rate_detail, we should 
 * stop using them
 * and stop setting them in specs

@miq-bot add_label chargeback, technical debt, euwe/no
@miq-bot assign @gtanzillo 