### PR TITLE
Add MiqUserRole to RBAC

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -17,7 +17,7 @@ class MiqGroup < ApplicationRecord
   virtual_column :miq_user_role_name, :type => :string,  :uses => :miq_user_role
   virtual_column :read_only,          :type => :boolean
 
-  delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
+  delegate :self_service?, :limited_self_service?, :disallowed_roles, :to => :miq_user_role, :allow_nil => true
 
   validates :description, :presence => true, :unique_within_region => true
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
@@ -41,6 +41,10 @@ class MiqGroup < ApplicationRecord
 
   def name
     description
+  end
+
+  def self.with_allowed_roles_for(user_or_group)
+    includes(:miq_user_role).where.not({:miq_user_roles => {:name => user_or_group.disallowed_roles}})
   end
 
   def self.next_sequence

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -66,6 +66,14 @@ class MiqUserRole < ApplicationRecord
     (settings || {}).fetch_path(:restrictions, :vms) == :user
   end
 
+  def disallowed_roles
+    !super_admin_user? && Rbac::Filterer::DISALLOWED_ROLES_FOR_USER_ROLE[name]
+  end
+
+  def self.with_allowed_roles_for(user_or_group)
+    where.not(:name => user_or_group.disallowed_roles)
+  end
+
   def self.seed
     seed_from_array(YAML.load_file(FIXTURE_YAML))
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
 
   delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
              :to => :current_group, :allow_nil => true
-  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?,
+  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?, :disallowed_roles,
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -51,6 +51,13 @@ module Rbac
       Storage
     )
 
+    # key: MiqUserRole#name - user's role
+    # value:
+    #   array - disallowed roles for the user's role
+    DISALLOWED_ROLES_FOR_USER_ROLE = {
+      'EvmRole-tenant_administrator' => %w(EvmRole-super_administrator)
+    }.freeze
+
     # key: descendant::klass
     # value:
     #   if it is a symbol/method_name:

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -448,6 +448,9 @@ module Rbac
       elsif klass == MiqGroup && miq_group.try!(:self_service?)
         # Self Service users searching for groups only see their group
         scope.where(:id => miq_group.id)
+      elsif [MiqUserRole, MiqGroup].include?(klass) && (user_or_group = miq_group || user) &&
+            user_or_group.disallowed_roles
+        scope.with_allowed_roles_for(user_or_group)
       else
         scope
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -331,6 +331,32 @@ describe Rbac::Filterer do
           get_rbac_results_for_and_expect_objects(MiqGroup, [user.current_group])
         end
       end
+
+      context 'with EvmRole-tenant_administrator' do
+        let(:tenant_administrator_user_role) do
+          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::DEFAULT_TENANT_ROLE_NAME)
+        end
+
+        let!(:super_administrator_user_role) do
+          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::SUPER_ADMIN_ROLE_NAME)
+        end
+
+        let(:group) do
+          FactoryGirl.create(:miq_group, :tenant => default_tenant, :miq_user_role => tenant_administrator_user_role)
+        end
+
+        let!(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+        it 'can see all roles expect to EvmRole-super_administrator' do
+          expect(MiqUserRole.count).to eq(2)
+          get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role])
+        end
+
+        it 'can see all groups expect to group with role EvmRole-super_administrator' do
+          expect(MiqUserRole.count).to eq(2)
+          get_rbac_results_for_and_expect_objects(MiqGroup, [group])
+        end
+      end
     end
 
     context "with Hosts" do


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/135

For now just fix the mentioned issue.

Hide super_administator role for Users and Groups with tenant_admininistrator role 

@miq-bot add_label rbac, bug

cc @martinpovolny 

@miq-bot assign @gtanzillo  
