### PR TITLE
Fix Host getting disconnected from Cluster when migrating a VM in RHEV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -404,7 +404,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
 
       # If the vm has a host but the refresh does not include it in the "hosts" hash
       if host.blank? && vm_inv[:host].present?
-        host = partial_host_hash(vm_inv[:host])
+        host_inv = vm_inv[:host].merge(:cluster => ems_cluster)
+        host = partial_host_hash(host_inv)
         added_hosts << host if host
       end
 
@@ -445,7 +446,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
 
   def self.partial_host_hash(partial_host_inv)
     ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(partial_host_inv[:href])
-    { :ems_ref => ems_ref, :uid_ems => partial_host_inv[:id] }
+    {
+      :ems_ref     => ems_ref,
+      :uid_ems     => partial_host_inv[:id],
+      :ems_cluster => partial_host_inv[:cluster]
+    }
   end
 
   def self.create_vm_hash(template, ems_ref, vm_id, name)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -85,13 +85,41 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       @ems.reload
       vm = @ems.vms.where(:name => "migrate_test_1").first
       expect(vm.host.name).to eq("pluto-vdsg.eng.lab.tlv.redhat.com")
+      expect(vm.host.ems_ref).to eq("/api/hosts/0b4c3cf3-3b51-479a-bd36-ab968151a9a9")
+
+      assert_host(vm.host)
 
       VCR.use_cassette("#{described_class.name.underscore}_after_migration", :allow_unused_http_interactions => true) do
         EmsRefresh.refresh(vm)
       end
 
       vm.reload
+
+      # Check that the VM is on a new host
       expect(vm.host.name).to eq("lilach-vdsa.tlv.redhat.com")
+      expect(vm.host.ems_ref).to eq("/api/hosts/bfb0c0b4-8616-4bbf-9210-9de48892adc6")
+
+      # And everything else about the hosts are the same
+      assert_host(vm.host)
+    end
+
+    def assert_host(host)
+      expect(host.ems_cluster).not_to be_nil
+      expect(host.ems_cluster.name).to eq("Default")
+
+      expect(host.storages.count).to eq(1)
+
+      storage = host.storages.find_by(:name => "data1_new")
+      expect(storage.ems_ref).to eq("/api/storagedomains/2ef34a5b-2046-4707-9180-7723aad1b8ce")
+
+      expect(host.lans.count).to eq(2)
+      lan = host.lans.find_by(:name => "rhevm")
+      expect(lan.name).to eq("rhevm")
+
+      expect(host.switches.count).to eq(2)
+      switch = host.switches.find_by(:name => "rhevm")
+      expect(switch.name).to eq("rhevm")
+      expect(switch.lans).to include(lan)
     end
   end
 


### PR DESCRIPTION
When building a minimal host hash for migrated vm targeted refresh include the ems_cluster with the host so that it doesn't clear the ems_cluster_id when saving.

https://github.com/ManageIQ/manageiq/pull/13511 fixed saving a VM when it gets migrated to a new host but as a result the cluster link to that host got cleared when it was saved.  This adds the cluster link to the minimal host hash so that it is saved properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1420003