### PR TITLE
Container Provider Refresh Refactor Image Registries Collection

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -26,7 +26,6 @@ module ManageIQ::Providers::Kubernetes
       get_endpoints(inventory)
       get_services(inventory)
       get_component_statuses(inventory)
-      get_registries
       get_images
       EmsRefresh.log_inv_debug_trace(@data, "data:")
       @data
@@ -35,11 +34,6 @@ module ManageIQ::Providers::Kubernetes
     def get_images
       images = @data_index.fetch_path(:container_image, :by_ref_and_registry_host_port).try(:values) || []
       process_collection(images, :container_images) { |n| n }
-    end
-
-    def get_registries
-      registries = @data_index.fetch_path(:container_image_registry, :by_host_and_port).try(:values) || []
-      process_collection(registries, :container_image_registries) { |n| n }
     end
 
     def get_nodes(inventory)
@@ -692,6 +686,7 @@ module ManageIQ::Providers::Kubernetes
         if stored_container_image_registry.nil?
           @data_index.store_path(
             :container_image_registry, :by_host_and_port, host_port, container_image_registry)
+          process_collection_item(container_image_registry, :container_image_registries) { |r| r }
           stored_container_image_registry = container_image_registry
         end
       end


### PR DESCRIPTION
After collecting images from Openshift new image registries are added
and should be collected. The previous registries are also cleared to
prevent duplicates.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1418590