### PR TITLE
Remove wrong paranthesis in Gemfile.dev.rb example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ end
 # To develop a gem locally and override its source to a checked out repo
 #   you can use this helper method in Gemfile.dev.rb e.g.
 #
-# override_gem 'manageiq-ui-classic', :path => File.expand_path("../manageiq-ui-classic", __dir__))
+# override_gem 'manageiq-ui-classic', :path => File.expand_path("../manageiq-ui-classic", __dir__)
 #
 def override_gem(name, *args)
   if dependencies.any?


### PR DESCRIPTION
The example that shows how to override a gem using the 'Gemfile.dev.rb'
file contains an extra parenthesis that makes it fail if you blindly
copy it (I did, my fault). This patch removes it.