### PR TITLE
Dictionary.gettext(): fix plural for complex model names

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -8,7 +8,12 @@ class Dictionary
 
     i18n_result = i18n_lookup(opts[:type], key)
     i18n_result ||= i18n_lookup(opts[:type], key.split(".").last)
-    i18n_result = i18n_result.pluralize if i18n_result && opts[:plural]
+    i18n_result = if i18n_result && opts[:plural]
+                    m = /(.+)(\s+\(.+\))/.match(i18n_result)
+                    m ? "#{m[1].pluralize}#{m[2]}" : i18n_result.pluralize
+                  else
+                    i18n_result
+                  end
 
     result = if i18n_result
                opts[:translate] ? _(i18n_result) : i18n_result


### PR DESCRIPTION
Creating plural for model names would not work for complex model names such as
`Automation Manager (Ansible Tower)`

Before:
```
$ bundle exec rails console
> ui_lookup(:model => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
=> "Automation Manager (Ansible Tower)"
> ui_lookup(:models => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
=> "Automation Manager (Ansible Tower)s"
```

After:
```
$ bundle exec rails console
> ui_lookup(:model => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
=> "Automation Manager (Ansible Tower)"
> ui_lookup(:models => 'ManageIQ::Providers::AnsibleTower::AutomationManager')
=> "Automation Managers (Ansible Tower)"
```