### PR TITLE
Change the callback used in UuidMixin

### DIFF
--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -1,7 +1,7 @@
 module UuidMixin
   extend ActiveSupport::Concern
   included do
-    before_validation :set_guid, :on => :create if respond_to?(:before_validation)
+    before_create :set_guid, :on => :create
   end
 
   private


### PR DESCRIPTION
Prior to fab74b285e2d93f85456d9a0985081b5eb7b9aff cloud managers used to
ensure dependent managers (for example network, storage) via
`before_validation`. The above commit changed this to `before_create`.
The `UuidMixin`, which is responsible for setting the GUID of a manager
was consequently only called on the main (cloud) manager, but not for
dependent managers.

This patch proposes to change the `UuidMixin` to use `before_create`
callback.

After this patch is applied, unmodified providers will get their GUIDs.

Missing GUIDs were spotted by @sergio-ocon while trying to accept the changes
on the EBS storage manager.

@miq-bot add_label bug
@miq-bot assign @Fryguy 

cc @blomquisg 