### PR TITLE
specs: Do not seed things you won't need

### DIFF
--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -28,7 +28,6 @@ describe ChargebackContainerImage do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
-    ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
     @node = FactoryGirl.create(:container_node, :name => "node")

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -33,7 +33,6 @@ describe ChargebackContainerProject do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
-    ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
     @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems,

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -65,7 +65,6 @@ describe ChargebackVm do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
-    ChargebackRate.seed
     EvmSpecHelper.create_guid_miq_server_zone
     Timecop.travel(report_run_time)
     vm

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -58,7 +58,6 @@ describe ChargebackVm do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed
-    ChargebackRate.seed
 
     EvmSpecHelper.create_guid_miq_server_zone
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)


### PR DESCRIPTION
## What
Improve performance of chargeback specs.

## How
Chargeback specs consist of many `context`s. Each context needs to run this seed again and again.

## Why
Chargeback calculations are now totally independent of default chargeback_rate.

Yayx! I have dreamed about this for a while. 🍷 

@miq-bot add_label chargeback, test, euwe/no, technical debt, wip
@miq-bot assign @gtanzillo 
