### PR TITLE
Data Migration: Ansible Tower Configuration Manager type to Automation Manager

### DIFF
--- a/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
+++ b/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
@@ -3,10 +3,30 @@ class MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager < Active
     self.inheritance_column = :_type_disabled
   end
 
+  class ConfigurationScript < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ConfiguredSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
   def up
     say_with_time("Migrating STI_type_of ansible_tower_configuration_managers to automation_managers") do
       ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager'
+      )
+    end
+
+    say_with_time("Migrating STI_type_of ansible_tower_configuration_scripts to_be_of automation_manager") do
+      ConfigurationScript.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript'
+      )
+    end
+
+    say_with_time("Migrating STI_type_of ansible_tower_configured_systems to_be_of automation_manager") do
+      ConfiguredSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
       )
     end
   end
@@ -15,6 +35,18 @@ class MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager < Active
     say_with_time("Migrating STI_type_of ansible_tower_automation_managers to configuration_managers") do
       ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager'
+      )
+    end
+
+    say_with_time("Migrating STI_type_of ansible_tower_configuration_scripts to_be_of configuration_managers") do
+      ConfigurationScript.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript'
+      )
+    end
+
+    say_with_time("Migrating STI_type_of ansible_tower_configured_systems to_be_of configuration_managers") do
+      ConfiguredSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem'
       )
     end
   end

--- a/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
+++ b/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
@@ -1,0 +1,21 @@
+class MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Migrating STI_type_of ansible_tower_configuration_managers to automation_managers") do
+      ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager'
+      )
+    end
+  end
+
+  def down
+    say_with_time("Migrating STI_type_of ansible_tower_automation_managers to configuration_managers") do
+      ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager'
+      )
+    end
+  end
+end

--- a/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
+++ b/db/migrate/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager.rb
@@ -11,42 +11,74 @@ class MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager < Active
     self.inheritance_column = :_type_disabled
   end
 
+  class Job < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class EmsFolder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
   def up
-    say_with_time("Migrating STI_type_of ansible_tower_configuration_managers to automation_managers") do
+    say_with_time('Migrating STI type of ansible_tower configuration_managers to automation_managers') do
       ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager'
       )
     end
 
-    say_with_time("Migrating STI_type_of ansible_tower_configuration_scripts to_be_of automation_manager") do
+    say_with_time('Migrating STI type of ansible_tower configuration_scripts to be of automation_manager') do
       ConfigurationScript.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript'
       )
     end
 
-    say_with_time("Migrating STI_type_of ansible_tower_configured_systems to_be_of automation_manager") do
+    say_with_time('Migrating STI type of ansible_tower configured_systems to be of automation_manager') do
       ConfiguredSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
+      )
+    end
+
+    say_with_time('Migrating STI type of ansible_tower jobs to be of automation_manager') do
+      Job.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job'
+      )
+    end
+
+    say_with_time('Migrating STI type of ansible_tower inventory_groups to be of automation_manager') do
+      EmsFolder.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup'
       )
     end
   end
 
   def down
-    say_with_time("Migrating STI_type_of ansible_tower_automation_managers to configuration_managers") do
+    say_with_time('Migrating STI type of ansible_tower automation_managers to configuration_managers') do
       ExtManagementSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager'
       )
     end
 
-    say_with_time("Migrating STI_type_of ansible_tower_configuration_scripts to_be_of configuration_managers") do
+    say_with_time('Migrating STI type of ansible_tower configuration_scripts to be of configuration_managers') do
       ConfigurationScript.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript'
       )
     end
 
-    say_with_time("Migrating STI_type_of ansible_tower_configured_systems to_be_of configuration_managers") do
+    say_with_time('Migrating STI type of ansible_tower configured_systems to be of configuration_managers') do
       ConfiguredSystem.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem').update_all(
         :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem'
+      )
+    end
+
+    say_with_time('Migrating STI type of ansible_tower jobs to be of configuration_managers') do
+      Job.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job'
+      )
+    end
+
+    say_with_time('Migrating STI type of ansible_tower inventory_groups to be of configuration_manager') do
+      EmsFolder.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup'
       )
     end
   end

--- a/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
+++ b/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
@@ -2,32 +2,96 @@ require_migration
 
 describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
   let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+  let(:configuration_script_stub) { migration_stub(:ConfigurationScript) }
+  let(:configured_system_stub) { migration_stub(:ConfiguredSystem) }
 
   migration_context :up do
-    it 'migrates Ansible Tower Configuration Manager to Automation Manager type' do
-      configuration_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+    context 'migrate_configuration_managers' do
+      it 'migrates Ansible Tower ConfigurationManager to AutomationManager type' do
+        configuration_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager')
 
-      migrate
+        migrate
 
-      expect(configuration_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager')
+        expect(configuration_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager')
+      end
+
+      it 'will not migrate other than Ansible Tower ConfigurationManager' do
+        some_mananger = ems_stub.create!(:type => 'ManageIQ::Providers::SomeManager')
+
+        migrate
+
+        expect(some_mananger.reload.type).to eq('ManageIQ::Providers::SomeManager')
+      end
     end
 
-    it 'will not migrate other than Ansible Tower Configuration Manager' do
-      some_mananger = ems_stub.create!(:type => 'ManageIQ::Providers::SomeManager')
+    context 'migrate_configuration_scripts' do
+      it 'migrates Ansible Tower ConfigurationScript to be of AutomationManager type' do
+        cs = configuration_script_stub.create!(
+          :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript'
+        )
 
-      migrate
+        migrate
 
-      expect(some_mananger.reload.type).to eq('ManageIQ::Providers::SomeManager')
+        expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript')
+      end
+
+      it 'will not migrate ConfigurationScript of other than Ansible Tower ConfigurationManager' do
+        cs = configuration_script_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfigurationScript')
+
+        migrate
+
+        expect(cs.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfigurationScript')
+      end
+    end
+
+    context 'migrate_configured_systems' do
+      it 'migrates Ansible Tower ConfiguredSystem to be of AutomationManager type' do
+        cs = configured_system_stub.create!(
+          :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem'
+        )
+
+        migrate
+
+        expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem')
+      end
+
+      it 'will not migrate ConfiguredSystem of other than Ansible Tower ConfigurationManager' do
+        cs = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfiguredSystem')
+
+        migrate
+
+        expect(cs.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfiguredSystem')
+      end
     end
   end
 
   migration_context :down do
-    it 'migrates Ansible Tower Automation Manager to Configuration Manager type' do
+    it 'migrates Ansible Tower AutomationManager to ConfigurationManager type' do
       automation_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
 
       migrate
 
       expect(automation_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+    end
+
+    it 'migrates Ansible Tower ConfigurationScript to be of ConfigurationManager type' do
+      cs = configuration_script_stub.create!(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript'
+      )
+
+      migrate
+
+      expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript')
+    end
+
+    it 'migrates Ansible Tower AutomationManager to ConfigurationManager type' do
+      cs = configured_system_stub.create!(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
+      )
+
+      migrate
+
+      expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem')
     end
   end
 end

--- a/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
+++ b/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
@@ -4,6 +4,8 @@ describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
   let(:ems_stub) { migration_stub(:ExtManagementSystem) }
   let(:configuration_script_stub) { migration_stub(:ConfigurationScript) }
   let(:configured_system_stub) { migration_stub(:ConfiguredSystem) }
+  let(:job_stub) { migration_stub(:Job) }
+  let(:inventory_group_stub) { migration_stub(:EmsFolder) }
 
   migration_context :up do
     context 'migrate_configuration_managers' do
@@ -63,6 +65,44 @@ describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
         expect(cs.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfiguredSystem')
       end
     end
+
+    context 'migrate_jobs' do
+      it 'migrates Ansible Tower Job to be of AutomationManager type' do
+        job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
+
+        migrate
+
+        expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+      end
+
+      it 'will not migrate Job of other than Ansible Tower ConfigurationManager' do
+        job = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::Job')
+
+        migrate
+
+        expect(job.reload.type).to eq('ManageIQ::Providers::SomeManager::Job')
+      end
+    end
+
+    context 'migrate_inventory_groups' do
+      it 'migrates Ansible Tower InventoryGroup to be of AutomationManager type' do
+        ig = inventory_group_stub.create!(
+          :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup'
+        )
+
+        migrate
+
+        expect(ig.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
+      end
+
+      it 'will not migrate InventoryGroup of other than Ansible Tower ConfigurationManager' do
+        ig = inventory_group_stub.create!(:type => 'ManageIQ::Providers::SomeManager::InventoryGroup')
+
+        migrate
+
+        expect(ig.reload.type).to eq('ManageIQ::Providers::SomeManager::InventoryGroup')
+      end
+    end
   end
 
   migration_context :down do
@@ -84,7 +124,7 @@ describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
       expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript')
     end
 
-    it 'migrates Ansible Tower AutomationManager to ConfigurationManager type' do
+    it 'migrates Ansible Tower ConfiguredSystem to ConfigurationManager type' do
       cs = configured_system_stub.create!(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
       )
@@ -92,6 +132,22 @@ describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
       migrate
 
       expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem')
+    end
+
+    it 'migrates Ansible Tower Job to ConfigurationManager type' do
+      job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+
+      migrate
+
+      expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
+    end
+
+    it 'migrates Ansible Tower InventoryGroup to ConfigurationManager type' do
+      ig = inventory_group_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
+
+      migrate
+
+      expect(ig.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup')
     end
   end
 end

--- a/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
+++ b/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
@@ -9,145 +9,65 @@ describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
 
   migration_context :up do
     context 'migrate_configuration_managers' do
-      it 'migrates Ansible Tower ConfigurationManager to AutomationManager type' do
-        configuration_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager')
-
-        migrate
-
-        expect(configuration_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager')
-      end
-
-      it 'will not migrate other than Ansible Tower ConfigurationManager' do
-        some_mananger = ems_stub.create!(:type => 'ManageIQ::Providers::SomeManager')
-
-        migrate
-
-        expect(some_mananger.reload.type).to eq('ManageIQ::Providers::SomeManager')
-      end
-    end
-
-    context 'migrate_configuration_scripts' do
-      it 'migrates Ansible Tower ConfigurationScript to be of AutomationManager type' do
-        cs = configuration_script_stub.create!(
+      it 'migrates Ansible Tower ConfigurationManager and others to be of AutomationManager type' do
+        manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+        script = configuration_script_stub.create!(
           :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript'
         )
-
-        migrate
-
-        expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript')
-      end
-
-      it 'will not migrate ConfigurationScript of other than Ansible Tower ConfigurationManager' do
-        cs = configuration_script_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfigurationScript')
-
-        migrate
-
-        expect(cs.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfigurationScript')
-      end
-    end
-
-    context 'migrate_configured_systems' do
-      it 'migrates Ansible Tower ConfiguredSystem to be of AutomationManager type' do
-        cs = configured_system_stub.create!(
+        system = configured_system_stub.create!(
           :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem'
         )
-
-        migrate
-
-        expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem')
-      end
-
-      it 'will not migrate ConfiguredSystem of other than Ansible Tower ConfigurationManager' do
-        cs = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfiguredSystem')
-
-        migrate
-
-        expect(cs.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfiguredSystem')
-      end
-    end
-
-    context 'migrate_jobs' do
-      it 'migrates Ansible Tower Job to be of AutomationManager type' do
         job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
-
-        migrate
-
-        expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
-      end
-
-      it 'will not migrate Job of other than Ansible Tower ConfigurationManager' do
-        job = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::Job')
-
-        migrate
-
-        expect(job.reload.type).to eq('ManageIQ::Providers::SomeManager::Job')
-      end
-    end
-
-    context 'migrate_inventory_groups' do
-      it 'migrates Ansible Tower InventoryGroup to be of AutomationManager type' do
-        ig = inventory_group_stub.create!(
+        inventory_g = inventory_group_stub.create!(
           :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup'
         )
 
         migrate
 
-        expect(ig.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
+        expect(manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager')
+        expect(script.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript')
+        expect(system.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem')
+        expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+        expect(inventory_g.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
       end
 
-      it 'will not migrate InventoryGroup of other than Ansible Tower ConfigurationManager' do
-        ig = inventory_group_stub.create!(:type => 'ManageIQ::Providers::SomeManager::InventoryGroup')
+      it 'will not migrate things other than those of Ansible Tower ConfigurationManager' do
+        mananger = ems_stub.create!(:type => 'ManageIQ::Providers::SomeManager')
+        script = configuration_script_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfigurationScript')
+        system = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::ConfiguredSystem')
+        job = configured_system_stub.create!(:type => 'ManageIQ::Providers::SomeManager::Job')
+        inventory_g = inventory_group_stub.create!(:type => 'ManageIQ::Providers::SomeManager::InventoryGroup')
 
         migrate
 
-        expect(ig.reload.type).to eq('ManageIQ::Providers::SomeManager::InventoryGroup')
+        expect(mananger.reload.type).to eq('ManageIQ::Providers::SomeManager')
+        expect(script.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfigurationScript')
+        expect(system.reload.type).to eq('ManageIQ::Providers::SomeManager::ConfiguredSystem')
+        expect(job.reload.type).to eq('ManageIQ::Providers::SomeManager::Job')
+        expect(inventory_g.reload.type).to eq('ManageIQ::Providers::SomeManager::InventoryGroup')
       end
     end
   end
 
   migration_context :down do
     it 'migrates Ansible Tower AutomationManager to ConfigurationManager type' do
-      automation_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
-
-      migrate
-
-      expect(automation_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager')
-    end
-
-    it 'migrates Ansible Tower ConfigurationScript to be of ConfigurationManager type' do
-      cs = configuration_script_stub.create!(
+      manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
+      script = configuration_script_stub.create!(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript'
       )
-
-      migrate
-
-      expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript')
-    end
-
-    it 'migrates Ansible Tower ConfiguredSystem to ConfigurationManager type' do
-      cs = configured_system_stub.create!(
+      system = configured_system_stub.create!(
         :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem'
       )
-
-      migrate
-
-      expect(cs.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem')
-    end
-
-    it 'migrates Ansible Tower Job to ConfigurationManager type' do
       job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+      inventory_g = inventory_group_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
 
       migrate
 
+      expect(manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+      expect(script.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript')
+      expect(system.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem')
       expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
-    end
-
-    it 'migrates Ansible Tower InventoryGroup to ConfigurationManager type' do
-      ig = inventory_group_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryGroup')
-
-      migrate
-
-      expect(ig.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup')
+      expect(inventory_g.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::InventoryGroup')
     end
   end
 end

--- a/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
+++ b/spec/migrations/20170131160216_migrate_ansible_tower_configuration_manager_sti_type_to_automation_manager_spec.rb
@@ -1,0 +1,33 @@
+require_migration
+
+describe MigrateAnsibleTowerConfigurationManagerStiTypeToAutomationManager do
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it 'migrates Ansible Tower Configuration Manager to Automation Manager type' do
+      configuration_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+
+      migrate
+
+      expect(configuration_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager')
+    end
+
+    it 'will not migrate other than Ansible Tower Configuration Manager' do
+      some_mananger = ems_stub.create!(:type => 'ManageIQ::Providers::SomeManager')
+
+      migrate
+
+      expect(some_mananger.reload.type).to eq('ManageIQ::Providers::SomeManager')
+    end
+  end
+
+  migration_context :down do
+    it 'migrates Ansible Tower Automation Manager to Configuration Manager type' do
+      automation_manager = ems_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
+
+      migrate
+
+      expect(automation_manager.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager')
+    end
+  end
+end


### PR DESCRIPTION
Existing AnsibleTower Configruration Manager in the `ext_management_systems` table will be modified to have the new automation manager type.