### PR TITLE
Remove dead href parsing paths

### DIFF
--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -42,8 +42,7 @@ module Api
         guid = data["guid"]
         return klass.find_by(:guid => guid) if guid.present?
 
-        href = data["href"]
-        href =~ %r{^.*/#{collection}/#{BaseController::CID_OR_ID_MATCHER}$} ? klass.find(from_cid(href.split('/').last)) : {}
+        {}
       end
 
       def policy_subcollection_action(ctype, policy)

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -80,16 +80,7 @@ module Api
         return {:category => category, :name => name} if category && name
         return tag_path_to_spec(name) if name && name[0] == '/'
 
-        parse_tag_from_href(data)
-      end
-
-      def parse_tag_from_href(data)
-        href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/#{BaseController::CID_OR_ID_MATCHER}$})
-                 klass = collection_class(:tags)
-                 klass.find(from_cid(href.split('/').last))
-               end
-        tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
+        {}
       end
 
       def tag_path_to_spec(path)


### PR DESCRIPTION
If hrefs were supplied in the request body, they should have already
been parsed by `BaseController#update_multiple_collections` and given to
these methods as the id for the resource they represent. So these parts
of the code should been unreachable, and can be replaced by an empty
hash in the event that all other attempts to parse the resource at hand
have failed.

Follow up to #13671

@abellotti no rush on this, just wanted to make this PR so I don't forget about it.

@miq-bot add-label api, technical debt
@miq-bot assign @abellotti 

/cc @jntullo 

:scissors: :scissors: :scissors: 
