### PR TITLE
Only generate vpor for the TimeProfile specified, not all TimeProfiles

### DIFF
--- a/app/models/metric/ci_mixin/long_term_averages.rb
+++ b/app/models/metric/ci_mixin/long_term_averages.rb
@@ -10,14 +10,9 @@ module Metric::CiMixin::LongTermAverages
     end
   end
 
-  def generate_vim_performance_operating_ranges
-    # TODO: Support generation for all known TimeProfiles
-    generate_vim_performance_operating_range(TimeProfile.default_time_profile)
-  end
-
-  private
-
   def generate_vim_performance_operating_range(time_profile)
+    return unless time_profile.default? # TODO: Support all TimeProfiles
+
     vpor = vim_performance_operating_ranges
            .create_with(:days => Metric::LongTermAverages::AVG_DAYS)
            .find_or_create_by(:time_profile => time_profile)
@@ -25,8 +20,10 @@ module Metric::CiMixin::LongTermAverages
     vpor.save!
   end
 
+  private
+
   def averages_over_time_period(col, typ)
-    # TODO: Deal with choosing the right TimeProfile.  See #generate_vim_performance_operating_ranges
+    # TODO: Deal with choosing the right TimeProfile.  See #generate_vim_performance_operating_range
     #   For now just use the one vpor which is tied to the default TimeProfile.
     vpor = vim_performance_operating_ranges.first
     vpor.nil? ? 0 : vpor.values_to_metrics["#{col}_#{typ}_over_time_period"]

--- a/app/models/metric/ci_mixin/long_term_averages.rb
+++ b/app/models/metric/ci_mixin/long_term_averages.rb
@@ -25,7 +25,7 @@ module Metric::CiMixin::LongTermAverages
   def averages_over_time_period(col, typ)
     # TODO: Deal with choosing the right TimeProfile.  See #generate_vim_performance_operating_range
     #   For now just use the one vpor which is tied to the default TimeProfile.
-    vpor = vim_performance_operating_ranges.first
+    vpor = vim_performance_operating_ranges.detect(&:time_profile_id)
     vpor.nil? ? 0 : vpor.values_to_metrics["#{col}_#{typ}_over_time_period"]
   end
 end

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -93,6 +93,10 @@ class TimeProfile < ApplicationRecord
     days.sort == ALL_DAYS && hours.sort == ALL_HOURS
   end
 
+  def default?
+    entire_tz? && tz_or_default == DEFAULT_TZ
+  end
+
   def rebuild_daily_metrics
     oldest_hourly = MetricRollup.select(:timestamp).where(:capture_interval_name => "hourly").order(:timestamp).first
     destroy_metric_rollups

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -421,6 +421,12 @@ describe Metric do
             expect(perf.abs_min_cpu_usage_rate_average_value).to eq(1.0)
             expect(perf.abs_min_cpu_usage_rate_average_timestamp.utc.iso8601).to eq("2010-04-14T18:00:40Z")
           end
+
+          it "will have created an operating range" do
+            vpors = @vm1.vim_performance_operating_ranges
+            expect(vpors.size).to               eq(1)
+            expect(vpors.first.time_profile).to eq(@time_profile)
+          end
         end
 
         context "calling perf_rollup_range to daily on the Vm" do
@@ -611,7 +617,7 @@ describe Metric do
         end
       end
 
-      context "#generate_vim_performance_operating_ranges" do
+      context "#generate_vim_performance_operating_range" do
         before do
           Timecop.travel(Time.parse("2010-05-01T00:00:00Z"))
           cases = [
@@ -644,7 +650,7 @@ describe Metric do
         end
 
         it "should calculate the correct normal operating range values" do
-          @vm1.generate_vim_performance_operating_ranges
+          @vm1.generate_vim_performance_operating_range(@time_profile)
 
           expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.692)
           expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.085)
@@ -653,8 +659,8 @@ describe Metric do
         it "should calculate the correct right-size values" do
           allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:mem_recommendation_minimum).and_return(0)
 
-          @vm1.generate_vim_performance_operating_ranges
-          @vm2.generate_vim_performance_operating_ranges
+          @vm1.generate_vim_performance_operating_range(@time_profile)
+          @vm2.generate_vim_performance_operating_range(@time_profile)
 
           expect(@vm1.recommended_vcpus).to eq(1)
           expect(@vm1.recommended_mem).to eq(4)

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -11,6 +11,18 @@ describe TimeProfile do
     expect(t.tz).to be_nil
   end
 
+  describe "#default?" do
+    it "with a default profile" do
+      tp = TimeProfile.seed
+      expect(tp).to be_default
+    end
+
+    it "with a non-default profile" do
+      tp = FactoryGirl.create(:time_profile, :tz => "Hawaii")
+      expect(tp).to_not be_default
+    end
+  end
+
   context "will seed the database" do
     before(:each) do
       TimeProfile.seed


### PR DESCRIPTION
This fixes 2 bugs from #12792

- Only generate vpor for the TimeProfile specified, not all TimeProfiles.  Otherwise if you have 10 TimeProfiles, it would regenerate the default one 10 times, even though it isn't necessary
- For backports, people will have records with a nil time_profile_id, and we should handle that.  On master, I will make a data migration, so once I do that I can remove the hack.

@gtanzillo Please review
cc @NickLaMuro @dmetzger57 