### PR TITLE
Add index route for arbitrary resource path collections

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -1,18 +1,32 @@
 module Api
   class AutomateController < BaseController
+    def index
+      resources = fetch_resources
+      render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
+    end
+
     def show
-      ae_browser = MiqAeBrowser.new(User.current_user)
-      begin
-        resources = ae_browser.search(@req.c_suffix, ae_search_options)
-      rescue => err
-        raise BadRequestError, err.to_s
-      end
-      attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
-      resources = resources.collect { |resource| resource.slice(*attributes) } if attributes.present?
+      resources = fetch_resources(@req.c_suffix)
       render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
     end
 
     private
+
+    def fetch_resources(object_ref = nil)
+      resources = ae_browser.search(object_ref, ae_search_options)
+      resources.collect! { |resource| resource.slice(*attribute_params) } if attribute_params.present?
+      resources
+    rescue => err
+      raise BadRequestError, err.to_s
+    end
+
+    def ae_browser
+      @ae_browser ||= MiqAeBrowser.new(User.current_user)
+    end
+
+    def attribute_params
+      @attribute_params ||= params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
+    end
 
     def ae_search_options
       # For /api/automate (discovering domains, scope is 1 if unspecified)

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -1,16 +1,12 @@
 module Api
   class SettingsController < BaseController
-    def show
-      category = @req.c_id
-      selected_sections =
-        if category
-          raise NotFoundError, "Settings category #{category} not found" unless exposed_settings.include?(category)
-          category
-        else
-          exposed_settings
-        end
+    def index
+      render_resource :settings, ::Settings.to_hash.slice(*Array(exposed_settings).collect(&:to_sym))
+    end
 
-      render_resource :settings, ::Settings.to_hash.slice(*Array(selected_sections).collect(&:to_sym))
+    def show
+      raise NotFoundError, "Settings category #{@req.c_id} not found" unless exposed_settings.include?(@req.c_id)
+      render_resource :settings, ::Settings.to_hash.slice(*Array(@req.c_id).collect(&:to_sym))
     end
 
     private

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -1,18 +1,22 @@
 module Api
   class SettingsController < BaseController
     def index
-      render_resource :settings, ::Settings.to_hash.slice(*Array(exposed_settings).collect(&:to_sym))
+      render_resource :settings, slice_settings(exposed_settings)
     end
 
     def show
       raise NotFoundError, "Settings category #{@req.c_id} not found" unless exposed_settings.include?(@req.c_id)
-      render_resource :settings, ::Settings.to_hash.slice(*Array(@req.c_id).collect(&:to_sym))
+      render_resource :settings, slice_settings(@req.c_id)
     end
 
     private
 
     def exposed_settings
       ApiConfig.collections[:settings][:categories]
+    end
+
+    def slice_settings(keys)
+      ::Settings.to_hash.slice(*Array(keys).collect(&:to_sym))
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,13 @@ Vmdb::Application.routes.draw do
           next unless collection.options.include?(:collection)
 
           if collection.options.include?(:arbitrary_resource_path)
-            match "(/*c_suffix)", :action => API_ACTIONS[verb], :via => verb
+            case verb
+            when :get
+              root :action => :index
+              get "/*c_suffix", :action => :show
+            else
+              match "(/*c_suffix)", :action => API_ACTIONS[verb], :via => verb
+            end
           else
             case verb
             when :get


### PR DESCRIPTION
This helps simplify the `SettingsController` by removing a conditional. The benefit to `AutomateController` is less tangible, but I do like that it encouraged smaller methods and code reuse, while making things more consistent and "Rails-y"

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 