### PR TITLE
update product features for configuration_script_payloads

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -51,11 +51,11 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: configuration_script_view
+        :identifier: embedded_configuration_script_payload_view
     :resource_actions:
       :get:
       - :name: read
-        :identifier: configuration_script_view
+        :identifier: embedded_configuration_script_payload_view
   :auth:
     :description: REST API Authentication
     :options:


### PR DESCRIPTION
This is an update to the product features used for `configuration_script_payloads` that is dependent/based on #13716 

@miq-bot add_label api, wip
@miq-bot assign @abellotti 
cc: @lgalis 