### PR TITLE
Reports: remove need to declare includes

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -81,7 +81,16 @@ module MiqReport::Generator
   end
 
   def get_include_for_find
-    (include_as_hash || {}).deep_merge(include_for_find || {}).presence
+    (include_as_hash.presence || invent_includes).deep_merge(include_for_find || {}).presence
+  end
+
+  def invent_includes
+    return {} unless col_order
+    col_order.each_with_object({}) do |col, ret|
+      next unless col.include?(".")
+      *rels, _col = col.split(".")
+      rels.inject(ret) { |h, rel| h[rel.to_sym] ||= {} } unless col =~ /managed\./
+    end
   end
 
   def include_as_hash(includes = include, klass = nil)

--- a/product/views/CloudObjectStoreContainer-cloud_object_store_containers.yaml
+++ b/product/views/CloudObjectStoreContainer-cloud_object_store_containers.yaml
@@ -23,19 +23,6 @@ cols:
 - bytes
 - object_count
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_tenant:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreContainer.yaml
+++ b/product/views/CloudObjectStoreContainer.yaml
@@ -23,19 +23,6 @@ cols:
 - bytes
 - object_count
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_tenant:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
+++ b/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
@@ -24,21 +24,6 @@ cols:
 - last_modified
 - etag
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_object_store_container:
-    columns:
-    - key
-  cloud_tenant:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreObject.yaml
+++ b/product/views/CloudObjectStoreObject.yaml
@@ -24,21 +24,6 @@ cols:
 - last_modified
 - etag
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_object_store_container:
-    columns:
-    - key
-  cloud_tenant:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudSubnet.yaml
+++ b/product/views/CloudSubnet.yaml
@@ -26,15 +26,6 @@ cols:
 - dns_nameservers_show
 - total_vms
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudTenant.yaml
+++ b/product/views/CloudTenant.yaml
@@ -22,15 +22,6 @@ cols:
 - name
 - total_vms
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolume-based_volumes.yaml
+++ b/product/views/CloudVolume-based_volumes.yaml
@@ -25,19 +25,6 @@ cols:
 - volume_type
 - bootable
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  availability_zone:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolume.yaml
+++ b/product/views/CloudVolume.yaml
@@ -25,18 +25,6 @@ cols:
 - volume_type
 - bootable
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  availability_zone:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolumeBackup-cloud_volume_backups.yaml
+++ b/product/views/CloudVolumeBackup-cloud_volume_backups.yaml
@@ -23,19 +23,6 @@ cols:
 - size
 - status
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_volume:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
-# Included tables and columns for query performance
-# include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolumeBackup.yaml
+++ b/product/views/CloudVolumeBackup.yaml
@@ -23,16 +23,6 @@ cols:
 - size
 - status
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_volume:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+++ b/product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
@@ -24,16 +24,6 @@ cols:
 - status
 - total_based_volumes
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_volume:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/CloudVolumeSnapshot.yaml
+++ b/product/views/CloudVolumeSnapshot.yaml
@@ -24,16 +24,6 @@ cols:
 - status
 - total_based_volumes
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  cloud_volume:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -22,18 +22,6 @@ cols:
 - name
 - state
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_group:
-    columns:
-    - name
-  container_image:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerBuild.yaml
+++ b/product/views/ContainerBuild.yaml
@@ -24,19 +24,6 @@ cols:
 - output_name
 - completion_deadline_seconds
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerGroup.yaml
+++ b/product/views/ContainerGroup.yaml
@@ -26,18 +26,6 @@ cols:
 - dns_policy
 - running_containers_summary
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerImage.yaml
+++ b/product/views/ContainerImage.yaml
@@ -24,15 +24,6 @@ cols:
 - image_ref
 - display_registry
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerImageRegistry.yaml
+++ b/product/views/ContainerImageRegistry.yaml
@@ -22,14 +22,6 @@ cols:
 - host
 - port
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - host

--- a/product/views/ContainerNode.yaml
+++ b/product/views/ContainerNode.yaml
@@ -25,15 +25,6 @@ cols:
 - kernel_version
 - container_runtime_version
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerProject.yaml
+++ b/product/views/ContainerProject.yaml
@@ -28,15 +28,6 @@ cols:
 - containers_count
 - images_count
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerReplicator.yaml
+++ b/product/views/ContainerReplicator.yaml
@@ -23,18 +23,6 @@ cols:
 - replicas
 - current_replicas
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerRoute.yaml
+++ b/product/views/ContainerRoute.yaml
@@ -21,18 +21,6 @@ db: ContainerRoute
 cols:
 - name
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerService.yaml
+++ b/product/views/ContainerService.yaml
@@ -25,18 +25,6 @@ cols:
 - session_affinity
 - container_groups_count
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerTemplate.yaml
+++ b/product/views/ContainerTemplate.yaml
@@ -21,18 +21,6 @@ db: ContainerTemplate
 cols:
 - name
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  container_project:
-    columns:
-    - name
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/FloatingIp.yaml
+++ b/product/views/FloatingIp.yaml
@@ -22,18 +22,6 @@ cols:
 - address
 - fixed_ip_address
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-  vm:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - address

--- a/product/views/LoadBalancer.yaml
+++ b/product/views/LoadBalancer.yaml
@@ -23,15 +23,6 @@ cols:
 - description
 - total_vms
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
@@ -26,18 +26,6 @@ cols:
 - authentication_status
 - total_configured_systems
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-  provider:
-    columns:
-    - url
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
@@ -27,15 +27,6 @@ cols:
 - total_security_groups
 - total_cloud_networks
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -26,18 +26,6 @@ cols:
 - authentication_status
 - total_configured_systems
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-  provider:
-    columns:
-    - url
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -27,18 +27,6 @@ cols:
 - total_configuration_profiles
 - total_configured_systems
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-  provider:
-    columns:
-    - url
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_StorageManager.yaml
+++ b/product/views/ManageIQ_Providers_StorageManager.yaml
@@ -24,12 +24,6 @@ cols:
 - port
 - region_description
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}

--- a/product/views/MiddlewareDatasource.yaml
+++ b/product/views/MiddlewareDatasource.yaml
@@ -21,17 +21,6 @@ db: MiddlewareDatasource
 cols:
 - name
 
-
-# Included tables (joined, has_one, has_many) and columns
-include:
-  middleware_server:
-    columns:
-    - name
-    - hostname
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareDeployment.yaml
+++ b/product/views/MiddlewareDeployment.yaml
@@ -22,17 +22,6 @@ cols:
 - name
 - status
 
-
-# Included tables (joined, has_one, has_many) and columns
-include:
-  middleware_server:
-    columns:
-    - name
-    - hostname
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareDomain.yaml
+++ b/product/views/MiddlewareDomain.yaml
@@ -22,16 +22,6 @@ cols:
 - name
 - feed
 
-
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareMessaging.yaml
+++ b/product/views/MiddlewareMessaging.yaml
@@ -22,16 +22,6 @@ cols:
 - name
 - messaging_type
 
-
-# Included tables (joined, has_one, has_many) and columns
-include:
-  middleware_server:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareServer.yaml
+++ b/product/views/MiddlewareServer.yaml
@@ -25,15 +25,6 @@ cols:
 - hostname
 
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareServerGroup.yaml
+++ b/product/views/MiddlewareServerGroup.yaml
@@ -23,16 +23,6 @@ cols:
 - name
 - profile
 
-
-# Included tables (joined, has_one, has_many) and columns
-include:
-  middleware_domain:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/NetworkPort.yaml
+++ b/product/views/NetworkPort.yaml
@@ -24,18 +24,6 @@ cols:
 - ipaddresses
 - cloud_subnets_names
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-#  device:
-#    columns:
-#    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/NetworkRouter.yaml
+++ b/product/views/NetworkRouter.yaml
@@ -23,15 +23,6 @@ cols:
 - status
 - total_vms
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/SecurityGroup.yaml
+++ b/product/views/SecurityGroup.yaml
@@ -23,15 +23,6 @@ cols:
 - description
 - total_vms
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  ext_management_system:
-    columns:
-    - name
-
-# Included tables and columns for query performance
-include_for_find:
-
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ServiceTemplateCatalog.yaml
+++ b/product/views/ServiceTemplateCatalog.yaml
@@ -22,15 +22,6 @@ cols:
 - name
 - description
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  tenant:
-    columns:
-      - name
-
-# Included tables and columns for query performance
-include_for_find:
-  
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/VmdbDatabaseConnection.yaml
+++ b/product/views/VmdbDatabaseConnection.yaml
@@ -28,18 +28,6 @@ cols:
 - wait_time
 - command
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-  miq_server:
-    columns:
-    - name
-  miq_worker:
-    columns:
-    - type
-
 # Order of columns (from all tables)
 col_order:
 - zone.name

--- a/product/views/ems_block_storage.yaml
+++ b/product/views/ems_block_storage.yaml
@@ -24,12 +24,6 @@ cols:
 - port
 - region_description
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}

--- a/product/views/ems_object_storage.yaml
+++ b/product/views/ems_object_storage.yaml
@@ -24,12 +24,6 @@ cols:
 - port
 - region_description
 
-# Included tables (joined, has_one, has_many) and columns
-include:
-  zone:
-    columns:
-    - name
-
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}


### PR DESCRIPTION
Blocked:

- [x] #13639 (first 3 commits) - simplification of the includes.

For reports, the columns are stated 2 times:
- `includes` which defines the joined table columns.
- `cols` which defines the database columns in the base table.
- `sort_cols` which defines the joined table columns and the base table columns, and this is ordered.

This change focuses on the unnecessary `includes`. If the value is missing, the report simply derives the value from `sort_cols`.

The long term goal is to just specify the columns once (i.e. `sort_cols`) and not require `includes` or `cols`. (they would be supported, just not required) This will simplify extracting metadata from reports.

@lpichler Just double checking custom attributes with you. Pretty sure they are in `cols` and not `includes` but wanted to double check.