### PR TITLE
Bulk tag multiple services

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1550,6 +1550,8 @@
         :identifier: service_admin
       - :name: suspend
         :identifier: service_admin
+      - :name: assign_tags
+        :identifier: service_tag
     :resource_actions:
       :get:
       - :name: read

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -645,4 +645,152 @@ describe "Tag Collections API" do
       expect(response.parsed_body).to include(expected)
     end
   end
+
+  context 'Services assign_tags action' do
+    let(:bad_tag) { {:category => "cc", :name => "002"} }
+    let(:service1)                { FactoryGirl.create(:service) }
+    let(:service2)                { FactoryGirl.create(:service) }
+
+    it 'can bulk assign tags to multiple services' do
+      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      request_body = {
+        'action'    => 'assign_tags',
+        'resources' => [
+          { 'id' => service1.id, 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'id' => service2.id, 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+        ]
+      }
+
+      run_post(services_url, request_body)
+
+      expected = {
+        'results' => [
+          a_hash_including('success'      => true,
+                           'tag_category' => tag1[:category],
+                           'tag_name'     => tag1[:name]),
+          a_hash_including('success'      => true,
+                           'tag_category' => tag2[:category],
+                           'tag_name'     => tag2[:name])
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can bulk assign tags to multiple services by href' do
+      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      request_body = {
+        'action'    => 'assign_tags',
+        'resources' => [
+          { 'href' => services_url(service1.id), 'tags' => [{ 'category' => tag1[:category], 'name' => tag1[:name] }] },
+          { 'href' => services_url(service2.id), 'tags' => [{ 'category' => tag2[:category], 'name' => tag2[:name] }] }
+        ]
+      }
+
+      run_post(services_url, request_body)
+
+      expected = {
+        'results' => [
+          a_hash_including('success'      => true,
+                           'tag_category' => tag1[:category],
+                           'tag_name'     => tag1[:name]),
+          a_hash_including('success'      => true,
+                           'tag_category' => tag2[:category],
+                           'tag_name'     => tag2[:name])
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'will return success and failure messages for each service and tag' do
+      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      request_body = {
+        'action'    => 'assign_tags',
+        'resources' => [
+          { 'id' => 999_999, 'tags' => [{'category' => 'department', 'name' => 'finance'}] },
+          { 'id' => service2.id, 'tags' => [
+            {'category' => bad_tag[:category], 'name' => bad_tag[:name]},
+            {'category' => tag1[:category], 'name' => tag1[:name]}
+          ]}
+        ]
+      }
+
+      run_post(services_url, request_body)
+
+      expected = {
+        'results' => [
+          a_hash_including('success' => false, 'message' => a_string_including("Couldn't find Service")),
+          a_hash_including('success'      => false,
+                           'tag_category' => bad_tag[:category],
+                           'tag_name'     => bad_tag[:name]),
+          a_hash_including('success'      => true,
+                           'tag_category' => tag1[:category],
+                           'tag_name'     => tag1[:name])
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'fails without an appropriate role' do
+      api_basic_authorize
+
+      run_post(services_url, :action => 'assign_tags')
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can bulk assign tags by href' do
+      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      request_body = {
+        'action'    => 'assign_tags',
+        'resources' => [
+          { 'id' => service1.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag1[:path]).id)}] },
+          { 'id' => service2.id, 'tags' => [{'href' => tags_url(Tag.find_by(:name => tag2[:path]).id)}] }
+        ]
+      }
+
+      run_post(services_url, request_body)
+
+      expected = {
+        'results' => [
+          a_hash_including('success'      => true,
+                           'tag_category' => tag1[:category],
+                           'tag_name'     => tag1[:name]),
+          a_hash_including('success'      => true,
+                           'tag_category' => tag2[:category],
+                           'tag_name'     => tag2[:name])
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can bulk assign tags by id' do
+      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      request_body = {
+        'action'    => 'assign_tags',
+        'resources' => [
+          { 'id' => service1.id, 'tags' => [{'id' => Tag.find_by(:name => tag1[:path]).id}] },
+          { 'id' => service2.id, 'tags' => [{'id' => Tag.find_by(:name => tag2[:path]).id}] }
+        ]
+      }
+
+      run_post(services_url, request_body)
+
+      expected = {
+        'results' => [
+          a_hash_including('success'      => true,
+                           'tag_category' => tag1[:category],
+                           'tag_name'     => tag1[:name]),
+          a_hash_including('success'      => true,
+                           'tag_category' => tag2[:category],
+                           'tag_name'     => tag2[:name])
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Bulk tag multiple services

Sample request:
```
POST /api/services
{ 
  "action" : "assign_tags",
  "resources" : [
    { "href" : "http://localhost:3000/services/11", "tags" : [ { "category" : "department", "name" : "finance" } ]} 
    { "href" : "http://localhost:3000/services/12", "tags" : [ { "category" : "department", "name" : "finance" }]}
  ]
}
```
Links 
----------------
* [Pivotal ticket](https://www.pivotaltracker.com/story/show/136355609)

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 
