### PR TITLE
Add quick development instructions to provider generator

### DIFF
--- a/lib/generators/provider/templates/README.md
+++ b/lib/generators/provider/templates/README.md
@@ -16,6 +16,8 @@ ManageIQ plugin for the <%= class_name %> provider.
 
 See the section on pluggable providers in the [ManageIQ Developer Setup](http://manageiq.org/docs/guides/developer_setup)
 
+For quick local setup run `bin/setup`, which will clone the core ManageIQ repository under the *spec* directory and setup necessary config files. If you have already cloned it, you can run `bin/update` to bring the core ManageIQ code up to date.
+
 ## License
 
 The gem is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
This PR adds some "quick dev" instructions to the README.

It is also to keep the generator in sync with https://github.com/ManageIQ/manageiq-providers-azure/pull/33.