### PR TITLE
Power state for services that do not have an associated service_template

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -50,8 +50,6 @@ class Service < ApplicationRecord
   delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
   delegate :user, :to => :miq_request, :allow_nil => true
-  delegate :atomic?, :to => :service_template
-  delegate :composite?, :to => :service_template
 
   include ServiceMixin
   include OwnershipMixin
@@ -209,6 +207,14 @@ class Service < ApplicationRecord
       return update_power_status(action)
     end
     false
+  end
+
+  def composite?
+    service_template ? service_template.composite? : children.present?
+  end
+
+  def atomic?
+    service_template ? service_template.atomic? : children.empty?
   end
 
   def map_composite_power_states(action)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -501,8 +501,18 @@ describe Service do
     it "returns children" do
       create_deep_tree
       expect(@service.children).to match_array([@service_c1, @service_c2])
+      expect(@service.service_template).to be_nil
+      expect(@service.composite?).to be_truthy
+      expect(@service.atomic?).to be_falsey
       expect(@service.services).to match_array([@service_c1, @service_c2]) # alias
       expect(@service.direct_service_children).to match_array([@service_c1, @service_c2]) # alias
+    end
+
+    it "returns no children" do
+      @service = FactoryGirl.create(:service)
+      expect(@service.children).to be_empty
+      expect(@service.composite?).to be_falsey
+      expect(@service.atomic?).to be_truthy
     end
   end
 


### PR DESCRIPTION
For the cases in Automate where a `Service` does not have an associated `ServiceTemplate`

1. If children exist we have a composite service
2. If no children exist we have an atomic service

https://bugzilla.redhat.com/show_bug.cgi?id=1419730
