### PR TITLE
Lock gemfile version of hashie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false
 gem "hamlit",                         "~>2.7.0"
-gem "hashie",                         ">=3.4.6",       :require => false
+gem "hashie",                         "~>3.4.6",       :require => false
 gem "high_voltage",                   "~>2.4.0"
 gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false


### PR DESCRIPTION
This current version of hashie is breaking omniauth for google

pegging to an older version while we get this working