### PR TITLE
[WIP] kubernetes refresh: better parse old pod images references

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -143,6 +143,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                                        :image_ref => "docker-pullable://reg.example.com:1234/name1@sha256:321bcd"},
                        :registry   => {:name => "reg.example.com", :host => "reg.example.com", :port => "1234"}},
 
+                      # digest from old docker
+                      {:image_name => "reg.example.com:1234/name1:tagos",
+                       :image      => {:name => "name1", :tag => "tagos", :digest => "sha256:321bcd",
+                                       :image_ref => "docker://sha256:321bcd"},
+                       :registry   => {:name => "reg.example.com", :host => "reg.example.com", :port => "1234"}},
+
                       {:image_name => "example@sha256:1234567abcdefg",
                        :image      => {:name => "example", :tag => nil, :digest => "sha256:1234567abcdefg",
                                        :image_ref => example_ref},

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -99,8 +99,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       expect(parser.send(:parse_openshift_image,
                          image_without_dockerImage_fields).except(:registered_on)).to eq(
                            :container_image_registry => nil,
-                           :digest                   => nil,
-                           :image_ref                => "docker-pullable://sha256:abcdefg",
+                           :digest                   => image_digest,
+                           :image_ref                => "docker-pullable://#{image_digest}",
                            :name                     => "sha256",
                            :tag                      => "abcdefg"
                          )
@@ -110,8 +110,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       expect(parser.send(:parse_openshift_image,
                          image_without_dockerConfig).except(:registered_on)).to eq(
                            :container_image_registry => nil,
-                           :digest                   => nil,
-                           :image_ref                => "docker-pullable://sha256:abcdefg",
+                           :digest                   => image_digest,
+                           :image_ref                => "docker-pullable://#{image_digest}",
                            :name                     => "sha256",
                            :tag                      => "abcdefg",
                            :architecture             => nil,
@@ -127,8 +127,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       expect(parser.send(:parse_openshift_image,
                          image_without_environment_variables).except(:registered_on)).to eq(
                            :container_image_registry => nil,
-                           :digest                   => nil,
-                           :image_ref                => "docker-pullable://sha256:abcdefg",
+                           :digest                   => image_digest,
+                           :image_ref                => "docker-pullable://#{image_digest}",
                            :name                     => "sha256",
                            :tag                      => "abcdefg",
                            :architecture             => nil,


### PR DESCRIPTION
Older docker versions (up to 1.10) will show the image reference in a
pod as "docker://sha256:<digest>", this should parse it to get the
digest from it as in some cases it is not available from the image name.