### PR TITLE
Don't send 'next_run=false' to oVirt 3.6

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     state = vm.attributes.fetch_path(:status, :state)
     if state == 'up'
       vm.update_memory(virtual, guaranteed, :next_run => true)
-      vm.update_memory(virtual, nil, :next_run => false)
+      vm.update_memory(virtual, nil)
     else
       vm.update_memory(virtual, guaranteed)
     end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -59,7 +59,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       }
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:status, :state).and_return('up')
       expect(@rhevm_vm).to receive(:update_memory).with(8.gigabytes, 2.gigabytes, :next_run => true)
-      expect(@rhevm_vm).to receive(:update_memory).with(8.gigabytes, nil, :next_run => false)
+      expect(@rhevm_vm).to receive(:update_memory).with(8.gigabytes, nil)
       @ems.vm_reconfigure(@vm, :spec => spec)
     end
 
@@ -79,7 +79,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       adjusted = 8.gigabytes + 256.megabytes
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:status, :state).and_return('up')
       expect(@rhevm_vm).to receive(:update_memory).with(adjusted, 2.gigabytes, :next_run => true)
-      expect(@rhevm_vm).to receive(:update_memory).with(adjusted, nil, :next_run => false)
+      expect(@rhevm_vm).to receive(:update_memory).with(adjusted, nil)
       @ems.vm_reconfigure(@vm, :spec => spec)
     end
 
@@ -90,7 +90,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       adjusted = 8.gigabytes
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:status, :state).and_return('up')
       expect(@rhevm_vm).to receive(:update_memory).with(adjusted, 2.gigabytes, :next_run => true)
-      expect(@rhevm_vm).to receive(:update_memory).with(adjusted, nil, :next_run => false)
+      expect(@rhevm_vm).to receive(:update_memory).with(adjusted, nil)
       @ems.vm_reconfigure(@vm, :spec => spec)
     end
 
@@ -101,7 +101,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       adjusted = 1.gigabyte
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:status, :state).and_return('up')
       expect(@rhevm_vm).to receive(:update_memory).with(1.gigabyte, adjusted, :next_run => true)
-      expect(@rhevm_vm).to receive(:update_memory).with(1.gigabyte, nil, :next_run => false)
+      expect(@rhevm_vm).to receive(:update_memory).with(1.gigabyte, nil)
       @ems.vm_reconfigure(@vm, :spec => spec)
     end
 


### PR DESCRIPTION
In oVirt virtual machines have two sets of settings: the settings used
by the current running virtual machine, and the settings that will be
used the next time the virtual machine is started. To select which one
to update it is necessary to use the 'next_run' parameter. For example,
to update the memory that will be used the next time is started the
API request should be like this:

  PUT /ovirt-engine/api/vms/{vm:id};next_run=true

The value 'false' should tell the server to update the current running
configuration. But in version 3.6 of oVirt it is just ignored, the mere
presence of the 'next_run' parameter is interpreted as a request to
modify the next start settings, regardless of its value.

Currently the oVirt provider uses 'next_run=false' explicitly, and as a
result it fails to update the current settings. This patch changes the
provider so that it doesn't send the 'next_run' parameter when its value
is 'false'.

https://bugzilla.redhat.com/1356468