### PR TITLE
Save and Return configuration information of a ServiceTemplate 

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -62,7 +62,7 @@ class ServiceTemplate < ApplicationRecord
 
   def self.create_catalog_item(options, auth_user)
     transaction do
-      create(options.except(:config_info).merge(:options => { :config_info => options[:config_info] })).tap do |service_template|
+      create_from_options(options).tap do |service_template|
         config_info = options[:config_info].except(:provision, :retirement, :reconfigure)
 
         workflow_class = MiqProvisionWorkflow.class_for_source(config_info[:src_vm_id])
@@ -362,16 +362,29 @@ class ServiceTemplate < ApplicationRecord
     save!
   end
 
+  def self.create_from_options(options)
+    create(options.except(:config_info).merge(:options => { :config_info => options[:config_info] }))
+  end
+  private_class_method :create_from_options
+
   private
 
   def construct_config_info
     config_info = {}
     if service_resources.where(:resource_type => 'MiqRequest').exists?
-      config_info.merge!(service_resources.find_by(:resource_type => 'MiqRequest').resource.options)
+      config_info.merge!(service_resources.find_by(:resource_type => 'MiqRequest').resource.options.compact)
     end
 
+    config_info.merge!(resource_actions_info)
+  end
+
+  def resource_actions_info
+    config_info = {}
     resource_actions.each do |resource_action|
-      resource_options = resource_action.attributes.merge!(:fqname => resource_action.fqname)
+      resource_options = resource_action.slice(:dialog_id,
+                                               :configuration_template_type,
+                                               :configuration_template_id).compact
+      resource_options[:fqname] = resource_action.fqname
       config_info.merge!(resource_action.action.downcase.to_sym => resource_options.symbolize_keys)
     end
     config_info

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -58,10 +58,11 @@ class ServiceTemplate < ApplicationRecord
 
   virtual_has_one :custom_actions, :class_name => "Hash"
   virtual_has_one :custom_action_buttons, :class_name => "Array"
+  virtual_has_one :config_info, :class_name => "Hash"
 
   def self.create_catalog_item(options, auth_user)
     transaction do
-      create(options.except(:config_info)).tap do |service_template|
+      create(options.except(:config_info).merge(:options => { :config_info => options[:config_info] })).tap do |service_template|
         config_info = options[:config_info].except(:provision, :retirement, :reconfigure)
 
         workflow_class = MiqProvisionWorkflow.class_for_source(config_info[:src_vm_id])
@@ -137,6 +138,10 @@ class ServiceTemplate < ApplicationRecord
 
   def request_type
     "clone_to_service"
+  end
+
+  def config_info
+    options[:config_info] || construct_config_info
   end
 
   def create_service(service_task, parent_svc = nil)
@@ -355,5 +360,20 @@ class ServiceTemplate < ApplicationRecord
       resource_actions.build(build_options)
     end
     save!
+  end
+
+  private
+
+  def construct_config_info
+    config_info = {}
+    if service_resources.where(:resource_type => 'MiqRequest').exists?
+      config_info.merge!(service_resources.find_by(:resource_type => 'MiqRequest').resource.options)
+    end
+
+    resource_actions.each do |resource_action|
+      resource_options = resource_action.attributes.merge!(:fqname => resource_action.fqname)
+      config_info.merge!(resource_action.action.downcase.to_sym => resource_options.symbolize_keys)
+    end
+    config_info
   end
 end

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -8,7 +8,7 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
 
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
-      create(options.except(:config_info)) do |service_template|
+      create_from_options(options).tap do |service_template|
         config_info = validate_config_info(options)
 
         service_template.job_template = if config_info[:configuration_script_id]
@@ -52,4 +52,12 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
     config_info
   end
   private_class_method :validate_config_info
+
+  private
+
+  def construct_config_info
+    config_info = {}
+    config_info[:configuration_script_id] = job_template.id if job_template
+    config_info.merge!(resource_actions_info)
+  end
 end

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -5,7 +5,7 @@ class ServiceTemplateOrchestration < ServiceTemplate
 
   def self.create_catalog_item(options, _auth_user = nil)
     transaction do
-      create(options.except(:config_info)).tap do |service_template|
+      create_from_options(options).tap do |service_template|
         config_info = validate_config_info(options)
 
         service_template.orchestration_template = if config_info[:template_id]
@@ -54,4 +54,15 @@ class ServiceTemplateOrchestration < ServiceTemplate
     config_info
   end
   private_class_method :validate_config_info
+
+  private
+
+  def construct_config_info
+    config_info = {}
+
+    config_info[:template_id] = orchestration_template.id if orchestration_template
+    config_info[:manager_id] = orchestration_manager.id if orchestration_manager
+
+    config_info.merge!(resource_actions_info)
+  end
 end

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -34,6 +34,7 @@ describe ServiceTemplateAnsibleTower do
       expect(service_template.dialogs.first).to eq(service_dialog)
       expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
       expect(service_template.job_template).to eq(configuration_script)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
     end
 
     it 'validates the presence of a configuration_script_id or configuration' do
@@ -49,6 +50,23 @@ describe ServiceTemplateAnsibleTower do
       service_template = ServiceTemplateAnsibleTower.create_catalog_item(catalog_item_options)
 
       expect(service_template.job_template).to eq(configuration_script)
+    end
+  end
+
+  describe '#config_info' do
+    it 'returns the correct format' do
+      job_template = FactoryGirl.create(:configuration_script)
+      service_template = FactoryGirl.create(:service_template_ansible_tower, :job_template => job_template)
+      ra = FactoryGirl.create(:resource_action, :action => 'Provision', :fqname => '/a/b/c')
+      service_template.create_resource_actions(:provision => { :fqname => ra.fqname })
+
+      expected_config_info = {
+        :configuration_script_id => job_template.id,
+        :provision               => {
+          :fqname => ra.fqname
+        }
+      }
+      expect(service_template.config_info).to eq(expected_config_info)
     end
   end
 end

--- a/spec/models/service_template_orchestration_spec.rb
+++ b/spec/models/service_template_orchestration_spec.rb
@@ -138,6 +138,7 @@ describe ServiceTemplateOrchestration do
       expect(service_template.orchestration_template).to eq(template)
       expect(service_template.orchestration_manager).to eq(manager)
       expect(service_template.resource_actions.pluck(:action)).to include('Provision', 'Retirement')
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
     end
 
     it 'requires both a template_id and manager_id' do
@@ -162,6 +163,27 @@ describe ServiceTemplateOrchestration do
       service_template = ServiceTemplateOrchestration.create_catalog_item(catalog_item_options)
       expect(service_template.orchestration_template).to eq(template)
       expect(service_template.orchestration_manager).to eq(manager)
+    end
+  end
+
+  describe '#config_info' do
+    it 'returns the correct format' do
+      template = FactoryGirl.create(:orchestration_template)
+      manager = FactoryGirl.create(:ext_management_system)
+      service_template = FactoryGirl.create(:service_template_orchestration,
+                                            :orchestration_template => template,
+                                            :orchestration_manager  => manager)
+      ra = FactoryGirl.create(:resource_action, :action => 'Provision', :fqname => '/a/b/c')
+      service_template.create_resource_actions(:provision => { :fqname => ra.fqname })
+
+      expected_config_info = {
+        :template_id => template.id,
+        :manager_id  => manager.id,
+        :provision   => {
+          :fqname => ra.fqname
+        }
+      }
+      expect(service_template.config_info).to eq(expected_config_info)
     end
   end
 end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -462,20 +462,23 @@ describe ServiceTemplate do
     end
 
     it 'will build the config_info if not created through #create_catalog_item' do
+      dialog = FactoryGirl.create(:dialog)
       template = FactoryGirl.create(:service_template)
       request = FactoryGirl.create(:service_template_provision_request,
                                    :requester => @user,
-                                   :options   => {:foo => 'bar'})
-      template.create_resource_actions(:provision => { :fqname => @ra.fqname })
+                                   :options   => {:foo => 'bar', :baz => nil })
+      template.create_resource_actions(:provision => { :fqname => @ra.fqname, :dialog_id => dialog.id })
       add_and_save_service(template, request)
       template.reload
 
       expected_config_info = {
         :foo       => 'bar',
-        :provision => a_hash_including(:fqname => '/a/b/c')
-
+        :provision => {
+          :fqname    => '/a/b/c',
+          :dialog_id => dialog.id
+        }
       }
-      expect(template.config_info).to include(expected_config_info)
+      expect(template.config_info).to eq(expected_config_info)
     end
   end
 


### PR DESCRIPTION
This adds a config_info attribute to `ServiceTemplate`. This attribute is needed so that the API can return the same catalog item format that is expected on `create` and `update`, ie:

```
      {
        :name         => 'Ansible Tower',
        :service_type => 'generic_ansible_tower',
        :prov_type    => 'amazon',
        :display      => 'false',
        :description  => 'a description',
        :config_info  => {
          :configuration_script_id => configuration_script.id,
          :provision               => {
            :fqname    => ra1.fqname,
            :dialog_id => service_dialog.id
          },
          :retirement              => {
            :fqname    => ra2.fqname,
            :dialog_id => service_dialog.id
          }
        }
      }
```

This also updates the `create_catalog_item` method to store the options. If the catalog item was not created through the `create_catalog_item` method, the `construct_config_info` method will build the catalog item's data into the correct format.

@miq-bot add_label enhancement, services
@miq-bot assign @gmcculloug 

cc: @bzwei 