### PR TITLE
Temporarily bypass asset lookup in tests 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,13 @@ require 'rspec/rails'
 require 'vcr'
 require 'cgi'
 
+# FIXME: This bypasses the lookup of Javascript dependencies in tests until they can be found and uncoupled
+class << ActionController::Base.helpers
+  def image_path(path, options = {})
+    path
+  end
+end
+
 # Fail tests that try to include stuff in `main`
 require_relative 'support/test_contamination'
 Spec::Support::TestContamination.setup


### PR DESCRIPTION
Bypass asset lookup in tests until calls to `image_path` in models can be found and removed.

This is based on a suggestion by @himdel. It addresses #13792.