### PR TITLE
Change inventory collection interface to kwargs

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < ManagerRefresh::Inventory::Target
   def inventory_groups
     collections[:inventory_groups] ||= ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::AutomationManager::InventoryRootGroup,
+      :model_class    => ManageIQ::Providers::AutomationManager::InventoryRootGroup,
       :association    => :inventory_root_groups,
       :parent         => @root,
       :builder_params => {:manager => @root}
@@ -10,7 +10,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < 
 
   def configured_systems
     collections[:configured_systems] ||= ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem,
+      :model_class    => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem,
       :association    => :configured_systems,
       :parent         => @root,
       :manager_ref    => [:manager_ref],
@@ -20,7 +20,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < 
 
   def configuration_scripts
     collections[:configuration_scripts] ||= ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
+      :model_class    => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript,
       :association    => :configuration_scripts,
       :parent         => @root,
       :manager_ref    => [:manager_ref],

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -9,7 +9,7 @@ module ManagerRefresh
 
     delegate :each, :size, :to => :to_a
 
-    def initialize(model_class, manager_ref: nil, association: nil, parent: nil, strategy: nil, saved: nil,
+    def initialize(model_class: nil, manager_ref: nil, association: nil, parent: nil, strategy: nil, saved: nil,
                    custom_save_block: nil, delete_method: nil, data_index: nil, data: nil, dependency_attributes: nil,
                    attributes_blacklist: nil, attributes_whitelist: nil, complete: nil, update_only: nil,
                    check_changed: nil, custom_manager_uuid: nil, custom_db_finder: nil, arel: nil, builder_params: {})
@@ -257,7 +257,7 @@ module ManagerRefresh
     def clone
       # A shallow copy of InventoryCollection, the copy will share @data of the original collection, otherwise we would
       # be copying a lot of records in memory.
-      self.class.new(model_class,
+      self.class.new(:model_class           => model_class,
                      :manager_ref           => manager_ref,
                      :association           => association,
                      :parent                => parent,

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -211,7 +211,9 @@ module ManagerRefresh
     end
 
     def fixed_attributes
-      presence_validators = model_class.validators.detect { |x| x.kind_of? ActiveRecord::Validations::PresenceValidator }
+      if model_class
+        presence_validators = model_class.validators.detect { |x| x.kind_of? ActiveRecord::Validations::PresenceValidator }
+      end
       # Attributes that has to be always on the entity, so attributes making unique index of the record + attributes
       # that have presence validation
       fixed_attributes    = manager_ref
@@ -272,30 +274,40 @@ module ManagerRefresh
     end
 
     def association_to_foreign_key_mapping
+      return {} unless model_class
+
       @association_to_foreign_key_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
         obj[x.name] = x.foreign_key
       end
     end
 
     def foreign_key_to_association_mapping
+      return {} unless model_class
+
       @foreign_key_to_association_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
         obj[x.foreign_key] = x.name
       end
     end
 
     def association_to_foreign_type_mapping
+      return {} unless model_class
+
       @association_to_foreign_type_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
         obj[x.name] = x.foreign_type if x.polymorphic?
       end
     end
 
     def foreign_type_to_association_mapping
+      return {} unless model_class
+
       @foreign_type_to_association_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
         obj[x.foreign_type] = x.name if x.polymorphic?
       end
     end
 
     def base_class_name
+      return "" unless model_class
+
       @base_class_name ||= model_class.base_class.name
     end
 
@@ -305,7 +317,9 @@ module ManagerRefresh
 
       strategy_name  = ", strategy: #{strategy}" if strategy
 
-      "InventoryCollection:<#{@model_class}>#{whitelist}#{blacklist}#{strategy_name}"
+      name = model_class || association
+
+      "InventoryCollection:<#{name}>#{whitelist}#{blacklist}#{strategy_name}"
     end
 
     def inspect

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -354,11 +354,11 @@ describe ManagerRefresh::SaveInventory do
           # Initialize the InventoryCollections
           @data             = {}
           @data[:vms]       = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::Vm,
+            :model_class => ManageIQ::Providers::CloudManager::Vm,
             :parent      => @ems,
             :association => :vms)
           @data[:hardwares] = ::ManagerRefresh::InventoryCollection.new(
-            Hardware,
+            :model_class => Hardware,
             :parent      => @ems,
             :association => :hardwares,
             :manager_ref => [:vm_or_template])
@@ -472,35 +472,35 @@ describe ManagerRefresh::SaveInventory do
     # Initialize the InventoryCollections
     @data                 = {}
     @data[:vms]           = ::ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::CloudManager::Vm,
+      :model_class => ManageIQ::Providers::CloudManager::Vm,
       :parent      => @ems,
       :association => :vms)
     @data[:key_pairs]     = ::ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::CloudManager::AuthKeyPair,
+      :model_class => ManageIQ::Providers::CloudManager::AuthKeyPair,
       :parent      => @ems,
       :association => :key_pairs,
       :manager_ref => [:name])
     @data[:miq_templates] = ::ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::CloudManager::Template,
+      :model_class => ManageIQ::Providers::CloudManager::Template,
       :parent      => @ems,
       :association => :miq_templates)
     @data[:hardwares]     = ::ManagerRefresh::InventoryCollection.new(
-      Hardware,
+      :model_class => Hardware,
       :parent      => @ems,
       :association => :hardwares,
       :manager_ref => [:vm_or_template])
     @data[:disks]         = ::ManagerRefresh::InventoryCollection.new(
-      Disk,
+      :model_class => Disk,
       :parent      => @ems,
       :association => :disks,
       :manager_ref => [:hardware, :device_name])
     @data[:networks]      = ::ManagerRefresh::InventoryCollection.new(
-      Network,
+      :model_class => Network,
       :parent      => @ems,
       :association => :networks,
       :manager_ref => [:hardware, :description])
     @data[:flavors]       = ::ManagerRefresh::InventoryCollection.new(
-      Flavor,
+      :model_class => Flavor,
       :parent      => @ems,
       :association => :flavors,
       :manager_ref => [:name])

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
@@ -433,15 +433,15 @@ describe ManagerRefresh::SaveInventory do
         it 'test network_port -> stack -> resource -> stack' do
           @data                                  = {}
           @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::OrchestrationStack,
+            :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
             :parent      => @ems,
             :association => :orchestration_stacks)
           @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-            OrchestrationStackResource,
+            :model_class => OrchestrationStackResource,
             :parent      => @ems,
             :association => :orchestration_stacks_resources)
           @data[:network_ports]                  = ::ManagerRefresh::InventoryCollection.new(
-            NetworkPort,
+            :model_class => NetworkPort,
             :parent      => @ems.network_manager,
             :association => :network_ports)
 
@@ -503,15 +503,15 @@ describe ManagerRefresh::SaveInventory do
         it 'test network_port -> stack -> resource -> stack reverted' do
           @data                                  = {}
           @data[:network_ports]                  = ::ManagerRefresh::InventoryCollection.new(
-            NetworkPort,
+            :model_class => NetworkPort,
             :parent      => @ems.network_manager,
             :association => :network_ports)
           @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-            OrchestrationStackResource,
+            :model_class => OrchestrationStackResource,
             :parent      => @ems,
             :association => :orchestration_stacks_resources)
           @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::OrchestrationStack,
+            :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
             :parent      => @ems,
             :association => :orchestration_stacks)
 
@@ -575,7 +575,7 @@ describe ManagerRefresh::SaveInventory do
           # data dependencies and saving it according to the tree.
           @data                 = {}
           @data[:network_ports] = ::ManagerRefresh::InventoryCollection.new(
-            NetworkPort,
+            :model_class => NetworkPort,
             :parent      => @ems.network_manager,
             :association => :network_ports)
 
@@ -616,15 +616,15 @@ describe ManagerRefresh::SaveInventory do
           # edge correctly and this cycle is solvable.
           @data                                  = {}
           @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::OrchestrationStack,
+            :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
             :parent      => @ems,
             :association => :orchestration_stacks)
           @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-            OrchestrationStackResource,
+            :model_class => OrchestrationStackResource,
             :parent      => @ems,
             :association => :orchestration_stacks_resources)
           @data[:network_ports]                  = ::ManagerRefresh::InventoryCollection.new(
-            NetworkPort,
+            :model_class => NetworkPort,
             :parent      => @ems.network_manager,
             :association => :network_ports)
 
@@ -686,15 +686,15 @@ describe ManagerRefresh::SaveInventory do
         it 'test network_port -> stack -> resource -> stack and network_port -> resource -> stack -> resource -> stack ' do
           @data                                  = {}
           @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::OrchestrationStack,
+            :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
             :parent      => @ems,
             :association => :orchestration_stacks)
           @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-            OrchestrationStackResource,
+            :model_class => OrchestrationStackResource,
             :parent      => @ems,
             :association => :orchestration_stacks_resources)
           @data[:network_ports]                  = ::ManagerRefresh::InventoryCollection.new(
-            NetworkPort,
+            :model_class => NetworkPort,
             :parent      => @ems.network_manager,
             :association => :network_ports)
 
@@ -982,11 +982,11 @@ describe ManagerRefresh::SaveInventory do
     # Initialize the InventoryCollections
     @data                                  = {}
     @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::CloudManager::OrchestrationStack,
+      :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
       :parent      => @ems,
       :association => :orchestration_stacks)
     @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-      OrchestrationStackResource,
+      :model_class => OrchestrationStackResource,
       :parent      => @ems,
       :association => :orchestration_stacks_resources)
   end
@@ -996,11 +996,11 @@ describe ManagerRefresh::SaveInventory do
     # the order of the InventoryCollections
     @data                                  = {}
     @data[:orchestration_stacks_resources] = ::ManagerRefresh::InventoryCollection.new(
-      OrchestrationStackResource,
+      :model_class => OrchestrationStackResource,
       :parent      => @ems,
       :association => :orchestration_stacks_resources)
     @data[:orchestration_stacks]           = ::ManagerRefresh::InventoryCollection.new(
-      ManageIQ::Providers::CloudManager::OrchestrationStack,
+      :model_class => ManageIQ::Providers::CloudManager::OrchestrationStack,
       :parent      => @ems,
       :association => :orchestration_stacks)
   end

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -155,7 +155,7 @@ describe ManagerRefresh::SaveInventory do
 
         initialize_inventory_collections([:disks])
         @data[:disks] = ::ManagerRefresh::InventoryCollection.new(
-          Disk,
+          :model_class => Disk,
           :association => :disks,
           :parent      => @vm3,
           :manager_ref => [:hardware, :device_name]
@@ -222,7 +222,7 @@ describe ManagerRefresh::SaveInventory do
 
         initialize_inventory_collections([:disks])
         @data[:disks] = ::ManagerRefresh::InventoryCollection.new(
-          Disk,
+          :model_class => Disk,
           :association => :disks,
           :parent      => @vm3,
           :manager_ref => [:hardware, :device_name])
@@ -301,14 +301,14 @@ describe ManagerRefresh::SaveInventory do
         vm_refs = ["vm_ems_ref_3", "vm_ems_ref_4"]
 
         @data[:vms]       = ::ManagerRefresh::InventoryCollection.new(
-          ManageIQ::Providers::CloudManager::Vm,
-          :arel => @ems.vms.where(:ems_ref => vm_refs))
+          :model_class => ManageIQ::Providers::CloudManager::Vm,
+          :arel        => @ems.vms.where(:ems_ref => vm_refs))
         @data[:hardwares] = ::ManagerRefresh::InventoryCollection.new(
-          Hardware,
+          :model_class => Hardware,
           :arel        => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
           :manager_ref => [:vm_or_template])
         @data[:disks]     = ::ManagerRefresh::InventoryCollection.new(
-          Disk,
+          :model_class => Disk,
           :arel        => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
           :manager_ref => [:hardware, :device_name])
 
@@ -385,18 +385,18 @@ describe ManagerRefresh::SaveInventory do
         vm_refs = ["vm_ems_ref_3", "vm_ems_ref_5"]
 
         @data[:vms]             = ::ManagerRefresh::InventoryCollection.new(
-          ManageIQ::Providers::CloudManager::Vm,
-          :arel => @ems.vms.where(:ems_ref => vm_refs))
+          :model_class => ManageIQ::Providers::CloudManager::Vm,
+          :arel        => @ems.vms.where(:ems_ref => vm_refs))
         @data[:hardwares]       = ::ManagerRefresh::InventoryCollection.new(
-          Hardware,
+          :model_class => Hardware,
           :arel        => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
           :manager_ref => [:vm_or_template])
         @data[:disks]           = ::ManagerRefresh::InventoryCollection.new(
-          Disk,
+          :model_class => Disk,
           :arel        => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
           :manager_ref => [:hardware, :device_name])
         @data[:image_hardwares] = ::ManagerRefresh::InventoryCollection.new(
-          Hardware,
+          :model_class         => Hardware,
           :arel                => @ems.hardwares,
           :manager_ref         => [:vm_or_template],
           :strategy            => :local_db_cache_all,
@@ -670,7 +670,7 @@ describe ManagerRefresh::SaveInventory do
     # Initialize the InventoryCollections
     @data = {}
     all_collections.each do |collection|
-      @data[collection] = ::ManagerRefresh::InventoryCollection.new(*send("#{collection}_init_data"))
+      @data[collection] = ::ManagerRefresh::InventoryCollection.new(send("#{collection}_init_data"))
     end
   end
 
@@ -678,48 +678,53 @@ describe ManagerRefresh::SaveInventory do
     # Initialize the InventoryCollections
     @data = {}
     only_collections.each do |collection|
-      @data[collection] = ::ManagerRefresh::InventoryCollection.new(*send("#{collection}_init_data",
-                                                                          :extra_attributes => {
-                                                                            :complete => false}))
+      @data[collection] = ::ManagerRefresh::InventoryCollection.new(send("#{collection}_init_data",
+                                                                         :extra_attributes => {
+                                                                           :complete => false}))
     end
 
     (all_collections - only_collections).each do |collection|
-      @data[collection] = ::ManagerRefresh::InventoryCollection.new(*send("#{collection}_init_data",
-                                                                          :extra_attributes => {
-                                                                            :complete => false,
-                                                                            :strategy => :local_db_cache_all
-                                                                          }))
+      @data[collection] = ::ManagerRefresh::InventoryCollection.new(send("#{collection}_init_data",
+                                                                         :extra_attributes => {
+                                                                           :complete => false,
+                                                                           :strategy => :local_db_cache_all
+                                                                         }))
     end
   end
 
   def orchestration_stacks_init_data(extra_attributes: {})
-    init_data(ManageIQ::Providers::CloudManager::OrchestrationStack,
-              :orchestration_stacks,
+    extra_attributes[:model_class] = ManageIQ::Providers::CloudManager::OrchestrationStack
+
+    init_data(:orchestration_stacks,
               extra_attributes)
   end
 
   def orchestration_stacks_resources_init_data(extra_attributes: {})
-    init_data(OrchestrationStackResource,
-              :orchestration_stacks_resources,
+    extra_attributes[:model_class] = OrchestrationStackResource
+
+    init_data(:orchestration_stacks_resources,
               extra_attributes)
   end
 
   def vms_init_data(extra_attributes: {})
-    init_data(ManageIQ::Providers::CloudManager::Vm,
-              :vms,
+    extra_attributes[:model_class] = ManageIQ::Providers::CloudManager::Vm
+
+    init_data(:vms,
               extra_attributes)
   end
 
   def miq_templates_init_data(extra_attributes: {})
-    init_data(ManageIQ::Providers::CloudManager::Template,
-              :miq_templates,
+    extra_attributes[:model_class] = ManageIQ::Providers::CloudManager::Template
+
+    init_data(:miq_templates,
               extra_attributes)
   end
 
   def key_pairs_init_data(extra_attributes: {})
     extra_attributes[:manager_ref] = [:name]
-    init_data(ManageIQ::Providers::CloudManager::AuthKeyPair,
-              :key_pairs,
+    extra_attributes[:model_class] = ManageIQ::Providers::CloudManager::AuthKeyPair
+
+    init_data(:key_pairs,
               extra_attributes)
   end
 
@@ -731,8 +736,8 @@ describe ManagerRefresh::SaveInventory do
     end
 
     extra_attributes[:manager_ref] = [:vm_or_template]
-    init_data(Hardware,
-              :hardwares,
+    extra_attributes[:model_class] = Hardware
+    init_data(:hardwares,
               extra_attributes)
   end
 
@@ -744,19 +749,19 @@ describe ManagerRefresh::SaveInventory do
     end
 
     extra_attributes[:manager_ref] = [:hardware, :device_name]
-    init_data(Disk,
-              :disks,
+    extra_attributes[:model_class] = Disk
+    init_data(:disks,
               extra_attributes)
   end
 
-  def init_data(model_class, association, extra_attributes)
+  def init_data(association, extra_attributes)
     init_data = {
       :parent      => @ems,
       :association => association
     }
 
     init_data.merge!(extra_attributes)
-    return model_class, init_data
+    init_data
   end
 
   def association_attributes(model_class)

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -32,7 +32,7 @@ describe ManagerRefresh::SaveInventory do
           # Initialize the InventoryCollections
           data       = {}
           data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
+            :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
 
           # Fill the InventoryCollections with data
           add_data_to_inventory_collection(data[:vms], vm_data(1), vm_data(2))
@@ -51,7 +51,7 @@ describe ManagerRefresh::SaveInventory do
           # Initialize the InventoryCollections
           data       = {}
           data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
+            :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
 
           # Fill the InventoryCollections with data
           add_data_to_inventory_collection(data[:vms],
@@ -75,7 +75,7 @@ describe ManagerRefresh::SaveInventory do
           # Initialize the InventoryCollections
           data       = {}
           data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-            ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
+            :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
 
           # Fill the InventoryCollections with data, that have a modified name
           add_data_to_inventory_collection(data[:vms],
@@ -105,7 +105,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
+              :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms)
           end
 
           it 'has correct records in the DB' do
@@ -186,7 +186,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class   => ManageIQ::Providers::CloudManager::Vm,
               :parent        => @ems,
               :association   => :vms,
               :delete_method => :disconnect_inv)
@@ -238,7 +238,7 @@ describe ManagerRefresh::SaveInventory do
           # column
           it 'recognizes correct presence validators' do
             inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               :attributes_blacklist => [:ems_ref, :uid_ems, :name, :location])
@@ -254,7 +254,7 @@ describe ManagerRefresh::SaveInventory do
           it 'does not blacklist fixed attributes with default manager_ref' do
             # Fixed attributes are attributes used for unique ID of the DTO or attributes with presence validation
             inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               :attributes_blacklist => [:ems_ref, :uid_ems, :name, :location, :vendor, :raw_power_state])
@@ -265,7 +265,7 @@ describe ManagerRefresh::SaveInventory do
           it 'has fixed and internal attributes amongst whitelisted_attributes with default manager_ref' do
             # Fixed attributes are attributes used for unique ID of the DTO or attributes with presence validation
             inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               :attributes_whitelist => [:raw_power_state, :ext_management_system])
@@ -277,7 +277,7 @@ describe ManagerRefresh::SaveInventory do
 
           it 'does not blacklist fixed attributes when changing manager_ref' do
             inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :manager_ref          => [:uid_ems],
               :parent               => @ems,
               :association          => :vms,
@@ -289,7 +289,7 @@ describe ManagerRefresh::SaveInventory do
           it 'has fixed and internal attributes amongst whitelisted_attributes when changing manager_ref' do
             # Fixed attributes are attributes used for unique ID of the DTO or attributes with presence validation
             inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :manager_ref          => [:uid_ems],
               :parent               => @ems,
               :association          => :vms,
@@ -304,7 +304,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class => ManageIQ::Providers::CloudManager::Vm,
               :parent      => @ems,
               :association => :vms)
 
@@ -341,7 +341,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               :attributes_blacklist => [:name, :location, :raw_power_state])
@@ -379,7 +379,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               # TODO(lsmola) vendor is not getting caught by fixed attributes
@@ -418,7 +418,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class          => ManageIQ::Providers::CloudManager::Vm,
               :parent               => @ems,
               :association          => :vms,
               # TODO(lsmola) vendor is not getting caught by fixed attributes
@@ -460,7 +460,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class => ManageIQ::Providers::CloudManager::Vm,
               :parent      => @ems,
               :association => :vms,
               :complete    => false)
@@ -493,7 +493,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             data       = {}
             data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm, :parent => availability_zone, :association => :vms)
+              :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => availability_zone, :association => :vms)
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
@@ -522,7 +522,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             data       = {}
             data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm, :parent => cloud_tenant, :association => :vms)
+              :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => cloud_tenant, :association => :vms)
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
@@ -551,7 +551,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             data       = {}
             data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm, :parent => cloud_tenant, :association => :vms)
+              :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => cloud_tenant, :association => :vms)
 
             # Fill the InventoryCollections with data, that have one new VM and are missing one VM
             add_data_to_inventory_collection(data[:vms],
@@ -584,7 +584,7 @@ describe ManagerRefresh::SaveInventory do
             # Initialize the InventoryCollections
             data       = {}
             data[:vms] = ::ManagerRefresh::InventoryCollection.new(
-              ManageIQ::Providers::CloudManager::Vm,
+              :model_class => ManageIQ::Providers::CloudManager::Vm,
               :parent      => cloud_tenant,
               :association => :vms,
               :complete    => false)


### PR DESCRIPTION
The inventory collection now takes only kwargs. Model class was last classic argument. But model class is not required in some cases, e.g. when using a custom saving code.