### PR TITLE
Fix nesting of describes in snapshots spec

### DIFF
--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -31,35 +31,35 @@ RSpec.describe "Snapshots API" do
         expect(response).to have_http_status(:forbidden)
       end
     end
-  end
 
-  describe "GET /api/vms/:c_id/snapshots/:s_id" do
-    it "can show a VM's snapshot" do
-      api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
-      vm = FactoryGirl.create(:vm_vmware)
-      create_time = Time.zone.parse("2017-01-11T00:00:00Z")
-      snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm, :create_time => create_time)
+    describe "GET /api/vms/:c_id/snapshots/:s_id" do
+      it "can show a VM's snapshot" do
+        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
+        vm = FactoryGirl.create(:vm_vmware)
+        create_time = Time.zone.parse("2017-01-11T00:00:00Z")
+        snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm, :create_time => create_time)
 
-      run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
 
-      expected = {
-        "create_time"       => create_time.iso8601,
-        "href"              => a_string_matching("#{vms_url(vm.id)}/snapshots/#{snapshot.id}"),
-        "id"                => snapshot.id,
-        "vm_or_template_id" => vm.id
-      }
-      expect(response.parsed_body).to include(expected)
-      expect(response).to have_http_status(:ok)
-    end
+        expected = {
+          "create_time"       => create_time.iso8601,
+          "href"              => a_string_matching("#{vms_url(vm.id)}/snapshots/#{snapshot.id}"),
+          "id"                => snapshot.id,
+          "vm_or_template_id" => vm.id
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
 
-    it "will not show a snapshot unless authorized" do
-      api_basic_authorize
-      vm = FactoryGirl.create(:vm_vmware)
-      snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
+      it "will not show a snapshot unless authorized" do
+        api_basic_authorize
+        vm = FactoryGirl.create(:vm_vmware)
+        snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
-      run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
+        run_get("#{vms_url(vm.id)}/snapshots/#{snapshot.id}")
 
-      expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
     describe "POST /api/vms/:c_id/snapshots" do


### PR DESCRIPTION
I messed up the nesting with these specs. i started to fix this while working on a new snapshots API feature, but decided to break this out because I don't want the diff to obscure some critical changes I'm about to make.

@miq-bot add-label api, test
@miq-bot assign @abellotti 