### PR TITLE
Don't provision to datastores in maintenance mode

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1858,6 +1858,10 @@ class Host < ApplicationRecord
     storages.where(:host_storages => {:read_only => true})
   end
 
+  def available_storages
+    writable_storages.reject(&:maintenance)
+  end
+
   def archived?
     ems_id.nil?
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1042,6 +1042,9 @@ class MiqRequestWorkflow
     storages = hosts.each_with_object({}) do |host, hash|
       host.writable_storages.each { |s| hash[s.id] = s }
     end.values
+
+    storages.reject!(&:maintenance)
+
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id
       storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1040,10 +1040,8 @@ class MiqRequestWorkflow
     MiqPreloader.preload(hosts, :storages)
 
     storages = hosts.each_with_object({}) do |host, hash|
-      host.writable_storages.each { |s| hash[s.id] = s }
+      host.available_storages.each { |s| hash[s.id] = s }
     end.values
-
-    storages.reject!(&:maintenance)
 
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id

--- a/db/migrate/20170203141631_add_maintenance_to_storages.rb
+++ b/db/migrate/20170203141631_add_maintenance_to_storages.rb
@@ -1,0 +1,5 @@
+class AddMaintenanceToStorages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :storages, :maintenance, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6540,6 +6540,7 @@ storages:
 - master
 - ems_ref
 - storage_domain_type
+- maintenance
 storages_vms_and_templates:
 - storage_id
 - vm_or_template_id

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -6,6 +6,7 @@ module MiqAeMethodService
     expose :storages,              :association => true
     expose :read_only_storages
     expose :writable_storages
+    expose :available_storages
     expose :vms,                   :association => true
     expose :ext_management_system, :association => true
     expose :hardware,              :association => true


### PR DESCRIPTION
Track if a datastore is in maintenance mode and do not allow them to be selected in provisioning.

A datastore that is in a datastore cluster can be put in maintenance mode so that storage DRS will not use it.  Provisions to these datastores will fail with "The operation is not allowed in the current state"

https://github.com/ManageIQ/manageiq-gems-pending/pull/24 collected the property from the provider.
https://github.com/ManageIQ/manageiq-providers-vmware/pull/6 adds the refresh_parser component

https://bugzilla.redhat.com/show_bug.cgi?id=1394909