### PR TITLE
Update MiqExpression::Tag

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -2,7 +2,7 @@ class MiqExpression::Tag
   TAG_REGEX = /
 (?<model_name>([[:alnum:]]*(::)?)+)
 \.(?<associations>([a-z_]+\.)*)
-(?<namespace>\bmanaged\b)
+(?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)
 /x
 
@@ -10,6 +10,7 @@ class MiqExpression::Tag
     match = TAG_REGEX.match(field) || return
 
     associations = match[:associations].split(".")
+    namespace = match[:namespace] == 'user_tag' ? 'user' : match[:namespace]
     new(match[:model_name].classify.safe_constantize, associations, "/#{namespace}/#{match[:column]}")
   end
 

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,10 +1,12 @@
-class MiqExpression::Tag
+class MiqExpression::Tag < MiqExpression::Field
   TAG_REGEX = /
 (?<model_name>([[:alnum:]]*(::)?)+)
 \.(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)
 /x
+
+  attr_reader :namespace
 
   def self.parse(field)
     match = TAG_REGEX.match(field) || return
@@ -14,11 +16,8 @@ class MiqExpression::Tag
     new(match[:model_name].classify.safe_constantize, associations, "/#{namespace}/#{match[:column]}")
   end
 
-  attr_reader :model, :associations, :namespace
-
   def initialize(model, associations, namespace)
-    @model = model
-    @associations = associations
+    super(model, associations, namespace.split("/").last)
     @namespace = namespace
   end
 

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,7 +1,6 @@
 class MiqExpression::Tag
   def self.parse(tag)
     klass, ns = tag.split(".")
-    klass, ns = "nil", klass if ns.nil? # support managed-label
     ns = "/" + ns.split("-").join("/")
     ns = ns.sub(/(\/user_tag\/)/, "/user/") # replace with correct namespace for user tags
     new(klass.safe_constantize, ns)

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -6,19 +6,22 @@ class MiqExpression::Tag < MiqExpression::Field
 -(?<column>[a-z]+[_[:alnum:]]+)
 /x
 
+  MANAGED_NAMESPACE      = 'managed'.freeze
+  USER_NAMESPACE         = 'user'.freeze
+
   attr_reader :namespace
 
   def self.parse(field)
     match = TAG_REGEX.match(field) || return
 
     associations = match[:associations].split(".")
-    namespace = match[:namespace] == 'user_tag' ? 'user' : match[:namespace]
-    new(match[:model_name].classify.safe_constantize, associations, "/#{namespace}/#{match[:column]}")
+    model = match[:model_name].classify.safe_constantize
+    new(model, associations, match[:column], match[:namespace] == MANAGED_NAMESPACE)
   end
 
-  def initialize(model, associations, namespace)
-    super(model, associations, namespace.split("/").last)
-    @namespace = namespace
+  def initialize(model, associations, column, managed = true)
+    super(model, associations, column)
+    @namespace = "/#{managed ? MANAGED_NAMESPACE : USER_NAMESPACE}/#{column}"
   end
 
   def contains(value)

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -41,10 +41,4 @@ class MiqExpression::Tag < MiqExpression::Field
   def attribute_supported_by_sql?
     false
   end
-
-  def eql?(other)
-    other && other.model == model && other.namespace == namespace && other.associations == associations
-  end
-
-  alias == eql?
 end

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -2,54 +2,54 @@ require "rails_helper"
 
 RSpec.describe MiqExpression::Tag do
   describe ".parse" do
-    it "with model.managed-in_field" do
-      field = "Vm.managed-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", []))
+    it "with model.managed-in_tag" do
+      tag = "Vm.managed-service_level"
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", []))
     end
 
-    it "with model.last.managed-in_field" do
-      field = "Vm.host.managed-environment"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/environment", ['host']))
+    it "with model.last.managed-in_tag" do
+      tag = "Vm.host.managed-environment"
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/environment", ['host']))
     end
 
-    it "with model.managed-in_field" do
-      field = "Vm.managed-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", []))
+    it "with model.managed-in_tag" do
+      tag = "Vm.managed-service_level"
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", []))
     end
 
-    it "with model.associations.associations.managed-in_field" do
-      field = "Vm.service.user.managed-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", %w(service user)))
+    it "with model.associations.associations.managed-in_tag" do
+      tag = "Vm.service.user.managed-service_level"
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", %w(service user)))
     end
 
-    it "with model.associations.managed-in_field" do
-      field = "service.user.managed-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Service, "/managed/service_level", ['user']))
+    it "with model.associations.managed-in_tag" do
+      tag = "service.user.managed-service_level"
+      expect(described_class.parse(tag)).to eq(described_class.new(Service, "/managed/service_level", ['user']))
     end
 
-    it "with model.associations.user_tag-in_field" do
-      field = "service.user.user_tag-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Service, "/user/service_level", ['user']))
+    it "with model.associations.user_tag-in_tag" do
+      tag = "service.user.user_tag-service_level"
+      expect(described_class.parse(tag)).to eq(described_class.new(Service, "/user/service_level", ['user']))
     end
 
-    it "with invalid case model.associations.managed-in_field" do
-      field = "service.user.mXaXnXaXged-service_level"
-      expect(described_class.parse(field)).to be_nil
+    it "with invalid case model.associations.managed-in_tag" do
+      tag = "service.user.mXaXnXaXged-service_level"
+      expect(described_class.parse(tag)).to be_nil
     end
 
-    it "returns nil with invalid case managed-field" do
-      field = "managed-service_level"
-      expect(described_class.parse(field)).to be_nil
+    it "returns nil with invalid case managed-tag" do
+      tag = "managed-service_level"
+      expect(described_class.parse(tag)).to be_nil
     end
 
     it "returns nil with invalid case managed" do
-      field = "managed"
-      expect(described_class.parse(field)).to be_nil
+      tag = "managed"
+      expect(described_class.parse(tag)).to be_nil
     end
 
     it "returns nil with invalid case model.managed" do
-      field = "Vm.managed"
-      expect(described_class.parse(field)).to be_nil
+      tag = "Vm.managed"
+      expect(described_class.parse(tag)).to be_nil
     end
   end
 

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -2,11 +2,6 @@ require "rails_helper"
 
 RSpec.describe MiqExpression::Tag do
   describe ".parse" do
-    it "with managed-field" do
-      field = "managed.location"
-      expect(described_class.parse(field)).to eq(described_class.new(nil, "/location"))
-    end
-
     it "with model.managed-in_field" do
       field = "Vm.managed-service_level"
       expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level"))

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -4,32 +4,32 @@ RSpec.describe MiqExpression::Tag do
   describe ".parse" do
     it "with model.managed-in_tag" do
       tag = "Vm.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", []))
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, [], "/managed/service_level"))
     end
 
     it "with model.last.managed-in_tag" do
       tag = "Vm.host.managed-environment"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/environment", ['host']))
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, ['host'], "/managed/environment"))
     end
 
     it "with model.managed-in_tag" do
       tag = "Vm.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", []))
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, [], "/managed/service_level"))
     end
 
     it "with model.associations.associations.managed-in_tag" do
       tag = "Vm.service.user.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, "/managed/service_level", %w(service user)))
+      expect(described_class.parse(tag)).to eq(described_class.new(Vm, %w(service user), "/managed/service_level"))
     end
 
     it "with model.associations.managed-in_tag" do
       tag = "service.user.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Service, "/managed/service_level", ['user']))
+      expect(described_class.parse(tag)).to eq(described_class.new(Service, ['user'], "/managed/service_level"))
     end
 
     it "with model.associations.user_tag-in_tag" do
       tag = "service.user.user_tag-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Service, "/user/service_level", ['user']))
+      expect(described_class.parse(tag)).to eq(described_class.new(Service, ['user'], "/user/service_level"))
     end
 
     it "with invalid case model.associations.managed-in_tag" do
@@ -55,25 +55,25 @@ RSpec.describe MiqExpression::Tag do
 
   describe "#column_type" do
     it "is always a string" do
-      expect(described_class.new(Vm, "/host").column_type).to eq(:string)
+      expect(described_class.new(Vm, [], "/host").column_type).to eq(:string)
     end
   end
 
   describe "#numeric?" do
     it "is never numeric" do
-      expect(described_class.new(Vm, "/host")).not_to be_numeric
+      expect(described_class.new(Vm, [], "/host")).not_to be_numeric
     end
   end
 
   describe "#sub_type" do
     it "is always a string" do
-      expect(described_class.new(Vm, "/host").sub_type).to eq(:string)
+      expect(described_class.new(Vm, [], "/host").sub_type).to eq(:string)
     end
   end
 
   describe "#attribute_supported_by_sql?" do
     it "is always false" do
-      expect(described_class.new(Vm, "/host")).not_to be_attribute_supported_by_sql
+      expect(described_class.new(Vm, [], "/host")).not_to be_attribute_supported_by_sql
     end
   end
 end

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -4,12 +4,52 @@ RSpec.describe MiqExpression::Tag do
   describe ".parse" do
     it "with model.managed-in_field" do
       field = "Vm.managed-service_level"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level"))
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", []))
     end
 
     it "with model.last.managed-in_field" do
       field = "Vm.host.managed-environment"
-      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/host"))
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/environment", ['host']))
+    end
+
+    it "with model.managed-in_field" do
+      field = "Vm.managed-service_level"
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", []))
+    end
+
+    it "with model.associations.associations.managed-in_field" do
+      field = "Vm.service.user.managed-service_level"
+      expect(described_class.parse(field)).to eq(described_class.new(Vm, "/managed/service_level", %w(service user)))
+    end
+
+    it "with model.associations.managed-in_field" do
+      field = "service.user.managed-service_level"
+      expect(described_class.parse(field)).to eq(described_class.new(Service, "/managed/service_level", ['user']))
+    end
+
+    it "with model.associations.user_tag-in_field" do
+      field = "service.user.user_tag-service_level"
+      expect(described_class.parse(field)).to eq(described_class.new(Service, "/user/service_level", ['user']))
+    end
+
+    it "with invalid case model.associations.managed-in_field" do
+      field = "service.user.mXaXnXaXged-service_level"
+      expect(described_class.parse(field)).to be_nil
+    end
+
+    it "returns nil with invalid case managed-field" do
+      field = "managed-service_level"
+      expect(described_class.parse(field)).to be_nil
+    end
+
+    it "returns nil with invalid case managed" do
+      field = "managed"
+      expect(described_class.parse(field)).to be_nil
+    end
+
+    it "returns nil with invalid case model.managed" do
+      field = "Vm.managed"
+      expect(described_class.parse(field)).to be_nil
     end
   end
 

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -4,32 +4,44 @@ RSpec.describe MiqExpression::Tag do
   describe ".parse" do
     it "with model.managed-in_tag" do
       tag = "Vm.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, [], "/managed/service_level"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
     end
 
     it "with model.last.managed-in_tag" do
       tag = "Vm.host.managed-environment"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, ['host'], "/managed/environment"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => ['host'],
+                                                            :namespace    => "/managed/environment")
     end
 
     it "with model.managed-in_tag" do
       tag = "Vm.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, [], "/managed/service_level"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
     end
 
     it "with model.associations.associations.managed-in_tag" do
       tag = "Vm.service.user.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Vm, %w(service user), "/managed/service_level"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => %w(service user),
+                                                            :namespace    => "/managed/service_level")
     end
 
     it "with model.associations.managed-in_tag" do
       tag = "service.user.managed-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Service, ['user'], "/managed/service_level"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Service,
+                                                            :associations => ['user'],
+                                                            :namespace    => "/managed/service_level")
     end
 
     it "with model.associations.user_tag-in_tag" do
       tag = "service.user.user_tag-service_level"
-      expect(described_class.parse(tag)).to eq(described_class.new(Service, ['user'], "/user/service_level"))
+      expect(described_class.parse(tag)).to have_attributes(:model        => Service,
+                                                            :associations => ['user'],
+                                                            :namespace    => "/user/service_level")
     end
 
     it "with invalid case model.associations.managed-in_tag" do

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2216,11 +2216,6 @@ describe MiqExpression do
       expect(subject).to eq(:datetime)
     end
 
-    it "with managed-field" do
-      @field = "managed.location"
-      expect(subject).to eq(:string)
-    end
-
     it "with model.managed-in_field" do
       @field = "Vm.managed-service_level"
       expect(subject).to eq(:string)


### PR DESCRIPTION
### **Goal:**
- define valid forms of tag in MiqExpression, add such test cases and remove invalid cases
- use this class for parsing on couple in MiqExpression with using functionality from `MiqExpression:Field`

### How can tags looks like in MiqExpression ?
1) `model.managed-column`
2) `model.user_tag-column` I am not sure of usage of 'user_tag' tags but code counts with this form.
Do you have idea where it can be used ? @gtanzillo @dclarizio 

3) `model.associations.....managed-column`
     `model.associations.....user_tag-column`
other forms of tag in MiqExpression are invalid.

I did not find other form of tag in MiqExpression but If I miss any please let me know.

cc @kbrock @imtayadeway 

@miq-bot assign @gtanzillo 