### PR TITLE
Update validation regex to prohibit only numbers for Azure VM provisioning

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -228,8 +228,8 @@
           :required_method:
             - :validate_vm_name
             - :validate_regex
-          :required_regex: !ruby/regexp /^[^-_][a-zA-Z0-9_-]{1,15}(?<![-_])$/
-          :required_regex_fail_details: The name must be composed only of 1-15 English alphabet characters (a-z), numbers (0-9), dashes (-) or underscores (_). The first and last character must be an English alphabet character.
+          :required_regex: !ruby/regexp /^[^-_](?!\d+$)[a-zA-Z0-9_-]{1,15}(?<![-_])$/
+          :required_regex_fail_details: The name must be composed only of 1-15 English alphabet characters (a-z), numbers (0-9), dashes (-) or underscores (_) and cannot contain only numbers. The first and last character must be an English alphanumeric character.
           :required: true
           :notes: 
           :display: :edit


### PR DESCRIPTION
This is an enhancement to https://github.com/ManageIQ/manageiq/pull/12947. Apparently, there is an undocumented restriction that a VM cannot contain only numbers. This addresses that.

Original BZ is https://bugzilla.redhat.com/show_bug.cgi?id=1377889
