### PR TITLE
MiqExpression#fields supports value with an integer

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1628,7 +1628,7 @@ class MiqExpression
         ret = []
         tg = self.class.parse_field_or_tag(val)
         ret << tg if tg
-        tg = self.class.parse_field_or_tag(expression["value"])
+        tg = self.class.parse_field_or_tag(expression["value"].to_s)
         ret << tg if tg
         ret
       else

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2619,7 +2619,7 @@ describe MiqExpression do
       expression = {
         "AND" => [
           {">=" => {"field" => "EmsClusterPerformance-cpu_usagemhz_rate_average", "value" => "0"}},
-          {"<"  => {"field" => "Vm-name", "value" => "5"}}
+          {"<"  => {"field" => "Vm-name", "value" => 5}}
         ]
       }
       actual = described_class.new(expression).fields.sort_by(&:column)
@@ -2636,6 +2636,16 @@ describe MiqExpression do
           {"<"  => {"field" => "Vm.managed-favorite_color", "value" => "5"}}
         ]
       }
+      actual = described_class.new(expression).fields
+      expect(actual).to contain_exactly(
+        an_object_having_attributes(:model => EmsClusterPerformance, :column => "cpu_usagemhz_rate_average"),
+        an_object_having_attributes(:model => Vm, :namespace => "/managed/favorite_color")
+      )
+    end
+
+    it "extracts values" do
+      expression =
+        {">=" => {"field" => "EmsClusterPerformance-cpu_usagemhz_rate_average", "value" => "Vm.managed-favorite_color"}}
       actual = described_class.new(expression).fields
       expect(actual).to contain_exactly(
         an_object_having_attributes(:model => EmsClusterPerformance, :column => "cpu_usagemhz_rate_average"),


### PR DESCRIPTION
reports have an `MiqExpression` with "value" => integer (e.g.: `"value" => 5`)

This allows these to work.

Currently `MiqExpression#fields` is only used for sanity reporting