### PR TITLE
Extract non-generic shared code into mixins in API

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -142,16 +142,6 @@ module Api
         invoke_custom_action(type, resource, action, data)
       end
 
-      def refresh_dialog_fields_action(dialog, refresh_fields, resource_ident)
-        result = {}
-        refresh_fields.each do |field|
-          dynamic_field = dialog.field(field)
-          return action_result(false, "Unknown dialog field #{field} specified") unless dynamic_field
-          result[field] = dynamic_field.update_and_serialize_values
-        end
-        action_result(true, "Refreshing dialog fields for #{resource_ident}", :result => result)
-      end
-
       private
 
       def add_subcollection_data_to_resource(resource, type, subcollection_data)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -103,30 +103,6 @@ module Api
         delete_resource_action(klass, type, id)
       end
 
-      def retire_resource(type, id, data = nil)
-        klass = collection_class(type)
-        if id
-          msg = "Retiring #{type} id #{id}"
-          resource = resource_search(id, type, klass)
-          if data && data["date"]
-            opts = {}
-            opts[:date] = data["date"]
-            opts[:warn] = data["warn"] if data["warn"]
-            msg << " on: #{opts}"
-            api_log_info(msg)
-            resource.retire(opts)
-          else
-            msg << " immediately."
-            api_log_info(msg)
-            resource.retire_now
-          end
-          resource
-        else
-          raise BadRequestError, "Must specify an id for retiring a #{type} resource"
-        end
-      end
-      alias generic_retire_resource retire_resource
-
       private
 
       def add_subcollection_data_to_resource(resource, type, subcollection_data)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -142,18 +142,6 @@ module Api
         invoke_custom_action(type, resource, action, data)
       end
 
-      def set_ownership_resource(type, id, data = nil)
-        raise BadRequestError, "Must specify an id for setting ownership of a #{type} resource" unless id
-        raise BadRequestError, "Must specify an owner or group for setting ownership data = #{data}" if data.blank?
-
-        api_action(type, id) do |klass|
-          resource_search(id, type, klass)
-          api_log_info("Setting ownership to #{type} #{id}")
-          ownership = parse_ownership(data)
-          set_ownership_action(klass, type, id, ownership)
-        end
-      end
-
       def refresh_dialog_fields_action(dialog, refresh_fields, resource_ident)
         result = {}
         refresh_fields.each do |field|
@@ -236,19 +224,6 @@ module Api
 
       def resource_custom_action_button(resource, action)
         resource.custom_action_buttons.find { |b| b.name.downcase == action.downcase }
-      end
-
-      def set_ownership_action(klass, type, id, ownership)
-        if ownership.blank?
-          action_result(false, "Must specify a valid owner or group for setting ownership")
-        else
-          result = klass.set_ownership([id], ownership)
-          details = ownership.each.collect { |key, obj| "#{key}: #{obj.name}" }.join(", ")
-          desc = "setting ownership of #{type} id #{id} to #{details}"
-          result == true ? action_result(true, desc) : action_result(false, result.values.join(", "))
-        end
-      rescue => err
-        action_result(false, err.to_s)
       end
 
       def validate_id(id, klass)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -127,21 +127,6 @@ module Api
       end
       alias generic_retire_resource retire_resource
 
-      def custom_action_resource(type, id, data = nil)
-        action = @req.action.downcase
-        id ||= @req.c_id
-        if id.blank?
-          raise BadRequestError, "Must specify an id for invoking the custom action #{action} on a #{type} resource"
-        end
-
-        api_log_info("Invoking #{action} on #{type} id #{id}")
-        resource = resource_search(id, type, collection_class(type))
-        unless resource_custom_action_names(resource).include?(action)
-          raise BadRequestError, "Unsupported Custom Action #{action} for the #{type} resource specified"
-        end
-        invoke_custom_action(type, resource, action, data)
-      end
-
       private
 
       def add_subcollection_data_to_resource(resource, type, subcollection_data)
@@ -171,49 +156,6 @@ module Api
         add_href_to_result(result, type, id)
         log_result(result)
         result
-      end
-
-      def invoke_custom_action(type, resource, action, data)
-        custom_button = resource_custom_action_button(resource, action)
-        if custom_button.resource_action.dialog_id
-          return invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
-        end
-
-        result = begin
-                   custom_button.invoke(resource)
-                   action_result(true, "Invoked custom action #{action} for #{type} id: #{resource.id}")
-                 rescue => err
-                   action_result(false, err.to_s)
-                 end
-        add_href_to_result(result, type, resource.id)
-        log_result(result)
-        result
-      end
-
-      def invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
-        result = begin
-                   wf_result = submit_custom_action_dialog(resource, custom_button, data)
-                   action_result(true,
-                                 "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",
-                                 :result => wf_result[:request])
-                 rescue => err
-                   action_result(false, err.to_s)
-                 end
-        add_href_to_result(result, type, resource.id)
-        log_result(result)
-        result
-      end
-
-      def submit_custom_action_dialog(resource, custom_button, data)
-        wf = ResourceActionWorkflow.new({}, User.current_user, custom_button.resource_action, :target => resource)
-        data.each { |key, value| wf.set_value(key, value) } if data.present?
-        wf_result = wf.submit_request
-        raise StandardError, Array(wf_result[:errors]).join(", ") if wf_result[:errors].present?
-        wf_result
-      end
-
-      def resource_custom_action_button(resource, action)
-        resource.custom_action_buttons.find { |b| b.name.downcase == action.downcase }
       end
 
       def validate_id(id, klass)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -115,11 +115,6 @@ module Api
         objs.collect(&:id).first
       end
 
-      def parse_owner(resource)
-        return nil if resource.blank?
-        parse_id(resource, :users) || parse_by_attr(resource, :users)
-      end
-
       def parse_group(resource)
         return nil if resource.blank?
         parse_id(resource, :groups) || parse_by_attr(resource, :groups)
@@ -144,13 +139,6 @@ module Api
         availability_zone_id = parse_id(data, :availability_zones)
         raise BadRequestError, 'Missing availability zone identifier href or id' if availability_zone_id.nil?
         resource_search(availability_zone_id, :availability_zones, collection_class(:availability_zones))
-      end
-
-      def parse_ownership(data)
-        {
-          :owner => collection_class(:users).find_by_id(parse_owner(data["owner"])),
-          :group => collection_class(:groups).find_by_id(parse_group(data["group"]))
-        }.compact if data.present?
       end
 
       # RBAC Aware type specific resource fetches

--- a/app/controllers/api/service_catalogs_controller.rb
+++ b/app/controllers/api/service_catalogs_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ServiceCatalogsController < BaseController
+    include Shared::DialogFields
     include Subcollections::ServiceTemplates
   end
 end

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ServiceDialogsController < BaseController
+    include Shared::DialogFields
+
     before_action :set_additional_attributes, :only => [:index, :show]
 
     def refresh_dialog_fields_resource(type, id = nil, data = nil)

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ServiceTemplatesController < BaseController
+    include Shared::DialogFields
     include Subcollections::ServiceDialogs
     include Subcollections::Tags
     include Subcollections::ResourceActions

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -2,6 +2,7 @@ module Api
   class ServicesController < BaseController
     include Shared::CustomActions
     include Shared::Ownable
+    include Shared::Retirable
     include Subcollections::ServiceDialogs
     include Subcollections::Tags
     include Subcollections::Vms

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ServicesController < BaseController
+    include Shared::Ownable
     include Subcollections::ServiceDialogs
     include Subcollections::Tags
     include Subcollections::Vms

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ServicesController < BaseController
+    include Shared::CustomActions
     include Shared::Ownable
     include Subcollections::ServiceDialogs
     include Subcollections::Tags

--- a/app/controllers/api/shared/custom_actions.rb
+++ b/app/controllers/api/shared/custom_actions.rb
@@ -1,0 +1,63 @@
+module Api
+  module Shared
+    module CustomActions
+      def custom_action_resource(type, id, data = nil)
+        action = @req.action.downcase
+        id ||= @req.c_id
+        if id.blank?
+          raise BadRequestError, "Must specify an id for invoking the custom action #{action} on a #{type} resource"
+        end
+
+        api_log_info("Invoking #{action} on #{type} id #{id}")
+        resource = resource_search(id, type, collection_class(type))
+        unless resource_custom_action_names(resource).include?(action)
+          raise BadRequestError, "Unsupported Custom Action #{action} for the #{type} resource specified"
+        end
+        invoke_custom_action(type, resource, action, data)
+      end
+
+      def invoke_custom_action(type, resource, action, data)
+        custom_button = resource_custom_action_button(resource, action)
+        if custom_button.resource_action.dialog_id
+          return invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
+        end
+
+        result = begin
+                   custom_button.invoke(resource)
+                   action_result(true, "Invoked custom action #{action} for #{type} id: #{resource.id}")
+                 rescue => err
+                   action_result(false, err.to_s)
+                 end
+        add_href_to_result(result, type, resource.id)
+        log_result(result)
+        result
+      end
+
+      def invoke_custom_action_with_dialog(type, resource, action, data, custom_button)
+        result = begin
+                   wf_result = submit_custom_action_dialog(resource, custom_button, data)
+                   action_result(true,
+                                 "Invoked custom dialog action #{action} for #{type} id: #{resource.id}",
+                                 :result => wf_result[:request])
+                 rescue => err
+                   action_result(false, err.to_s)
+                 end
+        add_href_to_result(result, type, resource.id)
+        log_result(result)
+        result
+      end
+
+      def submit_custom_action_dialog(resource, custom_button, data)
+        wf = ResourceActionWorkflow.new({}, User.current_user, custom_button.resource_action, :target => resource)
+        data.each { |key, value| wf.set_value(key, value) } if data.present?
+        wf_result = wf.submit_request
+        raise StandardError, Array(wf_result[:errors]).join(", ") if wf_result[:errors].present?
+        wf_result
+      end
+
+      def resource_custom_action_button(resource, action)
+        resource.custom_action_buttons.find { |b| b.name.downcase == action.downcase }
+      end
+    end
+  end
+end

--- a/app/controllers/api/shared/dialog_fields.rb
+++ b/app/controllers/api/shared/dialog_fields.rb
@@ -1,0 +1,15 @@
+module Api
+  module Shared
+    module DialogFields
+      def refresh_dialog_fields_action(dialog, refresh_fields, resource_ident)
+        result = {}
+        refresh_fields.each do |field|
+          dynamic_field = dialog.field(field)
+          return action_result(false, "Unknown dialog field #{field} specified") unless dynamic_field
+          result[field] = dynamic_field.update_and_serialize_values
+        end
+        action_result(true, "Refreshing dialog fields for #{resource_ident}", :result => result)
+      end
+    end
+  end
+end

--- a/app/controllers/api/shared/ownable.rb
+++ b/app/controllers/api/shared/ownable.rb
@@ -1,0 +1,42 @@
+module Api
+  module Shared
+    module Ownable
+      def set_ownership_resource(type, id, data = nil)
+        raise BadRequestError, "Must specify an id for setting ownership of a #{type} resource" unless id
+        raise BadRequestError, "Must specify an owner or group for setting ownership data = #{data}" if data.blank?
+
+        api_action(type, id) do |klass|
+          resource_search(id, type, klass)
+          api_log_info("Setting ownership to #{type} #{id}")
+          ownership = parse_ownership(data)
+          set_ownership_action(klass, type, id, ownership)
+        end
+      end
+
+      def set_ownership_action(klass, type, id, ownership)
+        if ownership.blank?
+          action_result(false, "Must specify a valid owner or group for setting ownership")
+        else
+          result = klass.set_ownership([id], ownership)
+          details = ownership.each.collect { |key, obj| "#{key}: #{obj.name}" }.join(", ")
+          desc = "setting ownership of #{type} id #{id} to #{details}"
+          result == true ? action_result(true, desc) : action_result(false, result.values.join(", "))
+        end
+      rescue => err
+        action_result(false, err.to_s)
+      end
+
+      def parse_ownership(data)
+        {
+          :owner => collection_class(:users).find_by_id(parse_owner(data["owner"])),
+          :group => collection_class(:groups).find_by_id(parse_group(data["group"]))
+        }.compact if data.present?
+      end
+
+      def parse_owner(resource)
+        return nil if resource.blank?
+        parse_id(resource, :users) || parse_by_attr(resource, :users)
+      end
+    end
+  end
+end

--- a/app/controllers/api/shared/ownable.rb
+++ b/app/controllers/api/shared/ownable.rb
@@ -27,10 +27,11 @@ module Api
       end
 
       def parse_ownership(data)
+        return unless data.present?
         {
-          :owner => collection_class(:users).find_by_id(parse_owner(data["owner"])),
-          :group => collection_class(:groups).find_by_id(parse_group(data["group"]))
-        }.compact if data.present?
+          :owner => collection_class(:users).find_by(:id => parse_owner(data["owner"])),
+          :group => collection_class(:groups).find_by(:id => parse_group(data["group"]))
+        }.compact
       end
 
       def parse_owner(resource)

--- a/app/controllers/api/shared/retirable.rb
+++ b/app/controllers/api/shared/retirable.rb
@@ -1,0 +1,29 @@
+module Api
+  module Shared
+    module Retirable
+      def retire_resource(type, id, data = nil)
+        klass = collection_class(type)
+        if id
+          msg = "Retiring #{type} id #{id}"
+          resource = resource_search(id, type, klass)
+          if data && data["date"]
+            opts = {}
+            opts[:date] = data["date"]
+            opts[:warn] = data["warn"] if data["warn"]
+            msg << " on: #{opts}"
+            api_log_info(msg)
+            resource.retire(opts)
+          else
+            msg << " immediately."
+            api_log_info(msg)
+            resource.retire_now
+          end
+          resource
+        else
+          raise BadRequestError, "Must specify an id for retiring a #{type} resource"
+        end
+      end
+      alias generic_retire_resource retire_resource
+    end
+  end
+end

--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class TemplatesController < BaseController
+    include Shared::Ownable
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
     include Subcollections::Tags

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class VmsController < BaseController
     include Shared::Ownable
+    include Shared::Retirable
     include Subcollections::Tags
     include Subcollections::Policies
     include Subcollections::PolicyProfiles

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class VmsController < BaseController
+    include Shared::Ownable
     include Subcollections::Tags
     include Subcollections::Policies
     include Subcollections::PolicyProfiles


### PR DESCRIPTION
These methods are included in every API controller, but only used by a few of them. By extracting them into separate mixins we can include them in only the controllers that need them.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 