### PR TITLE
External Logging link for container nodes

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
@@ -32,4 +32,37 @@ describe ContainerNode do
     )
     expect(node.container_images.count).to eq(1)
   end
+
+  describe "#external_logging_path" do
+    def get_query(path)
+      index = ".operations.*"
+      prefix_len = (ContainerNode::EXTERNAL_LOGGING_PATH % {:index => index, :query => 'MARKER'}).index('MARKER')
+      path[prefix_len..(prefix_len + path[prefix_len..-1].index("index:'.operations.*'") - 4)]
+    end
+
+    it "will query for nothing when no name/fqdn is available" do
+      node = FactoryGirl.create(:container_node, :name => "")
+      query = get_query(node.external_logging_path)
+      expect(query).to eq("bool:(filter:(or:!((term:(hostname:'')))))")
+    end
+
+    it "queries both fqdn and hostname when both are avaialble only from kubernetes lables" do
+      node = FactoryGirl.create(:container_node, :name => "other_name")
+      node.labels.create(:name => "kubernetes.io/hostname", :value => "hello.world.com")
+      query = get_query(node.external_logging_path)
+      expect(query).to eq("bool:(filter:(or:!((term:(hostname:'hello.world.com')),(term:(hostname:'hello')))))")
+    end
+
+    it "queries both fqdn and hostname when both are avaialble" do
+      node = FactoryGirl.create(:container_node, :name => "hello.world.com")
+      query = get_query(node.external_logging_path)
+      expect(query).to eq("bool:(filter:(or:!((term:(hostname:'hello.world.com')),(term:(hostname:'hello')))))")
+    end
+
+    it "queries only for the name/fqdn when hostname can't be parsed" do
+      node = FactoryGirl.create(:container_node, :name => "hello")
+      query = get_query(node.external_logging_path)
+      expect(query).to eq("bool:(filter:(or:!((term:(hostname:'hello')))))")
+    end
+  end
 end


### PR DESCRIPTION
Adding the common logging link support for container nodes.

![gifrecord_2017-03-01_231329](https://cloud.githubusercontent.com/assets/3123328/23483698/b3a6e48e-fedc-11e6-9a67-6481d46f3c65.gif)
