### PR TITLE
Ensure field model name is model

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -31,10 +31,12 @@ class MiqExpression::Field
   end
 
   def self.is_field?(field)
-    if field.kind_of?(String)
-      match = FIELD_REGEX.match(field)
-      match.present? && match[:model_name].safe_constantize.present?
-    end
+    return false unless field.kind_of?(String)
+    match = FIELD_REGEX.match(field)
+    return false unless match
+    model = match[:model_name].safe_constantize
+    return false unless model
+    !!(model < ApplicationRecord)
   end
 
   def datetime?

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe MiqExpression::Field do
 
     it "does not detect a string to looks like a field but isn't" do
       expect(MiqExpression::Field.is_field?("NetworkManager-team")).to be_falsey
+      expect(described_class.is_field?("ManageIQ-name")).to be(false)
     end
   end
 end


### PR DESCRIPTION
It's not sufficient for a field to have a thing that looks like a
constant, we have to ensure that it's a model to form expressions on
it.

Fixes https://github.com/ManageIQ/manageiq/issues/13139

@miq-bot add-label core, bug
@miq-bot assign @gtanzillo 

/cc @kbrock 