### PR TITLE
Support for simple grouping external management systems

### DIFF
--- a/db/migrate/20170206094628_add_manager_group_to_ext_management_system.rb
+++ b/db/migrate/20170206094628_add_manager_group_to_ext_management_system.rb
@@ -1,0 +1,5 @@
+class AddManagerGroupToExtManagementSystem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ext_management_systems, :manager_group, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1263,6 +1263,7 @@ ext_management_systems:
 - last_metrics_update_date
 - last_metrics_success_date
 - tenant_mapping_enabled
+- manager_group
 file_depots:
 - id
 - name

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -2,12 +2,17 @@ module UuidMixin
   extend ActiveSupport::Concern
   included do
     before_validation :set_guid, :on => :create if respond_to?(:before_validation)
+    before_validation :set_manager_group, :on => :create if respond_to?(:before_validation)
   end
 
   private
 
   def set_guid
     self.guid ||= MiqUUID.new_guid if self.respond_to?(:guid) && self.respond_to?(:guid=)
+  end
+
+  def set_manager_group
+    self.manager_group ||= MiqUUID.new_guid if self.respond_to?(:manager_group) && self.respond_to?(:manager_group=)
   end
 
   def default_name_to_guid


### PR DESCRIPTION
Introducing a new column on ext_management_system table named `manager_group`. By default every ExtManagementSystem is given a random uuid for manager_group. The field is, by default, not used anywhere.

Usecase:
----------------
All Amazon Cloud Providers that connect with same AWS credentials will be given same manager_group. The whole group will then share a single S3 Storage Manager, which will also be assigned to same anager_group. Without the new field it is impossible to group them together.

[Decoupling S3 Storage Manager from Amazon Cloud Manager](https://github.com/ManageIQ/manageiq-providers-amazon/pull/133) depends on this PR being merged.