### PR TITLE
Resource action - Add service_action.

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -330,7 +330,9 @@ class ServiceTemplate < ApplicationRecord
                  ae_endpoint[:fqname]
                end
 
-      build_options = {:action => action[:name], :fqname => fqname}
+      build_options = {:action        => action[:name],
+                       :fqname        => fqname,
+                       :ae_attributes => {:service_action => action[:name]}}
       build_options.merge!(ae_endpoint.slice(:dialog,
                                              :dialog_id,
                                              :configuration_template,

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -483,6 +483,7 @@ describe ServiceTemplate do
       expect(service_template.service_resources.first.resource_type).to eq('MiqRequest')
       expect(service_template.dialogs.first).to eq(service_dialog)
       expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
+      expect(service_template.resource_actions.pluck(:ae_attributes)).to include({:service_action=>"Provision"}, {:service_action=>"Retirement"})
       expect(service_template.resource_actions.first.dialog).to eq(service_dialog)
       expect(service_template.resource_actions.last.dialog).to eq(service_dialog)
     end


### PR DESCRIPTION
The resource action service_action value is needed by the Generic Service state machine for Ansible Playbook processing.  

Related change:
https://github.com/ManageIQ/manageiq-ui-classic/pull/297