### PR TITLE
Fix VimPerformanceOperatingRanges after upgrade.

### DIFF
--- a/db/migrate/20170207215322_fix_vpor_time_profile_ids.rb
+++ b/db/migrate/20170207215322_fix_vpor_time_profile_ids.rb
@@ -1,0 +1,44 @@
+class FixVporTimeProfileIds < ActiveRecord::Migration[5.0]
+  class VimPerformanceOperatingRange < ActiveRecord::Base
+  end
+
+  class TimeProfile < ActiveRecord::Base
+    ALL_DAYS   = (0...7).to_a.freeze
+    ALL_HOURS  = (0...24).to_a.freeze
+    DEFAULT_TZ = "UTC".freeze
+
+    serialize :profile, Hash
+
+    def self.default
+      @default ||= begin
+        ar_region_class = ArRegion.anonymous_class_with_ar_region
+        region_cond = ar_region_class.region_to_conditions(ar_region_class.my_region_number)
+
+        where(region_cond)
+          .where(:rollup_daily_metrics => true)
+          .select do |tp|
+            tp.profile[:days].try(:sort) == ALL_DAYS &&
+              tp.profile[:hours].try(:sort) == ALL_HOURS &&
+              tp.profile[:tz] == DEFAULT_TZ
+          end
+          .first
+      end
+    end
+  end
+
+  def up
+    if VimPerformanceOperatingRange.where.not(:time_profile_id => nil).exists?
+      # User has already used an old version where TimeProfiles were corrected,
+      # so the TimeProfile-less records are invalid and should be deleted
+      say_with_time("Removing old VimPerformanceOperatingRanges") do
+        VimPerformanceOperatingRange.where(:time_profile_id => nil).delete_all
+      end
+    elsif TimeProfile.any?
+      # User has not used an old version where TimeProfiles were corrected,
+      # so the TimeProfile-less records just need to be updated to the default TP
+      say_with_time("Updating old VimPerformanceOperatingRanges to the default TimeProfile") do
+        VimPerformanceOperatingRange.where(:time_profile_id => nil).update_all(:time_profile_id => TimeProfile.default.id)
+      end
+    end
+  end
+end

--- a/spec/migrations/20170207215322_fix_vpor_time_profile_ids_spec.rb
+++ b/spec/migrations/20170207215322_fix_vpor_time_profile_ids_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe FixVporTimeProfileIds do
+  let(:vpor_stub)         { migration_stub(:VimPerformanceOperatingRange) }
+  let(:time_profile_stub) { migration_stub(:TimeProfile) }
+
+  migration_context :up do
+    it "when the user has previously corrected TimeProfile ids" do
+      tp = create_default_time_profile
+
+      to_delete = vpor_stub.create!
+      to_keep   = vpor_stub.create!(:time_profile_id => tp.id)
+
+      migrate
+
+      expect { to_delete.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(to_keep.reload).to be
+    end
+
+    it "when the user does not have previously corrected TimeProfile ids" do
+      tp = create_default_time_profile
+
+      to_update = vpor_stub.create!
+
+      migrate
+
+      expect(to_update.reload.time_profile_id).to eq(tp.id)
+    end
+  end
+
+  def create_default_time_profile
+    time_profile_stub.create!(
+      :profile => {
+        :tz    => time_profile_stub::DEFAULT_TZ,
+        :days  => time_profile_stub::ALL_DAYS,
+        :hours => time_profile_stub::ALL_HOURS
+      },
+      :rollup_daily_metrics => true
+    )
+  end
+end


### PR DESCRIPTION
After the backport of #12792 and #13700, a user can be in a state where
their VimPerformanceOperatingRanges are inconsistent.  Although it
doesn't really harm anything, this data migration makes it consistent
once again.

@gtanzillo Please review.