### PR TITLE
bulk unassign tags on services and vms 

### DIFF
--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -10,6 +10,15 @@ module Api
         action_result(false, err.to_s)
       end
 
+      def unassign_tags_resource(type, id, data)
+        resource = resource_search(id, type, collection_class(type))
+        data['tags'].collect do |tag|
+          tags_unassign_resource(resource, type, tag['id'], tag)
+        end
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
       def tags_query_resource(object)
         object ? object.tags.where(Tag.arel_table[:name].matches "#{Api::BaseController::TAG_NAMESPACE}%") : {}
       end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1552,6 +1552,8 @@
         :identifier: service_admin
       - :name: assign_tags
         :identifier: service_tag
+      - :name: unassign_tags
+        :identifier: service_tag
     :resource_actions:
       :get:
       - :name: read
@@ -1966,6 +1968,8 @@
       - :name: delete
         :identifier: vm_delete
       - :name: assign_tags
+        :identifier: vm_tag
+      - :name: unassign_tags
         :identifier: vm_tag
     :resource_actions:
       :get:


### PR DESCRIPTION
Adds ability to bulk unassign tags to multiple services / VM resources

Example:
```
{
        'action'    => 'unassign_tags',
        'resources' => [
          { 'id' => 1, 'tags' => [{'id' => 999}] },
          { 'id' => 2, 'tags' => [{'id' => 999}] }
        ]
      }
```

Links 
----------------
* [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/137959113)

@miq-bot assign @abellotti 
@miq-bot add_label enhancement, api