### PR TITLE
Move authorization config for snapshotting to vms section

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -215,7 +215,12 @@ module Api
                         else
                           [@req.subject, request_type_target.last]
                         end
-        aspec = collection_config.typed_collection_actions(cname, target)
+        aspec = if @req.subcollection?
+                  collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
+                    collection_config.typed_collection_actions(cname, target)
+                else
+                  collection_config.typed_collection_actions(cname, target)
+                end
         return if method_name == :get && aspec.nil?
         action_hash = fetch_action_hash(aspec, method_name, action_name)
         raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
@@ -235,7 +240,12 @@ module Api
       def validate_post_api_action(cname, mname, type, target)
         aname = @req.action
 
-        aspec = collection_config.typed_collection_actions(cname, target)
+        aspec = if @req.subcollection?
+                  collection_config.typed_subcollection_actions(@req.collection, cname, target) ||
+                    collection_config.typed_collection_actions(cname, target)
+                else
+                  collection_config.typed_collection_actions(cname, target)
+                end
         raise BadRequestError, "No actions are supported for #{cname} #{type}" unless aspec
 
         action_hash = fetch_action_hash(aspec, mname, aname)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1605,25 +1605,6 @@
     - :subcollection
     :verbs: *gpd
     :klass: Snapshot
-    :subcollection_actions:
-      :get:
-      - :name: read
-        :identifier: vm_snapshot_view
-      :post:
-      - :name: create
-        :identifier: vm_snapshot_add
-      - :name: delete
-        :identifier: vm_snapshot_delete
-    :subresource_actions:
-      :get:
-      - :name: read
-        :identifier: vm_snapshot_view
-      :post:
-      - :name: delete
-        :identifier: vm_snapshot_delete
-      :delete:
-      - :name: delete
-        :identifier: vm_snapshot_delete
   :software:
     :description: Software
     :options:
@@ -2046,6 +2027,25 @@
         :identifier: vm_protect
       - :name: resolve
         :identifier: vm_policy_sim
+    :snapshots_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: vm_snapshot_view
+      :post:
+      - :name: create
+        :identifier: vm_snapshot_add
+      - :name: delete
+        :identifier: vm_snapshot_delete
+    :snapshots_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: vm_snapshot_view
+      :post:
+      - :name: delete
+        :identifier: vm_snapshot_delete
+      :delete:
+      - :name: delete
+        :identifier: vm_snapshot_delete
   :zones:
     :description: Zones
     :identifier: zone

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -53,8 +53,8 @@ module Api
       self[collection_name]["#{target}_actions".to_sym]
     end
 
-    def typed_subcollection_actions(collection_name, subcollection_name)
-      self[collection_name]["#{subcollection_name}_subcollection_actions".to_sym]
+    def typed_subcollection_actions(collection_name, subcollection_name, target = :subcollection)
+      self[collection_name]["#{subcollection_name}_#{target}_actions".to_sym]
     end
 
     def typed_subcollection_action(collection_name, subcollection_name, method)

--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/vms/:c_id/snapshots/:s_id with delete action" do
       it "can queue a snapshot for deletion" do
-        api_basic_authorize(action_identifier(:snapshots, :delete, :subresource_actions, :delete))
+        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
@@ -154,7 +154,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if deleting is not supported" do
-        api_basic_authorize(action_identifier(:snapshots, :delete, :subresource_actions, :post))
+        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :post))
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
@@ -181,7 +181,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/vms/:c_id/snapshots with delete action" do
       it "can queue multiple snapshots for deletion" do
-        api_basic_authorize(action_identifier(:snapshots, :delete, :subresource_actions, :delete))
+        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice and Bob's VM", :host => host, :ext_management_system => ems)
@@ -220,7 +220,7 @@ RSpec.describe "Snapshots API" do
 
     describe "DELETE /api/vms/:c_id/snapshots/:s_id" do
       it "can delete a snapshot" do
-        api_basic_authorize(action_identifier(:snapshots, :delete, :subresource_actions, :delete))
+        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 


### PR DESCRIPTION
This is a two part move:

1. Allow collection-specific resource actions

Sometimes you have a subcollection whose role depends on the context
of the "super"-collection, e.g. tagging vms requires a separate
identifier to tagging hosts. This is fine and currently works, but we
haven't implemented this correctly for subcollection members. This
revision changes the way we look up subcollection role identifiers so
that it knows the difference between subcollection and member actions.

2. Move role identifiers to collection-specific section

This moves the snapshotting identifiers to the `:vms` section of the
config, since they are wholly concerned with VMs. When instance
snapshotting is implemented, they will need a whole new set of
identifiers.

@miq-bot add-label api, refactoring, enhancement
@miq-bot assign @abellotti 
