### PR TITLE
MiqExpression::Field.field? / Tag.tag?

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -26,6 +26,14 @@ class MiqExpression::Field
     @column = column
   end
 
+  def tag?
+    false
+  end
+
+  def field?
+    true
+  end
+
   def date?
     column_type == :date
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -14,6 +14,14 @@ class MiqExpression::Tag
     @namespace = namespace
   end
 
+  def tag?
+    true
+  end
+
+  def field?
+    false
+  end
+
   def contains(value)
     ids = model.find_tagged_with(:any => value, :ns => namespace).pluck(:id)
     model.arel_attribute(:id).in(ids)

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -234,4 +234,12 @@ RSpec.describe MiqExpression::Field do
       expect(MiqExpression::Field.is_field?("NetworkManager-team")).to be_falsey
     end
   end
+
+  describe "#tag?" do
+    it { expect(described_class.new(Vm, [], "name")).not_to be_tag }
+  end
+
+  describe "#field?" do
+    it { expect(described_class.new(Vm, [], "name")).to be_field }
+  end
 end

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -41,4 +41,12 @@ RSpec.describe MiqExpression::Tag do
       expect(described_class.new(Vm, "/host")).not_to be_attribute_supported_by_sql
     end
   end
+
+  describe "#tag?" do
+    it { expect(described_class.new(Vm, "/host")).to be_tag }
+  end
+
+  describe "#field?" do
+    it { expect(described_class.new(Vm, "/host")).not_to be_field }
+  end
 end


### PR DESCRIPTION
Pulled out of #13446

This adds accessors for Tag and Field to avoid `kind_of?(MiqExpression::Tag)`

/cc @lpichler @imtayadeway FYI