### PR TITLE
[DARGA] Use Array() for non-array propSet

### DIFF
--- a/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -2254,7 +2254,7 @@ class MiqVimInventory < MiqVimClientBase
     oc.MOR = oc.obj
     oc.delete('obj')
 
-    oc.propSet = [oc.propSet] unless oc.propSet.kind_of?(Array)
+    oc.propSet = Array(oc.propSet) unless oc.propSet.kind_of?(Array)
     oc.propSet.each do |ps|
       #
       # Here, ps.name can be a property path in the form: a.b.c
@@ -2333,7 +2333,7 @@ class MiqVimInventory < MiqVimClientBase
       oc.MOR = oc.obj
       oc.delete('obj')
 
-      oc.propSet = [oc.propSet] unless oc.propSet.kind_of?(Array)
+      oc.propSet = Array(oc.propSet) unless oc.propSet.kind_of?(Array)
       oc.propSet.each do |ps|
         #
         # Here, ps.name can be a property path in the form: a.b.c


### PR DESCRIPTION
Backport PR for https://github.com/ManageIQ/manageiq-gems-pending/pull/37

In some cases `RetrieveProperties` may be unable to return any of the requested props, e.g. when a host is disconnected or in some errored state.

Currently if `propSet` is `nil` refresh will fail with the following error:

```
ERROR -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::Refresher#refresh) EMS: [CSS_VC_MAN], id: [41000000000003] Refresh failed
ERROR -- : [NoMethodError]: undefined method `name' for nil:NilClass  Method:[rescue in block in refresh]
ERROR -- : (druby://127.0.0.1:46352) /var/www/miq/vmdb/gems/pending/VMwareWebService/MiqVimInventory.rb:2350:in `block (2 levels) in getMoPropMulti'
 (druby://127.0.0.1:46352) /var/www/miq/vmdb/gems/pending/VMwareWebService/MiqVimInventory.rb:2344:in `each'
 (druby://127.0.0.1:46352) /var/www/miq/vmdb/gems/pending/VMwareWebService/MiqVimInventory.rb:2344:in `block in getMoPropMulti'
 (druby://127.0.0.1:46352) /var/www/miq/vmdb/gems/pending/VMwareWebService/MiqVimInventory.rb:2339:in `each'
 (druby://127.0.0.1:46352) /var/www/miq/vmdb/gems/pending/VMwareWebService/MiqVimInventory.rb:2339:in `getMoPropMulti'
```
In the case where `ObjectContent.propSet` is `nil` `[oc.propSet]` will result
in `[nil]` where `Array(oc.propSet)` will result in `[]`

https://bugzilla.redhat.com/show_bug.cgi?id=1418000