### PR TITLE
[api] expose support methods for a Request workflow

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -35,8 +35,8 @@ class MiqRequest < ApplicationRecord
   virtual_column  :stamped_on,           :type => :datetime, :uses => :miq_approvals
   virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
   virtual_column  :v_workflow_class,     :type => :string,   :uses => :workflow
-  virtual_column  :v_supports_pxe?,      :type => :string,   :uses => :workflow
-  virtual_column  :v_supports_iso?,      :type => :string,   :uses => :workflow
+  virtual_column  :v_supports_pxe,       :type => :string,   :uses => :workflow
+  virtual_column  :v_supports_iso,       :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
@@ -45,6 +45,8 @@ class MiqRequest < ApplicationRecord
   delegate :class,                       :to => :workflow,   :prefix => :v_workflow
   delegate :supports_pxe?,               :to => :workflow,   :prefix => :v
   delegate :supports_iso?,               :to => :workflow,   :prefix => :v
+  alias_method :v_supports_pxe, :v_supports_pxe?
+  alias_method :v_supports_iso, :v_supports_iso?
 
   virtual_has_one :workflow
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -35,12 +35,16 @@ class MiqRequest < ApplicationRecord
   virtual_column  :stamped_on,           :type => :datetime, :uses => :miq_approvals
   virtual_column  :v_allowed_tags,       :type => :string,   :uses => :workflow
   virtual_column  :v_workflow_class,     :type => :string,   :uses => :workflow
+  virtual_column  :v_supports_pxe?,      :type => :string,   :uses => :workflow
+  virtual_column  :v_supports_iso?,      :type => :string,   :uses => :workflow
   virtual_column  :request_type_display, :type => :string
   virtual_column  :resource_type,        :type => :string
   virtual_column  :state,                :type => :string
 
   delegate :allowed_tags,                :to => :workflow,   :prefix => :v,  :allow_nil => true
   delegate :class,                       :to => :workflow,   :prefix => :v_workflow
+  delegate :supports_pxe?,               :to => :workflow,   :prefix => :v
+  delegate :supports_iso?,               :to => :workflow,   :prefix => :v
 
   virtual_has_one :workflow
 

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -246,14 +246,17 @@ RSpec.describe "Requests API" do
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class,v_supports_pxe?,v_supports_iso?"
 
       expected_response = a_hash_including(
         "id"               => request.id,
         "workflow"         => a_hash_including("values"),
         "v_allowed_tags"   => [a_hash_including("children")],
         "v_workflow_class" => a_hash_including(
-          "instance_logger" => a_hash_including("klass" => request.workflow.class.to_s))
+          "instance_logger" => a_hash_including("klass" => request.workflow.class.to_s)
+        ),
+        "v_supports_pxe?"  => request.workflow.supports_pxe?,
+        "v_supports_iso?"  => request.workflow.supports_iso?
       )
 
       expect(response.parsed_body).to match(expected_response)

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe "Requests API" do
       request.add_tag(t.name, t.children.first.name)
 
       api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
-      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class,v_supports_pxe?,v_supports_iso?"
+      run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class,v_supports_pxe,v_supports_iso"
 
       expected_response = a_hash_including(
         "id"               => request.id,
@@ -255,8 +255,8 @@ RSpec.describe "Requests API" do
         "v_workflow_class" => a_hash_including(
           "instance_logger" => a_hash_including("klass" => request.workflow.class.to_s)
         ),
-        "v_supports_pxe?"  => request.workflow.supports_pxe?,
-        "v_supports_iso?"  => request.workflow.supports_iso?
+        "v_supports_pxe"   => false,
+        "v_supports_iso"   => false
       )
 
       expect(response.parsed_body).to match(expected_response)


### PR DESCRIPTION
Created a virtual_column for `supports_iso?` and `support_pxe?` which is required to populate tabs in a Request Workflow in SUI

`api/requests/<id>?attributes=v_supports_pxe?,v_supports_iso?`

