### PR TITLE
Fix cid constant namespacing in the API

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -104,7 +104,7 @@ module Api
       end
 
       def href_id(href, collection)
-        if href.present? && href.match(%r{^.*/#{collection}/(#{CID_OR_ID_MATCHER})$})
+        if href.present? && href.match(%r{^.*/#{collection}/(#{BaseController::CID_OR_ID_MATCHER})$})
           from_cid(Regexp.last_match(1))
         end
       end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -1,8 +1,6 @@
 module Api
   class BaseController
     module Parser
-      include CompressedIds
-
       def parse_api_request
         @req = RequestAdapter.new(request, params)
       end

--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -43,7 +43,7 @@ module Api
         return klass.find_by(:guid => guid) if guid.present?
 
         href = data["href"]
-        href =~ %r{^.*/#{collection}/#{CID_OR_ID_MATCHER}$} ? klass.find(from_cid(href.split('/').last)) : {}
+        href =~ %r{^.*/#{collection}/#{BaseController::CID_OR_ID_MATCHER}$} ? klass.find(from_cid(href.split('/').last)) : {}
       end
 
       def policy_subcollection_action(ctype, policy)

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -85,7 +85,7 @@ module Api
 
       def parse_tag_from_href(data)
         href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/#{CID_OR_ID_MATCHER}$})
+        tag  = if href && href.match(%r{^.*/tags/#{BaseController::CID_OR_ID_MATCHER}$})
                  klass = collection_class(:tags)
                  klass.find(from_cid(href.split('/').last))
                end


### PR DESCRIPTION
Does a few things:

1. Qualify CID_OR_ID_MATCHER constant

Modules can use other modules' methods if included together in the same
class, but they can't reference another module's constants
unqualified. Thus, when referencing the `CID_OR_ID_MATCHER` constant,
which is included into `Api::BaseController` via `CompressedIds`, when
used in a module such as `Api::BaseController::Parser` it must be
qualified as `BaseController::CID_OR_ID_MATCHER`.

2. Since the namespacing is fixed, we no longer need to re-include `CompressedIds` in `Parser`

~~3. One of the references to `CID_OR_ID_MATCHER` could be remove, because it is dead code, AFAICT. The intention was to parser a policy href if provided, but if so it will already have been parsed and converted to an id.~~

EDIT: I'll tackle (3) in an follow up

@abellotti can you double check my assumptions here? Also, I'd love to add a test for assigning/unassigning tags by href (as opposed to name/category) but I couldn't get anything to work. Could we look at this together if you want a test? Alternatively I can add one in a follow up.

