### PR TITLE
Use skip instead of pending

### DIFF
--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -370,7 +370,7 @@ describe "Providers API" do
         let(:containers_class) { klass }
 
         it "supports creation with auth_key specified" do
-          pending if name != "Openshift"
+          skip if name != "Openshift"
 
           api_basic_authorize collection_action_identifier(:providers, :create)
 


### PR DESCRIPTION
`pending` will run the failing test and report a backtrace which adds
a lot of noise - using `skip` will still report that there are pending
specs but with a minimum of noise.

@miq-bot add-label test, api
@miq-bot assign @abellotti 