### PR TITLE
Added missing Automate sub menu key to permissions yml.

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -1,5 +1,6 @@
 ---
 - :aut
+- :automate
 - :clo
 - :cnt
 - :compute


### PR DESCRIPTION
Automate submenu was missing from product on appliance because of missing key in permissions.yml file.

https://bugzilla.redhat.com/show_bug.cgi?id=1420285

@dclarizio this issue can be recreated in dev environment by copying permissions.tmpl.yml to permissions.yml locally and restarting server in dev mode.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/22748891/9571871a-edf9-11e6-8200-56207c67cfd6.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/22748899/9a759a3a-edf9-11e6-899b-5106ad310d17.png)
