### PR TITLE
Add to network objects to direct rbac

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -7,6 +7,8 @@ module Rbac
     # 3. Class contains acts_as_miq_taggable
     CLASSES_THAT_PARTICIPATE_IN_RBAC = %w(
       AvailabilityZone
+      CloudNetwork
+      CloudSubnet
       CloudTenant
       CloudVolume
       ConfigurationProfile
@@ -27,8 +29,12 @@ module Rbac
       EmsFolder
       ExtManagementSystem
       Flavor
+      FloatingIp
       Host
+      LoadBalancer
       MiqCimInstance
+      NetworkPort
+      NetworkRouter
       OrchestrationTemplate
       OrchestrationStack
       ResourcePool


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1411702

there was requested only for FloatingIP and CloudNetworks in BZ but all objects menu Networks are using tags so added also the rest.

@miq-bot add_label rbac, bug
@miq-bot assign @gtanzillo 
