### PR TITLE
[EUWE] Fix the placement of the Smart Management on summary pages

### DIFF
--- a/app/views/cloud_network/_main.html.haml
+++ b/app/views/cloud_network/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/cloud_subnet/_main.html.haml
+++ b/app/views/cloud_subnet/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/floating_ip/_main.html.haml
+++ b/app/views/floating_ip/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/load_balancer/_main.html.haml
+++ b/app/views/load_balancer/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/network_port/_main.html.haml
+++ b/app/views/network_port/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/network_router/_main.html.haml
+++ b/app/views/network_router/_main.html.haml
@@ -4,6 +4,4 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-.row
-  .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}


### PR DESCRIPTION
before:
![screenshot from 2017-01-30 16-37-08](https://cloud.githubusercontent.com/assets/2270962/22429292/684a012c-e70a-11e6-921c-c1cdb3a2c48e.png)

after:
![screenshot from 2017-01-30 16-31-04](https://cloud.githubusercontent.com/assets/2270962/22429353/9951d786-e70a-11e6-875a-36a4336c0656.png)

I've noticed that more views had the same issue (probably copy & paste code) , so I've fixed also other views under Networks.

https://bugzilla.redhat.com/show_bug.cgi?id=1400471