### PR TITLE
Create ansible tower provider mixin

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider_mixin.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider_mixin.rb
@@ -1,0 +1,74 @@
+module ManageIQ::Providers::AnsibleTower::ProviderMixin
+  extend ActiveSupport::Concern
+
+  def self.included(klass)
+    klass.has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
+
+    klass.before_validation :ensure_managers
+
+    klass.validates :name, :presence => true, :uniqueness => true
+    klass.validates :url,  :presence => true
+  end
+
+  module ClassMethods
+    def raw_connect(base_url, username, password, verify_ssl)
+      require 'ansible_tower_client'
+      AnsibleTowerClient.logger = $log
+      AnsibleTowerClient::Connection.new(
+        :base_url   => base_url,
+        :username   => username,
+        :password   => password,
+        :verify_ssl => verify_ssl
+      )
+    end
+
+    def refresh_ems(provider_ids)
+      EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
+    end
+  end
+
+  def connect(options = {})
+    auth_type = options[:auth_type]
+    if missing_credentials?(auth_type) && (options[:username].nil? || options[:password].nil?)
+      raise _("no credentials defined")
+    end
+
+    verify_ssl = options[:verify_ssl] || self.verify_ssl
+    base_url   = options[:url] || url
+    username   = options[:username] || authentication_userid(auth_type)
+    password   = options[:password] || authentication_password(auth_type)
+
+    self.class.raw_connect(base_url, username, password, verify_ssl)
+  end
+
+  def verify_credentials(auth_type = nil, options = {})
+    require 'ansible_tower_client'
+    begin
+      with_provider_connection(options.merge(:auth_type => auth_type)) { |c| c.api.verify_credentials } ||
+        raise(MiqException::MiqInvalidCredentialsError, _("Username or password is not valid"))
+    rescue Faraday::ConnectionFailed, Faraday::SSLError => err
+      raise MiqException::MiqUnreachableError, err.message, err.backtrace
+    rescue AnsibleTowerClient::ConnectionError => err
+      raise MiqException::MiqCommunicationsError, err.message
+    end
+  end
+
+  def url=(new_url)
+    new_url  = "https://#{new_url}" unless new_url =~ %r{\Ahttps?:\/\/} # HACK: URI can't properly parse a URL with no scheme
+    uri      = URI(new_url)
+    uri.path = default_api_path if uri.path.blank?
+    default_endpoint.url = uri.to_s
+  end
+
+  private
+
+  def default_api_path
+    "/api/v1".freeze
+  end
+
+  def ensure_managers
+    build_automation_manager unless automation_manager
+    automation_manager.name    = _("%{name} Automation Manager") % {:name => name}
+    automation_manager.zone_id = zone_id
+  end
+end

--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -1,9 +1,9 @@
-class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
+class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
   include ManageIQ::Providers::AnsibleTower::ProviderMixin
 
   has_one :automation_manager,
           :foreign_key => "provider_id",
-          :class_name  => "ManageIQ::Providers::AnsibleTower::AutomationManager",
+          :class_name  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",
           :dependent   => :destroy,
           :autosave    => true
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service-providers-embedded_ansible-provider.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service-providers-embedded_ansible-provider.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_Provider < MiqAeServiceProvider
+  end
+end

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -13,26 +13,35 @@ describe EmbeddedAnsibleWorker::Runner do
       described_class.new(:guid => worker_guid)
     }
 
-    context "#update_embedded_ansible_manager" do
-      it "creates initial" do
-        runner.update_embedded_ansible_manager
+    context "#update_embedded_ansible_provider" do
+      before do
+        EvmSpecHelper.local_guid_miq_server_zone
+        MiqDatabase.seed
+        MiqDatabase.first.ansible_admin_password = "secret"
+      end
 
-        ansible = ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first
-        expect(ansible.zone).to eq(miq_server.zone)
-        expect(ansible.default_endpoint.url).to eq("https://fancyserver/ansibleapi/v1")
+      it "creates initial" do
+        runner.update_embedded_ansible_provider
+
+        provider = ManageIQ::Providers::EmbeddedAnsible::Provider.first
+        expect(provider.zone).to eq(miq_server.zone)
+        expect(provider.default_endpoint.url).to eq("https://fancyserver/ansibleapi/v1")
+        userid, password = provider.auth_user_pwd
+        expect(userid).to eq("admin")
+        expect(password).to eq("secret")
       end
 
       it "updates existing" do
-        runner.update_embedded_ansible_manager
+        runner.update_embedded_ansible_provider
         new_zone = FactoryGirl.create(:zone)
         miq_server.update(:hostname => "boringserver", :zone => new_zone)
 
-        runner.update_embedded_ansible_manager
-        expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager.count).to eq(1)
+        runner.update_embedded_ansible_provider
+        expect(ManageIQ::Providers::EmbeddedAnsible::Provider.count).to eq(1)
 
-        ansible = ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first
-        expect(ansible.zone).to eq(new_zone)
-        expect(ansible.default_endpoint.url).to eq("https://boringserver/ansibleapi/v1")
+        provider = ManageIQ::Providers::EmbeddedAnsible::Provider.first
+        expect(provider.zone).to eq(new_zone)
+        expect(provider.default_endpoint.url).to eq("https://boringserver/ansibleapi/v1")
       end
     end
   end


### PR DESCRIPTION
The majority of the behavior in the `AnsibleTower` and `EmbeddedAnsible` provider classes needs to be shared.

This PR creates a mixin with that shared behavior and also creates the `EmbeddedAnsible::Provider` class which is then used by the `EmbeddedAnsibleWorker` to update the provider's url and zone when it starts.

Paired with @jrafanie on this.