### PR TITLE
Remove unwanted Application Events from Timeline

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -239,7 +239,7 @@ class EmsEvent < EventStream
 
     target_type = "src_vm_or_template"  if target_type == "src_vm"
     target_type = "dest_vm_or_template" if target_type == "dest_vm"
-    target_type = "middleware_server"   if event.event_type == "hawkular_event"
+    target_type = "middleware_server"   if event.event_type == "hawkular_alert"
 
     event.send(target_type)
   end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers
                                       'firingMatch' => firing_match,
                                       'context'     => context,
                                       'tags'        => {
-                                        'miq.event_type'    => 'hawkular_event',
+                                        'miq.event_type'    => 'hawkular_alert',
                                         'miq.resource_type' => miq_alert[:based_on]
                                       })
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -20,7 +20,9 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
       'hawkular_datasource_remove.ok',
       'hawkular_deployment.ok',
       'hawkular_deployment_remove.ok',
-      'hawkular_event' # # general purpose detail level event
+      'hawkular_event', # general purpose detail level event
+      # filtered (not shown in timeline)
+      'hawkular_alert'
     ].to_set.freeze
   end
 

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -425,17 +425,17 @@ class MiqAlert < ApplicationRecord
           }},
           {:name => :operator, :description => _("Operator"), :values => ["Changed"]}
         ]},
-      {:name => "mw_heap_used", :description => _("JVM Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
+      {:name => "mw_heap_used", :description => _("JVM Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
         :options => [
           {:name => :value_mw_greater_than, :description => _("> Heap Max (%)"), :numeric => true},
           {:name => :value_mw_less_than, :description => _("< Heap Max (%)"), :numeric => true}
         ]},
-      {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
+      {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
         :options => [
           {:name => :value_mw_greater_than, :description => _("> Non Heap Committed (%)"), :numeric => true},
           {:name => :value_mw_less_than, :description => _("< Non Heap Committed (%)"), :numeric => true}
         ]},
-      {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
+      {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
         :options => [
           {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<=", "="]},
           {:name => :value_mw_garbage_collector, :description => _("Duration Per Minute (ms)"), :numeric => true}
@@ -501,7 +501,7 @@ class MiqAlert < ApplicationRecord
 
   def self.raw_events
     @raw_events ||= expression_by_name("event_threshold")[:options].find { |h| h[:name] == :event_types }[:values] +
-                    ['hawkular_event']
+                    ['hawkular_alert']
   end
 
   def self.event_alertable?(event)


### PR DESCRIPTION
Use a new event_type for events used for internally supporting "live alerting" with the hawkular provider.
By not declaring this event_type for the 'Application' event group (or any other group) it will not show up in the timeline.

Fixes Issue #13668 
https://github.com/ManageIQ/manageiq/issues/13668
