### PR TITLE
Middelware server group power ops

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -256,7 +256,6 @@ module ManageIQ::Providers
       run_generic_operation(:JDR, ems_ref)
     end
 
-
     def self.raw_alerts_connect(hostname, port, username, password)
       require 'hawkular_all'
       url = URI::HTTP.build(:host => hostname, :port => port.to_i, :path => '/hawkular/alerts').to_s

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -175,6 +175,21 @@ module ManageIQ::Providers
       with_provider_connection(&:alerts)
     end
 
+    # server ops
+    def shutdown_middleware_server(ems_ref, params)
+      timeout = params[:timeout] || 0
+      run_generic_operation(:Shutdown, ems_ref, :restart => false, :timeout => timeout)
+    end
+
+    def suspend_middleware_server(ems_ref, params)
+      timeout = params[:timeout] || 0
+      run_generic_operation(:Suspend, ems_ref, :timeout => timeout)
+    end
+
+    def resume_middleware_server(ems_ref)
+      run_generic_operation(:Resume, ems_ref)
+    end
+
     def reload_middleware_server(ems_ref)
       run_generic_operation(:Reload, ems_ref)
     end
@@ -195,6 +210,7 @@ module ManageIQ::Providers
       run_generic_operation(:Shutdown, ems_ref, :restart => true)
     end
 
+    # domain server ops
     def restart_middleware_domain_server(ems_ref)
       run_generic_operation(:Restart, ems_ref)
     end
@@ -203,23 +219,43 @@ module ManageIQ::Providers
       run_generic_operation(:Kill, ems_ref)
     end
 
-    def shutdown_middleware_server(ems_ref, params)
-      timeout = params[:timeout] || 0
-      run_generic_operation(:Shutdown, ems_ref, :restart => false, :timeout => timeout)
+    # server group ops
+    def start_middleware_server_group(ems_ref)
+      # blocking: boolean
+      run_generic_operation('Start Servers', ems_ref)
     end
 
-    def suspend_middleware_server(ems_ref, params)
+    def stop_middleware_server_group(ems_ref, params)
+      # blocking: boolean
+      # timeout: int
       timeout = params[:timeout] || 0
-      run_generic_operation(:Suspend, ems_ref, :timeout => timeout)
+      run_generic_operation('Stop Servers', ems_ref, :timeout => timeout)
     end
 
-    def resume_middleware_server(ems_ref)
-      run_generic_operation(:Resume, ems_ref)
+    def restart_middleware_server_group(ems_ref)
+      # blocking: boolean
+      run_generic_operation('Restart Servers', ems_ref)
+    end
+
+    def reload_middleware_server_group(ems_ref)
+      # blocking: boolean
+      run_generic_operation('Reload Servers', ems_ref)
+    end
+
+    def suspend_middleware_server_group(ems_ref, params)
+      # timeout: int
+      timeout = params[:timeout] || 0
+      run_generic_operation('Suspend Servers', ems_ref, :timeout => timeout)
+    end
+
+    def resume_middleware_server_group(ems_ref)
+      run_generic_operation('Resume Servers', ems_ref)
     end
 
     def create_jdr_report(ems_ref)
       run_generic_operation(:JDR, ems_ref)
     end
+
 
     def self.raw_alerts_connect(hostname, port, username, password)
       require 'hawkular_all'

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -221,29 +221,23 @@ module ManageIQ::Providers
 
     # server group ops
     def start_middleware_server_group(ems_ref)
-      # blocking: boolean
       run_generic_operation('Start Servers', ems_ref)
     end
 
     def stop_middleware_server_group(ems_ref, params)
-      # blocking: boolean
-      # timeout: int
       timeout = params[:timeout] || 0
       run_generic_operation('Stop Servers', ems_ref, :timeout => timeout)
     end
 
     def restart_middleware_server_group(ems_ref)
-      # blocking: boolean
       run_generic_operation('Restart Servers', ems_ref)
     end
 
     def reload_middleware_server_group(ems_ref)
-      # blocking: boolean
       run_generic_operation('Reload Servers', ems_ref)
     end
 
     def suspend_middleware_server_group(ems_ref, params)
-      # timeout: int
       timeout = params[:timeout] || 0
       run_generic_operation('Suspend Servers', ems_ref, :timeout => timeout)
     end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -176,12 +176,12 @@ module ManageIQ::Providers
     end
 
     # server ops
-    def shutdown_middleware_server(ems_ref, params)
+    def shutdown_middleware_server(ems_ref, params = {})
       timeout = params[:timeout] || 0
       run_generic_operation(:Shutdown, ems_ref, :restart => false, :timeout => timeout)
     end
 
-    def suspend_middleware_server(ems_ref, params)
+    def suspend_middleware_server(ems_ref, params = {})
       timeout = params[:timeout] || 0
       run_generic_operation(:Suspend, ems_ref, :timeout => timeout)
     end
@@ -224,7 +224,7 @@ module ManageIQ::Providers
       run_generic_operation('Start Servers', ems_ref)
     end
 
-    def stop_middleware_server_group(ems_ref, params)
+    def stop_middleware_server_group(ems_ref, params = {})
       timeout = params[:timeout] || 0
       run_generic_operation('Stop Servers', ems_ref, :timeout => timeout)
     end
@@ -237,7 +237,7 @@ module ManageIQ::Providers
       run_generic_operation('Reload Servers', ems_ref)
     end
 
-    def suspend_middleware_server_group(ems_ref, params)
+    def suspend_middleware_server_group(ems_ref, params = {})
       timeout = params[:timeout] || 0
       run_generic_operation('Suspend Servers', ems_ref, :timeout => timeout)
     end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4069,8 +4069,32 @@
       :description: Edit Tags of Middleware Server Groups
       :feature_type: control
       :identifier: middleware_server_group_tag
+    - :name: Reload middleware server group
+      :description: Trigger reload operation for Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_reload
+    - :name: Stop middleware server group
+      :description: Stop Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_stop
+    - :name: Start middleware server group
+      :description: Start Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_start
+    - :name: Suspend middleware server group
+      :description: Suspend Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_suspend
+    - :name: Resume middleware server group
+      :description: Resume a suspended Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_resume
+    - :name: Restart middleware server group
+      :description: Restart a Middleware Server Group
+      :feature_type: admin
+      :identifier: middleware_server_group_restart
     - :name: Add middleware deployment
-      :description: Add middleware deployment
+      :description: Add middleware deployment for Server Group
       :feature_type: admin
       :identifier: middleware_group_deployment_add
 


### PR DESCRIPTION
Adding support for server group operations, namely:
* suspend
* resume
* restart
* stop
* start

@miq-bot add_labels providers/hawkular, enhancement