### PR TITLE
Moved conversion of event to event_hash outside of EmsEvent so as to remove provider specific add_* methods

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -60,50 +60,6 @@ class EmsEvent < EventStream
     )
   end
 
-  def self.add_vc(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Vmware::InfraManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_rhevm(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_openstack(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_openstack_network(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Openstack::NetworkManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_cinder(ems_id, event)
-    add(ems_id, ManageIQ::Providers::StorageManager::CinderManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_swift(ems_id, event)
-    add(ems_id, ManageIQ::Providers::StorageManager::SwiftManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_openstack_infra(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_kubernetes(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_azure(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Azure::CloudManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_google(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, ems_id))
-  end
-
-  def self.add_vmware_vcloud(ems_id, event)
-    add(ems_id, ManageIQ::Providers::Vmware::CloudManager::EventParser.event_to_hash(event, ems_id))
-  end
-
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, _("event_type must be set in event") if event_type.nil?

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -25,7 +25,8 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
 
   def queue_event(event)
     _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-    EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
+    event_hash = ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 
   private

--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
 
   def queue_event(event)
     _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-    event_hash = ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
   def queue_event(event)
     event_data = extract_event_data(event)
     _log.info "#{log_prefix} Queuing event [#{event_data}]"
-    event_hash = ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -50,7 +50,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
   def queue_event(event)
     event_data = extract_event_data(event)
     _log.info "#{log_prefix} Queuing event [#{event_data}]"
-    EmsEvent.add_queue('add_kubernetes', @cfg[:ems_id], event_data)
+    event_hash = ManageIQ::Providers::Kubernetes::ContainerManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 
   def filtered?(event)

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::EventCatcher::Runner < Manag
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
   def add_openstack_queue(event)
-    event_hash = ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::Openstack::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  def add_openstack_queue(event_hash)
-    EmsEvent.add_queue('add_openstack', @cfg[:ems_id], event_hash)
+  def add_openstack_queue(event)
+    event_hash = ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::InfraManager::EventCatcher::Runner < Manag
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
   def add_openstack_queue(event)
-    event_hash = ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::Openstack::InfraManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  def add_openstack_queue(event_hash)
-    EmsEvent.add_queue('add_openstack_infra', @cfg[:ems_id], event_hash)
+  def add_openstack_queue(event)
+    event_hash = ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher::Runner < Man
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
   def add_openstack_queue(event)
-    event_hash = ManageIQ::Providers::Openstack::NetworkManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Openstack::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  def add_openstack_queue(event_hash)
-    EmsEvent.add_queue('add_openstack_network', @cfg[:ems_id], event_hash)
+  def add_openstack_queue(event)
+    event_hash = ManageIQ::Providers::Openstack::NetworkManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -41,7 +41,8 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
 
   def queue_event(event)
     _log.info "#{log_prefix} Caught event [#{event[:name]}]"
-    EmsEvent.add_queue('add_rhevm', @cfg[:ems_id], event.to_hash)
+    event_hash = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 
   def filtered?(event)

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
 
   def queue_event(event)
     _log.info "#{log_prefix} Caught event [#{event[:name]}]"
-    event_hash = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, :ems_id)
+    event_hash = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/event_catcher/runner.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::StorageManager::CinderManager::EventCatcher::Runner <
   ManageIQ::Providers::BaseManager::EventCatcher::Runner
   def add_cinder_queue(event_hash)
-    EmsEvent.add_queue('add_cinder', @cfg[:ems_id], event_hash)
+    event_hash = ManageIQ::Providers::StorageManager::CinderManager::EventParser.event_to_hash(event_hash, :ems_id)
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/event_catcher/runner.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::StorageManager::CinderManager::EventCatcher::Runner <
   ManageIQ::Providers::BaseManager::EventCatcher::Runner
   def add_cinder_queue(event_hash)
-    event_hash = ManageIQ::Providers::StorageManager::CinderManager::EventParser.event_to_hash(event_hash, :ems_id)
+    event_hash = ManageIQ::Providers::StorageManager::CinderManager::EventParser.event_to_hash(event_hash, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 end


### PR DESCRIPTION
EmsEvent has many provider specific add_* methods to add events to the event queue. This pull request tries to eliminate those methods by computing event_hash at provider end and passing it directly to the common "add" method.
