### PR TITLE
Reduces depth of openstack infra resource query

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -99,7 +99,7 @@ module ManageIQ
         # To further speed up the query we only search for those resources we care about - those whose
         # physical_resource_id matches the id of a nova server
         server_ids = servers.map{|s| s.id}
-        @orchestration_service.list_resources(:stack => stack, :nested_depth => 50, :physical_resource_id => server_ids).body['resources']
+        @orchestration_service.list_resources(:stack => stack, :nested_depth => 2, :physical_resource_id => server_ids).body['resources']
       end
 
       def servers


### PR DESCRIPTION
The stack resources query is only needed to retrieve role information. Setting the depth to a smaller number still allows for retrieval of this information, and speeds up the query by five seconds.

https://bugzilla.redhat.com/show_bug.cgi?id=1417273