### PR TITLE
Parse fields by MiqExpression::Field in value2tag

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -725,24 +725,8 @@ class MiqExpression
   end
 
   def self.value2tag(tag, val = nil)
-    tag, virtual_custom_attribute = escape_virtual_custom_attribute(tag)
-    model, *values = tag.to_s.gsub(/[\.-]/, "/").split("/") # replace model path ".", column name "-" with "/"
-    values.map!{ |x|  URI::RFC2396_Parser.new.unescape(x) } if virtual_custom_attribute
-
-    case values.first
-    when "user_tag"
-      values[0] = "user"
-    when "managed", "user"
-      # Keep as-is
-    else
-      values.unshift("virtual") # add in tag designation
-    end
-
-    unless val.nil?
-      values << val.to_s.gsub(/\//, "%2f") # encode embedded / characters in values since / is used as a tag seperator
-    end
-
-    [model.downcase, "/#{values.join('/')}"]
+    target = parse_field_or_tag(tag)
+    [target.model.to_s.downcase, target.tag_path_with(val)]
   end
 
   def self.normalize_ruby_operator(str)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -190,7 +190,7 @@ class MiqExpression
     when "contains"
       op_args["tag"] ||= col_name
       operands = if context_type != "hash"
-                   ref, val = value2tag(preprocess_managed_tag(op_args["tag"]), op_args["value"])
+                   ref, val = value2tag(op_args["tag"], op_args["value"])
                    ["<exist ref=#{ref}>#{val}</exist>"]
                  elsif context_type == "hash"
                    # This is only for supporting reporting "display filters"
@@ -700,19 +700,6 @@ class MiqExpression
   # Escape any unescaped forward slashes and/or interpolation
   def self.sanitize_regular_expression(string)
     string.gsub(%r{\\*/}, "\\/").gsub(/\\*#/, "\\\#")
-  end
-
-  def self.preprocess_managed_tag(tag)
-    path, val = tag.split("-")
-    path_arr = path.split(".")
-    if path_arr.include?("managed") || path_arr.include?("user_tag")
-      name = nil
-      while path_arr.first != "managed" && path_arr.first != "user_tag"
-        name = path_arr.shift
-      end
-      return [name].concat(path_arr).join(".") + "-" + val
-    end
-    tag
   end
 
   def self.escape_virtual_custom_attribute(attribute)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1236,11 +1236,7 @@ class MiqExpression
 
   def self.parse_field_or_tag(str)
     # managed.location, Model.x.y.managed-location
-    if str =~ /(^|[.])managed[-.]/
-      MiqExpression::Tag.parse(str)
-    else
-      Field.parse(str)
-    end
+    MiqExpression::Field.parse(str) || MiqExpression::CountField.parse(str) || MiqExpression::Tag.parse(str)
   end
 
   def fields(expression = exp)

--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -17,4 +17,10 @@ class MiqExpression::CountField < MiqExpression::Target
   def initialize(model, associations)
     super(model, associations, nil)
   end
+
+  private
+
+  def tag_values
+    ['virtual'] + @associations
+  end
 end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -42,4 +42,10 @@ class MiqExpression::Tag < MiqExpression::Target
   def attribute_supported_by_sql?
     false
   end
+
+  private
+
+  def tag_path
+    @namespace
+  end
 end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -66,6 +66,17 @@ class MiqExpression::Target
   end
 
   def tag_path_with(value = nil)
-    ''
+    # encode embedded / characters in values since / is used as a tag seperator
+    "#{tag_path}#{value.nil? ? '' : '/' + value.to_s.gsub(/\//, "%2f")}"
+  end
+
+  private
+
+  def tag_path
+    "/#{tag_values.join('/')}"
+  end
+
+  def tag_values
+    ['virtual'] + @associations + [@column]
   end
 end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -64,4 +64,8 @@ class MiqExpression::Target
       reflections.last.klass
     end
   end
+
+  def tag_path_with(value = nil)
+    ''
+  end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1754,41 +1754,37 @@ describe MiqExpression do
     end
   end
 
-  context "value2tag" do
-    it "virtual default" do
-      expect(described_class.value2tag("env")).to eq ["env", "/virtual"]
+  context 'value2tag' do
+    it 'dotted notation with CountField' do
+      expect(described_class.value2tag('Vm.disks')).to eq ['vm', '/virtual/disks']
     end
 
-    it "dotted notation" do
-      expect(described_class.value2tag("env.prod.ny")).to eq ["env", "/virtual/prod/ny"]
-    end
-
-    it "with value" do
-      expect(described_class.value2tag("env", "thing1")).to eq ["env", "/virtual/thing1"]
+    it 'dotted notation with CountField' do
+      expect(described_class.value2tag('Vm.host.policy_events')).to eq ['vm', '/virtual/host/policy_events']
     end
 
     it "dotted notation with value" do
-      expect(described_class.value2tag("env.prod.ny", "thing1")).to eq ["env", "/virtual/prod/ny/thing1"]
+      expect(described_class.value2tag("Vm.host-name", "thing1")).to eq ["vm", "/virtual/host/name/thing1"]
     end
 
     it "value with escaped slash" do
-      expect(described_class.value2tag("env.prod.ny", "thing1/thing2")).to eq ["env", "/virtual/prod/ny/thing1%2fthing2"]
+      expect(described_class.value2tag("Vm.host-name", "thing1/thing2")).to eq ["vm", "/virtual/host/name/thing1%2fthing2"]
     end
 
     it "user_tag" do
-      expect(described_class.value2tag("env.user_tag.ny", "thing1")).to eq ["env", "/user/ny/thing1"]
+      expect(described_class.value2tag("Vm.user_tag-name", "thing1")).to eq ["vm", "/user/name/thing1"]
     end
 
     it "model and column" do
-      expect(described_class.value2tag("env.vm-name", "thing1")).to eq ["env", "/virtual/vm/name/thing1"]
+      expect(described_class.value2tag("Vm-name", "thing1")).to eq ["vm", "/virtual/name/thing1"]
     end
 
     it "managed" do
-      expect(described_class.value2tag("env.managed.host", "thing1")).to eq ["env", "/managed/host/thing1"]
+      expect(described_class.value2tag("Vm.managed-host", "thing1")).to eq ["vm", "/managed/host/thing1"]
     end
 
     it "managed" do
-      expect(described_class.value2tag("env.managed.host")).to eq ["env", "/managed/host"]
+      expect(described_class.value2tag("Vm.managed-host")).to eq ["vm", "/managed/host"]
     end
 
     it "false value" do


### PR DESCRIPTION
This is basically replacing commit https://github.com/ManageIQ/manageiq/pull/11112/commits/8a6626d8b3a894bd4a82339f981498f25d000fb6

I want to parse virtual custom attributes in MiqExpression::Field similarly as here https://github.com/ManageIQ/manageiq/pull/11112/commits/6fbce18e993364777ff0c885876f4a6ccddbfb1f with some special characters in addition.

and parsing fields in MiqExpression is going thru `value2tag` so I need to add this part to parsing by MiqExpression::Field and do it from on place.


please review @imtayadeway 
@miq-bot assign @gtanzillo 


