### PR TITLE
[EUWE] Allow configuration managers providers and configuration scripts trees to display the advanced search box

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -933,8 +933,7 @@ class ProviderForemanController < ApplicationController
   def replace_search_box(presenter, r)
     # Replace the searchbox
     presenter.replace(:adv_searchbox_div,
-                      r[:partial => 'layouts/x_adv_searchbox',
-                        :locals  => {:nameonly => x_active_tree == :configuration_manager_providers_tree}])
+                      r[:partial => 'layouts/x_adv_searchbox'])
 
     presenter[:clear_gtl_list_grid] = @gtl_type && @gtl_type != 'list'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1396,7 +1396,7 @@ module ApplicationHelper
   end
 
   def tree_with_advanced_search?
-    %i(containers images cs_filter configuration_scripts foreman_providers instances providers vandt
+    %i(containers images configuration_manager_providers configuration_scripts cs_filter instances providers vandt
      images_filter instances_filter templates_filter templates_images_filter containers_filter
      vms_filter vms_instances_filter storage).include?(x_tree[:type])
   end

--- a/app/views/provider_foreman/explorer.html.haml
+++ b/app/views/provider_foreman/explorer.html.haml
@@ -1,5 +1,5 @@
 - content_for :search do
-  = render(:partial => "layouts/x_adv_searchbox", :locals => {:nameonly => x_active_tree == :configuration_manager_providers_tree})
+  = render(:partial => "layouts/x_adv_searchbox")
   = render(:partial => 'layouts/quick_search')
 
 -# These are the initial divs that will go inside center_cell_div

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1386,8 +1386,20 @@ describe ApplicationHelper do
                                            :tree => :configuration_scripts_tree,
                                            :type => :configuration_scripts
                                          }
-                                       }
-                                      )
+                                       })
+      result = helper.tree_with_advanced_search?
+      expect(result).to be_truthy
+    end
+
+    it 'should return true for the configuration providers tree' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :configuration_manager_providers_tree,
+                                       :trees       => {
+                                         :configuration_manager_providers_tree => {
+                                           :tree => :configuration_manager_providers_tree,
+                                           :type => :configuration_manager_providers
+                                         }
+                                       })
       result = helper.tree_with_advanced_search?
       expect(result).to be_truthy
     end


### PR DESCRIPTION
Allow configuration managers providers and configuration scripts trees to display the advanced search box

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1411372

Backport for https://github.com/ManageIQ/manageiq-ui-classic/pull/295

Steps for Testing/QA
-------------------------------

Steps to Reproduce:
1. Add Tower provider
2. Navigate to Compute -> Cloud -> Providers
3. Navigate back to Config. Management 

