### PR TITLE
String in Logger.level is not supported in ruby version < 2.3.0

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Vmdb::Application.routes.draw do
 
   if Rails.env.development? && defined?(Rails::Server)
     logger = Logger.new(STDOUT)
-    logger.level = ::Settings.log.level_websocket
+    logger.level = Logger.const_get(::Settings.log.level_websocket.upcase)
     mount WebsocketServer.new(:logger => logger) => '/ws'
   end
 end


### PR DESCRIPTION
introduced in https://github.com/ManageIQ/manageiq/pull/13726 and just for development env 

Support symbol and string log level setting is for ruby > 2.3.0:
https://github.com/ruby/ruby/commit/398abe4c51a5b30ed0aede285a69f73f05d629ca

@miq-bot add_label developer, bug

thanks @skateman 

### Reproduce:
use ruby version < 2.3.0 and then `rails s` is causing 
```
/usr/local/opt/rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/activerecord-session_store-1.0.0/lib/active_record/session_store/extension/logger_silencer.rb:35:in `<': comparison of Fixnum with String failed (ArgumentError)
	from /usr/local/opt/rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/activerecord-session_store-1.0.0/lib/active_record/session_store/extension/logger_silencer.rb:35:in `add_with_threadsafety'
	from /usr/local/opt/rbenv/versions/2.2.6/lib/ruby/2.2.0/logger.rb:434:in `info'
	from /Users/liborpichler/manageiq/manageiq/lib/websocket_server.rb:8:in `initialize'
	from /Users/liborpichler/manageiq/manageiq/config/routes.rb:73:in `new'
	
```