### PR TITLE
Add method for validating global filters names

### DIFF
--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -4,6 +4,10 @@ class MiqSearch < ApplicationRecord
 
   validates_uniqueness_of :name, :scope => "db"
 
+  # validate if the name of a new filter is unique in Global Filters
+  validates :description, :uniqueness => { :scope => "db", :conditions => -> { where.not(:search_type => 'user') },
+                          :if => proc { |miq_search| miq_search.search_type == 'global' } }
+
   has_many  :miq_schedules
 
   before_destroy :check_schedules_empty_on_destroy


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1381622

Add method for validating global filters' names
when saving global filter in expression editor
with the same name.

Originally, validating uniqueness of names of filters in miq_search.rb
in main manageiq repo was designed to compare names.
But name of a filter is a concatenation of its type (search_type) and its description.
There are different types of filters under Global Filters in the tree:
"global" and also "default". And this is the core of the problem.
It was compared something like "default_Analysis" to "global_Analysis".
Two different names so it didn't throw error and allowed you to save filter
with the same "name". We call it "name", but it is a :description of a filter
what we have to compare to fix the bug.

This PR just adds the method to MiqSearch.
The BZ will be completely fixed by merging this 
and another PR in manageiq-ui-classic repo:
https://github.com/ManageIQ/manageiq-ui-classic/pull/327