### PR TITLE
Api collection OPTIONS Enhancement to expose list of supported subcollections

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -436,6 +436,7 @@ module Api
                                        collection.virtual_reflections.keys.collect(&:to_s)).sort
             }
           end
+        options[:subcollections] = Array(collection_config[resource].subcollections).sort
         options[:data] = data
         render :json => options
       end

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -185,10 +185,12 @@ RSpec.describe 'Arbitration Rule API' do
 
       attributes = (ArbitrationRule.attribute_names - ArbitrationRule.virtual_attribute_names).sort.as_json
       reflections = (ArbitrationRule.reflections.keys | ArbitrationRule.virtual_reflections.keys.collect(&:to_s)).sort
+      subcollections = Array(Api::ApiConfig.collections[:arbitration_rules].subcollections).collect(&:to_s).sort
       expected = {
         'attributes'         => attributes,
         'virtual_attributes' => ArbitrationRule.virtual_attribute_names.sort.as_json,
         'relationships'      => reflections,
+        'subcollections'     => subcollections,
         'data'               => {
           'field_values' => ArbitrationRule.field_values
         }

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -656,6 +656,7 @@ describe "Querying" do
         'attributes'         => (Vm.attribute_names - Vm.virtual_attribute_names).sort.as_json,
         'virtual_attributes' => Vm.virtual_attribute_names.sort.as_json,
         'relationships'      => (Vm.reflections.keys | Vm.virtual_reflections.keys.collect(&:to_s)).sort,
+        'subcollections'     => Array(Api::ApiConfig.collections[:vms].subcollections).collect(&:to_s).sort,
         'data'               => {}
       }
       run_options(vms_url)


### PR DESCRIPTION

```
OPTIONS /api/vms

{
  ....
  "subcollections" : [
    "accounts",
    "custom_attributes",
    ...
  ]
  "data" : {
  }
}
```

This enhancement is necessary for continuing work on the API Client to support subcollections.

