### PR TITLE
Chargeback: Skip calculation when there is zero consumed hours

### DIFF
--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -26,9 +26,9 @@ class Chargeback
         # values are grouped by resource_id and timestamp (query_start_time...query_end_time)
         records.group_by(&:resource_id).each do |_, metric_rollup_records|
           metric_rollup_records = metric_rollup_records.select { |x| x.resource.present? }
-          consumption = ConsumptionWithRollups.new(metric_rollup_records, query_start_time, query_end_time)
           next if metric_rollup_records.empty?
-          yield(consumption)
+          consumption = ConsumptionWithRollups.new(metric_rollup_records, query_start_time, query_end_time)
+          yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end
       end
     end


### PR DESCRIPTION
Consumed_hours_in_interval are used for calculating **average** metrics. When you divide by zero you get Infinity as a result. The report formater breaks when it gets Infinity.

```
    WARN -- : <AuditFailure> MIQ(Async.rescue in _async_generate_table) userid: [admin] - Infinity
    ERROR -- : MIQ(MiqQueue#deliver) Message id: [6427], Error: [Infinity]
    ERROR -- : [FloatDomainError]: Infinity  Method:[rescue in deliver]
    ERROR -- : activesupport-5.0.0.1/lib/active_support/number_helper/number_to_human_size_converter.rb:53:in `to_i'
```

This is a corner case. It can happen only few hours after you add provider with C&U. Then it is possible some metric rollup exists in the interval, while the full consumed hours is zero.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1416626

@miq-bot add_label chargeback, bug, euwe/yes, blocker
@miq-bot assign @gtanzillo 