### PR TITLE
Escape label names and values when put into tags

### DIFF
--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -29,7 +29,7 @@ describe ChargebackContainerImage do
     EvmSpecHelper.create_guid_miq_server_zone
     @node = FactoryGirl.create(:container_node, :name => "node")
     @image = FactoryGirl.create(:container_image, :ext_management_system => ems)
-    @label = FactoryGirl.build(:custom_attribute, :name => "version_label-1", :value => "1.0.0-rc_2", :section => 'docker_labels')
+    @label = FactoryGirl.build(:custom_attribute, :name => "version/1.2/_label-1", :value => "test/1.0.0  rc_2", :section => 'docker_labels')
     @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
     @group = FactoryGirl.create(:container_group, :ext_management_system => ems, :container_project => @project,
                                 :container_node => @node)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1409526

Unlike tags, labels can include unexpected special characters like slashes, dots, commas, dashes... that crash the tagging mechanism that relies on formatted strings. This change encodes and decodes the names and values of labels to safer strings to use in tags. 

@lpichler @gtanzillo Please review
cc @simon3z this was crashing chargeback assignments by label

@miq-bot add_label chargeback, bug, providers/containers