### PR TITLE
Fix SQL error on Tag.tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,9 +27,16 @@ class Tag < ApplicationRecord
   end
 
   def self.tags(options = {})
-    query = Tag.includes(:taggings)
-    query = query.where(Tagging.arel_table[:taggable_type].eq options[:taggable_type])
-    query = query.where(Tag.arel_table[:name].matches "#{options[:ns]}%") if options[:ns]
+    query = Tag.joins(:taggings)
+
+    if options[:taggable_type].present?
+      query = query.where(Tagging.arel_table[:taggable_type].eq(options[:taggable_type]))
+    end
+
+    if options[:ns].present?
+      query = query.where(Tag.arel_table[:name].matches("#{options[:ns]}%"))
+    end
+
     Tag.filter_ns(query, options[:ns])
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,6 +7,37 @@ describe Tag do
     end
   end
 
+  describe ".tags" do
+    let!(:account) { FactoryGirl.create(:account) }
+    let!(:tag) { FactoryGirl.create(:tag) }
+
+    it "returns tags with tagged items" do
+      Tagging.create(:taggable => account, :tag => tag)
+
+      expect(Tag.tags).to eq [tag]
+    end
+
+    it "does not return tags without tagged items" do
+      expect(Tag.tags).to eq []
+    end
+
+    it "can be filtered by taggable type" do
+      Tagging.create(:taggable => account, :tag => tag)
+
+      expect(Tag.tags(:taggable_type => 'Account')).to eq [tag]
+      expect(Tag.tags(:taggable_type => 'User')).to eq []
+    end
+
+    context "when filtered by tag namespaces" do
+      it "returns tag names w" do
+        Tagging.create(:taggable => account, :tag => tag)
+
+        expect(Tag.tags(:ns => '/namespace/cat')).to eq [tag.name.split('/').last]
+        expect(Tag.tags(:ns => '/foo/bar')).to eq []
+      end
+    end
+  end
+
   context ".filter_ns" do
     it "normal case" do
       tag1 = double


### PR DESCRIPTION
This commit fixes the 'missing FROM-clause entry for table "taggings"' error
from Tag.tags, and adds regression specs to the class, effectively fixing the issue #13508.