### PR TITLE
Expose username for ansible authentications

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -1,7 +1,5 @@
 class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def prepare
-    update_embedded_ansible_provider
-
     Thread.new do
       setup_ansible
       started_worker_record
@@ -20,6 +18,8 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
         heartbeat
         send(poll_method)
       end
+
+      update_embedded_ansible_provider
 
       _log.info("entering ansible monitor loop")
       loop do

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -70,11 +70,9 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
     provider.save!
 
-    auth = {
-      :userid   => "admin",
-      :password => MiqDatabase.first.ansible_admin_password
-    }
-    provider.update_authentication(:default => auth)
+    admin_auth = MiqDatabase.first.ansible_admin_authentication
+
+    provider.update_authentication(:default => {:userid => admin_auth.userid, :password => admin_auth.password})
   end
 
   # Base class methods we override since we don't have a separate process.  We might want to make these opt-in features in the base class that this subclass can choose to opt-out.

--- a/app/models/mixins/ansible_authentications.rb
+++ b/app/models/mixins/ansible_authentications.rb
@@ -29,43 +29,43 @@ module AnsibleAuthentications
     auth.save!
   end
 
-  def ansible_rabbitmq_password
-    auth = authentication_type(ANSIBLE_RABBITMQ_TYPE)
-    auth.nil? ? nil : auth.password
+  def ansible_rabbitmq_authentication
+    authentication_type(ANSIBLE_RABBITMQ_TYPE)
   end
 
-  def ansible_rabbitmq_password=(password)
-    auth = authentication_for_type(ANSIBLE_RABBITMQ_TYPE, "Ansible Rabbitmq Password")
+  def set_ansible_rabbitmq_authentication(password, userid = "tower")
+    auth = authentication_for_type(ANSIBLE_RABBITMQ_TYPE, "Ansible Rabbitmq Authentication")
 
-    auth.userid   = "tower"
+    auth.userid   = userid
     auth.password = password
     auth.save!
+    auth
   end
 
-  def ansible_admin_password
-    auth = authentication_type(ANSIBLE_ADMIN_TYPE)
-    auth.nil? ? nil : auth.password
+  def ansible_admin_authentication
+    authentication_type(ANSIBLE_ADMIN_TYPE)
   end
 
-  def ansible_admin_password=(password)
-    auth = authentication_for_type(ANSIBLE_ADMIN_TYPE, "Ansible Admin Password")
+  def set_ansible_admin_authentication(password, userid = "admin")
+    auth = authentication_for_type(ANSIBLE_ADMIN_TYPE, "Ansible Admin Authentication")
 
-    auth.userid   = "admin"
+    auth.userid   = userid
     auth.password = password
     auth.save!
+    auth
   end
 
-  def ansible_database_password
-    auth = authentication_type(ANSIBLE_DATABASE_TYPE)
-    auth.nil? ? nil : auth.password
+  def ansible_database_authentication
+    authentication_type(ANSIBLE_DATABASE_TYPE)
   end
 
-  def ansible_database_password=(password)
-    auth = authentication_for_type(ANSIBLE_DATABASE_TYPE, "Ansible Database Password")
+  def set_ansible_database_authentication(password, userid = "awx")
+    auth = authentication_for_type(ANSIBLE_DATABASE_TYPE, "Ansible Database Authentication")
 
-    auth.userid   = "awx"
+    auth.userid   = userid
     auth.password = password
     auth.save!
+    auth
   end
 
   private

--- a/app/models/mixins/ansible_authentications.rb
+++ b/app/models/mixins/ansible_authentications.rb
@@ -24,9 +24,7 @@ module AnsibleAuthentications
 
   def ansible_secret_key=(key)
     auth = authentication_for_type(ANSIBLE_SECRET_KEY_TYPE, "Ansible Secret Key")
-
-    auth.auth_key = key
-    auth.save!
+    update_ansible_authentication(auth, :auth_key => key)
   end
 
   def ansible_rabbitmq_authentication
@@ -35,10 +33,7 @@ module AnsibleAuthentications
 
   def set_ansible_rabbitmq_authentication(userid: "tower", password:)
     auth = authentication_for_type(ANSIBLE_RABBITMQ_TYPE, "Ansible Rabbitmq Authentication")
-
-    auth.userid   = userid
-    auth.password = password
-    auth.save!
+    update_ansible_authentication(auth, :userid => userid, :password => password)
     auth
   end
 
@@ -48,10 +43,7 @@ module AnsibleAuthentications
 
   def set_ansible_admin_authentication(userid: "admin", password:)
     auth = authentication_for_type(ANSIBLE_ADMIN_TYPE, "Ansible Admin Authentication")
-
-    auth.userid   = userid
-    auth.password = password
-    auth.save!
+    update_ansible_authentication(auth, :userid => userid, :password => password)
     auth
   end
 
@@ -61,10 +53,7 @@ module AnsibleAuthentications
 
   def set_ansible_database_authentication(userid: "awx", password:)
     auth = authentication_for_type(ANSIBLE_DATABASE_TYPE, "Ansible Database Authentication")
-
-    auth.userid   = userid
-    auth.password = password
-    auth.save!
+    update_ansible_authentication(auth, :userid => userid, :password => password)
     auth
   end
 
@@ -79,5 +68,12 @@ module AnsibleAuthentications
     auth.resource = self
     auth.authtype = auth_type
     auth
+  end
+
+  def update_ansible_authentication(auth, auth_fields)
+    auth_fields.each do |field, value|
+      auth.public_send("#{field}=", value)
+    end
+    auth.save!
   end
 end

--- a/app/models/mixins/ansible_authentications.rb
+++ b/app/models/mixins/ansible_authentications.rb
@@ -33,7 +33,7 @@ module AnsibleAuthentications
     authentication_type(ANSIBLE_RABBITMQ_TYPE)
   end
 
-  def set_ansible_rabbitmq_authentication(password, userid = "tower")
+  def set_ansible_rabbitmq_authentication(userid: "tower", password:)
     auth = authentication_for_type(ANSIBLE_RABBITMQ_TYPE, "Ansible Rabbitmq Authentication")
 
     auth.userid   = userid
@@ -46,7 +46,7 @@ module AnsibleAuthentications
     authentication_type(ANSIBLE_ADMIN_TYPE)
   end
 
-  def set_ansible_admin_authentication(password, userid = "admin")
+  def set_ansible_admin_authentication(userid: "admin", password:)
     auth = authentication_for_type(ANSIBLE_ADMIN_TYPE, "Ansible Admin Authentication")
 
     auth.userid   = userid
@@ -59,7 +59,7 @@ module AnsibleAuthentications
     authentication_type(ANSIBLE_DATABASE_TYPE)
   end
 
-  def set_ansible_database_authentication(password, userid = "awx")
+  def set_ansible_database_authentication(userid: "awx", password:)
     auth = authentication_for_type(ANSIBLE_DATABASE_TYPE, "Ansible Database Authentication")
 
     auth.userid   = userid

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -104,8 +104,8 @@ class EmbeddedAnsible
 
   def self.generate_database_authentication
     auth = miq_database.set_ansible_database_authentication(:password => generate_password)
-    connection.select_value("CREATE ROLE #{auth.userid} WITH LOGIN PASSWORD #{connection.quote(auth.password)}")
-    connection.select_value("CREATE DATABASE awx OWNER #{auth.userid} ENCODING 'utf8'")
+    connection.select_value("CREATE ROLE #{connection.quote_column_name(auth.userid)} WITH LOGIN PASSWORD #{connection.quote(auth.password)}")
+    connection.select_value("CREATE DATABASE awx OWNER #{connection.quote_column_name(auth.userid)} ENCODING 'utf8'")
     auth
   end
   private_class_method :generate_database_authentication

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -103,10 +103,10 @@ class EmbeddedAnsible
   private_class_method :generate_rabbitmq_authentication
 
   def self.generate_database_authentication
-    conn = ActiveRecord::Base.connection
     auth = miq_database.set_ansible_database_authentication(generate_password)
-    conn.select_value("CREATE ROLE #{conn.quote(auth.userid)} WITH LOGIN PASSWORD #{conn.quote(auth.password)}")
-    conn.select_value("CREATE DATABASE awx OWNER #{conn.quote(auth.userid)} ENCODING 'utf8'")
+    connection.select_value("CREATE ROLE #{auth.userid} WITH LOGIN PASSWORD #{connection.quote(auth.password)}")
+    connection.select_value("CREATE DATABASE awx OWNER #{auth.userid} ENCODING 'utf8'")
+    auth
   end
   private_class_method :generate_database_authentication
 
@@ -152,4 +152,9 @@ class EmbeddedAnsible
     SecureRandom.base64(18).tr("+/", "-_")
   end
   private_class_method :generate_password
+
+  def self.connection
+    ActiveRecord::Base.connection
+  end
+  private_class_method :connection
 end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -92,30 +92,29 @@ class EmbeddedAnsible
   end
   private_class_method :configure_secret_key
 
-  def self.generate_admin_password
-    miq_database.ansible_admin_password = generate_password
+  def self.generate_admin_authentication
+    miq_database.set_ansible_admin_authentication(generate_password)
   end
-  private_class_method :generate_admin_password
+  private_class_method :generate_admin_authentication
 
-  def self.generate_rabbitmq_password
-    miq_database.ansible_rabbitmq_password = generate_password
+  def self.generate_rabbitmq_authentication
+    miq_database.set_ansible_rabbitmq_authentication(generate_password)
   end
-  private_class_method :generate_rabbitmq_password
+  private_class_method :generate_rabbitmq_authentication
 
-  def self.generate_database_password
+  def self.generate_database_authentication
     conn = ActiveRecord::Base.connection
-    password = generate_password
-    conn.select_value("CREATE ROLE awx WITH LOGIN PASSWORD #{conn.quote(password)}")
-    conn.select_value("CREATE DATABASE awx OWNER awx ENCODING 'utf8'")
-    miq_database.ansible_database_password = password
+    auth = miq_database.set_ansible_database_authentication(generate_password)
+    conn.select_value("CREATE ROLE #{conn.quote(auth.userid)} WITH LOGIN PASSWORD #{conn.quote(auth.password)}")
+    conn.select_value("CREATE DATABASE awx OWNER #{conn.quote(auth.userid)} ENCODING 'utf8'")
   end
-  private_class_method :generate_database_password
+  private_class_method :generate_database_authentication
 
   def self.inventory_file_contents
-    admin_password    = miq_database.ansible_admin_password || generate_admin_password
-    rabbitmq_password = miq_database.ansible_rabbitmq_password || generate_rabbitmq_password
-    database_password = miq_database.ansible_database_password || generate_database_password
-    db_config         = Rails.configuration.database_configuration[Rails.env]
+    admin_auth    = miq_database.ansible_admin_authentication || generate_admin_authentication
+    rabbitmq_auth = miq_database.ansible_rabbitmq_authentication || generate_rabbitmq_authentication
+    database_auth = miq_database.ansible_database_authentication || generate_database_authentication
+    db_config     = Rails.configuration.database_configuration[Rails.env]
 
     <<-EOF.strip_heredoc
       [tower]
@@ -124,19 +123,19 @@ class EmbeddedAnsible
       [database]
 
       [all:vars]
-      admin_password='#{admin_password}'
+      admin_password='#{admin_auth.password}'
 
       pg_host='#{db_config["host"] || "localhost"}'
       pg_port='#{db_config["port"] || "5432"}'
 
       pg_database='awx'
-      pg_username='awx'
-      pg_password='#{database_password}'
+      pg_username='#{database_auth.userid}'
+      pg_password='#{database_auth.password}'
 
       rabbitmq_port=5672
       rabbitmq_vhost=tower
-      rabbitmq_username=tower
-      rabbitmq_password='#{rabbitmq_password}'
+      rabbitmq_username='#{rabbitmq_auth.userid}'
+      rabbitmq_password='#{rabbitmq_auth.password}'
       rabbitmq_cookie=cookiemonster
       rabbitmq_use_long_name=false
       rabbitmq_enable_manager=false

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -93,17 +93,17 @@ class EmbeddedAnsible
   private_class_method :configure_secret_key
 
   def self.generate_admin_authentication
-    miq_database.set_ansible_admin_authentication(generate_password)
+    miq_database.set_ansible_admin_authentication(:password => generate_password)
   end
   private_class_method :generate_admin_authentication
 
   def self.generate_rabbitmq_authentication
-    miq_database.set_ansible_rabbitmq_authentication(generate_password)
+    miq_database.set_ansible_rabbitmq_authentication(:password => generate_password)
   end
   private_class_method :generate_rabbitmq_authentication
 
   def self.generate_database_authentication
-    auth = miq_database.set_ansible_database_authentication(generate_password)
+    auth = miq_database.set_ansible_database_authentication(:password => generate_password)
     connection.select_value("CREATE ROLE #{auth.userid} WITH LOGIN PASSWORD #{connection.quote(auth.password)}")
     connection.select_value("CREATE DATABASE awx OWNER #{auth.userid} ENCODING 'utf8'")
     auth

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -238,11 +238,17 @@ describe EmbeddedAnsible do
       let(:quoted_password) { ActiveRecord::Base.connection.quote(password) }
       let(:connection)      { double(:quote => quoted_password) }
 
+      before do
+        allow(connection).to receive(:quote_column_name) do |name|
+          ActiveRecord::Base.connection.quote_column_name(name)
+        end
+      end
+
       it "creates the database" do
         allow(described_class).to receive(:connection).and_return(connection)
         expect(described_class).to receive(:generate_password).and_return(password)
-        expect(connection).to receive(:select_value).with("CREATE ROLE awx WITH LOGIN PASSWORD #{quoted_password}")
-        expect(connection).to receive(:select_value).with("CREATE DATABASE awx OWNER awx ENCODING 'utf8'")
+        expect(connection).to receive(:select_value).with("CREATE ROLE \"awx\" WITH LOGIN PASSWORD #{quoted_password}")
+        expect(connection).to receive(:select_value).with("CREATE DATABASE awx OWNER \"awx\" ENCODING 'utf8'")
 
         auth = described_class.send(:generate_database_authentication)
         expect(auth.userid).to eq("awx")

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -185,9 +185,9 @@ describe EmbeddedAnsible do
       end
 
       it "uses the existing passwords when they are set in the database" do
-        miq_database.set_ansible_admin_authentication("adminpassword")
-        miq_database.set_ansible_rabbitmq_authentication("rabbitpassword", "rabbituser")
-        miq_database.set_ansible_database_authentication("databasepassword", "databaseuser")
+        miq_database.set_ansible_admin_authentication(:password => "adminpassword")
+        miq_database.set_ansible_rabbitmq_authentication(:userid => "rabbituser", :password => "rabbitpassword")
+        miq_database.set_ansible_database_authentication(:userid => "databaseuser", :password => "databasepassword")
 
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
@@ -210,9 +210,9 @@ describe EmbeddedAnsible do
 
     describe ".start" do
       it "runs the setup script with the correct args" do
-        miq_database.set_ansible_admin_authentication("adminpassword")
-        miq_database.set_ansible_rabbitmq_authentication("rabbitpassword", "rabbituser")
-        miq_database.set_ansible_database_authentication("databasepassword", "databaseuser")
+        miq_database.set_ansible_admin_authentication(:password => "adminpassword")
+        miq_database.set_ansible_rabbitmq_authentication(:userid => "rabbituser", :password => "rabbitpassword")
+        miq_database.set_ansible_database_authentication(:userid => "databaseuser", :password => "databasepassword")
 
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -17,7 +17,7 @@ describe EmbeddedAnsibleWorker::Runner do
       before do
         EvmSpecHelper.local_guid_miq_server_zone
         MiqDatabase.seed
-        MiqDatabase.first.set_ansible_admin_authentication("secret")
+        MiqDatabase.first.set_ansible_admin_authentication(:password => "secret")
       end
 
       it "creates initial" do

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -17,7 +17,7 @@ describe EmbeddedAnsibleWorker::Runner do
       before do
         EvmSpecHelper.local_guid_miq_server_zone
         MiqDatabase.seed
-        MiqDatabase.first.ansible_admin_password = "secret"
+        MiqDatabase.first.set_ansible_admin_authentication("secret")
       end
 
       it "creates initial" do


### PR DESCRIPTION
This builds on https://github.com/ManageIQ/manageiq/pull/13733 so I will keep this WIP until that PR is merged.

This PR changes the ansible userid/password authentication setters and getters to handle the user name as well as the password.

This allows us to move the knowledge of what the default username is for the various authentication types out of the EmbeddedAnsible class and worker and keep them as proper argument default values to the setter methods.