### PR TITLE
Remove display_filter_details

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -124,32 +124,6 @@ class MiqReport < ApplicationRecord
     }
   end
 
-  def self.display_filter_details(cols, mode)
-    # mode => :field || :tag
-    # Only return cols from has_many sub-tables
-    return [] if cols.nil?
-    cols.inject([]) do |r, c|
-      # eg. c = ["Host.Hardware.Disks : File Name", "Host.hardware.disks-filename"]
-      parts = c.last.split(".")
-      parts[-1] = parts.last.split("-").first # Strip off field name from last element
-
-      if parts.last == "managed"
-        next(r) unless mode == :tag
-        parts.pop # Remove "managed" from tail andjust just evaluate relationship
-      else
-        next(r) unless mode == :field
-      end
-
-      model = parts.shift
-      relats = MiqExpression.get_relats(model)
-      # Build relats hash fetch path like: [:reflections, :hardware, :reflections, :disks, :parent, :multivalue]
-      path = parts.inject([]) { |a, p| a << :reflections; a << p.to_sym }
-      path += [:parent, :multivalue]
-      multi = relats.fetch_path(*path)
-      multi == true ? r << c : r
-    end
-  end
-
   def list_schedules
     exp = MiqExpression.new("=" => {"field" => "MiqReport-id",
                                     "value" => id})


### PR DESCRIPTION
replacement of this [commit](https://github.com/ManageIQ/manageiq/pull/11112/commits/794b9867a959744e3f90d672a5995e22afd90a9a)

I want to parse virtual custom attributes by MiqExpression::Field similarly as is here [6fbce18](https://github.com/ManageIQ/manageiq/pull/11112/commits/6fbce18e993364777ff0c885876f4a6ccddbfb1f) with some special characters in addition.

For displaying virtual custom attributes in expression editor is used method `display_filter_details`,
so I need to handle it by `MiqExpression::Field`


@imtayadeway 

@miq-bot assign @gtanzillo 

@miq-bot add_label core, refactoring



