### PR TITLE
[EUWE] Fix failing specs after recent backports

### DIFF
--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -436,7 +436,8 @@ describe ChargebackVm do
     before do
       @tenant = FactoryGirl.create(:tenant)
       @tenant_child = FactoryGirl.create(:tenant, :ancestry => @tenant.id)
-      @vm_tenant = FactoryGirl.create(:vm_vmware, :tenant_id => @tenant_child.id, :name => "test_vm_tenant")
+      @vm_tenant = FactoryGirl.create(:vm_vmware, :tenant_id => @tenant_child.id, :name => "test_vm_tenant",
+                                      :created_on => month_beginning)
       ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
         @vm_tenant.metric_rollups <<
           FactoryGirl.create(:metric_rollup_vm_hr,


### PR DESCRIPTION
After we backported #13723 we found that one test fails as it process metric rollups that are older than the vm (this wouldn't happen outside of tests).

@miq-bot add_label bug, test
@miq-bot assign @simaishi 

/cc @gtanzillo 