### PR TITLE
Create service template with Ansible Tower after first creating a new job template

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
   module ApiCreate
-    def create_in_provider(manager_id, params)
+    def create_in_provider(manager_id, params, inline = false)
       manager = ExtManagementSystem.find(manager_id)
       job_template = manager.with_provider_connection do |connection|
         connection.api.job_templates.create!(params)
@@ -8,7 +8,11 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
 
       # Get the record in our database
       # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.refresh(manager) if !manager.missing_credentials? && manager.authentication_status_ok?
+      if inline && !manager.missing_credentials? && manager.authentication_status_ok?
+        EmsRefresh.refresh(manager)
+      elsif !manager.missing_credentials? && manager.authentication_status_ok?
+        EmsRefresh.queue_refresh(manager, nil, true)
+      end
 
       find_by(:manager_id => manager.id, :manager_ref => job_template.id)
     end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
@@ -8,9 +8,9 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
 
       # Get the record in our database
       # TODO: This needs to be targeted refresh so it doesn't take too long
-      if inline && !manager.missing_credentials? && manager.authentication_status_ok?
+      if inline && manager.authentication_status_ok?
         EmsRefresh.refresh(manager)
-      elsif !manager.missing_credentials? && manager.authentication_status_ok?
+      elsif manager.authentication_status_ok?
         EmsRefresh.queue_refresh(manager, nil, true)
       end
 

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script/api_create.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript
 
       # Get the record in our database
       # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.queue_refresh(manager, nil, true) if !manager.missing_credentials? && manager.authentication_status_ok?
+      EmsRefresh.refresh(manager) if !manager.missing_credentials? && manager.authentication_status_ok?
 
       find_by(:manager_id => manager.id, :manager_ref => job_template.id)
     end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -24,14 +24,14 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   #     :reconfigure (same as provision)
   #
   def self.create_catalog_item(options, _auth_user)
-    task_id = create_catalog_item_queue(options, _auth_user)
+    task_id = create_catalog_item_queue(options)
     task = MiqTask.wait_for_taskid(task_id)
     task.task_results
   end
 
-  def self.create_catalog_item_queue(options, _auth_user)
+  def self.create_catalog_item_queue(options)
     task_opts = {
-      :action => "Creating Ansible Tower Service Template",
+      :action => "Create Ansible Playbook Service Template",
       :userid => "system"
     }
 
@@ -88,14 +88,14 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :name                     => name,
       :description              => description || '',
       :project                  => playbook.configuration_script_source.manager_ref,
-      :playbook                 => playbook.manager_ref,
-      :inventory                => internal_tower.inventory_root_groups.first.id,
+      :playbook                 => playbook.name,
+      :inventory                => internal_tower.inventory_root_groups.first.ems_ref,
       :ask_variables_on_launch  => true,
       :ask_limit_on_launch      => true,
       :ask_inventory_on_launch  => true,
       :ask_credential_on_launch => true
     }.merge(info.slice(:extra_vars, :credential, :cloud_credential, :network_credential))
-    ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.create_in_provider(internal_tower.id, params)
+    ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.create_in_provider(internal_tower.id, params, true)
   end
   private_class_method :create_job_template
 

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -60,7 +60,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     config_info  = validate_config_info(options)
 
     transaction do
-      create(options.except(:config_info, :task_id)).tap do |service_template|
+      create_from_options(options.except(:task_id)).tap do |service_template|
         [:provision, :retirement, :reconfigure].each do |action|
           prepare_job_template_and_dialog(action, service_name, description, options) if config_info.key?(action)
         end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -28,7 +28,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   def self.create_catalog_item(options, _auth_user)
     task_id = create_catalog_item_queue(options, _auth_user)
     task = MiqTask.wait_for_taskid(task_id)
-    raise MiqException::Error, task.message unless task.status == "Ok"
+    raise task.message unless task.status == "Ok"
     task.task_results
   end
 

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -18,7 +18,9 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   #       :new_dialog_name
   #       :variables
   #       :hosts
-  #       :credentials
+  #       :cloud_credential_id
+  #       :network_credential_id
+  #       :credential_id
   #       :playbook_id
   #     :retirement (same as provision)
   #     :reconfigure (same as provision)
@@ -26,6 +28,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   def self.create_catalog_item(options, _auth_user)
     task_id = create_catalog_item_queue(options, _auth_user)
     task = MiqTask.wait_for_taskid(task_id)
+    raise MiqException::Error, task.message unless task.status == "Ok"
     task.task_results
   end
 

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -1,0 +1,49 @@
+describe ServiceTemplateAnsiblePlaybook do
+  describe '#create_catalog_item' do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group) }
+    let(:ems) do
+      FactoryGirl.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group])
+    end
+    let(:config_script) { FactoryGirl.create(:configuration_script) }
+    let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
+    let(:playbook) do
+      FactoryGirl.create(:configuration_script_payload,
+                         :configuration_script_source => script_source,
+                         :manager                     => ems,
+                         :inventory_root_group        => inventory_root_group,
+                         :type                        => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook')
+    end
+    let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
+    let(:catalog_item_options) do
+      {
+        :name                     => 'test_ansible_catalog_item',
+        :description              => 'test ansible',
+        :service_template_catalog => service_template_catalog,
+        :config_info              => {
+          :provision         => {
+            :new_dialog_name => 'test_dialog',
+            :hosts           => 'many',
+            :credential      => 6,
+            :playbook_id     => playbook.id,
+          },
+        }
+      }
+    end
+
+    it '#create_catalog_item' do
+      expect(ServiceTemplateAnsiblePlaybook).to receive(:create_catalog_item_queue)
+      expect(MiqTask).to receive(:wait_for_taskid).with(any_args).once.and_return(instance_double('MiqTask', :task_results => {}))
+
+      ServiceTemplateAnsiblePlaybook.create_catalog_item(catalog_item_options, nil)
+    end
+
+    it '#create_catalog_item_task' do
+      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript).to receive(:create_in_provider)
+      service_template = ServiceTemplateAnsiblePlaybook.create_catalog_item_task(catalog_item_options, nil)
+
+      expect(service_template.name).to eq('test_ansible_catalog_item')
+      expect(service_template.resource_actions.pluck(:action)).to include('Provision')
+    end
+  end
+end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -17,11 +17,11 @@ describe ServiceTemplateAnsiblePlaybook do
     let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
     let(:catalog_item_options) do
       {
-        :name                     => 'test_ansible_catalog_item',
-        :description              => 'test ansible',
-        :service_template_catalog => service_template_catalog,
-        :config_info              => {
-          :provision         => {
+        :name                        => 'test_ansible_catalog_item',
+        :description                 => 'test ansible',
+        :service_template_catalog_id => service_template_catalog.id,
+        :config_info                 => {
+          :provision => {
             :new_dialog_name => 'test_dialog',
             :hosts           => 'many',
             :credential      => 6,
@@ -43,6 +43,8 @@ describe ServiceTemplateAnsiblePlaybook do
       service_template = ServiceTemplateAnsiblePlaybook.create_catalog_item_task(catalog_item_options, nil)
 
       expect(service_template.name).to eq('test_ansible_catalog_item')
+      expect(service_template.description).to eq('test ansible')
+      expect(service_template.service_template_catalog_id).to eq(service_template_catalog.id)
       expect(service_template.resource_actions.pluck(:action)).to include('Provision')
     end
   end


### PR DESCRIPTION
> Running from console with these options and subsequent command:

```
options = { :name => 'db_console', :description => 'test ansible', :service_template_catalog_id => ServiceTemplateCatalog.last.id, :config_info => { :provision => { :new_dialog_name => 'hello_world', :hosts => 'blah', :credential => '<real credential id associated this tower instance>', :playbook_id => '<id of playbook>'}}}

ServiceTemplateAnsiblePlaybook.create_catalog_item(options, nil)
```

> You should build a `job_template` on the provider that looks something like this:

<img width="1432" alt="screen shot 2017-02-08 at 3 19 39 pm" src="https://cloud.githubusercontent.com/assets/697347/22755646/194295ee-ee12-11e6-88b6-5b052bc8287d.png">


https://www.pivotaltracker.com/story/show/137306185
