### PR TITLE
Instead of default(system) assign current user to generating report task

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -138,7 +138,7 @@ module MiqReport::Generator
 
     sync = options.delete(:report_sync) || ::Settings.product.report_sync
 
-    task = MiqTask.create(:name => "Generate Report: '#{name}'")
+    task = MiqTask.create(:name => "Generate Report: '#{name}'", :userid => options[:userid])
 
     report_result = MiqReportResult.create(
       :name          => title,


### PR DESCRIPTION
Assign current user to task generating report.

BEFORE:
When user queue report for generation, ```miq_task``` associated with generating report assigned to default user (which is ```system```). As result user can not see this task
<img width="1049" alt="before" src="https://cloud.githubusercontent.com/assets/6556758/22753810/71e375e4-ee0b-11e6-90f7-4dee0c2f772c.png">

AFTER:
<img width="1046" alt="after" src="https://cloud.githubusercontent.com/assets/6556758/22753819/7a950f68-ee0b-11e6-981c-23138a50b33f.png">

@miq-bot add-label reporting

\cc @gtanzillo 
   