### PR TITLE
[WIP] Endpoint: certificate_authorities, parse_certificate_authorities methods

### DIFF
--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -115,15 +115,17 @@ describe Endpoint do
       expect(endpoint).not_to be_valid
     end
 
-    it "ssl_cert_store parses valid cert(s)" do
+    it "parses valid cert(s)" do
       endpoint.certificate_authority = pem1
       expect(endpoint).to be_valid
-      expect(endpoint.send(:parse_certificate_authority).size).to eq(1)
+      expect(endpoint.certificate_authorities).to eq([pem1])
+      expect(endpoint.send(:parse_certificate_authorities).size).to eq(1)
       expect(endpoint.ssl_cert_store).to be_a(OpenSSL::X509::Store)
 
       endpoint.certificate_authority = pem1 + pem2
       expect(endpoint).to be_valid
-      expect(endpoint.send(:parse_certificate_authority).size).to eq(2)
+      expect(endpoint.certificate_authorities).to eq([pem1, pem2])
+      expect(endpoint.send(:parse_certificate_authorities).size).to eq(2)
       expect(endpoint.ssl_cert_store).to be_a(OpenSSL::X509::Store)
     end
   end


### PR DESCRIPTION
Followup to #13567.
Have an upcoming use for the splitting & parsing without stuffing them into a `OpenSSL::X509::Store`.

cc @jhernand @simon3z 

@miq-bot add-label providers, refactoring