### PR TITLE
Merge inflections initializers & extract them from config/application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -107,40 +107,7 @@ module Vmdb
     end
 
     initializer :load_inflections, :before => :load_vmdb_settings do
-      # Add new inflection rules using the following format
-      # (all these examples are active by default):
-      # ActiveSupport::Inflector.inflections do |inflect|
-      #   inflect.plural /^(ox)$/i, '\1en'
-      #   inflect.singular /^(ox)en/i, '\1'
-      #   inflect.irregular 'person', 'people'
-      #   inflect.uncountable %w( fish sheep )
-      # end
-      ActiveSupport::Inflector.inflections do |inflect|
-        inflect.singular(/class$/, "class")
-        inflect.singular(/Class$/, "Class")
-        inflect.singular(/OsProcess$/, "OsProcess")
-        inflect.singular(/osprocess$/, "osprocess")
-        inflect.singular(/vms_and_templates$/, "vm_or_template")
-        inflect.plural(/vm_or_template$/, "vms_and_templates")
-        inflect.singular(/VmsAndTemplates$/, "VmOrTemplate")
-        inflect.plural(/VmOrTemplate$/, "VmsAndTemplates")
-        inflect.singular(/Indexes$/, "Index")       # for Class name(s)
-        inflect.plural(/Index$/, "Indexes")         # for Class name(s)
-        inflect.singular(/indexes$/, "index")       # for table name(s)
-        inflect.plural(/index$/, "indexes")         # for table name(s)
-        inflect.plural(/VM and Instance$/, "VMs and Instances")
-        inflect.plural(/VM Template and Image$/, "VM Templates and Images")
-        inflect.singular(/Queue$/, "Queue")       # for Class name(s)
-        inflect.plural(/Queue$/, "Queue")         # for Class name(s)
-        inflect.singular(/queue$/, "queue")       # for table name(s)
-        inflect.plural(/queue$/, "queue")         # for table name(s)
-        inflect.singular(/quota$/, "quota")
-        inflect.singular(/Quota$/, "Quota")
-        inflect.plural(/quota$/, "quotas")
-        inflect.irregular("container_quota", "container_quotas")
-
-        inflect.acronym 'ManageIQ'
-      end
+      Vmdb::Inflections.load_inflections
     end
 
     # Note: If an initializer doesn't have an after, Rails will add one based

--- a/config/initializers/as_inflections.rb
+++ b/config/initializers/as_inflections.rb
@@ -1,3 +1,0 @@
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.singular(/(base)s$/i, '\1') # Override rails default: "bases".singularize => "base" not "basis"
-end

--- a/lib/vmdb/inflections.rb
+++ b/lib/vmdb/inflections.rb
@@ -1,0 +1,41 @@
+module Vmdb
+  module Inflections
+    def self.load_inflections
+      # Add new inflection rules using the following format
+      # (all these examples are active by default):
+      # ActiveSupport::Inflector.inflections do |inflect|
+      #   inflect.plural /^(ox)$/i, '\1en'
+      #   inflect.singular /^(ox)en/i, '\1'
+      #   inflect.irregular 'person', 'people'
+      #   inflect.uncountable %w( fish sheep )
+      # end
+      ActiveSupport::Inflector.inflections do |inflect|
+        inflect.singular(/(base)s$/i, '\1') # Override rails default: "bases".singularize => "base" not "basis"
+        inflect.singular(/class$/, "class")
+        inflect.singular(/Class$/, "Class")
+        inflect.singular(/OsProcess$/, "OsProcess")
+        inflect.singular(/osprocess$/, "osprocess")
+        inflect.singular(/vms_and_templates$/, "vm_or_template")
+        inflect.plural(/vm_or_template$/, "vms_and_templates")
+        inflect.singular(/VmsAndTemplates$/, "VmOrTemplate")
+        inflect.plural(/VmOrTemplate$/, "VmsAndTemplates")
+        inflect.singular(/Indexes$/, "Index")       # for Class name(s)
+        inflect.plural(/Index$/, "Indexes")         # for Class name(s)
+        inflect.singular(/indexes$/, "index")       # for table name(s)
+        inflect.plural(/index$/, "indexes")         # for table name(s)
+        inflect.plural(/VM and Instance$/, "VMs and Instances")
+        inflect.plural(/VM Template and Image$/, "VM Templates and Images")
+        inflect.singular(/Queue$/, "Queue")       # for Class name(s)
+        inflect.plural(/Queue$/, "Queue")         # for Class name(s)
+        inflect.singular(/queue$/, "queue")       # for table name(s)
+        inflect.plural(/queue$/, "queue")         # for table name(s)
+        inflect.singular(/quota$/, "quota")
+        inflect.singular(/Quota$/, "Quota")
+        inflect.plural(/quota$/, "quotas")
+        inflect.irregular("container_quota", "container_quotas")
+
+        inflect.acronym 'ManageIQ'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on feedback from https://github.com/ManageIQ/manageiq/pull/13632#pullrequestreview-18946512

@Fryguy let me know what you think of this.  I felt like the inflections themselves shouldn't pollute `config/application.rb`.  That's why I moved them.