### PR TITLE
Do not look into default rates when searching for Rollup cols to charge on

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -23,4 +23,14 @@ class ChargeableField < ApplicationRecord
     fixture_file = File.join(FIXTURE_DIR, 'chargeable_fields.yml')
     File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
   end
+
+  def self.chargeable_cols_on_metric_rollup
+    existing_cols = MetricRollup.attribute_names
+    chargeable_cols = pluck(:metric) & existing_cols
+    chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }
+  end
+
+  VIRTUAL_COL_USES = {
+    'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
+  }.freeze
 end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -1,4 +1,8 @@
 class ChargeableField < ApplicationRecord
+  VIRTUAL_COL_USES = {
+    'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
+  }.freeze
+
   belongs_to :measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
 
   validates :metric, :uniqueness => true, :presence => true
@@ -29,8 +33,4 @@ class ChargeableField < ApplicationRecord
     chargeable_cols = pluck(:metric) & existing_cols
     chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }
   end
-
-  VIRTUAL_COL_USES = {
-    'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
-  }.freeze
 end

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -1,9 +1,5 @@
 class Chargeback
   class ConsumptionHistory
-    VIRTUAL_COL_USES = {
-      'v_derived_cpu_total_cores_used' => 'cpu_usage_rate_average'
-    }.freeze
-
     def self.for_report(cb_class, options)
       base_rollup = base_rollup_scope
       timerange = options.report_time_range
@@ -42,13 +38,7 @@ class Chargeback
         :parent_storage     => :tags,
         :parent_ems         => :tags)
                                 .select(*Metric::BASE_COLS).order('resource_id, timestamp')
-
-      perf_cols = MetricRollup.attribute_names
-      rate_cols = ChargebackRate.where(:default => true).flat_map do |rate|
-        rate.chargeback_rate_details.map(&:metric).select { |metric| perf_cols.include?(metric.to_s) }
-      end
-      rate_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.flatten!
-      base_rollup.select(*rate_cols)
+      base_rollup.select(*ChargeableField.chargeable_cols_on_metric_rollup)
     end
     private_class_method :base_rollup_scope
   end


### PR DESCRIPTION
## What
Use ChargeableFields instead of default rate to define what cols on metric rollup we can charge.

Also, let's make the code less complex.

@miq-bot add_label chargeback, technical debt, euwe/no
@miq-bot assign @gtanzillo 

