### PR TITLE
Introduce Vm/Chargeback tab [backend-part]

### DIFF
--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -9,7 +9,7 @@ class Chargeback
     :tag,                  # like /managed/environment/prod (Mutually exclusive with :user)
     :report_cols,          # cols visible in the final report
     :provide_id,
-    :entity_id,            # 1/2/3.../all rails id of entity
+    :entity_id,            # 1/2/3.../all rails id of entity (ContainerProject or Vm)
     :service_id,
     :groupby,
     :groupby_tag,

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -111,7 +111,9 @@ class ChargebackVm < Chargeback
     @vms ||=
       begin
         # Find Vms by user or by tag
-        if @options[:owner]
+        if @options[:entity_id]
+          Vm.where(:id => @options[:entity_id])
+        elsif @options[:owner]
           user = User.find_by_userid(@options[:owner])
           if user.nil?
             _log.error("Unable to find user '#{@options[:owner]}'. Calculating chargeback costs aborted.")
@@ -137,7 +139,7 @@ class ChargebackVm < Chargeback
           end
           service.vms
         else
-          raise _("must provide options :owner or :tag")
+          raise _('Unable to find strategy for VM selection')
         end
       end
   end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5498,6 +5498,10 @@
         :description: Display Timelines for VMs
         :feature_type: view
         :identifier: vm_timeline
+      - :name: VM's Chargeback
+        :description: Show Chargeback Preview for a VM
+        :feature_type: view
+        :identifier: vm_chargeback
     - :name: Operate
       :description: Perform Operations on VMs
       :feature_type: control

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -197,6 +197,7 @@
   - vm_snapshot
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-auditor
   :read_only: true
@@ -304,6 +305,7 @@
   - vm_snapshot_view
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-desktop
   :read_only: true
@@ -356,6 +358,7 @@
   - vm_shelve
   - vm_shelve_offload
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-operator
   :read_only: true
@@ -493,6 +496,7 @@
   - vm_sync
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-security
   :read_only: true
@@ -591,6 +595,7 @@
   - vm_snapshot_revert
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-support
   :read_only: true
@@ -684,6 +689,7 @@
   - vm_snapshot
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-user
   :read_only: true
@@ -773,6 +779,7 @@
   - vm_snapshot
   - vm_tag
   - vm_timeline
+  - vm_chargeback
 
 - :name: EvmRole-user_limited_self_service
   :read_only: true
@@ -875,6 +882,7 @@
   - vm_sync
   - vm_tag
   - vm_timeline
+  - vm_chargeback
   - vm_vmrc_console
   - vm_vnc_console
   - cockpit_console
@@ -933,6 +941,7 @@
   - vm_sync
   - vm_tag
   - vm_timeline
+  - vm_chargeback
   - vm_vmrc_console
   - vm_vnc_console
   - cockpit_console

--- a/product/charts/miq_reports/vm_chargeback.yaml
+++ b/product/charts/miq_reports/vm_chargeback.yaml
@@ -1,0 +1,203 @@
+title: Chargeback Preview
+name: Chargeback Preview for Single VM
+db: ChargebackVm
+
+cols:
+- display_range
+- chargeback_rates
+- fixed_compute_metric
+- fixed_compute_1_cost
+- fixed_compute_2_cost
+- cpu_allocated_metric
+- cpu_allocated_cost
+- cpu_used_metric
+- cpu_used_cost
+- cpu_cost
+- memory_allocated_metric
+- memory_allocated_cost
+- memory_used_metric
+- memory_used_cost
+- memory_cost
+- disk_io_used_metric
+- disk_io_used_cost
+- net_io_used_metric
+- net_io_used_cost
+- fixed_storage_1_cost
+- fixed_storage_2_cost
+- storage_allocated_metric
+- storage_allocated_cost
+- storage_used_metric
+- storage_used_cost
+- storage_metric
+- storage_cost
+- total_cost
+
+col_order:
+- display_range
+- chargeback_rates
+- fixed_compute_metric
+- fixed_compute_1_cost
+- fixed_compute_2_cost
+- cpu_allocated_metric
+- cpu_allocated_cost
+- cpu_used_metric
+- cpu_used_cost
+- cpu_cost
+- memory_allocated_metric
+- memory_allocated_cost
+- memory_used_metric
+- memory_used_cost
+- memory_cost
+- disk_io_used_metric
+- disk_io_used_cost
+- net_io_used_metric
+- net_io_used_cost
+- fixed_storage_1_cost
+- fixed_storage_2_cost
+- storage_allocated_metric
+- storage_allocated_cost
+- storage_used_metric
+- storage_used_cost
+- storage_metric
+- storage_cost
+- total_cost
+
+headers:
+- Day
+- Chargeback Rates
+- Fixed Compute Metric
+- Fixed Compute Cost 1
+- Fixed Compute Cost 2
+- vCPUs Allocated over Time Period
+- vCPUs Allocated Cost
+- CPU Used
+- CPU Used Cost
+- CPU Total Cost
+- Memory Allocated over Time Period
+- Memory Allocated Cost
+- Memory Used
+- Memory Used Cost
+- Memory Total Cost
+- Disk I/O Used
+- Disk I/O Used Cost
+- Network I/O Used
+- Network I/O Used Cost
+- Fixed Storage Cost 1
+- Fixed Storage Cost 2
+- Storage Allocated
+- Storage Allocated Cost
+- Storage Used
+- Storage Used Cost
+- Storage Total
+- Storage Total Cost
+- Total Cost
+
+order: Ascending
+
+sortby:
+- vm_name
+- start_date
+
+group: y
+template_type: report
+db_options:
+  :rpt_type: ChargebackVm
+  :options:
+    :interval: daily
+    :interval_size: 14
+    :end_interval_offset: 1
+    :groupby: date
+col_formats:
+tz: UTC
+time_profile_id:
+display_filter:
+col_options:
+  cpu_allocated_cost:
+    :grouping:
+    - :total
+  cpu_allocated_metric:
+    :grouping:
+    - :total
+  cpu_cost:
+    :grouping:
+    - :total
+  cpu_metric:
+    :grouping:
+    - :total
+  cpu_used_cost:
+    :grouping:
+    - :total
+  cpu_used_metric:
+    :grouping:
+    - :total
+  disk_io_used_cost:
+    :grouping:
+    - :total
+  disk_io_used_metric:
+    :grouping:
+    - :total
+  fixed_compute_metric:
+    :grouping:
+    - :total
+  fixed_compute_1_cost:
+    :grouping:
+    - :total
+  fixed_compute_2_cost:
+    :grouping:
+    - :total
+  fixed_cost:
+    :grouping:
+    - :total
+  fixed_storage_1_cost:
+    :grouping:
+    - :total
+  fixed_storage_2_cost:
+    :grouping:
+    - :total
+  memory_allocated_cost:
+    :grouping:
+    - :total
+  memory_allocated_metric:
+    :grouping:
+    - :total
+  memory_cost:
+    :grouping:
+    - :total
+  memory_metric:
+    :grouping:
+    - :total
+  memory_used_cost:
+    :grouping:
+    - :total
+  memory_used_metric:
+    :grouping:
+    - :total
+  net_io_used_cost:
+    :grouping:
+    - :total
+  net_io_used_metric:
+    :grouping:
+    - :total
+  storage_allocated_cost:
+    :grouping:
+    - :total
+  storage_allocated_metric:
+    :grouping:
+    - :total
+  storage_cost:
+    :grouping:
+    - :total
+  storage_metric:
+    :grouping:
+    - :total
+  storage_used_cost:
+    :grouping:
+    - :total
+  storage_used_metric:
+    :grouping:
+    - :total
+  total_cost:
+    :grouping:
+    - :total
+rpt_options:
+  :page_size: US-Letter


### PR DESCRIPTION
For the ability to quickly view chargeback of a single VM. That is useful to get a quick notion of costs associated with the given VM.

@miq-bot add_label chargeback, enhancement, euwe/no
@miq-bot assign @martinpovolny 