### PR TITLE
Support alerts on container nodes

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -79,4 +79,10 @@ class ContainerNode < ApplicationRecord
   def cockpit_url
     URI::HTTP.build(:host => ipaddress, :port => 9090)
   end
+
+  def evaluate_alert(_alert_id, _event)
+    # currently only EmsEvents from hawkular are tested for node alerts,
+    # and these should automaticaly be translated to alerts.
+    true
+  end
 end

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -196,6 +196,7 @@ class EmsEvent < EventStream
     target_type = "src_vm_or_template"  if target_type == "src_vm"
     target_type = "dest_vm_or_template" if target_type == "dest_vm"
     target_type = "middleware_server"   if event.event_type == "hawkular_alert"
+    target_type = "container_node"      if event.event_type == "datawarehouse_alert"
 
     event.send(target_type)
   end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -20,6 +20,7 @@ class MiqAlert < ApplicationRecord
     ExtManagementSystem
     MiqServer
     MiddlewareServer
+    ContainerNode
   )
 
   def self.base_tables
@@ -434,7 +435,9 @@ class MiqAlert < ApplicationRecord
         :options => [
           {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<=", "="]},
           {:name => :value_mw_garbage_collector, :description => _("Duration Per Minute (ms)"), :numeric => true}
-        ]}
+        ]},
+      {:name => "dwh_generic", :description => _("All Datawarehouse alerts"), :db => ["ContainerNode"], :responds_to_events => "datawarehouse_alert",
+        :options => []}
     ]
   end
 
@@ -496,7 +499,7 @@ class MiqAlert < ApplicationRecord
 
   def self.raw_events
     @raw_events ||= expression_by_name("event_threshold")[:options].find { |h| h[:name] == :event_types }[:values] +
-                    ['hawkular_alert']
+                    %w(hawkular_alert datawarehouse_alert)
   end
 
   def self.event_alertable?(event)
@@ -557,6 +560,10 @@ class MiqAlert < ApplicationRecord
   def evaluate_script
     # TODO
     true
+  end
+
+  def evaluate_method_dwh_generic(target, options)
+    target.evaluate_alert(id, options)
   end
 
   def evaluate_middleware(target, options)


### PR DESCRIPTION
Add the ability to define miq alerts on container nodes.
The usual flow miq alert statuses are created: an ems event is collected and then evaluated for an alert[1]
Currently only ems events from Hawkular are evaluated for alerts on container nodes.
Since we are offloading the logic of triggering to Hawkular every ems event already means a miq_alert_status needs to be created (if a miq alert has been defined)

Currently we only support defining the miq alert on all the nodes in the enterprise since that is what we would use (actual target object is found based on metadata on the incoming event)

Extracted from #12773

[1] https://github.com/ManageIQ/manageiq/blob/ff425fdb1b65b96fe4f5d6eb8beaa31fdc718b0c/lib/ems_event_helper.rb#L33