### PR TITLE
Speed up REGEX for invalid fields in MiqExpression::Field

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,7 +1,7 @@
 class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
-\.?(?<associations>[a-z_\.]+)*
+\.?(?<associations>[a-z_\.]+)?
 -(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x
 


### PR DESCRIPTION
Not sure whether these failing cases can happen at all, I just noticed it during other PRs.
When we have associations in invalid field then it is taking more time. see third example(`Vm.hardware.host.asdasd-`).

benchmark script
```ruby
require 'benchmark'

n = 10

fields = %w(
  Vm-
  Vm.hardware-
  Vm.hardware.host.asdasd-
  Vm.hardware.host-name
  Vm.host-name
  Vm-name
)


Benchmark.bm do |x|
  fields.each do |field|
    x.report("\n" + field + "\n") do
      n.times do
        MiqExpression::Field.parse(field)
      end
    end
  end
end

```

### before
```
      user     system      total        real
Vm-
  0.000000   0.000000   0.000000 (  0.000028)

Vm.hardware-
  0.000000   0.000000   0.000000 (  0.000942)

Vm.hardware.host.asdasd-
  3.040000   0.010000   3.050000 (  3.046951)

Vm.hardware.host-name
  0.000000   0.000000   0.000000 (  0.000119)

Vm.host-name
  0.000000   0.000000   0.000000 (  0.000072)

Vm-name
  0.000000   0.000000   0.000000 (  0.000084)
```

### after

```
       user     system      total        real

Vm-
  0.000000   0.000000   0.000000 (  0.000032)

Vm.hardware-
  0.000000   0.000000   0.000000 (  0.000048)

Vm.hardware.host.asdasd-
  0.000000   0.000000   0.000000 (  0.000043)

Vm.hardware.host-name
  0.000000   0.000000   0.000000 (  0.000068)

Vm.host-name
  0.000000   0.000000   0.000000 (  0.000088)

Vm-name
  0.000000   0.000000   0.000000 (  0.000045)
```

@kbrock @imtayadeway 


