### PR TITLE
Migrate Ansible Tower Configuration Manager settings to be of Automation Manager

### DIFF
--- a/db/migrate/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager.rb
+++ b/db/migrate/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager.rb
@@ -6,7 +6,7 @@ class MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager < Activ
   def up
     say_with_time('Migrate /ems_refresh/ansible_tower_configuration% to be of Automation Manager') do
       SettingsChange.where('key LIKE ?', '/ems_refresh/ansible_tower_configuration%').each do |s|
-        s.key = s.key.sub(%r{^/ems_refresh/ansible_tower_configuration}, '/ems_refresh/ansible_tower_automation')
+        s.key = s.key.sub('/ansible_tower_configuration', '/ansible_tower_automation')
         s.save!
       end
     end
@@ -15,8 +15,8 @@ class MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager < Activ
       ' to be of Automation Manager') do
       SettingsChange.where('key LIKE ?', '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%').each do |s|
         s.key = s.key.sub(
-          %r{^/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration},
-          '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation'
+          '/ems_refresh_worker_ansible_tower_configuration',
+          '/ems_refresh_worker_ansible_tower_automation'
         )
         s.save!
       end
@@ -26,7 +26,7 @@ class MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager < Activ
   def down
     say_with_time('Migrate /ems_refresh/ansible_tower_automation% back to be of Configuration Manager') do
       SettingsChange.where("key LIKE ?", "/ems_refresh/ansible_tower_automation%").each do |s|
-        s.key = s.key.sub(%r{^/ems_refresh/ansible_tower_automation}, '/ems_refresh/ansible_tower_configuration')
+        s.key = s.key.sub('/ansible_tower_automation', '/ansible_tower_configuration')
         s.save!
       end
     end
@@ -35,8 +35,8 @@ class MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager < Activ
       ' back to be of Configuration Manager') do
       SettingsChange.where('key LIKE ?', '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%').each do |s|
         s.key = s.key.sub(
-          %r{^/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation},
-          '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration'
+          '/ems_refresh_worker_ansible_tower_automation',
+          '/ems_refresh_worker_ansible_tower_configuration'
         )
         s.save!
       end

--- a/db/migrate/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager.rb
+++ b/db/migrate/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager.rb
@@ -1,0 +1,45 @@
+class MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  def up
+    say_with_time('Migrate /ems_refresh/ansible_tower_configuration% to be of Automation Manager') do
+      SettingsChange.where('key LIKE ?', '/ems_refresh/ansible_tower_configuration%').each do |s|
+        s.key = s.key.sub(%r{^/ems_refresh/ansible_tower_configuration}, '/ems_refresh/ansible_tower_automation')
+        s.save!
+      end
+    end
+
+    say_with_time('Migrate /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%' \
+      ' to be of Automation Manager') do
+      SettingsChange.where('key LIKE ?', '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%').each do |s|
+        s.key = s.key.sub(
+          %r{^/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration},
+          '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation'
+        )
+        s.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time('Migrate /ems_refresh/ansible_tower_automation% back to be of Configuration Manager') do
+      SettingsChange.where("key LIKE ?", "/ems_refresh/ansible_tower_automation%").each do |s|
+        s.key = s.key.sub(%r{^/ems_refresh/ansible_tower_automation}, '/ems_refresh/ansible_tower_configuration')
+        s.save!
+      end
+    end
+
+    say_with_time('Migrate /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%' \
+      ' back to be of Configuration Manager') do
+      SettingsChange.where('key LIKE ?', '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%').each do |s|
+        s.key = s.key.sub(
+          %r{^/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation},
+          '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration'
+        )
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager_spec.rb
+++ b/spec/migrations/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager_spec.rb
@@ -6,90 +6,70 @@ describe MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager do
   migration_context :up do
     it 'changes the key of /ems_refresh/ansible_tower_configuration% to /ems_refresh/ansible_tower_automation%' do
       s1 = settings_change_stub.create!(
-        :key   => '/ems_refresh/ansible_tower_configuration_abc/abc',
-        :value => "targetedThing"
-      )
-      s2 = settings_change_stub.create!(
         :key   => '/ems_refresh/ansible_tower_configuration/abc',
         :value => "targetedThingAbc"
       )
-      s3 = settings_change_stub.create!(
+      s2 = settings_change_stub.create!(
         :key   => '/ems_refresh/ansible_tower_something/abc',
         :value => "something"
       )
 
       migrate
 
-      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_automation_abc/abc')
-      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_automation/abc')
-      expect(s3.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
+      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_automation/abc')
+      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
     end
 
     it 'changes the keys /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%' \
       ' to /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%' do
       s1 = settings_change_stub.create!(
-        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration_abc/abc',
-        :value => "targetedThing"
-      )
-      s2 = settings_change_stub.create!(
         :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration/abc',
         :value => "targetedThingAbc"
       )
-      s3 = settings_change_stub.create!(
+      s2 = settings_change_stub.create!(
         :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc',
         :value => "something"
       )
 
       migrate
 
-      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation_abc/abc')
-      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation/abc')
-      expect(s3.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
+      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation/abc')
+      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
     end
   end
 
   migration_context :down do
     it 'changes the keys of /ems_refresh/ansible_tower_automation% back to be of Configuration Manager' do
       s1 = settings_change_stub.create!(
-        :key   => '/ems_refresh/ansible_tower_automation_abc/abc',
-        :value => "targetedThing"
-      )
-      s2 = settings_change_stub.create!(
         :key   => '/ems_refresh/ansible_tower_automation/abc',
         :value => "targetedThingAbc"
       )
-      s3 = settings_change_stub.create!(
+      s2 = settings_change_stub.create!(
         :key   => '/ems_refresh/ansible_tower_something/abc',
         :value => "something"
       )
 
       migrate
 
-      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_configuration_abc/abc')
-      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_configuration/abc')
-      expect(s3.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
+      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_configuration/abc')
+      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
     end
 
     it 'changes the keys of /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%' \
       ' back to be of Configuration Manager' do
       s1 = settings_change_stub.create!(
-        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation_abc/abc',
-        :value => "targetedThing"
-      )
-      s2 = settings_change_stub.create!(
         :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation/abc',
         :value => "targetedThingAbc"
       )
-      s3 = settings_change_stub.create!(
+      s2 = settings_change_stub.create!(
         :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc',
         :value => "something"
       )
 
       migrate
 
-      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration_abc/abc')
-      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration/abc')
-      expect(s3.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
+      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration/abc')
+      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
     end
   end
 end

--- a/spec/migrations/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager_spec.rb
+++ b/spec/migrations/20170202195228_migrate_ansible_tower_configuration_manager_settings_to_automation_manager_spec.rb
@@ -1,0 +1,95 @@
+require_migration
+
+describe MigrateAnsibleTowerConfigurationManagerSettingsToAutomationManager do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+
+  migration_context :up do
+    it 'changes the key of /ems_refresh/ansible_tower_configuration% to /ems_refresh/ansible_tower_automation%' do
+      s1 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_configuration_abc/abc',
+        :value => "targetedThing"
+      )
+      s2 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_configuration/abc',
+        :value => "targetedThingAbc"
+      )
+      s3 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_something/abc',
+        :value => "something"
+      )
+
+      migrate
+
+      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_automation_abc/abc')
+      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_automation/abc')
+      expect(s3.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
+    end
+
+    it 'changes the keys /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration%' \
+      ' to /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%' do
+      s1 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration_abc/abc',
+        :value => "targetedThing"
+      )
+      s2 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration/abc',
+        :value => "targetedThingAbc"
+      )
+      s3 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc',
+        :value => "something"
+      )
+
+      migrate
+
+      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation_abc/abc')
+      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation/abc')
+      expect(s3.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
+    end
+  end
+
+  migration_context :down do
+    it 'changes the keys of /ems_refresh/ansible_tower_automation% back to be of Configuration Manager' do
+      s1 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_automation_abc/abc',
+        :value => "targetedThing"
+      )
+      s2 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_automation/abc',
+        :value => "targetedThingAbc"
+      )
+      s3 = settings_change_stub.create!(
+        :key   => '/ems_refresh/ansible_tower_something/abc',
+        :value => "something"
+      )
+
+      migrate
+
+      expect(s1.reload.key).to eq('/ems_refresh/ansible_tower_configuration_abc/abc')
+      expect(s2.reload.key).to eq('/ems_refresh/ansible_tower_configuration/abc')
+      expect(s3.reload.key).to eq('/ems_refresh/ansible_tower_something/abc')
+    end
+
+    it 'changes the keys of /workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation%' \
+      ' back to be of Configuration Manager' do
+      s1 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation_abc/abc',
+        :value => "targetedThing"
+      )
+      s2 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_automation/abc',
+        :value => "targetedThingAbc"
+      )
+      s3 = settings_change_stub.create!(
+        :key   => '/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc',
+        :value => "something"
+      )
+
+      migrate
+
+      expect(s1.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration_abc/abc')
+      expect(s2.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration/abc')
+      expect(s3.reload.key).to eq('/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_something/abc')
+    end
+  end
+end


### PR DESCRIPTION
These 2 keys:
* `/ems_refresh/ansible_tower_automation`
* `/workers/worker_base/queue_worker_base/ems_refresh_worker/ems_refresh_worker_ansible_tower_configuration`
 

(Ref: this previous [PR's `config/settings.yml`](https://github.com/ManageIQ/manageiq/pull/13630/files#diff-646ad6b10917e4385cbcc8c8524e24a2)