### PR TITLE
Add eager loading for ServiceCatalogItems 

### DIFF
--- a/product/views/ServiceTemplate.yaml
+++ b/product/views/ServiceTemplate.yaml
@@ -40,7 +40,9 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-
+  :picture:
+    :binary_blob: {}
+    
 # Order of columns (from all tables)
 col_order:
 - name


### PR DESCRIPTION
Service -> Catalog

Remove N+1 queries and include `:binary_blob`
binary_blob is loaded here:
```
app/models/picture.rb:53:in `extension'
app/models/picture.rb:64:in `basename'
app/decorators/service_template_decorator.rb:9:in `listicon_image'
app/controllers/application_controller.rb:984:in `listicon_image'
```

