### PR TITLE
Use throw :abort to halt callback in Job model

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -49,7 +49,7 @@ class Job < ApplicationRecord
   def check_active_on_destroy
     if self.is_active?
       _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
-      return false
+      throw :abort
     end
 
     _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -274,6 +274,25 @@ describe Job do
     end
   end
 
+  context "before_destroy callback" do
+    before(:each) do
+      @job = Job.create_job("VmScan", :name => "Hello, World!")
+    end
+
+    it "allows to deletes not active job" do
+      expect(Job.count).to eq 1
+      @job.destroy
+      expect(Job.count).to eq 0
+    end
+
+    it "doesn't allows to deletes active job" do
+      @job.update_attributes!(:state => "Scanning")
+      expect(Job.count).to eq 1
+      @job.destroy
+      expect(Job.count).to eq 1
+    end
+  end
+
   private
 
   def assert_queue_message


### PR DESCRIPTION
Use ```throw :abort``` to halt callback in ```Job``` model

@miq-bot add-label bug, core

\cc @Fryguy 