### PR TITLE
[Depends on manageiq-content#33] Change default provisioning entry point for AutomationManagement.

### DIFF
--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -33,7 +33,7 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
   end
 
   def self.default_provisioning_entry_point(_service_type)
-    '/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/provision_from_bundle'
+    '/AutomationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/provision_from_bundle'
   end
 
   def self.default_reconfiguration_entry_point


### PR DESCRIPTION
Change the default provisioning entry point from ConfigurationManagement to AutomationManagement for Ansible Tower.

Depends on https://github.com/ManageIQ/manageiq-content/pull/33