### PR TITLE
[WIP] Change disks for removal while saving inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -227,7 +227,11 @@ module EmsRefresh::SaveInventory
       h[:storage_profile_id] = h.fetch_path(:storage_profile, :id)
     end
 
-    save_inventory_multi(hardware.disks, hashes, :use_association, [:controller_type, :location], nil, [:storage, :backing, :storage_profile])
+    # Only those disks that are no longer referenced by this hardware and are not
+    # backed by other storage should be deleted.
+    deletes = hardware.disks.where(:backing_id => nil)
+    save_inventory_multi(hardware.disks, hashes, deletes,
+                         [:controller_type, :location], nil, [:storage, :backing, :storage_profile])
   end
 
   def save_network_inventory(guest_device, hash)


### PR DESCRIPTION
Amazon provider now has a storage manager responsible for collecting the inventory of available block storage. Once cloud volumes are attached to an existing VM, a link between the volume and a corresponding `vm.hardware.disk` is established. However, as soon as the cloud manager refreshes its inventory, it will delete any disk not collected by it - since cloud manager is not collecting cloud volumes it deletes all links between volumes and VM disks.

Contrary to this, the storage manager does not delete disks collected by the cloud manager while saving the inventory of disks.

Some more details are available in [this doc](https://docs.google.com/document/d/1Li94Xq5ZBXzD7j5fxuEoGRlL5asEInrw-E2eYi1snJY/edit?usp=sharing). The problem is that the cloud manager "collects" ephemeral storage and stores it as a one or more disks. Since OpenStack is using similar approach, I suspect the same issue is present there as well.

Currently, `save_disks_inventory` is only called from within `save_hardware_inventory`, but I am still not certain whether the approach here is correct.

@miq-bot assign @Ladas 
@miq-bot add_label providers/storage, storage, providers/amazon