### PR TITLE
Set websocket worker's loglevel for development based on ::Settings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Vmdb::Application.routes.draw do
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 
   if Rails.env.development? && defined?(Rails::Server)
-    mount WebsocketServer.new(:logger => Logger.new(STDOUT)) => '/ws'
+    logger = Logger.new(STDOUT)
+    logger.level = ::Settings.log.level_websocket
+    mount WebsocketServer.new(:logger => logger) => '/ws'
   end
 end


### PR DESCRIPTION
This way we will inherit the loglevel configuration for `WebsocketWorker` when started with `rails s`