### PR TITLE
Make Service bools default to false

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -70,6 +70,10 @@ class Service < ApplicationRecord
 
   validates_presence_of :name
 
+  default_value_for :retired, false
+
+  validates :retired, :inclusion => { :in => [true, false] }
+
   supports :reconfigure do
     unsupported_reason_add(:reconfigure, _("Reconfigure unsupported")) unless validate_reconfigure
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -70,8 +70,10 @@ class Service < ApplicationRecord
 
   validates_presence_of :name
 
+  default_value_for :display, false
   default_value_for :retired, false
 
+  validates :display, :inclusion => { :in => [true, false] }
   validates :retired, :inclusion => { :in => [true, false] }
 
   supports :reconfigure do

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -133,6 +133,9 @@ class ServiceTemplate < ApplicationRecord
     # Hide child services by default
     nh[:display] = false if parent_svc
 
+    # If display is nil, set it to false
+    nh[:display] = false if nh[:display].nil?
+
     # convert template class name to service class name by naming convention
     nh[:type] = self.class.name.sub('Template', '')
 

--- a/db/migrate/20170207173837_set_service_display_and_retired_to_false.rb
+++ b/db/migrate/20170207173837_set_service_display_and_retired_to_false.rb
@@ -1,0 +1,14 @@
+class SetServiceDisplayAndRetiredToFalse < ActiveRecord::Migration[5.0]
+  class Service < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    Service.where(:retired => nil).update_all(:retired => false)
+    Service.where(:display => nil).update_all(:display => false)
+  end
+
+  def down
+    # NOP
+  end
+end

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
@@ -154,7 +154,7 @@ EOF
     end
 
     it "#finish_retirement" do
-      expect(service_service.retired).to be_nil
+      expect(service_service).not_to be_retired
       expect(service_service.retirement_state).to be_nil
       expect(service_service.retires_on).to be_nil
 

--- a/spec/migrations/20170207173837_set_service_display_and_retired_to_false_spec.rb
+++ b/spec/migrations/20170207173837_set_service_display_and_retired_to_false_spec.rb
@@ -1,0 +1,39 @@
+require_migration
+
+RSpec.describe SetServiceDisplayAndRetiredToFalse do
+  migration_context :up do
+    it "sets any null display values to false" do
+      service = migration_stub(:Service).create!(:display => nil)
+
+      migrate
+
+      expect(service.reload.display).to be(false)
+    end
+
+    it "sets any null retired values to false" do
+      service = migration_stub(:Service).create!(:retired => nil)
+
+      migrate
+
+      expect(service.reload.retired).to be(false)
+    end
+  end
+
+  migration_context :down do
+    it "leaves false display values as false" do
+      service = migration_stub(:Service).create!(:display => false)
+
+      migrate
+
+      expect(service.reload.display).to be(false)
+    end
+
+    it "leaves false retired values as false" do
+      service = migration_stub(:Service).create!(:retired => false)
+
+      migrate
+
+      expect(service.reload.retired).to be(false)
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -647,6 +647,18 @@ describe Service do
     end
   end
 
+  describe "#retired" do
+    it "defaults to false" do
+      service = described_class.new
+      expect(service.retired).to be(false)
+    end
+
+    it "cannot be nil" do
+      service = FactoryGirl.build(:service, :retired => nil)
+      expect(service).not_to be_valid
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -647,6 +647,18 @@ describe Service do
     end
   end
 
+  describe "#display" do
+    it "defaults to false" do
+      service = described_class.new
+      expect(service.display).to be(false)
+    end
+
+    it "cannot be nil" do
+      service = FactoryGirl.build(:service, :display => nil)
+      expect(service).not_to be_valid
+    end
+  end
+
   describe "#retired" do
     it "defaults to false" do
       service = described_class.new


### PR DESCRIPTION
These values are booleans but currently support three values - `nil`, `false`, and `true`. This is not a problem if you are using Rails' boolean wrappers (i.e. `#retired?`, etc..), but queries can give some surprising results:

```ruby
Service.where.not(:retired => true) # => the services where retired = false, but not null
```

There are ways around this, but then anything that interacts with services on these fields has to know how to ask about nulls. Enforcing true/false at the model layer addresses this, and there is an additional data migration to make all current `NULL`s `false`.

@miq-bot add-label core
@miq-bot assign @Fryguy 

/cc @kbrock @chalettu 

EDIT:

Fixes https://github.com/ManageIQ/manageiq/issues/13790