### PR TITLE
[WIP] [POC] infer timezone in MiqExpression

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -244,7 +244,7 @@ module MiqReport::Generator
       time_range = Metric::Helper.time_range_from_offset(interval, db_options[:start_offset], db_options[:end_offset])
 
       # Only build where clause from expression for hourly report. It will not work properly for daily because many values are rolled up from hourly.
-      exp_sql, exp_includes = conditions.to_sql(tz) unless conditions.nil? || klass.respond_to?(:instances_are_derived?)
+      exp_sql, exp_includes = conditions.to_sql unless conditions.nil? || klass.respond_to?(:instances_are_derived?)
 
       results = klass.with_interval_and_time_range(interval, time_range)
                      .where(where_clause).where(options[:where_clause]).where(exp_sql)

--- a/lib/miq_expression/relative_datetime.rb
+++ b/lib/miq_expression/relative_datetime.rb
@@ -4,7 +4,7 @@ class MiqExpression::RelativeDatetime
     v.starts_with?("this", "last") || v.ends_with?("ago") || ["today", "yesterday", "now"].include?(v)
   end
 
-  def self.normalize(rel_time, tz, mode = "beginning", is_date = nil)
+  def self.normalize(rel_time, mode = "beginning", is_date = nil)
     # time_spec =
     #   <value> <interval> Ago
     #   "Today"
@@ -17,6 +17,7 @@ class MiqExpression::RelativeDatetime
     #   "This Month"
     #   "This Quarter"
 
+    tz = User.current_user.try(:get_timezone) || "UTC"
     rt = rel_time.downcase
 
     if rt.starts_with?("this", "last")

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -172,7 +172,6 @@ module Rbac
                                                     options[:userid],
                                                     options[:miq_group],
                                                     options[:miq_group_id])
-      tz                     = user.try(:get_timezone)
       attrs                  = {:user_filters => copy_hash(user_filters)}
       ids_clause             = nil
       target_ids             = nil
@@ -207,7 +206,7 @@ module Rbac
 
       user_filters['match_via_descendants'] = to_class(options[:match_via_descendants])
 
-      exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
+      exp_sql, exp_includes, exp_attrs = search_filter.to_sql if search_filter && !klass.try(:instances_are_derived?)
       attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
 
       # for belongs_to filters, scope_targets uses scope to make queries. want to remove limits for those.
@@ -227,7 +226,7 @@ module Rbac
       end
 
       if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
-        rejects     = targets.reject { |obj| matches_search_filters?(obj, search_filter, tz) }
+        rejects     = targets.reject { |obj| matches_search_filters?(obj, search_filter) }
         auth_count -= rejects.length unless options[:skip_counts]
         targets -= rejects
       end
@@ -562,8 +561,8 @@ module Rbac
       MiqPreloader.preload_and_map(sources, :storages)
     end
 
-    def matches_search_filters?(obj, filter, tz)
-      filter.nil? || filter.lenient_evaluate(obj, tz)
+    def matches_search_filters?(obj, filter)
+      filter.nil? || filter.lenient_evaluate(obj)
     end
   end
 end


### PR DESCRIPTION
I'm opening this just for discussion purposes right now....it'll break stuff so DO NOT MERGE!

Some refactorings-in-the-works reveal that the way we pass around timezones in MiqExpression when only a fraction of the operators need it leaves something to be desired. I think the design could be greatly improved if we inferred the timezone either from `User#get_timezone` or `Time.zone`. But I honestly don't know if that is set by every requester, and if it's not what it would take to overcome this. If you have the answer to any of these questions....do get in touch.

/cc @kbrock @gtanzillo 
