### PR TITLE
Reports: Use proper class for CloudManager/Vm view

### DIFF
--- a/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
@@ -15,7 +15,7 @@ title: VMs
 name: VMs
 
 # Main DB table report is based on
-db: VmOrTemplate
+db: ManageIQ::Providers::CloudManager::Vm
 
 # Columns to fetch from the main table
 cols:


### PR DESCRIPTION
`VmOrTemplate#availability_zone` does not exist
`CloudVM#availability_zone` does exist.

Updated CloudManager/Vm view to only show Cloud VMs (which it should be doing in the first place)