### PR TITLE
update specs to work with tower v3

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
@@ -17,11 +17,11 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
   #
   # To change credentials in cassettes:
   # replace with defaults - before committing
-  # ruby -pi -e 'gsub /dev-ansible-tower3.cloudforms.lab.eng.rdu2.redhat.com/, "dev-ansible-tower2.example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
+  # ruby -pi -e 'gsub /yourdomain.com/, "example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
   # replace with your working credentials
-  # ruby -pi -e 'gsub /dev-ansible-tower2.example.com/, "dev-ansible-tower3.cloudforms.lab.eng.rdu2.redhat.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
+  # ruby -pi -e 'gsub /example.com/, "yourdomain.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/*.yml
 
-  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower2.example.com/api/v1/" }
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
   let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
   let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
 
@@ -64,10 +64,10 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def assert_counts
     expect(Provider.count).to                                    eq(1)
-    expect(automation_manager).to                             have_attributes(:api_version => "2.4.2")
-    expect(automation_manager.configured_systems.count).to    eq(98)
-    expect(automation_manager.configuration_scripts.count).to eq(13)
-    expect(automation_manager.inventory_groups.count).to      eq(7)
+    expect(automation_manager).to                             have_attributes(:api_version => "3.0.1")
+    expect(automation_manager.configured_systems.count).to    eq(84)
+    expect(automation_manager.configuration_scripts.count).to eq(11)
+    expect(automation_manager.inventory_groups.count).to      eq(6)
     expect(automation_manager.configuration_script_sources.count).to eq(6)
     expect(automation_manager.configuration_script_payloads.count).to eq(438)
   end
@@ -93,7 +93,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
     expect(expected_configured_system).to have_attributes(
       :type                 => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem",
       :hostname             => "Ansible-Host",
-      :manager_ref          => "145",
+      :manager_ref          => "3",
       :virtual_instance_ref => "4233080d-7467-de61-76c9-c8307b6e4830",
     )
     expect(expected_configured_system.counterpart).to          eq(expected_counterpart_vm)
@@ -103,7 +103,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
   def assert_configuration_script_with_nil_survey_spec
     expect(expected_configuration_script).to have_attributes(
       :description => "Ansible-JobTemplate-Description",
-      :manager_ref => "149",
+      :manager_ref => "80",
       :name        => "Ansible-JobTemplate",
       :survey_spec => {},
       :variables   => {'abc' => 123},
@@ -116,18 +116,18 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
     expect(system).to have_attributes(
       :name        => "Ansible-JobTemplate-Survey",
       :description => "Ansible-JobTemplate-Description",
-      :manager_ref => "155",
+      :manager_ref => "81",
       :variables   => {'abc' => 123}
     )
     survey = system.survey_spec
     expect(survey).to be_a Hash
-    expect(survey['spec'].first['index']).to eq 0
+    expect(survey['spec'].first['question_name']).to eq('Survey')
   end
 
   def assert_inventory_root_group
     expect(expected_inventory_root_group).to have_attributes(
-      :name    => "Dev VC60",
-      :ems_ref => "17",
+      :name    => "Dev-VC60",
+      :ems_ref => "2",
       :type    => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
     )
   end
@@ -143,6 +143,6 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
   end
 
   def expected_inventory_root_group
-    @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev VC60").first
+    @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev-VC60").first
   end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
@@ -73,17 +73,15 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
   end
 
   def assert_playbooks
-    configuration_script_source = automation_manager.configuration_script_sources.find_by(:manager_ref => 29)
-    expect(configuration_script_source.configuration_script_payloads.first).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook)
-    expect(configuration_script_source.configuration_script_payloads.count).to eq(60)
-    expect(configuration_script_source.configuration_script_payloads.map(&:name)).to include('jboss-standalone/demo-aws-launch.yml')
+    expect(expected_configuration_script_source.configuration_script_payloads.first).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook)
+    expect(expected_configuration_script_source.configuration_script_payloads.count).to eq(1)
+    expect(expected_configuration_script_source.configuration_script_payloads.map(&:name)).to include('hello_world.yml')
   end
 
   def assert_configuration_script_sources
     expect(automation_manager.configuration_script_sources.count).to eq(6)
-    configuration_script_source = automation_manager.configuration_script_sources.find_by(:manager_ref => 4)
-    expect(configuration_script_source).to be_an_instance_of(ConfigurationScriptSource)
-    expect(configuration_script_source).to have_attributes(
+    expect(expected_configuration_script_source).to be_an_instance_of(ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to have_attributes(
       :name        => 'Demo Project',
       :description => 'A great demo',
     )
@@ -144,5 +142,9 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def expected_inventory_root_group
     @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev-VC60").first
+  end
+
+  def expected_configuration_script_source
+    @expected_configuration_script_source ||= automation_manager.configuration_script_sources.find_by(:name => 'Demo Project')
   end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
@@ -1,0 +1,130 @@
+describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
+  # To change credentials in cassettes:
+  # replace with defaults - before committing
+  # ruby -pi -e 'gsub /yourdomain.com/, "example.com"; gsub /admin:smartvm/, "testuser:secret"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+  # replace with your working credentials
+  # ruby -pi -e 'gsub /example.com/, "yourdomain.com"; gsub /testuser:secret/, "admin:smartvm"' spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower2.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:expected_counterpart_vm) { FactoryGirl.create(:vm, :uid_ems => "4233080d-7467-de61-76c9-c8307b6e4830") }
+  let(:provider) do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    FactoryGirl.create(:provider_ansible_tower,
+                       :zone       => zone,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+
+  it ".ems_type" do
+    expect(described_class.ems_type).to eq(:ansible_tower_automation)
+  end
+
+  it "will perform a full refresh" do
+    expected_counterpart_vm
+
+    2.times do
+      VCR.use_cassette(described_class.name.underscore + '_v2') do
+        EmsRefresh.refresh(automation_manager)
+        expect(automation_manager.reload.last_refresh_error).to be_nil
+      end
+
+      assert_counts
+      assert_configured_system
+      assert_configuration_script_with_nil_survey_spec
+      assert_configuration_script_with_survey_spec
+      assert_inventory_root_group
+      assert_configuration_script_sources
+      assert_playbooks
+    end
+  end
+
+  def assert_counts
+    expect(Provider.count).to                                    eq(1)
+    expect(automation_manager).to                             have_attributes(:api_version => "2.4.2")
+    expect(automation_manager.configured_systems.count).to    eq(168)
+    expect(automation_manager.configuration_scripts.count).to eq(14)
+    expect(automation_manager.inventory_groups.count).to      eq(8)
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(automation_manager.configuration_script_payloads.count).to eq(77)
+  end
+
+  def assert_playbooks
+    expect(expected_configuration_script_source.configuration_script_payloads.first).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook)
+    expect(expected_configuration_script_source.configuration_script_payloads.count).to eq(7)
+    expect(expected_configuration_script_source.configuration_script_payloads.map(&:name)).to include('create_ec2.yml')
+  end
+
+  def assert_configuration_script_sources
+    expect(automation_manager.configuration_script_sources.count).to eq(6)
+    expect(expected_configuration_script_source).to be_an_instance_of(ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to have_attributes(
+      :name        => 'db-projects',
+      :description => 'projects',
+    )
+  end
+
+  def assert_configured_system
+    expect(expected_configured_system).to have_attributes(
+      :type                 => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem",
+      :hostname             => "Ansible-Host",
+      :manager_ref          => "145",
+      :virtual_instance_ref => "4233080d-7467-de61-76c9-c8307b6e4830",
+    )
+    expect(expected_configured_system.counterpart).to          eq(expected_counterpart_vm)
+    expect(expected_configured_system.inventory_root_group).to eq(expected_inventory_root_group)
+  end
+
+  def assert_configuration_script_with_nil_survey_spec
+    expect(expected_configuration_script).to have_attributes(
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "149",
+      :name        => "Ansible-JobTemplate",
+      :survey_spec => {},
+      :variables   => {'abc' => 123},
+    )
+    expect(expected_configuration_script.inventory_root_group).to have_attributes(:ems_ref => "2")
+  end
+
+  def assert_configuration_script_with_survey_spec
+    system = automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate-Survey").first
+    expect(system).to have_attributes(
+      :name        => "Ansible-JobTemplate-Survey",
+      :description => "Ansible-JobTemplate-Description",
+      :manager_ref => "155",
+      :variables   => {'abc' => 123}
+    )
+    survey = system.survey_spec
+    expect(survey).to be_a Hash
+    expect(survey['spec'].first['index']).to eq 0
+  end
+
+  def assert_inventory_root_group
+    expect(expected_inventory_root_group).to have_attributes(
+      :name    => "Dev VC60",
+      :ems_ref => "17",
+      :type    => "ManageIQ::Providers::AutomationManager::InventoryRootGroup",
+    )
+  end
+
+  private
+
+  def expected_configured_system
+    @expected_configured_system ||= automation_manager.configured_systems.where(:hostname => "Ansible-Host").first
+  end
+
+  def expected_configuration_script
+    @expected_configuration_script ||= automation_manager.configuration_scripts.where(:name => "Ansible-JobTemplate").first
+  end
+
+  def expected_inventory_root_group
+    @expected_inventory_root_group ||= automation_manager.inventory_groups.where(:name => "Dev VC60").first
+  end
+
+  def expected_configuration_script_source
+    @expected_configuration_script_source ||= automation_manager.configuration_script_sources.find_by(:name => 'db-projects')
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/config
     body:
       encoding: US-ASCII
       string: ''
@@ -19,11 +19,11 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:22 GMT
+      - Thu, 09 Feb 2017 10:37:42 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower2.example.com/api/v1/config/
+      - https://dev-ansible-tower3.example.com/api/v1/config/
       Content-Length:
       - '0'
       Content-Type:
@@ -32,10 +32,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:22 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:43 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/config/
     body:
       encoding: US-ASCII
       string: ''
@@ -52,59 +52,245 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:23 GMT
+      - Thu, 09 Feb 2017 10:37:42 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.218s
+      - 0.217s
       Content-Length:
-      - '2540'
+      - '9766'
       Content-Type:
       - application/json
     body:
-      encoding: UTF-8
-      string: '{"eula": "TOWER SOFTWARE END USER LICENSE AGREEMENT\n\nUnless otherwise
-        agreed to, and executed in a definitive agreement, between\nAnsible, Inc.
-        (\u201cAnsible\u201d) and the individual or entity (\u201cCustomer\u201d)
-        signing or\nelectronically accepting these terms of use for the Tower Software
-        (\u201cEULA\u201d),\nall Tower Software, including any and all versions released
-        or made available\nby Ansible, shall be subject to the Ansible Software Subscription
-        and Services\nAgreement found at www.ansible.com/subscription-agreement (\u201cAgreement\u201d).\nAnsible
-        is not responsible for any additional obligations, conditions or\nwarranties
-        agreed to between Customer and an authorized distributor, or\nreseller, of
-        the Tower Software. BY DOWNLOADING AND USING THE TOWER SOFTWARE,\nOR BY CLICKING
-        ON THE \u201cYES\u201d BUTTON OR OTHER BUTTON OR MECHANISM DESIGNED TO\nACKNOWLEDGE
-        CONSENT TO THE TERMS OF AN ELECTRONIC COPY OF THIS EULA, THE\nCUSTOMER HEREBY
-        ACKNOWLEDGES THAT CUSTOMER HAS READ, UNDERSTOOD, AND AGREES TO\nBE BOUND BY
-        THE TERMS OF THIS EULA AND AGREEMENT, INCLUDING ALL TERMS\nINCORPORATED HEREIN
-        BY REFERENCE, AND THAT THIS EULA AND AGREEMENT IS\nEQUIVALENT TO ANY WRITTEN
-        NEGOTIATED AGREEMENT BETWEEN CUSTOMER AND ANSIBLE.\nTHIS EULA AND AGREEMENT
-        IS ENFORCEABLE AGAINST ANY PERSON OR ENTITY THAT USES\nOR AVAILS ITSELF OF
-        THE TOWER SOFTWARE OR ANY PERSON OR ENTITY THAT USES THE OR\nAVAILS ITSELF
-        OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
-        "license_info": {"deployment_id": "6002e746fa4bf7beb33e9fb80a63a9e1f3d3bd77",
-        "subscription_name": "Enterprise Tower 100 Partner NFR", "current_instances":
-        98, "features": {"surveys": true, "multiple_organizations": true, "system_tracking":
-        true, "enterprise_auth": true, "rebranding": true, "activity_streams": true,
-        "ldap": true, "ha": true}, "date_expired": false, "available_instances": 100,
-        "hostname": "27313f9d74884e36a7386f147c70ceae", "free_instances": 2, "instance_count":
-        100, "time_remaining": 8040434, "compliant": true, "grace_period_remaining":
-        10632434, "contact_email": "joesmit@redhat.com", "company_name": "Red Hat,
-        Inc.", "date_warning": false, "license_type": "enterprise", "license_key":
-        "license_key", "license_date":
-        1484329237, "contact_name": "Joe  Smith", "valid_key": true}, "analytics_status":
-        "detailed", "version": "2.4.2", "project_base_dir": "/var/lib/awx/projects",
-        "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
-        []}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJ
+        Q0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3Jl
+        ZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5z
+        aWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywg
+        dXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5k
+        IG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXi
+        gJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBc
+        blxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBv
+        ZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVz
+        ICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBu
+        b24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5v
+        bi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0
+        byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJt
+        IG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0
+        aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIg
+        b2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBm
+        cm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICji
+        gJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxp
+        Y2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJl
+        IG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0
+        d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNo
+        aXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJs
+        ZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91
+        LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3Vy
+        IHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90
+        IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFu
+        dCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJt
+        cyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUg
+        YXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhh
+        dCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNl
+        bnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4g
+        IFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNo
+        IGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcg
+        YWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQs
+        IFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2Ug
+        bWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGlu
+        dGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVt
+        YWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhh
+        dCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3Qg
+        YXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBh
+        cnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86
+        IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxv
+        dyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRl
+        cjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5l
+        ZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBw
+        cm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0
+        d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFw
+        cHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGlu
+        ZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBz
+        b3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlv
+        biBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBT
+        b2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxl
+        IGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3
+        YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMg
+        aW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBv
+        ciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5n
+        KSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRl
+        cml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dl
+        ciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUg
+        bmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90
+        aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIg
+        U29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVu
+        Y2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0
+        aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFu
+        Y2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3Vt
+        dmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5n
+        IG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVm
+        aW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRv
+        d2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRo
+        ZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0
+        IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmlj
+        ZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vu
+        c2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPi
+        gJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMg
+        TGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1h
+        dGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNv
+        ZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3Qg
+        dGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBk
+        ZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhl
+        ciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQg
+        dG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2Ug
+        aG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9m
+        IGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBF
+        dmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2Vk
+        IEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJl
+        ZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVy
+        bXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFs
+        bCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUg
+        bGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1
+        Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lz
+        ZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJs
+        ZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1
+        YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3
+        YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBv
+        ciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4g
+        dGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBu
+        b24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3Jl
+        ZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9u
+        IHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5k
+        IHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0
+        aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9y
+        IGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQg
+        V2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0
+        aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRl
+        ZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGlj
+        ZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2lu
+        ZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGll
+        ZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdl
+        bWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJl
+        ZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBv
+        biB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVy
+        bmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxz
+        IGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlv
+        ZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZl
+        cnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhl
+        IGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhl
+        IG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxs
+        IGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMg
+        ZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwg
+        b3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41
+        LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0
+        aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3
+        LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRv
+        IHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMw
+        KSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIg
+        cGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3
+        aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlv
+        dSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1p
+        dHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5v
+        ciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUg
+        bGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVu
+        dGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qg
+        c2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0
+        byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBv
+        bmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3Ry
+        aWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9m
+        IHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBs
+        aWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlh
+        YmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVk
+        IEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRo
+        ZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2
+        aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wu
+        ICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBT
+        dGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQg
+        d2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5z
+        aWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJl
+        IHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENv
+        bW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBS
+        ZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBp
+        biBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4g
+        U3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykg
+        d2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBB
+        bnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3Rp
+        bmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGli
+        aXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0
+        aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1l
+        bnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxl
+        IFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRo
+        ZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVh
+        ciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQg
+        c3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyBy
+        b2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1
+        bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVu
+        aXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFu
+        c2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5
+        b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlv
+        biA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3Ig
+        dHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMg
+        dG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1
+        c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5k
+        IGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVy
+        ZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRp
+        bmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQs
+        IHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNo
+        IG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQg
+        YWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZv
+        ciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4
+        cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHBy
+        b3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2Vh
+        YmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5
+        IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50
+        IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBv
+        ZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQg
+        cmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRo
+        ZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRo
+        aXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBO
+        YXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBv
+        ZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4g
+        IEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5z
+        aWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJl
+        ZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJv
+        cGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNl
+        X2luZm8iOnsiZGVwbG95bWVudF9pZCI6ImEzZGJkYzdmNTRlNDlhNjAzN2M0
+        MzFmYTc4YmZmZTc0NjY3ZmRhY2EiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFu
+        c2libGUgVG93ZXIgYnkgUmVkIEhhdCwgU3RhbmRhcmQgKDEwMCBNYW5hZ2Vk
+        IE5vZGVzKSIsImN1cnJlbnRfaW5zdGFuY2VzIjo4MywiZmVhdHVyZXMiOnsi
+        c3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwi
+        c3lzdGVtX3RyYWNraW5nIjp0cnVlLCJlbnRlcnByaXNlX2F1dGgiOnRydWUs
+        InJlYnJhbmRpbmciOnRydWUsImFjdGl2aXR5X3N0cmVhbXMiOnRydWUsImxk
+        YXAiOnRydWUsImhhIjp0cnVlfSwiZGF0ZV9leHBpcmVkIjpmYWxzZSwiYXZh
+        aWxhYmxlX2luc3RhbmNlcyI6MTAwLCJob3N0bmFtZSI6ImZmNmI5ZTFmNTYx
+        NTRhNjFiZWViNWE0ZGJkY2EzMjFhIiwiZnJlZV9pbnN0YW5jZXMiOjE3LCJp
+        bnN0YW5jZV9jb3VudCI6MTAwLCJ0aW1lX3JlbWFpbmluZyI6MzEyMTExNTcs
+        ImNvbXBsaWFudCI6dHJ1ZSwiZ3JhY2VfcGVyaW9kX3JlbWFpbmluZyI6MzM4
+        MDMxNTcsImNvbnRhY3RfZW1haWwiOiJqb2VzbWl0QHJlZGhhdC5jb20iLCJj
+        b21wYW55X25hbWUiOiJSZWQgSGF0LCBJbmMuIiwiZGF0ZV93YXJuaW5nIjpm
+        YWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImNvbnRhY3RfbmFt
+        ZSI6IkpvZSAgU21pdGgiLCJsaWNlbnNlX2RhdGUiOjE1MTc4NDc4MTksImxp
+        Y2Vuc2Vfa2V5IjoiZWQ5ZDAwZjFhMjU0ZTJiMGI3NzBiYWViMmIyNjg4YzQz
+        N2U5ZGVlNDE3OTY2N2RmYmZmY2QxOTNlNTA4YTI2MyIsInZhbGlkX2tleSI6
+        dHJ1ZX0sImFuYWx5dGljc19zdGF0dXMiOiJkZXRhaWxlZCIsInZlcnNpb24i
+        OiIzLjAuMSIsInByb2plY3RfYmFzZV9kaXIiOiIvdmFyL2xpYi9hd3gvcHJv
+        amVjdHMiLCJ0aW1lX3pvbmUiOiJBbWVyaWNhL05ld19Zb3JrIiwiYW5zaWJs
+        ZV92ZXJzaW9uIjoiMi4xLjAuMCIsInByb2plY3RfbG9jYWxfcGF0aHMiOltd
+        fQ==
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:23 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:44 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/inventories
     body:
       encoding: US-ASCII
       string: ''
@@ -121,11 +307,11 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:23 GMT
+      - Thu, 09 Feb 2017 10:37:43 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower2.example.com/api/v1/inventories/
+      - https://dev-ansible-tower3.example.com/api/v1/inventories/
       Content-Length:
       - '0'
       Content-Type:
@@ -134,10 +320,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:23 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:44 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/inventories/
     body:
       encoding: US-ASCII
       string: ''
@@ -154,129 +340,62 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:23 GMT
+      - Thu, 09 Feb 2017 10:37:44 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.072s
+      - 0.089s
       Content-Length:
-      - '9013'
+      - '11790'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"count": 7, "next": null, "previous": null, "results": [{"id": 2,
-        "type": "inventory", "url": "/api/v1/inventories/2/", "related": {"created_by":
-        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/2/scan_job_templates/",
-        "variable_data": "/api/v1/inventories/2/variable_data/", "root_groups": "/api/v1/inventories/2/root_groups/",
-        "script": "/api/v1/inventories/2/script/", "ad_hoc_commands": "/api/v1/inventories/2/ad_hoc_commands/",
-        "tree": "/api/v1/inventories/2/tree/", "hosts": "/api/v1/inventories/2/hosts/",
-        "groups": "/api/v1/inventories/2/groups/", "activity_stream": "/api/v1/inventories/2/activity_stream/",
-        "inventory_sources": "/api/v1/inventories/2/inventory_sources/", "organization":
-        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
-        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}}, "created": "2015-12-17T18:04:27.635Z", "modified":
-        "2016-08-15T20:26:37.816Z", "name": "AWS", "description": "CFME AWS Lab",
-        "organization": 1, "variables": "---", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, {"id": 6, "type": "inventory", "url": "/api/v1/inventories/6/", "related":
-        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "scan_job_templates":
-        "/api/v1/inventories/6/scan_job_templates/", "variable_data": "/api/v1/inventories/6/variable_data/",
-        "root_groups": "/api/v1/inventories/6/root_groups/", "script": "/api/v1/inventories/6/script/",
-        "ad_hoc_commands": "/api/v1/inventories/6/ad_hoc_commands/", "tree": "/api/v1/inventories/6/tree/",
-        "hosts": "/api/v1/inventories/6/hosts/", "groups": "/api/v1/inventories/6/groups/",
-        "activity_stream": "/api/v1/inventories/6/activity_stream/", "inventory_sources":
-        "/api/v1/inventories/6/inventory_sources/", "organization": "/api/v1/organizations/1/"},
-        "summary_fields": {"organization": {"name": "Default", "description": ""},
-        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}}, "created": "2016-01-06T22:16:35.875Z", "modified": "2016-01-06T22:16:35.875Z",
-        "name": "bd", "description": "", "organization": 1, "variables": "---", "has_active_failures":
-        false, "total_hosts": 0, "hosts_with_active_failures": 0, "total_groups":
-        0, "groups_with_active_failures": 0, "has_inventory_sources": false, "total_inventory_sources":
-        0, "inventory_sources_with_failures": 0}, {"id": 9, "type": "inventory", "url":
-        "/api/v1/inventories/9/", "related": {"created_by": "/api/v1/users/1/", "modified_by":
-        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/9/scan_job_templates/",
-        "variable_data": "/api/v1/inventories/9/variable_data/", "root_groups": "/api/v1/inventories/9/root_groups/",
-        "script": "/api/v1/inventories/9/script/", "ad_hoc_commands": "/api/v1/inventories/9/ad_hoc_commands/",
-        "tree": "/api/v1/inventories/9/tree/", "hosts": "/api/v1/inventories/9/hosts/",
-        "groups": "/api/v1/inventories/9/groups/", "activity_stream": "/api/v1/inventories/9/activity_stream/",
-        "inventory_sources": "/api/v1/inventories/9/inventory_sources/", "organization":
-        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
-        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}, "modified_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}}, "created": "2016-02-01T19:44:58.850Z", "modified":
-        "2016-02-09T22:39:26.451Z", "name": "db-test-inventory-put", "description":
-        "", "organization": 1, "variables": "---", "has_active_failures": false, "total_hosts":
-        1, "hosts_with_active_failures": 0, "total_groups": 1, "groups_with_active_failures":
-        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
-        0}, {"id": 17, "type": "inventory", "url": "/api/v1/inventories/17/", "related":
-        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/17/scan_job_templates/",
-        "variable_data": "/api/v1/inventories/17/variable_data/", "root_groups": "/api/v1/inventories/17/root_groups/",
-        "script": "/api/v1/inventories/17/script/", "ad_hoc_commands": "/api/v1/inventories/17/ad_hoc_commands/",
-        "tree": "/api/v1/inventories/17/tree/", "hosts": "/api/v1/inventories/17/hosts/",
-        "groups": "/api/v1/inventories/17/groups/", "activity_stream": "/api/v1/inventories/17/activity_stream/",
-        "inventory_sources": "/api/v1/inventories/17/inventory_sources/", "organization":
-        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
-        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}}, "created": "2016-03-31T18:42:30.808Z", "modified":
-        "2016-06-23T17:34:05.055Z", "name": "Dev VC60", "description": "", "organization":
-        1, "variables": "---", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        {"id": 1, "type": "inventory", "url": "/api/v1/inventories/1/", "related":
-        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/1/scan_job_templates/",
-        "variable_data": "/api/v1/inventories/1/variable_data/", "root_groups": "/api/v1/inventories/1/root_groups/",
-        "script": "/api/v1/inventories/1/script/", "ad_hoc_commands": "/api/v1/inventories/1/ad_hoc_commands/",
-        "tree": "/api/v1/inventories/1/tree/", "hosts": "/api/v1/inventories/1/hosts/",
-        "groups": "/api/v1/inventories/1/groups/", "activity_stream": "/api/v1/inventories/1/activity_stream/",
-        "inventory_sources": "/api/v1/inventories/1/inventory_sources/", "organization":
-        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
-        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}}, "created": "2015-12-17T16:51:16.902Z", "modified":
-        "2015-12-17T16:56:21.511Z", "name": "Openstack", "description": "", "organization":
-        1, "variables": "---", "has_active_failures": false, "total_hosts": 0, "hosts_with_active_failures":
-        0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        {"id": 3, "type": "inventory", "url": "/api/v1/inventories/3/", "related":
-        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/3/scan_job_templates/",
-        "variable_data": "/api/v1/inventories/3/variable_data/", "root_groups": "/api/v1/inventories/3/root_groups/",
-        "script": "/api/v1/inventories/3/script/", "ad_hoc_commands": "/api/v1/inventories/3/ad_hoc_commands/",
-        "tree": "/api/v1/inventories/3/tree/", "hosts": "/api/v1/inventories/3/hosts/",
-        "groups": "/api/v1/inventories/3/groups/", "activity_stream": "/api/v1/inventories/3/activity_stream/",
-        "inventory_sources": "/api/v1/inventories/3/inventory_sources/", "organization":
-        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
-        "description": ""}, "created_by": {"id": 1, "username": "testuser", "first_name":
-        "", "last_name": ""}}, "created": "2015-12-17T18:08:49.861Z", "modified":
-        "2016-01-15T21:12:24.696Z", "name": "Openstack RH Support", "description":
-        "RH Support Openstack Hosts", "organization": 1, "variables": "---", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, {"id": 8, "type": "inventory", "url":
-        "/api/v1/inventories/8/", "related": {"created_by": "/api/v1/users/1/", "scan_job_templates":
-        "/api/v1/inventories/8/scan_job_templates/", "variable_data": "/api/v1/inventories/8/variable_data/",
-        "root_groups": "/api/v1/inventories/8/root_groups/", "script": "/api/v1/inventories/8/script/",
-        "ad_hoc_commands": "/api/v1/inventories/8/ad_hoc_commands/", "tree": "/api/v1/inventories/8/tree/",
-        "hosts": "/api/v1/inventories/8/hosts/", "groups": "/api/v1/inventories/8/groups/",
-        "activity_stream": "/api/v1/inventories/8/activity_stream/", "inventory_sources":
-        "/api/v1/inventories/8/inventory_sources/", "organization": "/api/v1/organizations/1/"},
-        "summary_fields": {"organization": {"name": "Default", "description": ""},
-        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}}, "created": "2016-01-29T21:15:35.295Z", "modified": "2016-03-24T14:59:02.954Z",
-        "name": "Single AWS Host", "description": "54.86.210.90", "organization":
-        1, "variables": "---", "has_active_failures": true, "total_hosts": 1, "hosts_with_active_failures":
-        1, "total_groups": 0, "groups_with_active_failures": 0, "has_inventory_sources":
-        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0}]}'
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":6,"type":"inventory","url":"/api/v1/inventories/6/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/6/job_templates/","scan_job_templates":"/api/v1/inventories/6/scan_job_templates/","variable_data":"/api/v1/inventories/6/variable_data/","root_groups":"/api/v1/inventories/6/root_groups/","object_roles":"/api/v1/inventories/6/object_roles/","ad_hoc_commands":"/api/v1/inventories/6/ad_hoc_commands/","script":"/api/v1/inventories/6/script/","tree":"/api/v1/inventories/6/tree/","access_list":"/api/v1/inventories/6/access_list/","hosts":"/api/v1/inventories/6/hosts/","groups":"/api/v1/inventories/6/groups/","activity_stream":"/api/v1/inventories/6/activity_stream/","inventory_sources":"/api/v1/inventories/6/inventory_sources/","organization":"/api/v1/organizations/3/"},"summary_fields":{"organization":{"id":3,"name":"ACME
+        Corp","description":"Which belongs to goern"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":110,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":108,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":107,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":111,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":109,"name":"Read"}}},"created":"2017-01-30T10:53:48.130Z","modified":"2017-01-30T11:28:59.847Z","name":"acme-corp","description":"","organization":3,"variables":"---\nOCP_URL:
+        https://acme-ocp3-haproxy-0.acme.e2e.bos.redhat.com:8443\nOCP_MASTER: acme-ocp3-haproxy-0.acme.e2e.bos.redhat.com\nOCP_USER:
+        pltops\n\nOCP_PROJECT: coolstore-dev\nARTIFACTORY_API_URL: http://acme-dev-infra-artifactory.acme.e2e.bos.redhat.com:8081/artifactory/api/","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},{"id":7,"type":"inventory","url":"/api/v1/inventories/7/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/7/job_templates/","scan_job_templates":"/api/v1/inventories/7/scan_job_templates/","variable_data":"/api/v1/inventories/7/variable_data/","root_groups":"/api/v1/inventories/7/root_groups/","object_roles":"/api/v1/inventories/7/object_roles/","ad_hoc_commands":"/api/v1/inventories/7/ad_hoc_commands/","script":"/api/v1/inventories/7/script/","tree":"/api/v1/inventories/7/tree/","access_list":"/api/v1/inventories/7/access_list/","hosts":"/api/v1/inventories/7/hosts/","groups":"/api/v1/inventories/7/groups/","activity_stream":"/api/v1/inventories/7/activity_stream/","inventory_sources":"/api/v1/inventories/7/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":230,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":228,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":227,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":231,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":229,"name":"Read"}}},"created":"2017-02-08T21:53:20.409Z","modified":"2017-02-08T21:54:14.473Z","name":"bill","description":"bill
+        test","organization":1,"variables":"any: thing","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":1,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},{"id":5,"type":"inventory","url":"/api/v1/inventories/5/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/5/job_templates/","scan_job_templates":"/api/v1/inventories/5/scan_job_templates/","variable_data":"/api/v1/inventories/5/variable_data/","root_groups":"/api/v1/inventories/5/root_groups/","object_roles":"/api/v1/inventories/5/object_roles/","ad_hoc_commands":"/api/v1/inventories/5/ad_hoc_commands/","script":"/api/v1/inventories/5/script/","tree":"/api/v1/inventories/5/tree/","access_list":"/api/v1/inventories/5/access_list/","hosts":"/api/v1/inventories/5/hosts/","groups":"/api/v1/inventories/5/groups/","activity_stream":"/api/v1/inventories/5/activity_stream/","inventory_sources":"/api/v1/inventories/5/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":101,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":99,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":98,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":102,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":100,"name":"Read"}}},"created":"2017-01-24T21:45:07.434Z","modified":"2017-01-24T21:45:07.434Z","name":"db_test_inventory","description":"","organization":1,"variables":"","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},{"id":1,"type":"inventory","url":"/api/v1/inventories/1/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/1/job_templates/","scan_job_templates":"/api/v1/inventories/1/scan_job_templates/","variable_data":"/api/v1/inventories/1/variable_data/","root_groups":"/api/v1/inventories/1/root_groups/","object_roles":"/api/v1/inventories/1/object_roles/","ad_hoc_commands":"/api/v1/inventories/1/ad_hoc_commands/","script":"/api/v1/inventories/1/script/","tree":"/api/v1/inventories/1/tree/","access_list":"/api/v1/inventories/1/access_list/","hosts":"/api/v1/inventories/1/hosts/","groups":"/api/v1/inventories/1/groups/","activity_stream":"/api/v1/inventories/1/activity_stream/","inventory_sources":"/api/v1/inventories/1/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":18,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":16,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":15,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":19,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":17,"name":"Read"}}},"created":"2016-08-02T17:57:03.135Z","modified":"2017-01-24T21:42:36.042Z","name":"Demo
+        Inventory","description":"","organization":1,"variables":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},{"id":2,"type":"inventory","url":"/api/v1/inventories/2/","related":{"created_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/2/job_templates/","scan_job_templates":"/api/v1/inventories/2/scan_job_templates/","variable_data":"/api/v1/inventories/2/variable_data/","root_groups":"/api/v1/inventories/2/root_groups/","object_roles":"/api/v1/inventories/2/object_roles/","ad_hoc_commands":"/api/v1/inventories/2/ad_hoc_commands/","script":"/api/v1/inventories/2/script/","tree":"/api/v1/inventories/2/tree/","access_list":"/api/v1/inventories/2/access_list/","hosts":"/api/v1/inventories/2/hosts/","groups":"/api/v1/inventories/2/groups/","activity_stream":"/api/v1/inventories/2/activity_stream/","inventory_sources":"/api/v1/inventories/2/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":26,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":24,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":23,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":27,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":25,"name":"Read"}}},"created":"2016-08-30T22:38:00.334Z","modified":"2016-10-12T18:19:16.212Z","name":"Dev-VC60","description":"","organization":1,"variables":"---","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},{"id":4,"type":"inventory","url":"/api/v1/inventories/4/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_templates":"/api/v1/inventories/4/job_templates/","scan_job_templates":"/api/v1/inventories/4/scan_job_templates/","variable_data":"/api/v1/inventories/4/variable_data/","root_groups":"/api/v1/inventories/4/root_groups/","object_roles":"/api/v1/inventories/4/object_roles/","ad_hoc_commands":"/api/v1/inventories/4/ad_hoc_commands/","script":"/api/v1/inventories/4/script/","tree":"/api/v1/inventories/4/tree/","access_list":"/api/v1/inventories/4/access_list/","hosts":"/api/v1/inventories/4/hosts/","groups":"/api/v1/inventories/4/groups/","activity_stream":"/api/v1/inventories/4/activity_stream/","inventory_sources":"/api/v1/inventories/4/inventory_sources/","organization":"/api/v1/organizations/1/"},"summary_fields":{"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"use_role":{"description":"Can
+        use the inventory in a job template","id":65,"name":"Use"},"admin_role":{"description":"Can
+        manage all aspects of the inventory","id":63,"name":"Admin"},"adhoc_role":{"description":"May
+        run ad hoc commands on an inventory","id":62,"name":"Ad Hoc"},"update_role":{"description":"May
+        update project or inventory or group using the configured source update system","id":66,"name":"Update"},"read_role":{"description":"May
+        view settings for the inventory","id":64,"name":"Read"}}},"created":"2017-01-06T23:06:37.994Z","modified":"2017-01-06T23:06:37.994Z","name":"test","description":"","organization":1,"variables":"","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0}]}'
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:23 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:45 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/hosts
     body:
       encoding: US-ASCII
       string: ''
@@ -293,11 +412,11 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:23 GMT
+      - Thu, 09 Feb 2017 10:37:44 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower2.example.com/api/v1/hosts/
+      - https://dev-ansible-tower3.example.com/api/v1/hosts/
       Content-Length:
       - '0'
       Content-Type:
@@ -306,10 +425,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:23 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:46 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/hosts/
     body:
       encoding: US-ASCII
       string: ''
@@ -326,1477 +445,403 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:23 GMT
+      - Thu, 09 Feb 2017 10:37:45 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.269s
+      - 0.219s
       Content-Length:
-      - '75521'
+      - '91587'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"count": 98, "next": "/api/v1/hosts/?page=2", "previous": null, "results":
-        [{"id": 222, "type": "host", "url": "/api/v1/hosts/222/", "related": {"job_host_summaries":
-        "/api/v1/hosts/222/job_host_summaries/", "variable_data": "/api/v1/hosts/222/variable_data/",
-        "job_events": "/api/v1/hosts/222/job_events/", "ad_hoc_commands": "/api/v1/hosts/222/ad_hoc_commands/",
-        "fact_versions": "/api/v1/hosts/222/fact_versions/", "inventory_sources":
-        "/api/v1/hosts/222/inventory_sources/", "groups": "/api/v1/hosts/222/groups/",
-        "activity_stream": "/api/v1/hosts/222/activity_stream/", "all_groups": "/api/v1/hosts/222/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/222/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name": "AWS",
-        "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-24T21:50:46.601Z", "modified":
-        "2016-05-24T21:50:47.108Z", "name": "184.72.116.213", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-fef21b62", "variables":
-        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-fef21b62\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-26.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.26\", \"ec2_security_group_names\":
-        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
-        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
-        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-24T20:43:22.000Z\", \"ec2_ip_address\":
-        \"184.72.116.213\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
-        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
-        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 194, "type": "host", "url": "/api/v1/hosts/194/",
-        "related": {"job_host_summaries": "/api/v1/hosts/194/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/194/variable_data/", "job_events": "/api/v1/hosts/194/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/194/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/194/fact_versions/", "inventory_sources": "/api/v1/hosts/194/inventory_sources/",
-        "groups": "/api/v1/hosts/194/groups/", "activity_stream": "/api/v1/hosts/194/activity_stream/",
-        "all_groups": "/api/v1/hosts/194/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/194/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-05T19:44:30.739Z", "modified":
-        "2016-04-05T19:44:31.009Z", "name": "52.20.255.156", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-8b5739f2", "variables":
-        "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-8b5739f2\", \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-254.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.254\", \"ec2_security_group_names\":
-        \"EmsRefreshSpec-SecurityGroup-VPC\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-VPC\", \"ec2_architecture\":
-        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\",
-        \"ec2_client_token\": \"aPCzL1379967112359\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\":
-        \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\": \"/dev/sda1\",
-        \"ec2_subnet_id\": \"subnet-f849ff96\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
-        \"sg-80f755ef\", \"ec2_placement\": \"us-east-1e\", \"ec2_launch_time\": \"2013-09-23T20:11:52.000Z\",
-        \"ec2_ip_address\": \"52.20.255.156\", \"ec2_image_id\": \"ami-5769193e\",
-        \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\": \"paravirtual\",
-        \"ec2_monitored\": false, \"ec2_dns_name\": \"\", \"ec2_previous_state\":
-        \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\":
-        \"\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 221, "type": "host", "url": "/api/v1/hosts/221/",
-        "related": {"job_host_summaries": "/api/v1/hosts/221/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/221/variable_data/", "job_events": "/api/v1/hosts/221/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/221/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/221/fact_versions/", "inventory_sources": "/api/v1/hosts/221/inventory_sources/",
-        "groups": "/api/v1/hosts/221/groups/", "activity_stream": "/api/v1/hosts/221/activity_stream/",
-        "all_groups": "/api/v1/hosts/221/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/221/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-24T19:02:15.148Z", "modified":
-        "2016-05-24T19:02:15.435Z", "name": "52.90.6.108", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-d5608e49", "variables":
-        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-d5608e49\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-68.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.68\", \"ec2_security_group_names\":
-        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
-        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
-        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-24T18:47:02.000Z\", \"ec2_ip_address\":
-        \"52.90.6.108\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
-        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
-        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 195, "type": "host", "url": "/api/v1/hosts/195/",
-        "related": {"job_host_summaries": "/api/v1/hosts/195/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/195/variable_data/", "job_events": "/api/v1/hosts/195/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/195/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/195/fact_versions/", "inventory_sources": "/api/v1/hosts/195/inventory_sources/",
-        "groups": "/api/v1/hosts/195/groups/", "activity_stream": "/api/v1/hosts/195/activity_stream/",
-        "all_groups": "/api/v1/hosts/195/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/195/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-05T19:47:32.266Z", "modified":
-        "2016-04-05T19:47:32.550Z", "name": "52.91.186.182", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-1d3c2387", "variables":
-        "{\"ec2_kernel\": \"\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-1d3c2387\", \"ec2_instance_type\": \"t2.nano\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-183.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.183\", \"ec2_security_group_names\":
-        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"db-test-provision\", \"ec2_architecture\": \"x86_64\",
-        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
-        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/xvda\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-04-05T19:44:35.000Z\", \"ec2_ip_address\":
-        \"52.91.186.182\", \"ec2_image_id\": \"ami-60b6c60a\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"hvm\", \"ec2_monitored\": false, \"ec2_dns_name\":
-        \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 275, "type":
-        "host", "url": "/api/v1/hosts/275/", "related": {"job_host_summaries": "/api/v1/hosts/275/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/275/variable_data/", "job_events": "/api/v1/hosts/275/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/275/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/275/fact_versions/", "inventory_sources": "/api/v1/hosts/275/inventory_sources/",
-        "groups": "/api/v1/hosts/275/groups/", "activity_stream": "/api/v1/hosts/275/activity_stream/",
-        "all_groups": "/api/v1/hosts/275/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/275/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-26T07:37:27.657Z", "modified":
-        "2016-05-26T07:37:28.214Z", "name": "54.165.209.179", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-3eef18a2", "variables":
-        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-3eef18a2\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-224.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.224\", \"ec2_security_group_names\":
-        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
-        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
-        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-25T21:51:56.000Z\", \"ec2_ip_address\":
-        \"54.165.209.179\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
-        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
-        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 220, "type": "host", "url": "/api/v1/hosts/220/",
-        "related": {"job_host_summaries": "/api/v1/hosts/220/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/220/variable_data/", "job_events": "/api/v1/hosts/220/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/220/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/220/fact_versions/", "inventory_sources": "/api/v1/hosts/220/inventory_sources/",
-        "groups": "/api/v1/hosts/220/groups/", "activity_stream": "/api/v1/hosts/220/activity_stream/",
-        "all_groups": "/api/v1/hosts/220/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/220/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-23T21:24:21.556Z", "modified":
-        "2016-05-23T21:24:21.828Z", "name": "54.173.189.199", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-fb694e66", "variables":
-        "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-fb694e66\", \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-109.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.109\", \"ec2_security_group_names\":
-        \"EmsRefreshSpec-SecurityGroup-VPC\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"VMstate-8\", \"ec2_architecture\": \"x86_64\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"uBCLe1462913797292\",
-        \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\": \"\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-80f755ef\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-11T19:53:18.000Z\", \"ec2_ip_address\":
-        \"54.173.189.199\", \"ec2_image_id\": \"ami-5769193e\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
-        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
-        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 276, "type": "host", "url": "/api/v1/hosts/276/",
-        "related": {"job_host_summaries": "/api/v1/hosts/276/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/276/variable_data/", "job_events": "/api/v1/hosts/276/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/276/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/276/fact_versions/", "inventory_sources": "/api/v1/hosts/276/inventory_sources/",
-        "groups": "/api/v1/hosts/276/groups/", "activity_stream": "/api/v1/hosts/276/activity_stream/",
-        "all_groups": "/api/v1/hosts/276/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/276/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-27T20:49:25.335Z", "modified":
-        "2016-05-27T20:49:25.614Z", "name": "54.210.127.55", "description": "imported",
-        "inventory": 2, "enabled": true, "instance_id": "i-3d04fda1", "variables":
-        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
-        \"0\", \"ec2_id\": \"i-3d04fda1\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
-        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-125.ec2.internal\",
-        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.125\", \"ec2_security_group_names\":
-        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
-        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
-        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
-        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
-        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-27T20:35:16.000Z\", \"ec2_ip_address\":
-        \"54.210.127.55\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
-        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
-        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
-        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 386, "type": "host", "url": "/api/v1/hosts/386/",
-        "related": {"job_host_summaries": "/api/v1/hosts/386/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/386/variable_data/", "job_events": "/api/v1/hosts/386/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/386/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/386/fact_versions/", "inventory_sources": "/api/v1/hosts/386/inventory_sources/",
-        "groups": "/api/v1/hosts/386/groups/", "activity_stream": "/api/v1/hosts/386/activity_stream/",
-        "all_groups": "/api/v1/hosts/386/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/386/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.408Z", "modified":
-        "2016-07-25T18:41:44.864Z", "name": "ec2-174-129-183-120.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-cf7144b4", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-cf7144b4\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-141-134-252.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.141.134.252\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"VMWorld_001\", \"ec2_architecture\":
-        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"bill\", \"ec2_client_token\":
-        \"cd854056-ec87-11e1-853b-005056b25af6\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"ec2-174-129-183-120.compute-1.amazonaws.com\", \"ec2_persistent\": false,
-        \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\":
-        \"\", \"ec2_subnet_id\": \"\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
-        \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1b\", \"ec2_launch_time\": \"2012-08-22T18:33:01.000Z\",
-        \"ec2_ip_address\": \"174.129.183.120\", \"ec2_image_id\": \"ami-edaa1f84\",
-        \"ec2_root_device_type\": \"instance-store\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-174-129-183-120.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 387, "type":
-        "host", "url": "/api/v1/hosts/387/", "related": {"job_host_summaries": "/api/v1/hosts/387/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/387/variable_data/", "job_events": "/api/v1/hosts/387/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/387/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/387/fact_versions/", "inventory_sources": "/api/v1/hosts/387/inventory_sources/",
-        "groups": "/api/v1/hosts/387/groups/", "activity_stream": "/api/v1/hosts/387/activity_stream/",
-        "all_groups": "/api/v1/hosts/387/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/387/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.424Z", "modified":
-        "2016-07-25T18:41:44.871Z", "name": "ec2-184-169-243-31.us-west-1.compute.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-fdd815a4", "variables": "{\"ec2_kernel\": \"aki-99a0f1dc\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-fdd815a4\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-160-177-126.us-west-1.compute.internal\", \"ec2_eventsSet\": \"\",
-        \"ec2_private_ip_address\": \"10.160.177.126\", \"ec2_security_group_names\":
-        \"default\", \"ec2_vpc_id\": \"\", \"ec2_state_code\": 272, \"ec2_architecture\":
-        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"\", \"ec2_client_token\":
-        \"5bfd4308-0bf3-11e2-96b9-a4b197fffe9a\", \"ec2_region\": \"us-west-1\", \"ec2_public_dns_name\":
-        \"ec2-184-169-243-31.us-west-1.compute.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-e94055ac\", \"ec2_placement\": \"us-west-1a\",
-        \"ec2_launch_time\": \"2012-10-01T18:11:04.000Z\", \"ec2_ip_address\": \"184.169.243.31\",
-        \"ec2_image_id\": \"ami-3bc9997e\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-184-169-243-31.us-west-1.compute.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 388, "type":
-        "host", "url": "/api/v1/hosts/388/", "related": {"job_host_summaries": "/api/v1/hosts/388/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/388/variable_data/", "job_events": "/api/v1/hosts/388/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/388/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/388/fact_versions/", "inventory_sources": "/api/v1/hosts/388/inventory_sources/",
-        "groups": "/api/v1/hosts/388/groups/", "activity_stream": "/api/v1/hosts/388/activity_stream/",
-        "all_groups": "/api/v1/hosts/388/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/388/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.429Z", "modified":
-        "2016-07-25T18:41:44.875Z", "name": "ec2-204-236-137-154.us-west-1.compute.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-dc1ee486", "variables": "{\"ec2_kernel\": \"aki-36b79b73\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-dc1ee486\",
-        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-191-129-95.us-west-1.compute.internal\", \"ec2_eventsSet\": \"\",
-        \"ec2_private_ip_address\": \"10.191.129.95\", \"ec2_security_group_names\":
-        \"EmsRefreshSpec-SecurityGroup-OtherRegion\", \"ec2_vpc_id\": \"\", \"ec2_state_code\":
-        16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-OtherRegion\", \"ec2_architecture\":
-        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair-OtherRegion\", \"ec2_client_token\": \"TYBNt1377907963036\",
-        \"ec2_region\": \"us-west-1\", \"ec2_public_dns_name\": \"ec2-204-236-137-154.us-west-1.compute.amazonaws.com\",
-        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-2b87746f\", \"ec2_placement\": \"us-west-1a\",
-        \"ec2_launch_time\": \"2013-08-31T00:12:43.000Z\", \"ec2_ip_address\": \"204.236.137.154\",
-        \"ec2_image_id\": \"ami-183e175d\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-204-236-137-154.us-west-1.compute.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 381, "type":
-        "host", "url": "/api/v1/hosts/381/", "related": {"job_host_summaries": "/api/v1/hosts/381/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/381/variable_data/", "job_events": "/api/v1/hosts/381/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/381/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/381/fact_versions/", "inventory_sources": "/api/v1/hosts/381/inventory_sources/",
-        "groups": "/api/v1/hosts/381/groups/", "activity_stream": "/api/v1/hosts/381/activity_stream/",
-        "all_groups": "/api/v1/hosts/381/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/381/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.069Z", "modified":
-        "2016-07-13T15:50:39.590Z", "name": "ec2-54-157-236-18.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-6c1526f0", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-6c1526f0\",
-        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-181-210-78.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.181.210.78\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-157-236-18.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-07-01T17:52:29.000Z\", \"ec2_ip_address\": \"54.157.236.18\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-157-236-18.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 277, "type":
-        "host", "url": "/api/v1/hosts/277/", "related": {"job_host_summaries": "/api/v1/hosts/277/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/277/variable_data/", "job_events": "/api/v1/hosts/277/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/277/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/277/fact_versions/", "inventory_sources": "/api/v1/hosts/277/inventory_sources/",
-        "groups": "/api/v1/hosts/277/groups/", "activity_stream": "/api/v1/hosts/277/activity_stream/",
-        "all_groups": "/api/v1/hosts/277/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/277/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.139Z", "modified":
-        "2016-06-15T17:59:10.737Z", "name": "ec2-54-161-192-82.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-9c68fe00", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-9c68fe00\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-235-82-38.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.235.82.38\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-161-192-82.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-06-13T18:56:08.000Z\", \"ec2_ip_address\": \"54.161.192.82\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-161-192-82.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 382, "type":
-        "host", "url": "/api/v1/hosts/382/", "related": {"job_host_summaries": "/api/v1/hosts/382/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/382/variable_data/", "job_events": "/api/v1/hosts/382/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/382/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/382/fact_versions/", "inventory_sources": "/api/v1/hosts/382/inventory_sources/",
-        "groups": "/api/v1/hosts/382/groups/", "activity_stream": "/api/v1/hosts/382/activity_stream/",
-        "all_groups": "/api/v1/hosts/382/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/382/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.078Z", "modified":
-        "2016-07-13T15:50:39.594Z", "name": "ec2-54-167-151-39.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-f7b2a36b", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-f7b2a36b\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-180-170-159.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.180.170.159\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_mkanoor_0707_1653\",
-        \"ec2_architecture\": \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
-        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
-        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
-        \"\", \"ec2_key_name\": \"mk\", \"ec2_client_token\": \"\", \"ec2_region\":
-        \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-167-151-39.compute-1.amazonaws.com\",
-        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-07-07T20:54:44.000Z\", \"ec2_ip_address\": \"54.167.151.39\",
-        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
-        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
-        \"ec2-54-167-151-39.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
-        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
-        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 383, "type":
-        "host", "url": "/api/v1/hosts/383/", "related": {"job_host_summaries": "/api/v1/hosts/383/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/383/variable_data/", "job_events": "/api/v1/hosts/383/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/383/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/383/fact_versions/", "inventory_sources": "/api/v1/hosts/383/inventory_sources/",
-        "groups": "/api/v1/hosts/383/groups/", "activity_stream": "/api/v1/hosts/383/activity_stream/",
-        "all_groups": "/api/v1/hosts/383/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/383/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.085Z", "modified":
-        "2016-07-13T15:50:39.599Z", "name": "ec2-54-197-137-38.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-291708b5", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-291708b5\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-123-174-181.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.123.174.181\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_billyx_instance-store\",
-        \"ec2_architecture\": \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
-        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
-        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
-        \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\":
-        \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-197-137-38.compute-1.amazonaws.com\",
-        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-07-08T20:26:12.000Z\", \"ec2_ip_address\": \"54.197.137.38\",
-        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
-        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
-        \"ec2-54-197-137-38.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
-        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
-        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 278, "type":
-        "host", "url": "/api/v1/hosts/278/", "related": {"job_host_summaries": "/api/v1/hosts/278/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/278/variable_data/", "job_events": "/api/v1/hosts/278/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/278/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/278/fact_versions/", "inventory_sources": "/api/v1/hosts/278/inventory_sources/",
-        "groups": "/api/v1/hosts/278/groups/", "activity_stream": "/api/v1/hosts/278/activity_stream/",
-        "all_groups": "/api/v1/hosts/278/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/278/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.146Z", "modified":
-        "2016-06-15T17:59:10.742Z", "name": "ec2-54-204-178-162.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-60805cfc", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-60805cfc\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-182-240-219.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.182.240.219\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-204-178-162.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-06-02T13:53:30.000Z\", \"ec2_ip_address\": \"54.204.178.162\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-204-178-162.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 384, "type":
-        "host", "url": "/api/v1/hosts/384/", "related": {"job_host_summaries": "/api/v1/hosts/384/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/384/variable_data/", "job_events": "/api/v1/hosts/384/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/384/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/384/fact_versions/", "inventory_sources": "/api/v1/hosts/384/inventory_sources/",
-        "groups": "/api/v1/hosts/384/groups/", "activity_stream": "/api/v1/hosts/384/activity_stream/",
-        "all_groups": "/api/v1/hosts/384/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/384/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.090Z", "modified":
-        "2016-07-13T15:50:39.604Z", "name": "ec2-54-204-235-7.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-81e5d51d", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-81e5d51d\",
-        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-182-185-68.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.182.185.68\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-204-235-7.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-07-01T14:29:04.000Z\", \"ec2_ip_address\": \"54.204.235.7\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-204-235-7.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 385, "type":
-        "host", "url": "/api/v1/hosts/385/", "related": {"job_host_summaries": "/api/v1/hosts/385/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/385/variable_data/", "job_events": "/api/v1/hosts/385/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/385/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/385/fact_versions/", "inventory_sources": "/api/v1/hosts/385/inventory_sources/",
-        "groups": "/api/v1/hosts/385/groups/", "activity_stream": "/api/v1/hosts/385/activity_stream/",
-        "all_groups": "/api/v1/hosts/385/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/385/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.094Z", "modified":
-        "2016-07-13T15:50:39.608Z", "name": "ec2-54-211-15-200.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-2f4858b3", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-2f4858b3\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-43-148-212.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.43.148.212\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-211-15-200.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-07-07T21:38:29.000Z\", \"ec2_ip_address\": \"54.211.15.200\",
-        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
-        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
-        \"ec2-54-211-15-200.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
-        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
-        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 279, "type":
-        "host", "url": "/api/v1/hosts/279/", "related": {"job_host_summaries": "/api/v1/hosts/279/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/279/variable_data/", "job_events": "/api/v1/hosts/279/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/279/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/279/fact_versions/", "inventory_sources": "/api/v1/hosts/279/inventory_sources/",
-        "groups": "/api/v1/hosts/279/groups/", "activity_stream": "/api/v1/hosts/279/activity_stream/",
-        "all_groups": "/api/v1/hosts/279/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/279/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.151Z", "modified":
-        "2016-06-15T17:59:10.750Z", "name": "ec2-54-211-165-245.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-7f45c6e3", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-7f45c6e3\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-230-44-55.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.230.44.55\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
-        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
-        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
-        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-211-165-245.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-06-10T17:34:32.000Z\", \"ec2_ip_address\": \"54.211.165.245\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-211-165-245.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 389, "type":
-        "host", "url": "/api/v1/hosts/389/", "related": {"job_host_summaries": "/api/v1/hosts/389/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/389/variable_data/", "job_events": "/api/v1/hosts/389/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/389/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/389/fact_versions/", "inventory_sources": "/api/v1/hosts/389/inventory_sources/",
-        "groups": "/api/v1/hosts/389/groups/", "activity_stream": "/api/v1/hosts/389/activity_stream/",
-        "all_groups": "/api/v1/hosts/389/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/389/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.434Z", "modified":
-        "2016-07-25T18:41:44.880Z", "name": "ec2-54-221-202-53.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-680071e9", "variables": "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-680071e9\",
-        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-65-160-22.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.65.160.22\", \"ec2_security_group_names\": \"EmsRefreshSpec-SecurityGroup1,EmsRefreshSpec-SecurityGroup2\",
-        \"ec2_vpc_id\": \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-Basic3\",
-        \"ec2_architecture\": \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
-        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
-        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
-        \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\":
-        \"JwNdr1452196715903\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
-        \"ec2-54-221-202-53.compute-1.amazonaws.com\", \"ec2_persistent\": false,
-        \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\":
-        \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
-        \"sg-038e8a69,sg-12898d78\", \"ec2_placement\": \"us-east-1e\", \"ec2_launch_time\":
-        \"2016-03-29T07:49:56.000Z\", \"ec2_ip_address\": \"54.221.202.53\", \"ec2_image_id\":
-        \"ami-5769193e\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-221-202-53.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 390, "type":
-        "host", "url": "/api/v1/hosts/390/", "related": {"job_host_summaries": "/api/v1/hosts/390/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/390/variable_data/", "job_events": "/api/v1/hosts/390/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/390/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/390/fact_versions/", "inventory_sources": "/api/v1/hosts/390/inventory_sources/",
-        "groups": "/api/v1/hosts/390/groups/", "activity_stream": "/api/v1/hosts/390/activity_stream/",
-        "all_groups": "/api/v1/hosts/390/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/390/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.439Z", "modified":
-        "2016-07-25T18:41:44.884Z", "name": "ec2-54-224-129-8.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-10b27f76", "variables": "{\"ec2_kernel\": \"aki-08ed0761\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-10b27f76\",
-        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-185-241-50.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.185.241.50\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"WP_WEB_06\", \"ec2_architecture\":
-        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"miq\", \"ec2_client_token\": \"95bdee84-5d1a-11e3-a53a-005056b25643\", \"ec2_region\":
-        \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-224-129-8.compute-1.amazonaws.com\",
-        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1d\",
-        \"ec2_launch_time\": \"2014-11-10T23:12:06.000Z\", \"ec2_ip_address\": \"54.224.129.8\",
-        \"ec2_image_id\": \"ami-bda014d4\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-224-129-8.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 280, "type":
-        "host", "url": "/api/v1/hosts/280/", "related": {"job_host_summaries": "/api/v1/hosts/280/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/280/variable_data/", "job_events": "/api/v1/hosts/280/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/280/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/280/fact_versions/", "inventory_sources": "/api/v1/hosts/280/inventory_sources/",
-        "groups": "/api/v1/hosts/280/groups/", "activity_stream": "/api/v1/hosts/280/activity_stream/",
-        "all_groups": "/api/v1/hosts/280/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/280/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
-        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.158Z", "modified":
-        "2016-06-15T17:59:10.767Z", "name": "ec2-54-92-246-63.compute-1.amazonaws.com",
-        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
-        "i-cda32951", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
-        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-cda32951\",
-        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
-        \"ip-10-91-187-140.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
-        \"10.91.187.140\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
-        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_billya_0008\", \"ec2_architecture\":
-        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
-        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
-        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
-        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
-        \"ec2_public_dns_name\": \"ec2-54-92-246-63.compute-1.amazonaws.com\", \"ec2_persistent\":
-        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
-        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
-        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
-        \"ec2_launch_time\": \"2016-06-12T23:10:58.000Z\", \"ec2_ip_address\": \"54.92.246.63\",
-        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
-        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-92-246-63.compute-1.amazonaws.com\",
-        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
-        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 65, "type":
-        "host", "url": "/api/v1/hosts/65/", "related": {"created_by": "/api/v1/users/1/",
-        "modified_by": "/api/v1/users/1/", "job_host_summaries": "/api/v1/hosts/65/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/65/variable_data/", "job_events": "/api/v1/hosts/65/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/65/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/65/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/65/inventory_sources/", "groups": "/api/v1/hosts/65/groups/",
-        "activity_stream": "/api/v1/hosts/65/activity_stream/", "all_groups": "/api/v1/hosts/65/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/65/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/9/"}, "summary_fields": {"inventory": {"name": "db-test-inventory-put",
-        "description": "", "has_active_failures": false, "total_hosts": 1, "hosts_with_active_failures":
-        0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
-        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0},
-        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "recent_jobs": []}, "created": "2016-02-01T19:47:45.695Z", "modified":
-        "2016-02-01T19:47:45.695Z", "name": "127.0.0.1", "description": "db-test-host",
-        "inventory": 9, "enabled": true, "instance_id": "", "variables": "", "has_active_failures":
-        false, "has_inventory_sources": false, "last_job": null, "last_job_host_summary":
-        null}, {"id": 147, "type": "host", "url": "/api/v1/hosts/147/", "related":
-        {"job_host_summaries": "/api/v1/hosts/147/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/147/variable_data/", "job_events": "/api/v1/hosts/147/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/147/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/147/fact_versions/", "inventory_sources": "/api/v1/hosts/147/inventory_sources/",
-        "groups": "/api/v1/hosts/147/groups/", "activity_stream": "/api/v1/hosts/147/activity_stream/",
-        "all_groups": "/api/v1/hosts/147/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/147/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/396/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.737Z",
-        "modified": "2016-05-25T15:12:38.991Z", "name": "aab-brewery7", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "564d5056-49ea-a5aa-a71d-cf9b8138430b",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-brewery7/aab-brewery7.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
-        \"vmware_instanceUuid\": \"52ec15d3-0467-1880-8fc6-f91416816ad6\", \"vmware_distributedCpuEntitlement\":
-        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 340947141519,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16615,
-        \"ansible_ssh_host\": \"10.8.97.1\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"564d5056-49ea-a5aa-a71d-cf9b8138430b\",
-        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3679, \"vmware_uncommitted\": 150269087744, \"vmware_distributedMemoryEntitlement\":
-        1210, \"vmware_template\": false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
-        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 168, \"vmware_privateMemory\": 2316, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 47, \"vmware_overallStatus\": \"yellow\",
+      string: '{"count":84,"next":"/api/v1/hosts/?page=2","previous":null,"results":[{"id":2,"type":"host","url":"/api/v1/hosts/2/","related":{"job_host_summaries":"/api/v1/hosts/2/job_host_summaries/","variable_data":"/api/v1/hosts/2/variable_data/","job_events":"/api/v1/hosts/2/job_events/","ad_hoc_commands":"/api/v1/hosts/2/ad_hoc_commands/","fact_versions":"/api/v1/hosts/2/fact_versions/","inventory_sources":"/api/v1/hosts/2/inventory_sources/","groups":"/api/v1/hosts/2/groups/","activity_stream":"/api/v1/hosts/2/activity_stream/","all_groups":"/api/v1/hosts/2/all_groups/","ad_hoc_command_events":"/api/v1/hosts/2/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.863Z","modified":"2016-08-31T16:59:43.314Z","name":"56_vm","description":"imported","inventory":2,"enabled":false,"instance_id":"420cd95f-e1f0-7ae4-5412-4a7e8d79296e","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 392505881568, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"aab-brewery7\", \"vmware_uptimeSeconds\": 68275,
-        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_name\": \"aab-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2395, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 50, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 396}, {"id": 148, "type": "host", "url": "/api/v1/hosts/148/",
-        "related": {"job_host_summaries": "/api/v1/hosts/148/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/148/variable_data/", "job_events": "/api/v1/hosts/148/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/148/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/148/fact_versions/", "inventory_sources": "/api/v1/hosts/148/inventory_sources/",
-        "groups": "/api/v1/hosts/148/groups/", "activity_stream": "/api/v1/hosts/148/activity_stream/",
-        "all_groups": "/api/v1/hosts/148/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/148/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/379/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.742Z",
-        "modified": "2016-05-25T15:12:39.008Z", "name": "aab-idp", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "4233467e-9249-f495-f348-3ca09711bac1",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-idp/aab-idp.vmx\",
-        \"vmware_ipAddress\": \"192.168.122.1\", \"vmware_guestMemoryUsage\": 81,
-        \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat
-        Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_instanceUuid\":
+        \"500c097c-aa23-eddf-71b6-609859c29bf8\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] 56_vm/56_vm.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420cd95f-e1f0-7ae4-5412-4a7e8d79296e\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 195813, \"vmware_name\": \"56_vm\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"Owner: v56 v56\\nEmail: 56@56.com\\nSource: ag_rhel_7\\n\\nMIQ
+        GUID=9205ac68-6ace-11e6-87a7-0050568cfade\", \"vmware_maxMemoryUsage\": 2048,
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\":
+        0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":13,"type":"host","url":"/api/v1/hosts/13/","related":{"job_host_summaries":"/api/v1/hosts/13/job_host_summaries/","variable_data":"/api/v1/hosts/13/variable_data/","job_events":"/api/v1/hosts/13/job_events/","ad_hoc_commands":"/api/v1/hosts/13/ad_hoc_commands/","fact_versions":"/api/v1/hosts/13/fact_versions/","inventory_sources":"/api/v1/hosts/13/inventory_sources/","groups":"/api/v1/hosts/13/groups/","activity_stream":"/api/v1/hosts/13/activity_stream/","all_groups":"/api/v1/hosts/13/all_groups/","ad_hoc_command_events":"/api/v1/hosts/13/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/39/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":39,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.972Z","modified":"2016-10-12T18:19:15.949Z","name":"aab-brewery7","description":"imported","inventory":2,"enabled":true,"instance_id":"564d5056-49ea-a5aa-a71d-cf9b8138430b","variables":"{\"vmware_privateMemory\":
+        1301, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.1\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 48,
+        \"vmware_hostName\": \"aab-brewery7\", \"vmware_instanceUuid\": \"52ec15d3-0467-1880-8fc6-f91416816ad6\",
+        \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.97.1\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 91263, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] aab-brewery7/aab-brewery7.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 16594, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"564d5056-49ea-a5aa-a71d-cf9b8138430b\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 392896519586, \"vmware_name\": \"aab-brewery7\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 150214828032, \"vmware_hostMemoryUsage\":
+        1353, \"vmware_distributedMemoryEntitlement\": 704, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"CentOS 7.2 ImageFactory VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 341338514319, \"vmware_sharedMemory\":
+        93}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":39},{"id":14,"type":"host","url":"/api/v1/hosts/14/","related":{"job_host_summaries":"/api/v1/hosts/14/job_host_summaries/","variable_data":"/api/v1/hosts/14/variable_data/","job_events":"/api/v1/hosts/14/job_events/","ad_hoc_commands":"/api/v1/hosts/14/ad_hoc_commands/","fact_versions":"/api/v1/hosts/14/fact_versions/","inventory_sources":"/api/v1/hosts/14/inventory_sources/","groups":"/api/v1/hosts/14/groups/","activity_stream":"/api/v1/hosts/14/activity_stream/","all_groups":"/api/v1/hosts/14/all_groups/","ad_hoc_command_events":"/api/v1/hosts/14/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/16/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":16,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.977Z","modified":"2016-10-12T18:19:15.954Z","name":"aab-idp","description":"imported","inventory":2,"enabled":true,"instance_id":"4233467e-9249-f495-f348-3ca09711bac1","variables":"{\"vmware_privateMemory\":
+        1599, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"192.168.122.1\",
+        \"vmware_guestMemoryUsage\": 40, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        38, \"vmware_hostName\": \"aab-idp.aabsaml.redhat.com\", \"vmware_instanceUuid\":
         \"503399f4-212d-055a-556e-75cc9026f15d\", \"vmware_distributedCpuEntitlement\":
-        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 9389889743,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4171,
-        \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_overallStatus\": \"yellow\",
-        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"4233467e-9249-f495-f348-3ca09711bac1\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1838, \"vmware_uncommitted\":
-        42934411264, \"vmware_distributedMemoryEntitlement\": 917, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"SAML Provider\\n-
-        Keycloak\", \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 140, \"vmware_privateMemory\": 2200,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 47, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"aab-idp.aabsaml.redhat.com\", \"vmware_uptimeSeconds\":
-        84927, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        2, \"vmware_installBootRequired\": false, \"vmware_committed\": 26610165549,
-        \"vmware_name\": \"aab-idp\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2259, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 39, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 379}, {"id": 149, "type": "host", "url": "/api/v1/hosts/149/",
-        "related": {"job_host_summaries": "/api/v1/hosts/149/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/149/variable_data/", "job_events": "/api/v1/hosts/149/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/149/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/149/fact_versions/", "inventory_sources": "/api/v1/hosts/149/inventory_sources/",
-        "groups": "/api/v1/hosts/149/groups/", "activity_stream": "/api/v1/hosts/149/activity_stream/",
-        "all_groups": "/api/v1/hosts/149/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/149/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/383/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.747Z",
-        "modified": "2016-05-25T15:12:39.021Z", "name": "aab-ipaserver7", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "564d8be8-84bf-03ab-c421-a503da6db700",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-ipaserver7/aab-ipaserver7.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.9\", \"vmware_guestMemoryUsage\": 163, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"52605f18-24e2-1a63-46c8-2dd79ee2469f\", \"vmware_distributedCpuEntitlement\":
-        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 9834889773,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4176,
-        \"ansible_ssh_host\": \"10.8.97.9\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"564d8be8-84bf-03ab-c421-a503da6db700\",
-        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        1838, \"vmware_uncommitted\": 11639947264, \"vmware_distributedMemoryEntitlement\":
-        1230, \"vmware_template\": false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        621, \"vmware_privateMemory\": 3347, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 47, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_committed\":
-        9837626746, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"aab-ipaserver7.aabipa.redhat.com\",
-        \"vmware_uptimeSeconds\": 6033927, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"aab-ipaserver7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3469, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 37, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 383}]}'
-    http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:24 GMT
-- request:
-    method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 12 Oct 2016 16:13:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Api-Time:
-      - 0.273s
-      Content-Length:
-      - '92148'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"count": 98, "next": "/api/v1/hosts/?page=3", "previous": "/api/v1/hosts/?page=1",
-        "results": [{"id": 150, "type": "host", "url": "/api/v1/hosts/150/", "related":
-        {"job_host_summaries": "/api/v1/hosts/150/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/150/variable_data/", "job_events": "/api/v1/hosts/150/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/150/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/150/fact_versions/", "inventory_sources": "/api/v1/hosts/150/inventory_sources/",
-        "groups": "/api/v1/hosts/150/groups/", "activity_stream": "/api/v1/hosts/150/activity_stream/",
-        "all_groups": "/api/v1/hosts/150/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/150/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/393/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.752Z",
-        "modified": "2016-05-25T15:12:39.033Z", "name": "aab-miq-saml", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "42332064-1b21-3bc2-ee0b-09ae0799bc3b",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-miq-saml/aab-miq-saml.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.8\", \"vmware_guestMemoryUsage\": 1802, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"50332797-ee3a-a583-9dbc-02a5f6c24815\", \"vmware_distributedCpuEntitlement\":
-        311, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 30015379695,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16527,
-        \"ansible_ssh_host\": \"10.8.97.8\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"42332064-1b21-3bc2-ee0b-09ae0799bc3b\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3675, \"vmware_uncommitted\": 35646447616, \"vmware_distributedMemoryEntitlement\":
-        4264, \"vmware_template\": false, \"vmware_overallCpuDemand\": 311, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"ManageIQ SAML
-        External Auth Prototype\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 101, \"vmware_privateMemory\": 6295,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 287, \"vmware_overallStatus\":
-        \"green\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 53659726541, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"aab-miq-saml.aabsaml.redhat.com\", \"vmware_uptimeSeconds\":
-        83088, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_name\": \"aab-miq-saml\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 6370, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 63, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 393}, {"id": 249, "type": "host", "url": "/api/v1/hosts/249/",
-        "related": {"job_host_summaries": "/api/v1/hosts/249/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/249/variable_data/", "job_events": "/api/v1/hosts/249/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/249/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/249/fact_versions/", "inventory_sources": "/api/v1/hosts/249/inventory_sources/",
-        "groups": "/api/v1/hosts/249/groups/", "activity_stream": "/api/v1/hosts/249/activity_stream/",
-        "all_groups": "/api/v1/hosts/249/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/249/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.522Z", "modified":
-        "2016-05-25T14:07:46.673Z", "name": "ag-centos-3", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cef80-3008-d177-3d38-b3f4ade5e8e3",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500c4a54-021e-b5dc-d347-a147abd0aa36\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] ag-centos-3/ag-centos-3.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 16, \"vmware_uuid\": \"420cef80-3008-d177-3d38-b3f4ade5e8e3\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 1956827680, \"vmware_name\":
-        \"ag-centos-3\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 18652246016, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource: db-centos-7-template\\n\\nMIQ
-        GUID=303298f2-12e5-11e6-972c-52540020383c\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 1956815880, \"vmware_sharedMemory\": 0}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 250, "type": "host", "url": "/api/v1/hosts/250/",
-        "related": {"job_host_summaries": "/api/v1/hosts/250/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/250/variable_data/", "job_events": "/api/v1/hosts/250/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/250/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/250/fact_versions/", "inventory_sources": "/api/v1/hosts/250/inventory_sources/",
-        "groups": "/api/v1/hosts/250/groups/", "activity_stream": "/api/v1/hosts/250/activity_stream/",
-        "all_groups": "/api/v1/hosts/250/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/250/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.527Z", "modified":
-        "2016-05-25T14:07:46.677Z", "name": "ag-centos-4", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c3542-3bbb-1bc1-9f49-a1b43bfc9781",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500cd634-3e8e-7fa2-1022-873b72df686c\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] ag-centos-4/ag-centos-4.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 16, \"vmware_uuid\": \"420c3542-3bbb-1bc1-9f49-a1b43bfc9781\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 1956827681, \"vmware_name\":
-        \"ag-centos-4\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 18652246016, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource: db-centos-7-template\\n\\nMIQ
-        GUID=c40aeb50-139f-11e6-97b3-52540020383c\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 1956815880, \"vmware_sharedMemory\": 0}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 151, "type": "host", "url": "/api/v1/hosts/151/",
-        "related": {"job_host_summaries": "/api/v1/hosts/151/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/151/variable_data/", "job_events": "/api/v1/hosts/151/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/151/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/151/fact_versions/", "inventory_sources": "/api/v1/hosts/151/inventory_sources/",
-        "groups": "/api/v1/hosts/151/groups/", "activity_stream": "/api/v1/hosts/151/activity_stream/",
-        "all_groups": "/api/v1/hosts/151/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/151/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/368/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.757Z",
-        "modified": "2016-05-25T15:12:39.046Z", "name": "ag_cfme_5.5", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "4233b56a-db5f-66a0-f701-734b406046b1",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] CFME (Agrare)/CFME (Agrare).vmx\",
-        \"vmware_ipAddress\": \"10.8.99.221\", \"vmware_guestMemoryUsage\": 2252,
-        \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"50336b48-19a0-91bb-5f74-3da27ef38d57\", \"vmware_distributedCpuEntitlement\":
-        527, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 16725874104,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4181,
-        \"ansible_ssh_host\": \"10.8.99.221\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"4233b56a-db5f-66a0-f701-734b406046b1\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3679, \"vmware_uncommitted\": 168859942912, \"vmware_distributedMemoryEntitlement\":
-        2871, \"vmware_template\": false, \"vmware_overallCpuDemand\": 527, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        31, \"vmware_privateMemory\": 3939, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 503, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
-        16727780248, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-221.example.com\",
-        \"vmware_uptimeSeconds\": 1973006, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"ag_cfme_5.5\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3990, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 47, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 368}, {"id": 196, "type": "host", "url": "/api/v1/hosts/196/",
-        "related": {"job_host_summaries": "/api/v1/hosts/196/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/196/variable_data/", "job_events": "/api/v1/hosts/196/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/196/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/196/fact_versions/", "inventory_sources": "/api/v1/hosts/196/inventory_sources/",
-        "groups": "/api/v1/hosts/196/groups/", "activity_stream": "/api/v1/hosts/196/activity_stream/",
-        "all_groups": "/api/v1/hosts/196/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/196/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/373/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}]}, "created": "2016-04-08T13:22:58.967Z",
-        "modified": "2016-04-20T19:51:44.230Z", "name": "ag_cfme_5.5.2.4", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420cffcd-39ca-d9f6-8882-074070e680c2",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500c78d4-ecde-df05-725b-a7432327e3ba\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Red Hat
-        Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
-        363, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 2045253895, \"vmware_product_vendor\": \"Red Hat, Inc.\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"ag_cfme_5.5.2.4\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        857, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        43, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
-        cfme-5.5.2.4/cfme-5.5.2.4.vmx\", \"vmware_ipAddress\": \"10.8.99.210\", \"vmware_guestMemoryUsage\":
-        0, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
-        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
-        \"vmware_product_key\": 0, \"vmware_unshared\": 2045015083, \"vmware_staticMemoryEntitlement\":
-        8311, \"ansible_ssh_host\": \"10.8.99.210\", \"vmware_uuid\": \"420cffcd-39ca-d9f6-8882-074070e680c2\",
-        \"vmware_staticCpuEntitlement\": 2901, \"vmware_uncommitted\": 75264397312,
-        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 814, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
-        null, \"vmware_hostName\": \"dhcp-8-99-210.example.com\",
-        \"vmware_uptimeSeconds\": 1062063, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
-        true, "last_job": 362, "last_job_host_summary": 373}, {"id": 152, "type":
-        "host", "url": "/api/v1/hosts/152/", "related": {"job_host_summaries": "/api/v1/hosts/152/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/152/variable_data/", "job_events": "/api/v1/hosts/152/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/152/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/152/fact_versions/", "inventory_sources": "/api/v1/hosts/152/inventory_sources/",
-        "groups": "/api/v1/hosts/152/groups/", "activity_stream": "/api/v1/hosts/152/activity_stream/",
-        "all_groups": "/api/v1/hosts/152/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/152/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.762Z", "modified":
-        "2016-03-31T18:43:05.774Z", "name": "ag_cfme_5.5_clone", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c5dee-c354-5713-10df-9ec3de4fd88b",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 8040, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] aab-idp/aab-idp.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 4162, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\":
+        \"4233467e-9249-f495-f348-3ca09711bac1\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 26684838743, \"vmware_name\": \"aab-idp\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uncommitted\": 42231762944, \"vmware_hostMemoryUsage\": 1654, \"vmware_distributedMemoryEntitlement\":
+        710, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        716, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"SAML Provider\\n- Keycloak\", \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 9464723339,
+        \"vmware_sharedMemory\": 149}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":16},{"id":15,"type":"host","url":"/api/v1/hosts/15/","related":{"job_host_summaries":"/api/v1/hosts/15/job_host_summaries/","variable_data":"/api/v1/hosts/15/variable_data/","job_events":"/api/v1/hosts/15/job_events/","ad_hoc_commands":"/api/v1/hosts/15/ad_hoc_commands/","fact_versions":"/api/v1/hosts/15/fact_versions/","inventory_sources":"/api/v1/hosts/15/inventory_sources/","groups":"/api/v1/hosts/15/groups/","activity_stream":"/api/v1/hosts/15/activity_stream/","all_groups":"/api/v1/hosts/15/all_groups/","ad_hoc_command_events":"/api/v1/hosts/15/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/27/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":27,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.983Z","modified":"2016-10-12T18:19:15.958Z","name":"aab-ipaserver7","description":"imported","inventory":2,"enabled":true,"instance_id":"564d8be8-84bf-03ab-c421-a503da6db700","variables":"{\"vmware_privateMemory\":
+        3585, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.9\",
+        \"vmware_guestMemoryUsage\": 122, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 36,
+        \"vmware_hostName\": \"aab-ipaserver7.aabipa.redhat.com\", \"vmware_instanceUuid\":
+        \"52605f18-24e2-1a63-46c8-2dd79ee2469f\", \"vmware_distributedCpuEntitlement\":
+        23, \"ansible_ssh_host\": \"10.8.97.9\", \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 91224, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] aab-ipaserver7/aab-ipaserver7.vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4165,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 2, \"vmware_uuid\": \"564d8be8-84bf-03ab-c421-a503da6db700\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 9843190666, \"vmware_name\":
+        \"aab-ipaserver7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        11633213440, \"vmware_hostMemoryUsage\": 3636, \"vmware_distributedMemoryEntitlement\":
+        1269, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        715, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 9841623597, \"vmware_sharedMemory\": 381}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":27},{"id":16,"type":"host","url":"/api/v1/hosts/16/","related":{"job_host_summaries":"/api/v1/hosts/16/job_host_summaries/","variable_data":"/api/v1/hosts/16/variable_data/","job_events":"/api/v1/hosts/16/job_events/","ad_hoc_commands":"/api/v1/hosts/16/ad_hoc_commands/","fact_versions":"/api/v1/hosts/16/fact_versions/","inventory_sources":"/api/v1/hosts/16/inventory_sources/","groups":"/api/v1/hosts/16/groups/","activity_stream":"/api/v1/hosts/16/activity_stream/","all_groups":"/api/v1/hosts/16/all_groups/","ad_hoc_command_events":"/api/v1/hosts/16/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/37/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":37,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.988Z","modified":"2016-10-12T18:19:15.963Z","name":"aab-ldap","description":"imported","inventory":2,"enabled":true,"instance_id":"420c8f0d-4a8f-0b6d-fc3a-0c3cfab7b33f","variables":"{\"vmware_privateMemory\":
+        3825, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.22\",
+        \"vmware_guestMemoryUsage\": 122, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 36,
+        \"vmware_hostName\": \"aab-ldap\", \"vmware_instanceUuid\": \"500c1916-2acd-2e09-90bf-4db1d8dec048\",
+        \"vmware_distributedCpuEntitlement\": 23, \"ansible_ssh_host\": \"10.8.97.22\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 7939, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] aab-ldap/aab-ldap.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 4157, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\":
+        \"420c8f0d-4a8f-0b6d-fc3a-0c3cfab7b33f\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 10296769301, \"vmware_name\": \"aab-ldap\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uncommitted\": 11178840064, \"vmware_hostMemoryUsage\": 3874, \"vmware_distributedMemoryEntitlement\":
+        1295, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        715, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 10295996967, \"vmware_sharedMemory\": 143}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":37},{"id":17,"type":"host","url":"/api/v1/hosts/17/","related":{"job_host_summaries":"/api/v1/hosts/17/job_host_summaries/","variable_data":"/api/v1/hosts/17/variable_data/","job_events":"/api/v1/hosts/17/job_events/","ad_hoc_commands":"/api/v1/hosts/17/ad_hoc_commands/","fact_versions":"/api/v1/hosts/17/fact_versions/","inventory_sources":"/api/v1/hosts/17/inventory_sources/","groups":"/api/v1/hosts/17/groups/","activity_stream":"/api/v1/hosts/17/activity_stream/","all_groups":"/api/v1/hosts/17/all_groups/","ad_hoc_command_events":"/api/v1/hosts/17/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/31/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":31,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.993Z","modified":"2016-10-12T18:19:15.967Z","name":"aab-miq-saml","description":"imported","inventory":2,"enabled":true,"instance_id":"42332064-1b21-3bc2-ee0b-09ae0799bc3b","variables":"{\"vmware_privateMemory\":
+        16198, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.8\",
+        \"vmware_guestMemoryUsage\": 14417, \"vmware_overallCpuUsage\": 3886, \"vmware_suspendInterval\":
         0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
         Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
         \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
         0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostName\": \"dhcp-8-99-218.example.com\",
-        \"vmware_instanceUuid\": \"500c466e-9533-f7ec-6766-3a4963b79c64\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Share] ag_cfme_5.5_clone/ag_cfme_5.5_clone.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c5dee-c354-5713-10df-9ec3de4fd88b\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 14664741287,
-        \"vmware_name\": \"ag_cfme_5.5_clone\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 173436108800,
-        \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\": 0,
-        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        84, \"vmware_hostName\": \"aab-miq-saml.aabsaml.redhat.com\", \"vmware_instanceUuid\":
+        \"50332797-ee3a-a583-9dbc-02a5f6c24815\", \"vmware_distributedCpuEntitlement\":
+        4606, \"ansible_ssh_host\": \"10.8.97.8\", \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 2230594, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] aab-miq-saml/aab-miq-saml.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 16536, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"42332064-1b21-3bc2-ee0b-09ae0799bc3b\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 54733776702, \"vmware_name\": \"aab-miq-saml\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 34571448320, \"vmware_hostMemoryUsage\":
+        16298, \"vmware_distributedMemoryEntitlement\": 14841, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        4630, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
         \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource VM: ag_cfme_5.5\\n\\nMIQ
-        GUID=e435d0b2-d98d-11e5-864d-52540056dab7\", \"vmware_maxMemoryUsage\": 4096,
-        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 14663926893,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 198, "type":
-        "host", "url": "/api/v1/hosts/198/", "related": {"job_host_summaries": "/api/v1/hosts/198/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/198/variable_data/", "job_events": "/api/v1/hosts/198/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/198/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/198/fact_versions/", "inventory_sources": "/api/v1/hosts/198/inventory_sources/",
-        "groups": "/api/v1/hosts/198/groups/", "activity_stream": "/api/v1/hosts/198/activity_stream/",
-        "all_groups": "/api/v1/hosts/198/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/198/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-18T20:26:31.050Z", "modified":
-        "2016-04-18T20:26:31.250Z", "name": "ag_cfme_5.5_template", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c30ff-0d3d-501e-78da-35a68515d7d6",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        -1, \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"ManageIQ SAML External Auth Prototype\", \"vmware_maxMemoryUsage\": 16384,
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 31090378991,
+        \"vmware_sharedMemory\": 56}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":31},{"id":18,"type":"host","url":"/api/v1/hosts/18/","related":{"job_host_summaries":"/api/v1/hosts/18/job_host_summaries/","variable_data":"/api/v1/hosts/18/variable_data/","job_events":"/api/v1/hosts/18/job_events/","ad_hoc_commands":"/api/v1/hosts/18/ad_hoc_commands/","fact_versions":"/api/v1/hosts/18/fact_versions/","inventory_sources":"/api/v1/hosts/18/inventory_sources/","groups":"/api/v1/hosts/18/groups/","activity_stream":"/api/v1/hosts/18/activity_stream/","all_groups":"/api/v1/hosts/18/all_groups/","ad_hoc_command_events":"/api/v1/hosts/18/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/8/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":8,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.999Z","modified":"2016-10-12T18:19:15.972Z","name":"ag_cfme_5.5","description":"imported","inventory":2,"enabled":true,"instance_id":"4233b56a-db5f-66a0-f701-734b406046b1","variables":"{\"vmware_privateMemory\":
+        3945, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.99.221\",
+        \"vmware_guestMemoryUsage\": 3358, \"vmware_overallCpuUsage\": 695, \"vmware_suspendInterval\":
         0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
         Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        46, \"vmware_hostName\": \"dhcp-8-99-221.example.com\",
+        \"vmware_instanceUuid\": \"50336b48-19a0-91bb-5f74-3da27ef38d57\", \"vmware_distributedCpuEntitlement\":
+        767, \"ansible_ssh_host\": \"10.8.99.221\", \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 13112, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] CFME (Agrare)/CFME (Agrare).vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4181,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 4, \"vmware_uuid\": \"4233b56a-db5f-66a0-f701-734b406046b1\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 17570492529,
+        \"vmware_name\": \"ag_cfme_5.5\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        168016850944, \"vmware_hostMemoryUsage\": 3991, \"vmware_distributedMemoryEntitlement\":
+        4023, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 767, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel6_64Guest\", \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 17568966072, \"vmware_sharedMemory\": 25}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":8},{"id":19,"type":"host","url":"/api/v1/hosts/19/","related":{"job_host_summaries":"/api/v1/hosts/19/job_host_summaries/","variable_data":"/api/v1/hosts/19/variable_data/","job_events":"/api/v1/hosts/19/job_events/","ad_hoc_commands":"/api/v1/hosts/19/ad_hoc_commands/","fact_versions":"/api/v1/hosts/19/fact_versions/","inventory_sources":"/api/v1/hosts/19/inventory_sources/","groups":"/api/v1/hosts/19/groups/","activity_stream":"/api/v1/hosts/19/activity_stream/","all_groups":"/api/v1/hosts/19/all_groups/","ad_hoc_command_events":"/api/v1/hosts/19/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.004Z","modified":"2016-08-31T16:59:43.347Z","name":"ag_rhel_7","description":"imported","inventory":2,"enabled":false,"instance_id":"420c7162-30ec-7368-6e4f-89238167d850","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"NFS Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500c9dd7-01fd-6da9-77d1-6c94d6f4e978\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Share] ag_cfme_5.5_template/ag_cfme_5.5_template.vmtx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c30ff-0d3d-501e-78da-35a68515d7d6\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 15267197573,
-        \"vmware_name\": \"ag_cfme_5.5_template\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        172832849920, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500cb016-33eb-e588-c30a-80f2e2b63bcd\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_rhel_7/ag_rhel_7.vmtx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420c7162-30ec-7368-6e4f-89238167d850\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 258981, \"vmware_name\": \"ag_rhel_7\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
         0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
         \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
         true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":20,"type":"host","url":"/api/v1/hosts/20/","related":{"job_host_summaries":"/api/v1/hosts/20/job_host_summaries/","variable_data":"/api/v1/hosts/20/variable_data/","job_events":"/api/v1/hosts/20/job_events/","ad_hoc_commands":"/api/v1/hosts/20/ad_hoc_commands/","fact_versions":"/api/v1/hosts/20/fact_versions/","inventory_sources":"/api/v1/hosts/20/inventory_sources/","groups":"/api/v1/hosts/20/groups/","activity_stream":"/api/v1/hosts/20/activity_stream/","all_groups":"/api/v1/hosts/20/all_groups/","ad_hoc_command_events":"/api/v1/hosts/20/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/33/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":33,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.009Z","modified":"2016-10-12T18:19:15.976Z","name":"ag_rhel_7_1_clone_1","description":"imported","inventory":2,"enabled":true,"instance_id":"420c01b4-1d3e-31f6-3cf5-a830230525cd","variables":"{\"vmware_privateMemory\":
+        1893, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 31,
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c98d1-ce8e-2113-c9df-45c03ea5788b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 91227, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_rhel_7_1_clone_1/ag_rhel_7_1_clone_1.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        2107, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c01b4-1d3e-31f6-3cf5-a830230525cd\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 525499, \"vmware_name\":
+        \"ag_rhel_7_1_clone_1\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        0, \"vmware_hostMemoryUsage\": 1981, \"vmware_distributedMemoryEntitlement\":
+        746, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_staticCpuEntitlement\":
+        362, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"MIQ GUID=714dbebe-6ac6-11e6-ab93-54ee753e66dc\",
+        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 0, \"vmware_sharedMemory\": 155}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":33},{"id":21,"type":"host","url":"/api/v1/hosts/21/","related":{"job_host_summaries":"/api/v1/hosts/21/job_host_summaries/","variable_data":"/api/v1/hosts/21/variable_data/","job_events":"/api/v1/hosts/21/job_events/","ad_hoc_commands":"/api/v1/hosts/21/ad_hoc_commands/","fact_versions":"/api/v1/hosts/21/fact_versions/","inventory_sources":"/api/v1/hosts/21/inventory_sources/","groups":"/api/v1/hosts/21/groups/","activity_stream":"/api/v1/hosts/21/activity_stream/","all_groups":"/api/v1/hosts/21/all_groups/","ad_hoc_command_events":"/api/v1/hosts/21/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.015Z","modified":"2016-08-31T16:59:43.356Z","name":"ag_rhel_7_1_template","description":"imported","inventory":2,"enabled":false,"instance_id":"420c4a20-27ba-16ba-8bfa-11e1ecc69002","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper2.example.com\", \"vmware_instanceUuid\":
+        \"500cacc2-5cc4-80b1-faa9-6ad4c53e6d1f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] ag_rhel_7_1_template/ag_rhel_7_1_template.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c4a20-27ba-16ba-8bfa-11e1ecc69002\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 11168, \"vmware_name\":
+        \"ag_rhel_7_1_template\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
         \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource Template: ag_cfme_5.5\\n\\nMIQ
-        GUID=29d020a0-fd97-11e5-b063-5254006ea507\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 15267185779, \"vmware_sharedMemory\": 0}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 251, "type": "host", "url": "/api/v1/hosts/251/",
-        "related": {"job_host_summaries": "/api/v1/hosts/251/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/251/variable_data/", "job_events": "/api/v1/hosts/251/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/251/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/251/fact_versions/", "inventory_sources": "/api/v1/hosts/251/inventory_sources/",
-        "groups": "/api/v1/hosts/251/groups/", "activity_stream": "/api/v1/hosts/251/activity_stream/",
-        "all_groups": "/api/v1/hosts/251/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/251/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.532Z", "modified":
-        "2016-05-25T15:12:39.058Z", "name": "agrare-centos", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420cf83c-ed2f-38c6-8e24-7cec6866bea2",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] agrare-centos/agrare-centos.vmx\",
-        \"vmware_ipAddress\": \"10.8.99.228\", \"vmware_guestMemoryUsage\": 61, \"vmware_networks\":
-        [\"DPortGroup\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"dev-esxi6hyper1.example.com\",
-        \"vmware_instanceUuid\": \"500cb091-4426-4298-6b7d-210e8733426a\", \"vmware_distributedCpuEntitlement\":
-        68, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1956815884,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 1083,
-        \"ansible_ssh_host\": \"10.8.99.228\", \"vmware_overallStatus\": \"green\",
-        \"vmware_uuid\": \"420cf83c-ed2f-38c6-8e24-7cec6866bea2\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 9188, \"vmware_uncommitted\":
-        17370537984, \"vmware_distributedMemoryEntitlement\": 382, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 68, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=cb683378-12cb-11e6-8c90-54ee753e66dc\",
-        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 362, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 68, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 7166, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
-        \"vmware_uptimeSeconds\": 1731009, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        1956991403, \"vmware_name\": \"agrare-centos\", \"vmware_toolsVersionStatus\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=645f1d8e-59b3-11e6-a0df-54ee753e66dc\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":22,"type":"host","url":"/api/v1/hosts/22/","related":{"job_host_summaries":"/api/v1/hosts/22/job_host_summaries/","variable_data":"/api/v1/hosts/22/variable_data/","job_events":"/api/v1/hosts/22/job_events/","ad_hoc_commands":"/api/v1/hosts/22/ad_hoc_commands/","fact_versions":"/api/v1/hosts/22/fact_versions/","inventory_sources":"/api/v1/hosts/22/inventory_sources/","groups":"/api/v1/hosts/22/groups/","activity_stream":"/api/v1/hosts/22/activity_stream/","all_groups":"/api/v1/hosts/22/all_groups/","ad_hoc_command_events":"/api/v1/hosts/22/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.020Z","modified":"2016-08-31T16:59:43.360Z","name":"ag_rhel_7_2","description":"imported","inventory":2,"enabled":false,"instance_id":"420c83bf-8005-5ccd-2acb-1c4fbcd3fd49","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"NFS Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7
+        (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c4c1b-7b54-8176-a4a7-25d611774f1b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_rhel_7_2/ag_rhel_7_2.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420c83bf-8005-5ccd-2acb-1c4fbcd3fd49\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 195914, \"vmware_name\": \"ag_rhel_7_2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":23,"type":"host","url":"/api/v1/hosts/23/","related":{"job_host_summaries":"/api/v1/hosts/23/job_host_summaries/","variable_data":"/api/v1/hosts/23/variable_data/","job_events":"/api/v1/hosts/23/job_events/","ad_hoc_commands":"/api/v1/hosts/23/ad_hoc_commands/","fact_versions":"/api/v1/hosts/23/fact_versions/","inventory_sources":"/api/v1/hosts/23/inventory_sources/","groups":"/api/v1/hosts/23/groups/","activity_stream":"/api/v1/hosts/23/activity_stream/","all_groups":"/api/v1/hosts/23/all_groups/","ad_hoc_command_events":"/api/v1/hosts/23/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/25/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":25,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.025Z","modified":"2016-10-12T18:19:15.981Z","name":"akrzos-rhel7-performance","description":"imported","inventory":2,"enabled":true,"instance_id":"420c207c-baad-fae1-9bd6-8da00edab68d","variables":"{\"vmware_privateMemory\":
+        4254, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
+        81, \"vmware_overallCpuUsage\": 191, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 55,
+        \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c33be-6d66-9c60-41d8-7be3d9f1b81b\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_uptimeSeconds\": 91332, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] akrzos-rhel7-performance/akrzos-rhel7-performance.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        8280, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\": \"420c207c-baad-fae1-9bd6-8da00edab68d\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 6321421085, \"vmware_name\":
+        \"akrzos-rhel7-performance\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        50121744384, \"vmware_hostMemoryUsage\": 4420, \"vmware_distributedMemoryEntitlement\":
+        1870, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_staticCpuEntitlement\":
+        715, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 6320116600, \"vmware_sharedMemory\": 3590}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":25},{"id":24,"type":"host","url":"/api/v1/hosts/24/","related":{"job_host_summaries":"/api/v1/hosts/24/job_host_summaries/","variable_data":"/api/v1/hosts/24/variable_data/","job_events":"/api/v1/hosts/24/job_events/","ad_hoc_commands":"/api/v1/hosts/24/ad_hoc_commands/","fact_versions":"/api/v1/hosts/24/fact_versions/","inventory_sources":"/api/v1/hosts/24/inventory_sources/","groups":"/api/v1/hosts/24/groups/","activity_stream":"/api/v1/hosts/24/activity_stream/","all_groups":"/api/v1/hosts/24/all_groups/","ad_hoc_command_events":"/api/v1/hosts/24/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/41/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":41,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.031Z","modified":"2016-10-12T18:19:15.985Z","name":"akrzos-test-cfme-5612","description":"imported","inventory":2,"enabled":true,"instance_id":"420c6bba-c438-7e64-400a-07e67394c91b","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] akrzos-test-cfme-5612/akrzos-test-cfme-5612.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.227\", \"vmware_guestMemoryUsage\": 1146, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 311, \"ansible_ssh_host\": \"10.8.99.227\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 2960094962, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8300, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c6bba-c438-7e64-400a-07e67394c91b\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"4.1\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\": 63505080320,
+        \"vmware_distributedMemoryEntitlement\": 2296, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 311, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 53, \"vmware_privateMemory\": 3739, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_overallCpuUsage\":
+        311, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"akrzos-test-cfme-5612\", \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\":
+        7956, \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c3779-3198-9948-9ee3-7d3737a79e98\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 2961132774,
+        \"vmware_name\": \"akrzos-test-cfme-5612\", \"vmware_toolsVersionStatus\":
         \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        398, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        3793, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
         \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
         \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 36, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 212, "type": "host", "url": "/api/v1/hosts/212/",
-        "related": {"job_host_summaries": "/api/v1/hosts/212/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/212/variable_data/", "job_events": "/api/v1/hosts/212/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/212/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/212/fact_versions/", "inventory_sources": "/api/v1/hosts/212/inventory_sources/",
-        "groups": "/api/v1/hosts/212/groups/", "activity_stream": "/api/v1/hosts/212/activity_stream/",
-        "all_groups": "/api/v1/hosts/212/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/212/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.443Z", "modified":
-        "2016-05-25T14:07:45.279Z", "name": "agrare-dvs-test", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c6a2d-108c-91c5-6aaa-391e18d8215c",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] agrare-dvs-test/agrare-dvs-test.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper2.example.com\", \"vmware_instanceUuid\":
-        \"500caaac-ac35-3c7b-161c-c7d8e20103c0\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 503, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"420c6a2d-108c-91c5-6aaa-391e18d8215c\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        19519406080, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
-        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 316860, \"vmware_name\": \"agrare-dvs-test\",
-        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 252, "type": "host", "url": "/api/v1/hosts/252/",
-        "related": {"job_host_summaries": "/api/v1/hosts/252/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/252/variable_data/", "job_events": "/api/v1/hosts/252/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/252/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/252/fact_versions/", "inventory_sources": "/api/v1/hosts/252/inventory_sources/",
-        "groups": "/api/v1/hosts/252/groups/", "activity_stream": "/api/v1/hosts/252/activity_stream/",
-        "all_groups": "/api/v1/hosts/252/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/252/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.537Z", "modified":
-        "2016-05-25T14:07:46.687Z", "name": "agrare-dvs-test-1", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420ca3a3-3e75-b8cf-4a26-82f4d6e5d452",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper2.example.com\", \"vmware_instanceUuid\":
-        \"500c831a-ecc3-7478-5397-b5fad6ec94b0\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] agrare-dvs-test-1/agrare-dvs-test-1.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ca3a3-3e75-b8cf-4a26-82f4d6e5d452\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 2634, \"vmware_name\":
-        \"agrare-dvs-test-1\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
-        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 505,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 154, "type":
-        "host", "url": "/api/v1/hosts/154/", "related": {"job_host_summaries": "/api/v1/hosts/154/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/154/variable_data/", "job_events": "/api/v1/hosts/154/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/154/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/154/fact_versions/", "inventory_sources": "/api/v1/hosts/154/inventory_sources/",
-        "groups": "/api/v1/hosts/154/groups/", "activity_stream": "/api/v1/hosts/154/activity_stream/",
-        "all_groups": "/api/v1/hosts/154/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/154/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/374/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.772Z",
-        "modified": "2016-05-25T14:07:45.505Z", "name": "ag_rhel_7", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7162-30ec-7368-6e4f-89238167d850",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] ag_rhel_7/ag_rhel_7.vmtx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500cb016-33eb-e588-c30a-80f2e2b63bcd\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 497, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"420c7162-30ec-7368-6e4f-89238167d850\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        19519406080, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
-        true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
-        1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 11089, \"vmware_name\": \"ag_rhel_7\", \"vmware_toolsVersionStatus\":
-        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
-        \"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": true, "has_inventory_sources": true, "last_job": 362,
-        "last_job_host_summary": 374}, {"id": 153, "type": "host", "url": "/api/v1/hosts/153/",
-        "related": {"job_host_summaries": "/api/v1/hosts/153/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/153/variable_data/", "job_events": "/api/v1/hosts/153/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/153/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/153/fact_versions/", "inventory_sources": "/api/v1/hosts/153/inventory_sources/",
-        "groups": "/api/v1/hosts/153/groups/", "activity_stream": "/api/v1/hosts/153/activity_stream/",
-        "all_groups": "/api/v1/hosts/153/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/153/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.767Z", "modified":
-        "2016-03-31T18:43:05.783Z", "name": "ag_rhel7_template", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c638c-3ab6-9c76-d202-c3046d7f4d70",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500c5927-fc20-5833-b042-c747d3305bbe\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[datastore1] ag_rhel7_template/ag_rhel7_template.vmtx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c638c-3ab6-9c76-d202-c3046d7f4d70\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 24128453, \"vmware_name\":
-        \"ag_rhel7_template\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19498471952, \"vmware_hostMemoryUsage\":
-        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"datastore1\", \"NFS Share\"], \"vmware_cpuReservation\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 24117248,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 145, "type":
-        "host", "url": "/api/v1/hosts/145/", "related": {"job_host_summaries": "/api/v1/hosts/145/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/145/variable_data/", "job_events": "/api/v1/hosts/145/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/145/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/145/fact_versions/", "inventory_sources": "/api/v1/hosts/145/inventory_sources/",
-        "groups": "/api/v1/hosts/145/groups/", "activity_stream": "/api/v1/hosts/145/activity_stream/",
-        "all_groups": "/api/v1/hosts/145/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/145/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.725Z", "modified":
-        "2016-03-31T18:43:05.788Z", "name": "Ansible-Host", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "4233080d-7467-de61-76c9-c8307b6e4830",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"test-vc60-host2.example.com\", \"vmware_instanceUuid\":
-        \"50337917-876b-364f-6c3e-030ab9411b7e\", \"vmware_distributedCpuEntitlement\":
+        Share\"], \"vmware_guestId\": \"rhel6_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 50, \"vmware_ftLatencyStatus\": \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":41},{"id":3,"type":"host","url":"/api/v1/hosts/3/","related":{"job_host_summaries":"/api/v1/hosts/3/job_host_summaries/","variable_data":"/api/v1/hosts/3/variable_data/","job_events":"/api/v1/hosts/3/job_events/","ad_hoc_commands":"/api/v1/hosts/3/ad_hoc_commands/","fact_versions":"/api/v1/hosts/3/fact_versions/","inventory_sources":"/api/v1/hosts/3/inventory_sources/","groups":"/api/v1/hosts/3/groups/","activity_stream":"/api/v1/hosts/3/activity_stream/","all_groups":"/api/v1/hosts/3/all_groups/","ad_hoc_command_events":"/api/v1/hosts/3/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.883Z","modified":"2016-08-31T16:59:43.374Z","name":"Ansible-Host","description":"imported","inventory":2,"enabled":false,"instance_id":"4233080d-7467-de61-76c9-c8307b6e4830","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host2.example.com\",
+        \"vmware_instanceUuid\": \"50337917-876b-364f-6c3e-030ab9411b7e\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] Ansible-Host/Ansible-Host.vmx\", \"vmware_guestState\":
         \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
@@ -1813,101 +858,59 @@ http_interactions:
         -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
         \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
         null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 498,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 155, "type":
-        "host", "url": "/api/v1/hosts/155/", "related": {"job_host_summaries": "/api/v1/hosts/155/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/155/variable_data/", "job_events": "/api/v1/hosts/155/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/155/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/155/fact_versions/", "inventory_sources": "/api/v1/hosts/155/inventory_sources/",
-        "groups": "/api/v1/hosts/155/groups/", "activity_stream": "/api/v1/hosts/155/activity_stream/",
-        "all_groups": "/api/v1/hosts/155/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/155/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.777Z", "modified":
-        "2016-04-04T18:20:26.291Z", "name": "ansible-stupid-test", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e",
-        "variables": "vmware_annotation: null\nvmware_balloonedMemory: 0\nvmware_committed:
-        2461\nvmware_compressedMemory: 0\nvmware_connectionState: connected\nvmware_consumedOverheadMemory:
-        0\nvmware_cpuReservation: 0\nvmware_datastores:\n  - NFS Share\nvmware_distributedCpuEntitlement:
-        0\nvmware_distributedMemoryEntitlement: 0\nvmware_faultToleranceState: notConfigured\nvmware_ftLatencyStatus:
-        gray\nvmware_ftLogBandwidth: -1\nvmware_ftSecondaryLatency: -1\nvmware_guestFullName:
-        Red Hat Enterprise Linux 7 (64-bit)\nvmware_guestHeartbeatStatus: gray\nvmware_guestId:
-        rhel7_64Guest\nvmware_guestMemoryUsage: 0\nvmware_guestState: notRunning\nvmware_hostMemoryUsage:
-        0\nvmware_hostSystem: test-vc60-host2.example.com\nvmware_installBootRequired:
-        false\nvmware_instanceUuid: 500cb691-6d91-b961-c9da-7e23a1b1833d\nvmware_memoryReservation:
-        0\nvmware_memorySizeMB: 2048\nvmware_name: ansible-stupid-test\nvmware_networks:\n  -
-        VM Network\nvmware_numCpu: 1\nvmware_numEthernetCards: 1\nvmware_numMksConnections:
-        0\nvmware_numVirtualDisks: 1\nvmware_overallCpuDemand: 0\nvmware_overallCpuUsage:
-        0\nvmware_overallStatus: green\nvmware_powerState: poweredOff\nvmware_privateMemory:
-        0\nvmware_recordReplayState: inactive\nvmware_resourcePool: Resources\nvmware_sharedMemory:
-        0\nvmware_staticCpuEntitlement: 0\nvmware_staticMemoryEntitlement: 0\nvmware_suspendInterval:
-        0\nvmware_swappedMemory: 0\nvmware_template: false\nvmware_toolsInstallerMounted:
-        false\nvmware_toolsRunningStatus: guestToolsNotRunning\nvmware_toolsStatus:
-        toolsNotInstalled\nvmware_toolsVersionStatus: guestToolsNotInstalled\nvmware_uncommitted:
-        19482144768\nvmware_unshared: 507\nvmware_uptimeSeconds: 0\nvmware_uuid: 420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e\nvmware_vmPathName:
-        \"[NFS Share] ansible-stupid-test/ansible-stupid-test.vmx\"\n", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 156, "type": "host", "url": "/api/v1/hosts/156/", "related":
-        {"job_host_summaries": "/api/v1/hosts/156/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/156/variable_data/", "job_events": "/api/v1/hosts/156/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/156/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/156/fact_versions/", "inventory_sources": "/api/v1/hosts/156/inventory_sources/",
-        "groups": "/api/v1/hosts/156/groups/", "activity_stream": "/api/v1/hosts/156/activity_stream/",
-        "all_groups": "/api/v1/hosts/156/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/156/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.782Z", "modified":
-        "2016-05-25T14:07:45.321Z", "name": "bd-brewery7", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "423335cd-4f1c-debe-1a7d-4d8279336b70",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] bd-brewery7/bd-brewery7.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-02.example.com\", \"vmware_instanceUuid\":
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":25,"type":"host","url":"/api/v1/hosts/25/","related":{"job_host_summaries":"/api/v1/hosts/25/job_host_summaries/","variable_data":"/api/v1/hosts/25/variable_data/","job_events":"/api/v1/hosts/25/job_events/","ad_hoc_commands":"/api/v1/hosts/25/ad_hoc_commands/","fact_versions":"/api/v1/hosts/25/fact_versions/","inventory_sources":"/api/v1/hosts/25/inventory_sources/","groups":"/api/v1/hosts/25/groups/","activity_stream":"/api/v1/hosts/25/activity_stream/","all_groups":"/api/v1/hosts/25/all_groups/","ad_hoc_command_events":"/api/v1/hosts/25/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.036Z","modified":"2016-08-31T16:59:43.379Z","name":"ansible-stupid-test","description":"imported","inventory":2,"enabled":false,"instance_id":"420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host2.example.com\",
+        \"vmware_instanceUuid\": \"500cb691-6d91-b961-c9da-7e23a1b1833d\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ansible-stupid-test/ansible-stupid-test.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2461, \"vmware_name\":
+        \"ansible-stupid-test\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 507, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":26,"type":"host","url":"/api/v1/hosts/26/","related":{"job_host_summaries":"/api/v1/hosts/26/job_host_summaries/","variable_data":"/api/v1/hosts/26/variable_data/","job_events":"/api/v1/hosts/26/job_events/","ad_hoc_commands":"/api/v1/hosts/26/ad_hoc_commands/","fact_versions":"/api/v1/hosts/26/fact_versions/","inventory_sources":"/api/v1/hosts/26/inventory_sources/","groups":"/api/v1/hosts/26/groups/","activity_stream":"/api/v1/hosts/26/activity_stream/","all_groups":"/api/v1/hosts/26/all_groups/","ad_hoc_command_events":"/api/v1/hosts/26/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.041Z","modified":"2016-08-31T16:59:43.383Z","name":"bd-brewery7","description":"imported","inventory":2,"enabled":false,"instance_id":"423335cd-4f1c-debe-1a7d-4d8279336b70","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
         \"50335907-ffa8-7d93-7118-88e1d719219b\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 75161002519, \"vmware_guestState\": \"notRunning\",
-        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
-        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"423335cd-4f1c-debe-1a7d-4d8279336b70\",
-        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 28091973632, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"CentOS 7.1 ImageFactory
-        VM\", \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
-        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        75161199723, \"vmware_name\": \"bd-brewery7\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] bd-brewery7/bd-brewery7.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"423335cd-4f1c-debe-1a7d-4d8279336b70\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 75161199723, \"vmware_name\": \"bd-brewery7\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 28091973632, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
         0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 253, "type": "host", "url": "/api/v1/hosts/253/",
-        "related": {"job_host_summaries": "/api/v1/hosts/253/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/253/variable_data/", "job_events": "/api/v1/hosts/253/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/253/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/253/fact_versions/", "inventory_sources": "/api/v1/hosts/253/inventory_sources/",
-        "groups": "/api/v1/hosts/253/groups/", "activity_stream": "/api/v1/hosts/253/activity_stream/",
-        "all_groups": "/api/v1/hosts/253/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/253/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.542Z", "modified":
-        "2016-05-25T14:07:46.691Z", "name": "bd-emptyTemplate", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cda47-986f-cf2f-d0ce-5f9564163ea8",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"CentOS 7.1 ImageFactory VM\", \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 75161002519, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":27,"type":"host","url":"/api/v1/hosts/27/","related":{"job_host_summaries":"/api/v1/hosts/27/job_host_summaries/","variable_data":"/api/v1/hosts/27/variable_data/","job_events":"/api/v1/hosts/27/job_events/","ad_hoc_commands":"/api/v1/hosts/27/ad_hoc_commands/","fact_versions":"/api/v1/hosts/27/fact_versions/","inventory_sources":"/api/v1/hosts/27/inventory_sources/","groups":"/api/v1/hosts/27/groups/","activity_stream":"/api/v1/hosts/27/activity_stream/","all_groups":"/api/v1/hosts/27/all_groups/","ad_hoc_command_events":"/api/v1/hosts/27/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.047Z","modified":"2016-08-31T16:59:43.388Z","name":"bd-emptyTemplate","description":"imported","inventory":2,"enabled":false,"instance_id":"420cda47-986f-cf2f-d0ce-5f9564163ea8","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
         \"test-vc60-host2.example.com\", \"vmware_instanceUuid\":
         \"500cd702-268a-fc97-b839-197438a6d7f4\", \"vmware_distributedCpuEntitlement\":
@@ -1928,77 +931,22 @@ http_interactions:
         \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
         1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"MIQ GUID=1a6b069c-1783-11e6-892d-0242afe60688\",
         \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 502, \"vmware_sharedMemory\":
-        0}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 254, "type": "host", "url": "/api/v1/hosts/254/",
-        "related": {"job_host_summaries": "/api/v1/hosts/254/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/254/variable_data/", "job_events": "/api/v1/hosts/254/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/254/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/254/fact_versions/", "inventory_sources": "/api/v1/hosts/254/inventory_sources/",
-        "groups": "/api/v1/hosts/254/groups/", "activity_stream": "/api/v1/hosts/254/activity_stream/",
-        "all_groups": "/api/v1/hosts/254/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/254/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.547Z", "modified":
-        "2016-05-25T14:07:46.696Z", "name": "bd-test-publish-vm-1", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420ca0c6-8346-5304-1fb7-e8069923ce02",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
-        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":28,"type":"host","url":"/api/v1/hosts/28/","related":{"job_host_summaries":"/api/v1/hosts/28/job_host_summaries/","variable_data":"/api/v1/hosts/28/variable_data/","job_events":"/api/v1/hosts/28/job_events/","ad_hoc_commands":"/api/v1/hosts/28/ad_hoc_commands/","fact_versions":"/api/v1/hosts/28/fact_versions/","inventory_sources":"/api/v1/hosts/28/inventory_sources/","groups":"/api/v1/hosts/28/groups/","activity_stream":"/api/v1/hosts/28/activity_stream/","all_groups":"/api/v1/hosts/28/all_groups/","ad_hoc_command_events":"/api/v1/hosts/28/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.052Z","modified":"2016-08-31T16:59:43.393Z","name":"bdunne-VmEmpty","description":"imported","inventory":2,"enabled":false,"instance_id":"420c4091-3ea0-6031-88e2-bf3086cd0ec5","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM NFS Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
         0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500c2862-e777-fed8-d890-460be68723de\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[datastore1] bd-test-publish-vm-1/bd-test-publish-vm-1.vmtx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420ca0c6-8346-5304-1fb7-e8069923ce02\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 75071761854,
-        \"vmware_name\": \"bd-test-publish-vm-1\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        28181226039, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=9ecf6998-16eb-11e6-bd50-024267aede97\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 75071750144, \"vmware_sharedMemory\": 0}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 255, "type": "host", "url": "/api/v1/hosts/255/",
-        "related": {"job_host_summaries": "/api/v1/hosts/255/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/255/variable_data/", "job_events": "/api/v1/hosts/255/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/255/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/255/fact_versions/", "inventory_sources": "/api/v1/hosts/255/inventory_sources/",
-        "groups": "/api/v1/hosts/255/groups/", "activity_stream": "/api/v1/hosts/255/activity_stream/",
-        "all_groups": "/api/v1/hosts/255/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/255/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.552Z", "modified":
-        "2016-05-25T14:07:46.701Z", "name": "bdunne-VmEmpty", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c4091-3ea0-6031-88e2-bf3086cd0ec5",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500c49be-365b-6d6f-eb35-283590a82d38\", \"vmware_distributedCpuEntitlement\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c49be-365b-6d6f-eb35-283590a82d38\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] bdunne-VmEmpty/bdunne-VmEmpty.vmx\",
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
         0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
         \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c4091-3ea0-6031-88e2-bf3086cd0ec5\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 2440, \"vmware_name\":
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 47530, \"vmware_name\":
         \"bdunne-VmEmpty\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 3376017408, \"vmware_hostMemoryUsage\":
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 3376013312, \"vmware_hostMemoryUsage\":
         0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
         \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
         \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
@@ -2007,122 +955,100 @@ http_interactions:
         \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
         \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
         1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 500, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 157, "type": "host", "url": "/api/v1/hosts/157/", "related":
-        {"job_host_summaries": "/api/v1/hosts/157/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/157/variable_data/", "job_events": "/api/v1/hosts/157/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/157/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/157/fact_versions/", "inventory_sources": "/api/v1/hosts/157/inventory_sources/",
-        "groups": "/api/v1/hosts/157/groups/", "activity_stream": "/api/v1/hosts/157/activity_stream/",
-        "all_groups": "/api/v1/hosts/157/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/157/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.787Z", "modified":
-        "2016-05-25T15:12:39.089Z", "name": "bm-cfme-5.5.2.4", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c55e6-9917-0d86-b47c-e9e716c3b133",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500c352d-8daf-465f-8bf1-7ff5557f7fd8\", \"vmware_distributedCpuEntitlement\":
-        215, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
-        3759, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        8192, \"vmware_overallCpuUsage\": 215, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"bm-cfme-5.5.2.4\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        8093, \"vmware_overallCpuDemand\": 239, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        58, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        bm-cfme-5.5.2.4/bm-cfme-5.5.2.4.vmx\", \"vmware_ipAddress\": \"10.8.99.207\",
-        \"vmware_guestMemoryUsage\": 1884, \"vmware_guestFullName\": \"Red Hat Enterprise
-        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
-        null, \"ansible_ssh_host\": \"10.8.99.207\", \"vmware_product_key\": 0, \"vmware_unshared\":
-        42949672960, \"vmware_staticMemoryEntitlement\": 8311, \"vmware_toolsStatus\":
-        \"toolsOk\", \"vmware_uuid\": \"420c55e6-9917-0d86-b47c-e9e716c3b133\", \"vmware_staticCpuEntitlement\":
-        3675, \"vmware_uncommitted\": 532, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 43,
-        \"vmware_privateMemory\": 8019, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
-        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
-        \"vmware_hostName\": \"dhcp-8-99-207.example.com\",
-        \"vmware_uptimeSeconds\": 598592, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 51736568694,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 158, "type":
-        "host", "url": "/api/v1/hosts/158/", "related": {"job_host_summaries": "/api/v1/hosts/158/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/158/variable_data/", "job_events": "/api/v1/hosts/158/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/158/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/158/fact_versions/", "inventory_sources": "/api/v1/hosts/158/inventory_sources/",
-        "groups": "/api/v1/hosts/158/groups/", "activity_stream": "/api/v1/hosts/158/activity_stream/",
-        "all_groups": "/api/v1/hosts/158/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/158/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.793Z", "modified":
-        "2016-04-01T13:26:56.491Z", "name": "bm-cfme-5.5.4.2-2", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c3c2f-6dcd-bcc9-044e-03501d2781df",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500c5607-7423-28d2-b335-93aa98bea917\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_guestState\": \"notRunning\", \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 42949940500, \"vmware_product_vendor\": \"Red Hat, Inc.\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"bm-cfme-5.5.4.2-2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        bm-cfme-5.5.4.2-2/bm-cfme-5.5.4.2-2.vmx\", \"vmware_ipAddress\": \"10.8.99.241\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
-        \"toolsNotRunning\", \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960,
-        \"vmware_staticMemoryEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.241\",
-        \"vmware_uuid\": \"420c3c2f-6dcd-bcc9-044e-03501d2781df\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 8785150486, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0,
-        \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
-        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
-        \"vmware_hostName\": \"dhcp-8-99-241.example.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"inactive\", \"vmware_unshared\": 13785, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":29,"type":"host","url":"/api/v1/hosts/29/","related":{"job_host_summaries":"/api/v1/hosts/29/job_host_summaries/","variable_data":"/api/v1/hosts/29/variable_data/","job_events":"/api/v1/hosts/29/job_events/","ad_hoc_commands":"/api/v1/hosts/29/ad_hoc_commands/","fact_versions":"/api/v1/hosts/29/fact_versions/","inventory_sources":"/api/v1/hosts/29/inventory_sources/","groups":"/api/v1/hosts/29/groups/","activity_stream":"/api/v1/hosts/29/activity_stream/","all_groups":"/api/v1/hosts/29/all_groups/","ad_hoc_command_events":"/api/v1/hosts/29/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.057Z","modified":"2016-08-31T16:59:43.397Z","name":"bm-cfme-5.5.2.4","description":"imported","inventory":2,"enabled":false,"instance_id":"420c55e6-9917-0d86-b47c-e9e716c3b133","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] bm-cfme-5.5.2.4/bm-cfme-5.5.2.4.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 13947265556, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c55e6-9917-0d86-b47c-e9e716c3b133\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.0\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 37787557888, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-207.example.com\",
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c352d-8daf-465f-8bf1-7ff5557f7fd8\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 13948858122,
+        \"vmware_name\": \"bm-cfme-5.5.2.4\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
         \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 256, "type":
-        "host", "url": "/api/v1/hosts/256/", "related": {"job_host_summaries": "/api/v1/hosts/256/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/256/variable_data/", "job_events": "/api/v1/hosts/256/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/256/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/256/fact_versions/", "inventory_sources": "/api/v1/hosts/256/inventory_sources/",
-        "groups": "/api/v1/hosts/256/groups/", "activity_stream": "/api/v1/hosts/256/activity_stream/",
-        "all_groups": "/api/v1/hosts/256/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/256/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.562Z", "modified":
-        "2016-05-25T14:07:46.705Z", "name": "console_test1", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c2d64-33d1-9cdf-9e59-10456729d89e",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
-        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 2199, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":30,"type":"host","url":"/api/v1/hosts/30/","related":{"job_host_summaries":"/api/v1/hosts/30/job_host_summaries/","variable_data":"/api/v1/hosts/30/variable_data/","job_events":"/api/v1/hosts/30/job_events/","ad_hoc_commands":"/api/v1/hosts/30/ad_hoc_commands/","fact_versions":"/api/v1/hosts/30/fact_versions/","inventory_sources":"/api/v1/hosts/30/inventory_sources/","groups":"/api/v1/hosts/30/groups/","activity_stream":"/api/v1/hosts/30/activity_stream/","all_groups":"/api/v1/hosts/30/all_groups/","ad_hoc_command_events":"/api/v1/hosts/30/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.063Z","modified":"2016-08-31T16:59:43.402Z","name":"centos7_temp","description":"imported","inventory":2,"enabled":false,"instance_id":"420c37c4-1c29-d28b-1154-0a45081236f6","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c4372-559a-e757-7348-9f564eaa5482\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] centos7_temp/centos7_temp.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c37c4-1c29-d28b-1154-0a45081236f6\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1031529385, \"vmware_name\":
+        \"centos7_temp\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 33520832512, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1030959604, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":31,"type":"host","url":"/api/v1/hosts/31/","related":{"job_host_summaries":"/api/v1/hosts/31/job_host_summaries/","variable_data":"/api/v1/hosts/31/variable_data/","job_events":"/api/v1/hosts/31/job_events/","ad_hoc_commands":"/api/v1/hosts/31/ad_hoc_commands/","fact_versions":"/api/v1/hosts/31/fact_versions/","inventory_sources":"/api/v1/hosts/31/inventory_sources/","groups":"/api/v1/hosts/31/groups/","activity_stream":"/api/v1/hosts/31/activity_stream/","all_groups":"/api/v1/hosts/31/all_groups/","ad_hoc_command_events":"/api/v1/hosts/31/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/29/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":29,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.068Z","modified":"2016-10-12T18:19:15.990Z","name":"cfme_5612-1-stable-11082016","description":"imported","inventory":2,"enabled":true,"instance_id":"420c08bd-2105-aa50-fb22-f65495fb38ed","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] cfme_5612-1-stable-11082016/cfme_5612-1-stable-11082016.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.208\", \"vmware_guestMemoryUsage\": 81, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.208\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 2184119368, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8300, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c08bd-2105-aa50-fb22-f65495fb38ed\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"4.1\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\": 62240391168,
+        \"vmware_distributedMemoryEntitlement\": 519, \"vmware_product_appUrl\": null,
+        \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 90, \"vmware_privateMemory\": 824, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-208.example.com\", \"vmware_product_vendor\":
+        \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 8078, \"vmware_memorySizeMB\":
+        8192, \"vmware_instanceUuid\": \"500cc3ad-714e-1341-b993-0545df400b3e\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2184511652, \"vmware_name\": \"cfme_5612-1-stable-11082016\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 883, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 44, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":29},{"id":32,"type":"host","url":"/api/v1/hosts/32/","related":{"job_host_summaries":"/api/v1/hosts/32/job_host_summaries/","variable_data":"/api/v1/hosts/32/variable_data/","job_events":"/api/v1/hosts/32/job_events/","ad_hoc_commands":"/api/v1/hosts/32/ad_hoc_commands/","fact_versions":"/api/v1/hosts/32/fact_versions/","inventory_sources":"/api/v1/hosts/32/inventory_sources/","groups":"/api/v1/hosts/32/groups/","activity_stream":"/api/v1/hosts/32/activity_stream/","all_groups":"/api/v1/hosts/32/all_groups/","ad_hoc_command_events":"/api/v1/hosts/32/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.074Z","modified":"2016-08-31T16:59:43.411Z","name":"console_test1","description":"imported","inventory":2,"enabled":false,"instance_id":"420c2d64-33d1-9cdf-9e59-10456729d89e","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
         \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
         \"500ced40-5440-06c7-5f6a-a2965aa9d088\", \"vmware_distributedCpuEntitlement\":
@@ -2131,9 +1057,9 @@ http_interactions:
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
         0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
         \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c2d64-33d1-9cdf-9e59-10456729d89e\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 1038461431, \"vmware_name\":
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1038819962, \"vmware_name\":
         \"console_test1\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18460045312, \"vmware_hostMemoryUsage\":
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18460037120, \"vmware_hostMemoryUsage\":
         0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
         \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
         \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
@@ -2141,155 +1067,150 @@ http_interactions:
         -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
         \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
         \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
-        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1037885941,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 257, "type":
-        "host", "url": "/api/v1/hosts/257/", "related": {"job_host_summaries": "/api/v1/hosts/257/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/257/variable_data/", "job_events": "/api/v1/hosts/257/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/257/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/257/fact_versions/", "inventory_sources": "/api/v1/hosts/257/inventory_sources/",
-        "groups": "/api/v1/hosts/257/groups/", "activity_stream": "/api/v1/hosts/257/activity_stream/",
-        "all_groups": "/api/v1/hosts/257/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/257/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.568Z", "modified":
-        "2016-05-25T15:12:39.097Z", "name": "console_test2", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c36c5-f6f0-2788-8a92-ab545196b6d8",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] console_test2/console_test2.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1037894133, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":33,"type":"host","url":"/api/v1/hosts/33/","related":{"job_host_summaries":"/api/v1/hosts/33/job_host_summaries/","variable_data":"/api/v1/hosts/33/variable_data/","job_events":"/api/v1/hosts/33/job_events/","ad_hoc_commands":"/api/v1/hosts/33/ad_hoc_commands/","fact_versions":"/api/v1/hosts/33/fact_versions/","inventory_sources":"/api/v1/hosts/33/inventory_sources/","groups":"/api/v1/hosts/33/groups/","activity_stream":"/api/v1/hosts/33/activity_stream/","all_groups":"/api/v1/hosts/33/all_groups/","ad_hoc_command_events":"/api/v1/hosts/33/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.079Z","modified":"2016-08-31T16:59:43.415Z","name":"console_test2","description":"imported","inventory":2,"enabled":false,"instance_id":"420c36c5-f6f0-2788-8a92-ab545196b6d8","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
         \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
         \"500cff60-e993-de9a-aedb-0beca8e6ec75\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_unshared\": 1034506764, \"vmware_guestState\": \"notRunning\",
-        \"vmware_staticMemoryEntitlement\": 2110, \"vmware_toolsStatus\": \"toolsNotInstalled\",
-        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
-        \"vmware_uuid\": \"420c36c5-f6f0-2788-8a92-ab545196b6d8\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 923, \"vmware_uncommitted\":
-        16145362944, \"vmware_distributedMemoryEntitlement\": 335, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        94, \"vmware_privateMemory\": 297, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 74336, \"vmware_memorySizeMB\":
-        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 1034872571, \"vmware_name\": \"console_test2\",
-        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 349, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 23, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 258, "type": "host", "url": "/api/v1/hosts/258/",
-        "related": {"job_host_summaries": "/api/v1/hosts/258/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/258/variable_data/", "job_events": "/api/v1/hosts/258/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/258/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/258/fact_versions/", "inventory_sources": "/api/v1/hosts/258/inventory_sources/",
-        "groups": "/api/v1/hosts/258/groups/", "activity_stream": "/api/v1/hosts/258/activity_stream/",
-        "all_groups": "/api/v1/hosts/258/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/258/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.572Z", "modified":
-        "2016-05-25T15:12:39.104Z", "name": "console_test3", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420ca0fe-b0c3-3285-46ab-e50f7094d073",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] console_test3/console_test3.vmx\",
-        \"vmware_guestMemoryUsage\": 20, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-02.example.com\", \"vmware_instanceUuid\":
-        \"500c856f-41a9-79d7-4270-b6148c030d20\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_unshared\": 1027752460, \"vmware_guestState\": \"notRunning\",
-        \"vmware_staticMemoryEntitlement\": 2110, \"vmware_toolsStatus\": \"toolsNotInstalled\",
-        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
-        \"vmware_uuid\": \"420ca0fe-b0c3-3285-46ab-e50f7094d073\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 923, \"vmware_uncommitted\":
-        16152117248, \"vmware_distributedMemoryEntitlement\": 753, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        687, \"vmware_privateMemory\": 1355, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 490995, \"vmware_memorySizeMB\":
-        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 1027939208, \"vmware_name\": \"console_test3\",
-        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 1679, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 27, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 159, "type": "host", "url": "/api/v1/hosts/159/",
-        "related": {"job_host_summaries": "/api/v1/hosts/159/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/159/variable_data/", "job_events": "/api/v1/hosts/159/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/159/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/159/fact_versions/", "inventory_sources": "/api/v1/hosts/159/inventory_sources/",
-        "groups": "/api/v1/hosts/159/groups/", "activity_stream": "/api/v1/hosts/159/activity_stream/",
-        "all_groups": "/api/v1/hosts/159/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/159/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.798Z", "modified":
-        "2016-05-25T14:07:45.336Z", "name": "db-centos-7", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c132a-40df-d4fa-7b08-c4352c3450c4",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] db-rhel-7/db-rhel-7.vmx\",
-        \"vmware_ipAddress\": \"10.8.99.228\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
-        \"vmware_instanceUuid\": \"500c5397-47c9-d319-6cf6-08dea1250db5\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 1961247743,
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] console_test2/console_test2.vmx\",
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"ansible_ssh_host\": \"10.8.99.228\", \"vmware_overallStatus\": \"green\",
-        \"vmware_uuid\": \"420c132a-40df-d4fa-7b08-c4352c3450c4\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        18098212864, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
-        \"vmware_maxMemoryUsage\": 512, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 8796, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        1962074076, \"vmware_name\": \"db-centos-7\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 259, "type": "host", "url": "/api/v1/hosts/259/",
-        "related": {"job_host_summaries": "/api/v1/hosts/259/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/259/variable_data/", "job_events": "/api/v1/hosts/259/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/259/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/259/fact_versions/", "inventory_sources": "/api/v1/hosts/259/inventory_sources/",
-        "groups": "/api/v1/hosts/259/groups/", "activity_stream": "/api/v1/hosts/259/activity_stream/",
-        "all_groups": "/api/v1/hosts/259/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/259/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.577Z", "modified":
-        "2016-05-25T14:07:46.719Z", "name": "db-centos-7-template", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c2024-ecc0-3f93-4ed6-c8fe897ec8f2",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c36c5-f6f0-2788-8a92-ab545196b6d8\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1035103788, \"vmware_name\":
+        \"console_test2\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18463420416, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1034510860, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":34,"type":"host","url":"/api/v1/hosts/34/","related":{"job_host_summaries":"/api/v1/hosts/34/job_host_summaries/","variable_data":"/api/v1/hosts/34/variable_data/","job_events":"/api/v1/hosts/34/job_events/","ad_hoc_commands":"/api/v1/hosts/34/ad_hoc_commands/","fact_versions":"/api/v1/hosts/34/fact_versions/","inventory_sources":"/api/v1/hosts/34/inventory_sources/","groups":"/api/v1/hosts/34/groups/","activity_stream":"/api/v1/hosts/34/activity_stream/","all_groups":"/api/v1/hosts/34/all_groups/","ad_hoc_command_events":"/api/v1/hosts/34/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.084Z","modified":"2016-08-31T16:59:43.420Z","name":"console_test3","description":"imported","inventory":2,"enabled":false,"instance_id":"420ca0fe-b0c3-3285-46ab-e50f7094d073","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-02.example.com\", \"vmware_instanceUuid\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c856f-41a9-79d7-4270-b6148c030d20\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] console_test3/console_test3.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ca0fe-b0c3-3285-46ab-e50f7094d073\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1028206097, \"vmware_name\":
+        \"console_test3\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18470170624, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1027760652, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":36,"type":"host","url":"/api/v1/hosts/36/","related":{"job_host_summaries":"/api/v1/hosts/36/job_host_summaries/","variable_data":"/api/v1/hosts/36/variable_data/","job_events":"/api/v1/hosts/36/job_events/","ad_hoc_commands":"/api/v1/hosts/36/ad_hoc_commands/","fact_versions":"/api/v1/hosts/36/fact_versions/","inventory_sources":"/api/v1/hosts/36/inventory_sources/","groups":"/api/v1/hosts/36/groups/","activity_stream":"/api/v1/hosts/36/activity_stream/","all_groups":"/api/v1/hosts/36/all_groups/","ad_hoc_command_events":"/api/v1/hosts/36/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.095Z","modified":"2016-08-31T16:59:43.425Z","name":"db-centos-7","description":"imported","inventory":2,"enabled":false,"instance_id":"420c132a-40df-d4fa-7b08-c4352c3450c4","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_instanceUuid\": \"500c5397-47c9-d319-6cf6-08dea1250db5\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-rhel-7/db-rhel-7.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420c132a-40df-d4fa-7b08-c4352c3450c4\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 1962862717, \"vmware_name\": \"db-centos-7\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 20245696512, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 3, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1961248216, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:37:47 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/hosts/?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:46 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.219s
+      Content-Length:
+      - '88127'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count":84,"next":"/api/v1/hosts/?page=3","previous":"/api/v1/hosts/?page=1","results":[{"id":37,"type":"host","url":"/api/v1/hosts/37/","related":{"job_host_summaries":"/api/v1/hosts/37/job_host_summaries/","variable_data":"/api/v1/hosts/37/variable_data/","job_events":"/api/v1/hosts/37/job_events/","ad_hoc_commands":"/api/v1/hosts/37/ad_hoc_commands/","fact_versions":"/api/v1/hosts/37/fact_versions/","inventory_sources":"/api/v1/hosts/37/inventory_sources/","groups":"/api/v1/hosts/37/groups/","activity_stream":"/api/v1/hosts/37/activity_stream/","all_groups":"/api/v1/hosts/37/all_groups/","ad_hoc_command_events":"/api/v1/hosts/37/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.100Z","modified":"2016-08-31T16:59:43.429Z","name":"db-centos-7-rebuild-request","description":"imported","inventory":2,"enabled":false,"instance_id":"420c68c3-38ce-2ea8-93b0-9440e529811d","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c3ceb-025b-dcde-517f-8e7d06fbcb8e\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-centos-7-rebuild-request/db-centos-7-rebuild-request.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c68c3-38ce-2ea8-93b0-9440e529811d\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1951834603, \"vmware_name\":
+        \"db-centos-7-rebuild-request\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18641326080, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        2, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"Owner: D B\\nEmail:
+        db@rh.com\\nSource: db-centos-7-template\\n\\nMIQ GUID=74b8599c-2d86-11e6-a875-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951822934,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":38,"type":"host","url":"/api/v1/hosts/38/","related":{"job_host_summaries":"/api/v1/hosts/38/job_host_summaries/","variable_data":"/api/v1/hosts/38/variable_data/","job_events":"/api/v1/hosts/38/job_events/","ad_hoc_commands":"/api/v1/hosts/38/ad_hoc_commands/","fact_versions":"/api/v1/hosts/38/fact_versions/","inventory_sources":"/api/v1/hosts/38/inventory_sources/","groups":"/api/v1/hosts/38/groups/","activity_stream":"/api/v1/hosts/38/activity_stream/","all_groups":"/api/v1/hosts/38/all_groups/","ad_hoc_command_events":"/api/v1/hosts/38/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.106Z","modified":"2016-08-31T16:59:43.434Z","name":"db-centos-7-template","description":"imported","inventory":2,"enabled":false,"instance_id":"420c2024-ecc0-3f93-4ed6-c8fe897ec8f2","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
         \"500c5cc7-d345-bfcb-0ddc-523db3d350d5\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] db-centos-7-template/db-centos-7-template.vmtx\",
@@ -2308,68 +1229,39 @@ http_interactions:
         \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
         2, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
         \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951822920,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}]}'
-    http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:24 GMT
-- request:
-    method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 12 Oct 2016 16:13:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Api-Time:
-      - 0.279s
-      Content-Length:
-      - '94118'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"count": 98, "next": "/api/v1/hosts/?page=4", "previous": "/api/v1/hosts/?page=2",
-        "results": [{"id": 260, "type": "host", "url": "/api/v1/hosts/260/", "related":
-        {"job_host_summaries": "/api/v1/hosts/260/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/260/variable_data/", "job_events": "/api/v1/hosts/260/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/260/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/260/fact_versions/", "inventory_sources": "/api/v1/hosts/260/inventory_sources/",
-        "groups": "/api/v1/hosts/260/groups/", "activity_stream": "/api/v1/hosts/260/activity_stream/",
-        "all_groups": "/api/v1/hosts/260/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/260/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.582Z", "modified":
-        "2016-05-25T14:07:46.724Z", "name": "db-test-from-vc60", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c40b7-6ad1-28d9-e890-7ce150599d5c",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 8796, \"vmware_numMksConnections\":
-        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":42,"type":"host","url":"/api/v1/hosts/42/","related":{"job_host_summaries":"/api/v1/hosts/42/job_host_summaries/","variable_data":"/api/v1/hosts/42/variable_data/","job_events":"/api/v1/hosts/42/job_events/","ad_hoc_commands":"/api/v1/hosts/42/ad_hoc_commands/","fact_versions":"/api/v1/hosts/42/fact_versions/","inventory_sources":"/api/v1/hosts/42/inventory_sources/","groups":"/api/v1/hosts/42/groups/","activity_stream":"/api/v1/hosts/42/activity_stream/","all_groups":"/api/v1/hosts/42/all_groups/","ad_hoc_command_events":"/api/v1/hosts/42/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.127Z","modified":"2016-08-31T16:59:43.438Z","name":"db_cfme_5.5","description":"imported","inventory":2,"enabled":false,"instance_id":"420cdf52-153a-b5e4-22f9-a62e4aacd51c","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c5ba2-3a7c-0159-d2d0-df42dcc15d6f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db_cfme_5.5/db_cfme_5.5.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420cdf52-153a-b5e4-22f9-a62e4aacd51c\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 16793979593, \"vmware_name\": \"db_cfme_5.5\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 171306475520, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 16793560154,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":39,"type":"host","url":"/api/v1/hosts/39/","related":{"job_host_summaries":"/api/v1/hosts/39/job_host_summaries/","variable_data":"/api/v1/hosts/39/variable_data/","job_events":"/api/v1/hosts/39/job_events/","ad_hoc_commands":"/api/v1/hosts/39/ad_hoc_commands/","fact_versions":"/api/v1/hosts/39/fact_versions/","inventory_sources":"/api/v1/hosts/39/inventory_sources/","groups":"/api/v1/hosts/39/groups/","activity_stream":"/api/v1/hosts/39/activity_stream/","all_groups":"/api/v1/hosts/39/all_groups/","ad_hoc_command_events":"/api/v1/hosts/39/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.111Z","modified":"2016-08-31T16:59:43.443Z","name":"db-test-from-vc60","description":"imported","inventory":2,"enabled":false,"instance_id":"420c40b7-6ad1-28d9-e890-7ce150599d5c","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
         \"vmware_instanceUuid\": \"500c5399-55d1-e563-9f51-4dabcbf6a297\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
         \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] db-test-from-vc60/db-test-from-vc60.vmx\",
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
@@ -2386,69 +1278,118 @@ http_interactions:
         \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
         \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
         2, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
-        \"vmware_maxMemoryUsage\": 512, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_unshared\": 1951822914, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 197, "type": "host", "url": "/api/v1/hosts/197/", "related":
-        {"job_host_summaries": "/api/v1/hosts/197/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/197/variable_data/", "job_events": "/api/v1/hosts/197/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/197/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/197/fact_versions/", "inventory_sources": "/api/v1/hosts/197/inventory_sources/",
-        "groups": "/api/v1/hosts/197/groups/", "activity_stream": "/api/v1/hosts/197/activity_stream/",
-        "all_groups": "/api/v1/hosts/197/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/197/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-18T20:26:31.045Z", "modified":
-        "2016-05-25T15:12:39.113Z", "name": "Dev-IPA2", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c8a2f-dd0c-b175-6749-11c0278be69c",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] Dev-IPA2/Dev-IPA2.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.12\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951822914,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":83,"type":"host","url":"/api/v1/hosts/83/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/83/job_host_summaries/","variable_data":"/api/v1/hosts/83/variable_data/","job_events":"/api/v1/hosts/83/job_events/","ad_hoc_commands":"/api/v1/hosts/83/ad_hoc_commands/","fact_versions":"/api/v1/hosts/83/fact_versions/","inventory_sources":"/api/v1/hosts/83/inventory_sources/","groups":"/api/v1/hosts/83/groups/","activity_stream":"/api/v1/hosts/83/activity_stream/","all_groups":"/api/v1/hosts/83/all_groups/","ad_hoc_command_events":"/api/v1/hosts/83/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/"},"summary_fields":{"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"recent_jobs":[]},"created":"2017-01-24T21:42:35.958Z","modified":"2017-01-24T21:42:35.958Z","name":"db_test_host","description":"","inventory":1,"enabled":false,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null},{"id":40,"type":"host","url":"/api/v1/hosts/40/","related":{"job_host_summaries":"/api/v1/hosts/40/job_host_summaries/","variable_data":"/api/v1/hosts/40/variable_data/","job_events":"/api/v1/hosts/40/job_events/","ad_hoc_commands":"/api/v1/hosts/40/ad_hoc_commands/","fact_versions":"/api/v1/hosts/40/fact_versions/","inventory_sources":"/api/v1/hosts/40/inventory_sources/","groups":"/api/v1/hosts/40/groups/","activity_stream":"/api/v1/hosts/40/activity_stream/","all_groups":"/api/v1/hosts/40/all_groups/","ad_hoc_command_events":"/api/v1/hosts/40/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.116Z","modified":"2016-08-31T16:59:43.448Z","name":"db-test-nic-001","description":"imported","inventory":2,"enabled":false,"instance_id":"420cdb00-c3e1-d91f-286e-c9d36b1bae74","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cbbed-2c8e-32f6-60db-3b775df7b027\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-test-nic-001/db-test-nic-001.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cdb00-c3e1-d91f-286e-c9d36b1bae74\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 847898, \"vmware_name\":
+        \"db-test-nic-001\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19519406080, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"Owner: d b\\nEmail:
+        db@test.com\\nSource: gm-empty-template\\n\\nMIQ GUID=dcddc7aa-37c2-11e6-b434-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 526, \"vmware_sharedMemory\":
+        0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":41,"type":"host","url":"/api/v1/hosts/41/","related":{"job_host_summaries":"/api/v1/hosts/41/job_host_summaries/","variable_data":"/api/v1/hosts/41/variable_data/","job_events":"/api/v1/hosts/41/job_events/","ad_hoc_commands":"/api/v1/hosts/41/ad_hoc_commands/","fact_versions":"/api/v1/hosts/41/fact_versions/","inventory_sources":"/api/v1/hosts/41/inventory_sources/","groups":"/api/v1/hosts/41/groups/","activity_stream":"/api/v1/hosts/41/activity_stream/","all_groups":"/api/v1/hosts/41/all_groups/","ad_hoc_command_events":"/api/v1/hosts/41/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.122Z","modified":"2016-08-31T16:59:43.452Z","name":"db-test-nic-002","description":"imported","inventory":2,"enabled":false,"instance_id":"420cd79e-72a6-c2f0-634e-3d5d26e84f99","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c08df-53b3-75eb-19b3-8d30e57602b5\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-test-nic-002/db-test-nic-002.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cd79e-72a6-c2f0-634e-3d5d26e84f99\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2788, \"vmware_name\":
+        \"db-test-nic-002\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"Owner: d b\\nEmail:
+        db@test.com\\nSource: gm-empty-template\\n\\nMIQ GUID=0872fdfe-3d63-11e6-8368-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 526, \"vmware_sharedMemory\":
+        0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":4,"type":"host","url":"/api/v1/hosts/4/","related":{"job_host_summaries":"/api/v1/hosts/4/job_host_summaries/","variable_data":"/api/v1/hosts/4/variable_data/","job_events":"/api/v1/hosts/4/job_events/","ad_hoc_commands":"/api/v1/hosts/4/ad_hoc_commands/","fact_versions":"/api/v1/hosts/4/fact_versions/","inventory_sources":"/api/v1/hosts/4/inventory_sources/","groups":"/api/v1/hosts/4/groups/","activity_stream":"/api/v1/hosts/4/activity_stream/","all_groups":"/api/v1/hosts/4/all_groups/","ad_hoc_command_events":"/api/v1/hosts/4/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.923Z","modified":"2016-08-31T16:59:43.458Z","name":"Dev-IPA2","description":"imported","inventory":2,"enabled":false,"instance_id":"420c8a2f-dd0c-b175-6749-11c0278be69c","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"Dev-IPA2.ipatesting.lab.redhat.com\",
         \"vmware_instanceUuid\": \"500ca199-37a8-318a-e712-11c20210eab6\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 3345319061,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4193,
-        \"ansible_ssh_host\": \"10.8.97.12\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"420c8a2f-dd0c-b175-6749-11c0278be69c\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3679, \"vmware_uncommitted\": 31852716032, \"vmware_distributedMemoryEntitlement\":
-        646, \"vmware_template\": false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        2, \"vmware_privateMemory\": 1408, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 23, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
-        11955451415, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"Dev-IPA2.ipatesting.lab.redhat.com\",
-        \"vmware_uptimeSeconds\": 73968, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"Dev-IPA2\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 1448, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 41, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 160, "type": "host", "url": "/api/v1/hosts/160/",
-        "related": {"job_host_summaries": "/api/v1/hosts/160/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/160/variable_data/", "job_events": "/api/v1/hosts/160/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/160/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/160/fact_versions/", "inventory_sources": "/api/v1/hosts/160/inventory_sources/",
-        "groups": "/api/v1/hosts/160/groups/", "activity_stream": "/api/v1/hosts/160/activity_stream/",
-        "all_groups": "/api/v1/hosts/160/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/160/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.802Z", "modified":
-        "2016-03-31T18:43:05.816Z", "name": "gm-diskless-template", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420cfe93-0fa8-a8ca-b5e8-2fe63bc9986c",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] Dev-IPA2/Dev-IPA2.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420c8a2f-dd0c-b175-6749-11c0278be69c\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 12030052484, \"vmware_name\": \"Dev-IPA2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        36268908544, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 3419329754,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":43,"type":"host","url":"/api/v1/hosts/43/","related":{"job_host_summaries":"/api/v1/hosts/43/job_host_summaries/","variable_data":"/api/v1/hosts/43/variable_data/","job_events":"/api/v1/hosts/43/job_events/","ad_hoc_commands":"/api/v1/hosts/43/ad_hoc_commands/","fact_versions":"/api/v1/hosts/43/fact_versions/","inventory_sources":"/api/v1/hosts/43/inventory_sources/","groups":"/api/v1/hosts/43/groups/","activity_stream":"/api/v1/hosts/43/activity_stream/","all_groups":"/api/v1/hosts/43/all_groups/","ad_hoc_command_events":"/api/v1/hosts/43/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/18/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":18,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.133Z","modified":"2016-10-12T18:19:15.994Z","name":"djm","description":"imported","inventory":2,"enabled":true,"instance_id":"","variables":"{}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":18},{"id":35,"type":"host","url":"/api/v1/hosts/35/","related":{"job_host_summaries":"/api/v1/hosts/35/job_host_summaries/","variable_data":"/api/v1/hosts/35/variable_data/","job_events":"/api/v1/hosts/35/job_events/","ad_hoc_commands":"/api/v1/hosts/35/ad_hoc_commands/","fact_versions":"/api/v1/hosts/35/fact_versions/","inventory_sources":"/api/v1/hosts/35/inventory_sources/","groups":"/api/v1/hosts/35/groups/","activity_stream":"/api/v1/hosts/35/activity_stream/","all_groups":"/api/v1/hosts/35/all_groups/","ad_hoc_command_events":"/api/v1/hosts/35/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.090Z","modified":"2016-08-31T16:59:43.467Z","name":"d_vm_template","description":"imported","inventory":2,"enabled":false,"instance_id":"420c30d1-dbbd-60dd-464f-3ffeb0c661c2","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c863c-a4c7-37b0-895d-bd86d4401e47\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] d_vm_prov001/d_vm_prov001.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c30d1-dbbd-60dd-464f-3ffeb0c661c2\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 4482493, \"vmware_name\":
+        \"d_vm_template\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"MIQ GUID=c4c4143e-33d6-11e6-96fa-34363bc9458e\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\":
+        0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":45,"type":"host","url":"/api/v1/hosts/45/","related":{"job_host_summaries":"/api/v1/hosts/45/job_host_summaries/","variable_data":"/api/v1/hosts/45/variable_data/","job_events":"/api/v1/hosts/45/job_events/","ad_hoc_commands":"/api/v1/hosts/45/ad_hoc_commands/","fact_versions":"/api/v1/hosts/45/fact_versions/","inventory_sources":"/api/v1/hosts/45/inventory_sources/","groups":"/api/v1/hosts/45/groups/","activity_stream":"/api/v1/hosts/45/activity_stream/","all_groups":"/api/v1/hosts/45/all_groups/","ad_hoc_command_events":"/api/v1/hosts/45/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.143Z","modified":"2016-08-31T16:59:43.471Z","name":"gm-diskless-template","description":"imported","inventory":2,"enabled":false,"instance_id":"420cfe93-0fa8-a8ca-b5e8-2fe63bc9986c","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"NFS Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
         \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
         \"500c51bf-409b-1e00-38a7-deaec2daa35a\", \"vmware_distributedCpuEntitlement\":
@@ -2468,153 +1409,91 @@ http_interactions:
         -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
         \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
         null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 162, "type":
-        "host", "url": "/api/v1/hosts/162/", "related": {"job_host_summaries": "/api/v1/hosts/162/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/162/variable_data/", "job_events": "/api/v1/hosts/162/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/162/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/162/fact_versions/", "inventory_sources": "/api/v1/hosts/162/inventory_sources/",
-        "groups": "/api/v1/hosts/162/groups/", "activity_stream": "/api/v1/hosts/162/activity_stream/",
-        "all_groups": "/api/v1/hosts/162/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/162/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.813Z", "modified":
-        "2016-03-31T18:43:05.820Z", "name": "gm_disk_test", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420ca9fd-3a50-b271-f6d9-64b7b0d21dc0",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":46,"type":"host","url":"/api/v1/hosts/46/","related":{"job_host_summaries":"/api/v1/hosts/46/job_host_summaries/","variable_data":"/api/v1/hosts/46/variable_data/","job_events":"/api/v1/hosts/46/job_events/","ad_hoc_commands":"/api/v1/hosts/46/ad_hoc_commands/","fact_versions":"/api/v1/hosts/46/fact_versions/","inventory_sources":"/api/v1/hosts/46/inventory_sources/","groups":"/api/v1/hosts/46/groups/","activity_stream":"/api/v1/hosts/46/activity_stream/","all_groups":"/api/v1/hosts/46/all_groups/","ad_hoc_command_events":"/api/v1/hosts/46/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.148Z","modified":"2016-08-31T16:59:43.476Z","name":"gm-empty-template","description":"imported","inventory":2,"enabled":false,"instance_id":"420c4d7c-58ee-6d40-f01c-fa2659943824","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
         0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500cda7c-6c37-8bd2-c8a9-2a8f7aabe0f8\", \"vmware_distributedCpuEntitlement\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c9646-394a-f37a-de3a-c5c4b43249aa\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Share] gm_disk_test/gm_disk_test.vmx\", \"vmware_guestState\":
+        0, \"vmware_vmPathName\": \"[NFS Share] gm-empty-template/gm-empty-template.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c4d7c-58ee-6d40-f01c-fa2659943824\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2454, \"vmware_name\":
+        \"gm-empty-template\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 505, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":44,"type":"host","url":"/api/v1/hosts/44/","related":{"job_host_summaries":"/api/v1/hosts/44/job_host_summaries/","variable_data":"/api/v1/hosts/44/variable_data/","job_events":"/api/v1/hosts/44/job_events/","ad_hoc_commands":"/api/v1/hosts/44/ad_hoc_commands/","fact_versions":"/api/v1/hosts/44/fact_versions/","inventory_sources":"/api/v1/hosts/44/inventory_sources/","groups":"/api/v1/hosts/44/groups/","activity_stream":"/api/v1/hosts/44/activity_stream/","all_groups":"/api/v1/hosts/44/all_groups/","ad_hoc_command_events":"/api/v1/hosts/44/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.138Z","modified":"2016-08-31T16:59:43.480Z","name":"g_vm_prov009","description":"imported","inventory":2,"enabled":false,"instance_id":"420cc1a2-ba54-4c18-eb9b-47999a4b121b","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cd202-2d1b-b97c-1c31-664ca41963eb\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] g_vm_prov009/g_vm_prov009.vmx\", \"vmware_guestState\":
         \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
         \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
-        1, \"vmware_uuid\": \"420ca9fd-3a50-b271-f6d9-64b7b0d21dc0\", \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 2640, \"vmware_name\": \"gm_disk_test\", \"vmware_toolsVersionStatus\":
-        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        19482144768, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        1, \"vmware_uuid\": \"420cc1a2-ba54-4c18-eb9b-47999a4b121b\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 11055, \"vmware_name\": \"g_vm_prov009\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
         0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
         \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
         false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 523,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 161, "type":
-        "host", "url": "/api/v1/hosts/161/", "related": {"job_host_summaries": "/api/v1/hosts/161/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/161/variable_data/", "job_events": "/api/v1/hosts/161/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/161/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/161/fact_versions/", "inventory_sources": "/api/v1/hosts/161/inventory_sources/",
-        "groups": "/api/v1/hosts/161/groups/", "activity_stream": "/api/v1/hosts/161/activity_stream/",
-        "all_groups": "/api/v1/hosts/161/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/161/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.808Z", "modified":
-        "2016-05-25T14:07:45.352Z", "name": "gm-empty-template", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c4d7c-58ee-6d40-f01c-fa2659943824",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] gm-empty-template/gm-empty-template.vmtx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
-        \"500c9646-394a-f37a-de3a-c5c4b43249aa\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 505, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"420c4d7c-58ee-6d40-f01c-fa2659943824\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        19482144768, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
-        true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
-        1, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        2454, \"vmware_name\": \"gm-empty-template\", \"vmware_toolsVersionStatus\":
-        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 248, "type": "host", "url": "/api/v1/hosts/248/",
-        "related": {"job_host_summaries": "/api/v1/hosts/248/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/248/variable_data/", "job_events": "/api/v1/hosts/248/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/248/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/248/fact_versions/", "inventory_sources": "/api/v1/hosts/248/inventory_sources/",
-        "groups": "/api/v1/hosts/248/groups/", "activity_stream": "/api/v1/hosts/248/activity_stream/",
-        "all_groups": "/api/v1/hosts/248/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/248/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.517Z", "modified":
-        "2016-05-25T15:12:39.121Z", "name": "James-cfme", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c419a-52bd-046e-7a05-4341e44c3f29",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500cb5bf-aa2e-b4d6-c4a3-a236ee3dbce5\", \"vmware_distributedCpuEntitlement\":
-        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
-        6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
-        2519, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        4096, \"vmware_overallCpuUsage\": 143, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 47441293094, \"vmware_product_vendor\": \"Red Hat, Inc.\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"James-cfme\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        3987, \"vmware_overallCpuDemand\": 167, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        46, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        James-cfme/James-cfme.vmx\", \"vmware_ipAddress\": \"10.8.99.212\", \"vmware_guestMemoryUsage\":
-        1843, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
-        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
-        \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960, \"vmware_staticMemoryEntitlement\":
-        4193, \"ansible_ssh_host\": \"10.8.99.212\", \"vmware_uuid\": \"420c419a-52bd-046e-7a05-4341e44c3f29\",
-        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 504, \"vmware_template\":
-        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 36, \"vmware_privateMemory\": 3934, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
-        null, \"vmware_hostName\": \"dhcp-8-99-212.example.com\",
-        \"vmware_uptimeSeconds\": 508373, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 163, "type":
-        "host", "url": "/api/v1/hosts/163/", "related": {"job_host_summaries": "/api/v1/hosts/163/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/163/variable_data/", "job_events": "/api/v1/hosts/163/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/163/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/163/fact_versions/", "inventory_sources": "/api/v1/hosts/163/inventory_sources/",
-        "groups": "/api/v1/hosts/163/groups/", "activity_stream": "/api/v1/hosts/163/activity_stream/",
-        "all_groups": "/api/v1/hosts/163/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/163/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.818Z", "modified":
-        "2016-03-31T18:43:05.830Z", "name": "jason-brewery", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "42332ec3-7555-5c9c-d4c1-b0a88332a8c7",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
-        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"50336f60-16ec-53e2-2329-c7b3914c216b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":5,"type":"host","url":"/api/v1/hosts/5/","related":{"job_host_summaries":"/api/v1/hosts/5/job_host_summaries/","variable_data":"/api/v1/hosts/5/variable_data/","job_events":"/api/v1/hosts/5/job_events/","ad_hoc_commands":"/api/v1/hosts/5/ad_hoc_commands/","fact_versions":"/api/v1/hosts/5/fact_versions/","inventory_sources":"/api/v1/hosts/5/inventory_sources/","groups":"/api/v1/hosts/5/groups/","activity_stream":"/api/v1/hosts/5/activity_stream/","all_groups":"/api/v1/hosts/5/all_groups/","ad_hoc_command_events":"/api/v1/hosts/5/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.929Z","modified":"2016-08-31T16:59:43.485Z","name":"James-cfme","description":"imported","inventory":2,"enabled":false,"instance_id":"420c419a-52bd-046e-7a05-4341e44c3f29","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] James-cfme/James-cfme.vmx\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat
+        Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 13693518674, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c419a-52bd-046e-7a05-4341e44c3f29\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.0\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 50841702400, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-212.example.com\",
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500cb5bf-aa2e-b4d6-c4a3-a236ee3dbce5\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        6, \"vmware_installBootRequired\": false, \"vmware_committed\": 22294531224,
+        \"vmware_name\": \"James-cfme\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":47,"type":"host","url":"/api/v1/hosts/47/","related":{"job_host_summaries":"/api/v1/hosts/47/job_host_summaries/","variable_data":"/api/v1/hosts/47/variable_data/","job_events":"/api/v1/hosts/47/job_events/","ad_hoc_commands":"/api/v1/hosts/47/ad_hoc_commands/","fact_versions":"/api/v1/hosts/47/fact_versions/","inventory_sources":"/api/v1/hosts/47/inventory_sources/","groups":"/api/v1/hosts/47/groups/","activity_stream":"/api/v1/hosts/47/activity_stream/","all_groups":"/api/v1/hosts/47/all_groups/","ad_hoc_command_events":"/api/v1/hosts/47/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.154Z","modified":"2016-08-31T16:59:43.490Z","name":"jason-brewery","description":"imported","inventory":2,"enabled":false,"instance_id":"42332ec3-7555-5c9c-d4c1-b0a88332a8c7","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"50336f60-16ec-53e2-2329-c7b3914c216b\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] jason-brewery/jason-brewery.vmx\",
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
@@ -2632,813 +1511,328 @@ http_interactions:
         -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
         \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
         \"CentOS 7.1 ImageFactory VM\", \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_unshared\": 78033679207, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 164, "type": "host", "url": "/api/v1/hosts/164/", "related":
-        {"job_host_summaries": "/api/v1/hosts/164/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/164/variable_data/", "job_events": "/api/v1/hosts/164/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/164/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/164/fact_versions/", "inventory_sources": "/api/v1/hosts/164/inventory_sources/",
-        "groups": "/api/v1/hosts/164/groups/", "activity_stream": "/api/v1/hosts/164/activity_stream/",
-        "all_groups": "/api/v1/hosts/164/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/164/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/378/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.823Z",
-        "modified": "2016-05-25T15:12:39.128Z", "name": "joev-brewery-centos-72",
-        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
-        "420c0d63-5270-443c-61b9-8270a876db16", "variables": "{\"vmware_vmPathName\":
-        \"[NFS Share] joev-brewery-centos-72/joev-brewery-centos-72.vmx\", \"vmware_ipAddress\":
-        \"192.168.122.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM
-        Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500ca211-c5fe-3cbf-d6ef-a0794c1377f9\", \"vmware_distributedCpuEntitlement\":
-        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 80275128887,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16606,
-        \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"420c0d63-5270-443c-61b9-8270a876db16\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3679, \"vmware_uncommitted\": 134473236480, \"vmware_distributedMemoryEntitlement\":
-        3822, \"vmware_template\": false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        3099, \"vmware_privateMemory\": 13285, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 47, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
-        80276398600, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-brewery\",
-        \"vmware_uptimeSeconds\": 765558, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"joev-brewery-centos-72\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        13410, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 86, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": true, "has_inventory_sources": true, "last_job": 362,
-        "last_job_host_summary": 378}, {"id": 209, "type": "host", "url": "/api/v1/hosts/209/",
-        "related": {"job_host_summaries": "/api/v1/hosts/209/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/209/variable_data/", "job_events": "/api/v1/hosts/209/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/209/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/209/fact_versions/", "inventory_sources": "/api/v1/hosts/209/inventory_sources/",
-        "groups": "/api/v1/hosts/209/groups/", "activity_stream": "/api/v1/hosts/209/activity_stream/",
-        "all_groups": "/api/v1/hosts/209/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/209/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-20T19:46:07.486Z", "modified":
-        "2016-05-25T15:12:39.140Z", "name": "joev-ipa14", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420cf66e-39ca-eb2b-4b42-dd543f800b54",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-ipa-rhel7/joev-ipa-rhel7.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.14\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
-        \"vmware_instanceUuid\": \"500c9f91-a013-73e0-c4ca-87b2ab696b8b\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 3713910621,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16527,
-        \"ansible_ssh_host\": \"10.8.97.14\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"420cf66e-39ca-eb2b-4b42-dd543f800b54\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        3675, \"vmware_uncommitted\": 214383951872, \"vmware_distributedMemoryEntitlement\":
-        1008, \"vmware_template\": false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        149, \"vmware_privateMemory\": 2543, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 23, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
-        72473562411, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-ipa14.jvlcek.redhat.com\",
-        \"vmware_uptimeSeconds\": 65442, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"joev-ipa14\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2607, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 56, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 165, "type": "host", "url": "/api/v1/hosts/165/",
-        "related": {"job_host_summaries": "/api/v1/hosts/165/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/165/variable_data/", "job_events": "/api/v1/hosts/165/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/165/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/165/fact_versions/", "inventory_sources": "/api/v1/hosts/165/inventory_sources/",
-        "groups": "/api/v1/hosts/165/groups/", "activity_stream": "/api/v1/hosts/165/activity_stream/",
-        "all_groups": "/api/v1/hosts/165/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/165/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/370/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.830Z",
-        "modified": "2016-05-25T14:07:45.391Z", "name": "joev-ipa-ad", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c299f-aa19-c7ee-05a6-ef86163464a6",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-ipa-ad/joev-ipa-ad.vmx\",
-        \"vmware_ipAddress\": \"192.168.122.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
-        \"vmware_instanceUuid\": \"500ce8fc-49c2-24fb-d3c3-6d65553bcebc\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 76356796972,
+        \"vmware_unshared\": 78033679207, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":48,"type":"host","url":"/api/v1/hosts/48/","related":{"job_host_summaries":"/api/v1/hosts/48/job_host_summaries/","variable_data":"/api/v1/hosts/48/variable_data/","job_events":"/api/v1/hosts/48/job_events/","ad_hoc_commands":"/api/v1/hosts/48/ad_hoc_commands/","fact_versions":"/api/v1/hosts/48/fact_versions/","inventory_sources":"/api/v1/hosts/48/inventory_sources/","groups":"/api/v1/hosts/48/groups/","activity_stream":"/api/v1/hosts/48/activity_stream/","all_groups":"/api/v1/hosts/48/all_groups/","ad_hoc_command_events":"/api/v1/hosts/48/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/13/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":13,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.159Z","modified":"2016-10-12T18:19:15.999Z","name":"joev-apache-openldap","description":"imported","inventory":2,"enabled":true,"instance_id":"420c67c7-50d4-95be-7c65-a8f5f4be5ebb","variables":"{\"vmware_privateMemory\":
+        1142, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        41, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500ca39f-7fbc-f357-b7e0-eda686864da6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 91289, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] joev-apache-openldap/joev-apache-openldap.vmx\",
         \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_suspendInterval\": 0,
-        \"vmware_uuid\": \"420c299f-aa19-c7ee-05a6-ef86163464a6\", \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 155766673408, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
-        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 8796, \"vmware_committed\":
-        76357108972, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-ipa-ad.jvlcek.redhat.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"joev-ipa-ad\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 370}, {"id": 166, "type": "host", "url": "/api/v1/hosts/166/",
-        "related": {"job_host_summaries": "/api/v1/hosts/166/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/166/variable_data/", "job_events": "/api/v1/hosts/166/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/166/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/166/fact_versions/", "inventory_sources": "/api/v1/hosts/166/inventory_sources/",
-        "groups": "/api/v1/hosts/166/groups/", "activity_stream": "/api/v1/hosts/166/activity_stream/",
-        "all_groups": "/api/v1/hosts/166/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/166/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/364/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.836Z",
-        "modified": "2016-05-25T15:12:39.148Z", "name": "joev-miq", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c1eaa-1df4-00b3-e93d-4902edb3f496",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500cb184-a71e-c566-562e-263e0e4a1ec7\", \"vmware_distributedCpuEntitlement\":
-        71, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
-        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
-        1599, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_overallCpuUsage\": 71, \"vmware_overallStatus\": \"green\",
+        4181, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c67c7-50d4-95be-7c65-a8f5f4be5ebb\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2149990306, \"vmware_name\":
+        \"joev-apache-openldap\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        19326017536, \"vmware_hostMemoryUsage\": 1209, \"vmware_distributedMemoryEntitlement\":
+        582, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 2148819452, \"vmware_sharedMemory\": 164}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":13},{"id":49,"type":"host","url":"/api/v1/hosts/49/","related":{"job_host_summaries":"/api/v1/hosts/49/job_host_summaries/","variable_data":"/api/v1/hosts/49/variable_data/","job_events":"/api/v1/hosts/49/job_events/","ad_hoc_commands":"/api/v1/hosts/49/ad_hoc_commands/","fact_versions":"/api/v1/hosts/49/fact_versions/","inventory_sources":"/api/v1/hosts/49/inventory_sources/","groups":"/api/v1/hosts/49/groups/","activity_stream":"/api/v1/hosts/49/activity_stream/","all_groups":"/api/v1/hosts/49/all_groups/","ad_hoc_command_events":"/api/v1/hosts/49/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.164Z","modified":"2016-08-31T16:59:43.499Z","name":"joev-brewery-centos-72","description":"imported","inventory":2,"enabled":false,"instance_id":"420c0d63-5270-443c-61b9-8270a876db16","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
         \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 49588606995, \"vmware_product_vendor\": \"ManageIQ\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"joev-miq\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 4984,
-        \"vmware_overallCpuDemand\": 71, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        52, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        joev-miq/joev-miq.vmx\", \"vmware_ipAddress\": \"10.8.99.206\", \"vmware_guestMemoryUsage\":
-        0, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
-        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsNotRunning\",
-        \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960, \"vmware_staticMemoryEntitlement\":
-        6252, \"ansible_ssh_host\": \"10.8.99.206\", \"vmware_uuid\": \"420c1eaa-1df4-00b3-e93d-4902edb3f496\",
-        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 502, \"vmware_template\":
-        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 1696, \"vmware_privateMemory\": 4318, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_suspendInterval\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
-        null, \"vmware_hostName\": \"joev-miq.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
-        4897979, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
-        false, \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"red\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": 362, "last_job_host_summary":
-        364}, {"id": 213, "type": "host", "url": "/api/v1/hosts/213/", "related":
-        {"job_host_summaries": "/api/v1/hosts/213/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/213/variable_data/", "job_events": "/api/v1/hosts/213/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/213/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/213/fact_versions/", "inventory_sources": "/api/v1/hosts/213/inventory_sources/",
-        "groups": "/api/v1/hosts/213/groups/", "activity_stream": "/api/v1/hosts/213/activity_stream/",
-        "all_groups": "/api/v1/hosts/213/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/213/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.448Z", "modified":
-        "2016-05-25T14:07:45.414Z", "name": "joev-miq13_OLD", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c162b-c940-7f7a-e979-c46bf1618d2d",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500c9ed1-0284-53e1-6cb4-0043c63f4e65\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_guestState\": \"notRunning\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"ManageIQ\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"joev-miq13_OLD\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
-        joev-miq13_1/joev-miq13.vmx\", \"vmware_ipAddress\": \"10.8.97.13\", \"vmware_guestMemoryUsage\":
-        0, \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
-        null, \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.97.13\",
-        \"vmware_product_key\": 0, \"vmware_unshared\": 5653742444, \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c162b-c940-7f7a-e979-c46bf1618d2d\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 49587249152, \"vmware_template\":
-        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_suspendInterval\":
-        0, \"vmware_maxCpuUsage\": 8796, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
-        null, \"vmware_hostName\": \"joev-miq13.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
-        0, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 5654356315, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 167, "type": "host", "url": "/api/v1/hosts/167/", "related":
-        {"job_host_summaries": "/api/v1/hosts/167/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/167/variable_data/", "job_events": "/api/v1/hosts/167/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/167/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/167/fact_versions/", "inventory_sources": "/api/v1/hosts/167/inventory_sources/",
-        "groups": "/api/v1/hosts/167/groups/", "activity_stream": "/api/v1/hosts/167/activity_stream/",
-        "all_groups": "/api/v1/hosts/167/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/167/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/371/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.841Z",
-        "modified": "2016-05-25T14:07:45.421Z", "name": "joev-miq2", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7cbd-06ae-20a6-e3d5-0225e02bc245",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500c26de-061e-2bf8-6327-e3d24e6d6724\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_guestState\": \"notRunning\", \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"master\",
-        \"vmware_distributedMemoryEntitlement\": 0, \"vmware_product_appUrl\": null,
-        \"vmware_product_fullVersion\": null, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
-        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\":
-        \"green\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_committed\": 42950239702, \"vmware_product_vendor\": \"ManageIQ\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"joev-miq2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0,
-        \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        joev-miq-20160329/joev-miq-20160329.vmx\", \"vmware_ipAddress\": \"10.8.99.226\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
-        \"toolsNotRunning\", \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960,
-        \"vmware_staticMemoryEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.226\",
-        \"vmware_uuid\": \"420c7cbd-06ae-20a6-e3d5-0225e02bc245\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 6637666838, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0,
-        \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"ManageIQ\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
-        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
-        \"joev-miq2.jvlcek.redhat.com\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
-        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": 362, "last_job_host_summary":
-        371}, {"id": 261, "type": "host", "url": "/api/v1/hosts/261/", "related":
-        {"job_host_summaries": "/api/v1/hosts/261/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/261/variable_data/", "job_events": "/api/v1/hosts/261/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/261/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/261/fact_versions/", "inventory_sources": "/api/v1/hosts/261/inventory_sources/",
-        "groups": "/api/v1/hosts/261/groups/", "activity_stream": "/api/v1/hosts/261/activity_stream/",
-        "all_groups": "/api/v1/hosts/261/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/261/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.587Z", "modified":
-        "2016-05-25T15:12:39.160Z", "name": "joev-miq-23052016-16", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c5ac9-c0c4-9492-2da0-cf7d9ed8db59",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
-        \"vmware_instanceUuid\": \"500c30ac-bfdc-e869-e6dd-e0718ad311ea\", \"vmware_distributedCpuEntitlement\":
-        287, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
-        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
-        1925, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_overallCpuUsage\": 263, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 11234490713, \"vmware_product_vendor\": \"ManageIQ\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"joev-miq-23052016-16\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        3364, \"vmware_overallCpuDemand\": 287, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        54, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
-        joev-miq-23052016-13_1/joev-miq-23052016-13.vmx\", \"vmware_ipAddress\": \"10.8.97.16\",
-        \"vmware_guestMemoryUsage\": 2211, \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
-        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 4781044595, \"vmware_staticMemoryEntitlement\":
-        6231, \"ansible_ssh_host\": \"10.8.97.16\", \"vmware_uuid\": \"420c5ac9-c0c4-9492-2da0-cf7d9ed8db59\",
-        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 42588143616,
-        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 56, \"vmware_privateMemory\": 3298,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
-        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
-        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-miq16.jvlcek.redhat.com\",
-        \"vmware_uptimeSeconds\": 2076, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 1,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"yellow\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 262, "type":
-        "host", "url": "/api/v1/hosts/262/", "related": {"job_host_summaries": "/api/v1/hosts/262/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/262/variable_data/", "job_events": "/api/v1/hosts/262/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/262/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/262/fact_versions/", "inventory_sources": "/api/v1/hosts/262/inventory_sources/",
-        "groups": "/api/v1/hosts/262/groups/", "activity_stream": "/api/v1/hosts/262/activity_stream/",
-        "all_groups": "/api/v1/hosts/262/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/262/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.592Z", "modified":
-        "2016-05-25T14:07:46.738Z", "name": "joev-miq-5-13", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c460b-11e1-4858-978a-971e8d8f0202",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-miq-5-13/joev-miq-5-13.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
-        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
-        \"vmware_product_key\": 0, \"vmware_unshared\": 11148903262, \"vmware_guestState\":
-        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
-        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
-        \"420c460b-11e1-4858-978a-971e8d8f0202\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 42810253312, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
-        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-miq13.jvlcek.redhat.com\",
-        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        6144, \"vmware_instanceUuid\": \"500c98cb-ccfb-316f-c779-453c3a959bd6\", \"vmware_compressedMemory\":
-        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 17602705266, \"vmware_name\": \"joev-miq-5-13\",
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 263, "type": "host", "url": "/api/v1/hosts/263/",
-        "related": {"job_host_summaries": "/api/v1/hosts/263/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/263/variable_data/", "job_events": "/api/v1/hosts/263/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/263/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/263/fact_versions/", "inventory_sources": "/api/v1/hosts/263/inventory_sources/",
-        "groups": "/api/v1/hosts/263/groups/", "activity_stream": "/api/v1/hosts/263/activity_stream/",
-        "all_groups": "/api/v1/hosts/263/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/263/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.597Z", "modified":
-        "2016-05-25T14:07:46.742Z", "name": "jp-img2", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c5b6e-8f7e-2f89-fbd1-0261491d3f1d",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
-        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
-        \"dhcp-8-99-226.example.com\", \"vmware_instanceUuid\":
-        \"500c6f11-1d94-18b0-01ca-8072be00d302\", \"vmware_distributedCpuEntitlement\":
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"joev-brewery\",
+        \"vmware_instanceUuid\": \"500ca211-c5fe-3cbf-d6ef-a0794c1377f9\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Share] jp-img2/jp-img2.vmx\", \"vmware_guestState\":
-        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
-        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
-        2, \"vmware_uuid\": \"420c5b6e-8f7e-2f89-fbd1-0261491d3f1d\", \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 39930859107, \"vmware_name\": \"jp-img2\", \"vmware_toolsVersionStatus\":
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] joev-brewery-centos-72/joev-brewery-centos-72.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c0d63-5270-443c-61b9-8270a876db16\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 80276415289,
+        \"vmware_name\": \"joev-brewery-centos-72\", \"vmware_toolsVersionStatus\":
         \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        76227620864, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        151848341504, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
         0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
         \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
         false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
         0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
         \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
         \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 80275128887,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":50,"type":"host","url":"/api/v1/hosts/50/","related":{"job_host_summaries":"/api/v1/hosts/50/job_host_summaries/","variable_data":"/api/v1/hosts/50/variable_data/","job_events":"/api/v1/hosts/50/job_events/","ad_hoc_commands":"/api/v1/hosts/50/ad_hoc_commands/","fact_versions":"/api/v1/hosts/50/fact_versions/","inventory_sources":"/api/v1/hosts/50/inventory_sources/","groups":"/api/v1/hosts/50/groups/","activity_stream":"/api/v1/hosts/50/activity_stream/","all_groups":"/api/v1/hosts/50/all_groups/","ad_hoc_command_events":"/api/v1/hosts/50/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/32/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":32,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.170Z","modified":"2016-10-12T18:19:16.004Z","name":"joev-cfme-5.6.1.0-2","description":"imported","inventory":2,"enabled":true,"instance_id":"420cdba8-2c6a-f638-b7a6-8628b64e40ad","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-cfme-5.6.1.0-2/joev-cfme-5.6.1.0-2.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.209\", \"vmware_guestMemoryUsage\": 901, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 143, \"ansible_ssh_host\": \"10.8.99.209\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 2641884216, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8311, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420cdba8-2c6a-f638-b7a6-8628b64e40ad\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"4.1\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\": 61782626304,
+        \"vmware_distributedMemoryEntitlement\": 2336, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 143, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\":
         null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_unshared\": 39929610769, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 264, "type": "host", "url": "/api/v1/hosts/264/", "related":
-        {"job_host_summaries": "/api/v1/hosts/264/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/264/variable_data/", "job_events": "/api/v1/hosts/264/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/264/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/264/fact_versions/", "inventory_sources": "/api/v1/hosts/264/inventory_sources/",
-        "groups": "/api/v1/hosts/264/groups/", "activity_stream": "/api/v1/hosts/264/activity_stream/",
-        "all_groups": "/api/v1/hosts/264/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/264/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.602Z", "modified":
-        "2016-05-25T15:12:39.168Z", "name": "jprause-brewery7", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c665e-b42d-26d2-21a2-0a54d4d79cba",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jprause-brewery7/jprause-brewery7.vmx\",
-        \"vmware_ipAddress\": \"10.8.99.220\", \"vmware_guestMemoryUsage\": 983, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500c9982-6622-52b4-1301-0c870e7b42ac\", \"vmware_distributedCpuEntitlement\":
-        2470, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 131397764165,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16593,
-        \"ansible_ssh_host\": \"10.8.99.220\", \"vmware_overallStatus\": \"green\",
-        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"420c665e-b42d-26d2-21a2-0a54d4d79cba\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\":
-        18926092288, \"vmware_distributedMemoryEntitlement\": 5500, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 2494, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
-        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 103, \"vmware_privateMemory\": 16179, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 2470, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"jprause-brewery7\", \"vmware_uptimeSeconds\": 8438,
-        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 131398008309,
-        \"vmware_name\": \"jprause-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 16298, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"vmware_sharedMemory\": 78, \"vmware_privateMemory\": 4320, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_overallCpuUsage\":
+        143, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-cfme-56102.jvlcek.redhat.com\", \"vmware_product_vendor\": \"Red Hat,
+        Inc.\", \"vmware_uptimeSeconds\": 1978577, \"vmware_memorySizeMB\": 8192,
+        \"vmware_instanceUuid\": \"500c62ce-8cfd-47b2-a7ae-a3670d7adf69\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2642068354, \"vmware_name\": \"joev-cfme-5.6.1.0-2\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 4394, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
         \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 102, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 265, "type": "host", "url": "/api/v1/hosts/265/",
-        "related": {"job_host_summaries": "/api/v1/hosts/265/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/265/variable_data/", "job_events": "/api/v1/hosts/265/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/265/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/265/fact_versions/", "inventory_sources": "/api/v1/hosts/265/inventory_sources/",
-        "groups": "/api/v1/hosts/265/groups/", "activity_stream": "/api/v1/hosts/265/activity_stream/",
-        "all_groups": "/api/v1/hosts/265/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/265/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.607Z", "modified":
-        "2016-05-25T14:07:46.751Z", "name": "jprause-img-factory", "description":
-        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7636-ae0a-6f5e-9792-59774df7924a",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 51, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":32},{"id":52,"type":"host","url":"/api/v1/hosts/52/","related":{"job_host_summaries":"/api/v1/hosts/52/job_host_summaries/","variable_data":"/api/v1/hosts/52/variable_data/","job_events":"/api/v1/hosts/52/job_events/","ad_hoc_commands":"/api/v1/hosts/52/ad_hoc_commands/","fact_versions":"/api/v1/hosts/52/fact_versions/","inventory_sources":"/api/v1/hosts/52/inventory_sources/","groups":"/api/v1/hosts/52/groups/","activity_stream":"/api/v1/hosts/52/activity_stream/","all_groups":"/api/v1/hosts/52/all_groups/","ad_hoc_command_events":"/api/v1/hosts/52/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/40/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":40,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.180Z","modified":"2016-10-12T18:19:16.008Z","name":"joev-ipa14","description":"imported","inventory":2,"enabled":true,"instance_id":"420cf66e-39ca-eb2b-4b42-dd543f800b54","variables":"{\"vmware_privateMemory\":
+        3634, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.14\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_hostName\": \"joev-ipa14.jvlcek.redhat.com\", \"vmware_instanceUuid\":
+        \"500c9f91-a013-73e0-c4ca-87b2ab696b8b\", \"vmware_distributedCpuEntitlement\":
+        23, \"ansible_ssh_host\": \"10.8.97.14\", \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 91237, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] joev-ipa-rhel7/joev-ipa-rhel7.vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16528,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 4, \"vmware_uuid\": \"420cf66e-39ca-eb2b-4b42-dd543f800b54\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 73244744502,
+        \"vmware_name\": \"joev-ipa14\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        213613322240, \"vmware_hostMemoryUsage\": 3709, \"vmware_distributedMemoryEntitlement\":
+        1258, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 4484540253, \"vmware_sharedMemory\": 230}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":40},{"id":51,"type":"host","url":"/api/v1/hosts/51/","related":{"job_host_summaries":"/api/v1/hosts/51/job_host_summaries/","variable_data":"/api/v1/hosts/51/variable_data/","job_events":"/api/v1/hosts/51/job_events/","ad_hoc_commands":"/api/v1/hosts/51/ad_hoc_commands/","fact_versions":"/api/v1/hosts/51/fact_versions/","inventory_sources":"/api/v1/hosts/51/inventory_sources/","groups":"/api/v1/hosts/51/groups/","activity_stream":"/api/v1/hosts/51/activity_stream/","all_groups":"/api/v1/hosts/51/all_groups/","ad_hoc_command_events":"/api/v1/hosts/51/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.175Z","modified":"2016-08-31T16:59:43.513Z","name":"joev-ipa-ad","description":"imported","inventory":2,"enabled":false,"instance_id":"420c299f-aa19-c7ee-05a6-ef86163464a6","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"joev-ipa-ad.jvlcek.redhat.com\",
+        \"vmware_instanceUuid\": \"500ce8fc-49c2-24fb-d3c3-6d65553bcebc\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] joev-ipa-ad/joev-ipa-ad.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420c299f-aa19-c7ee-05a6-ef86163464a6\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 76381315189, \"vmware_name\": \"joev-ipa-ad\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 155742912512, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 76380557868,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":53,"type":"host","url":"/api/v1/hosts/53/","related":{"job_host_summaries":"/api/v1/hosts/53/job_host_summaries/","variable_data":"/api/v1/hosts/53/variable_data/","job_events":"/api/v1/hosts/53/job_events/","ad_hoc_commands":"/api/v1/hosts/53/ad_hoc_commands/","fact_versions":"/api/v1/hosts/53/fact_versions/","inventory_sources":"/api/v1/hosts/53/inventory_sources/","groups":"/api/v1/hosts/53/groups/","activity_stream":"/api/v1/hosts/53/activity_stream/","all_groups":"/api/v1/hosts/53/all_groups/","ad_hoc_command_events":"/api/v1/hosts/53/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/6/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":6,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.186Z","modified":"2016-10-12T18:19:16.013Z","name":"joev-ldap","description":"imported","inventory":2,"enabled":true,"instance_id":"420c5471-f1af-f5da-16ea-ea1c7a18a596","variables":"{\"vmware_privateMemory\":
+        3955, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.99.233\",
+        \"vmware_guestMemoryUsage\": 327, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
         0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
         4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
-        \"dhcp-8-99-249.example.com\", \"vmware_instanceUuid\":
-        \"500c7a0d-0538-3baf-ba22-fb070f840b89\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Share] jprause-img-factory/jprause-img-factory.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\": \"420c7636-ae0a-6f5e-9792-59774df7924a\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 47247487261,
-        \"vmware_name\": \"jprause-img-factory\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 68911484928, \"vmware_hostMemoryUsage\":
-        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
-        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
-        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
-        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 47245746717,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 214, "type":
-        "host", "url": "/api/v1/hosts/214/", "related": {"job_host_summaries": "/api/v1/hosts/214/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/214/variable_data/", "job_events": "/api/v1/hosts/214/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/214/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/214/fact_versions/", "inventory_sources": "/api/v1/hosts/214/inventory_sources/",
-        "groups": "/api/v1/hosts/214/groups/", "activity_stream": "/api/v1/hosts/214/activity_stream/",
-        "all_groups": "/api/v1/hosts/214/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/214/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.453Z", "modified":
-        "2016-04-28T14:28:03.840Z", "name": "jwong-dvs", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420ced0b-e0c4-19e1-d6ce-0b3e3e27b951",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500c7dde-7806-a68b-4beb-8c159d577b5a\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs/jwong-dvs.vmx\", \"vmware_guestState\":
-        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
-        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
-        1, \"vmware_uuid\": \"420ced0b-e0c4-19e1-d6ce-0b3e3e27b951\", \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 2637, \"vmware_name\": \"jwong-dvs\", \"vmware_toolsVersionStatus\":
-        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        19482144768, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=8c9d6da2-0beb-11e6-9f79-f45c89896441\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 497, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 215, "type": "host", "url": "/api/v1/hosts/215/", "related":
-        {"job_host_summaries": "/api/v1/hosts/215/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/215/variable_data/", "job_events": "/api/v1/hosts/215/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/215/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/215/fact_versions/", "inventory_sources": "/api/v1/hosts/215/inventory_sources/",
-        "groups": "/api/v1/hosts/215/groups/", "activity_stream": "/api/v1/hosts/215/activity_stream/",
-        "all_groups": "/api/v1/hosts/215/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/215/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.459Z", "modified":
-        "2016-04-28T14:28:03.844Z", "name": "jwong-dvs-3", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420ce9fa-088d-dc4d-bda2-c3ccf9940c59",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"CentOS
-        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
-        \"vmware_instanceUuid\": \"500ca6d1-803e-0267-330b-8a5fe6bf2581\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-3/jwong-dvs-3.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ce9fa-088d-dc4d-bda2-c3ccf9940c59\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 1657843239, \"vmware_name\":
-        \"jwong-dvs-3\", \"vmware_toolsVersionStatus\": \"guestToolsNeedUpgrade\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 43631378432, \"vmware_hostMemoryUsage\":
-        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=092ccea0-0bef-11e6-9f79-f45c89896441\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 1657831950, \"vmware_sharedMemory\": 0}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 216, "type": "host", "url": "/api/v1/hosts/216/",
-        "related": {"job_host_summaries": "/api/v1/hosts/216/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/216/variable_data/", "job_events": "/api/v1/hosts/216/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/216/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/216/fact_versions/", "inventory_sources": "/api/v1/hosts/216/inventory_sources/",
-        "groups": "/api/v1/hosts/216/groups/", "activity_stream": "/api/v1/hosts/216/activity_stream/",
-        "all_groups": "/api/v1/hosts/216/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/216/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.464Z", "modified":
-        "2016-04-28T14:45:55.906Z", "name": "jwong-dvs-4", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c2537-c895-afd7-3507-1d09da2896e6",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-4/jwong-dvs-4.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500cf709-a129-7cd4-3b95-870a28f47e18\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 499, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        2114, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"420c2537-c895-afd7-3507-1d09da2896e6\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 2297, \"vmware_uncommitted\":
-        17179869184, \"vmware_distributedMemoryEntitlement\": 67, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 6, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
-        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 142083, \"vmware_memorySizeMB\":
-        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 137207, \"vmware_name\": \"jwong-dvs-4\", \"vmware_toolsVersionStatus\":
-        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        23, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 17, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 266, "type": "host", "url": "/api/v1/hosts/266/",
-        "related": {"job_host_summaries": "/api/v1/hosts/266/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/266/variable_data/", "job_events": "/api/v1/hosts/266/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/266/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/266/fact_versions/", "inventory_sources": "/api/v1/hosts/266/inventory_sources/",
-        "groups": "/api/v1/hosts/266/groups/", "activity_stream": "/api/v1/hosts/266/activity_stream/",
-        "all_groups": "/api/v1/hosts/266/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/266/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.624Z", "modified":
-        "2016-05-25T14:07:46.756Z", "name": "jwong-dvs-re-fix", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c2e04-8e26-2344-b100-d20f97098ce6",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
-        \"vmware_instanceUuid\": \"500c1d49-da1d-84eb-36e1-60b02a4eba1c\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-re-fix/jwong-dvs-re-fix.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c2e04-8e26-2344-b100-d20f97098ce6\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 161316, \"vmware_name\":
-        \"jwong-dvs-re-fix\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=ab2163a6-12f2-11e6-8713-f45c89896441\", \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 218, "type":
-        "host", "url": "/api/v1/hosts/218/", "related": {"job_host_summaries": "/api/v1/hosts/218/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/218/variable_data/", "job_events": "/api/v1/hosts/218/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/218/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/218/fact_versions/", "inventory_sources": "/api/v1/hosts/218/inventory_sources/",
-        "groups": "/api/v1/hosts/218/groups/", "activity_stream": "/api/v1/hosts/218/activity_stream/",
-        "all_groups": "/api/v1/hosts/218/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/218/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.474Z", "modified":
-        "2016-05-25T15:12:39.176Z", "name": "jwong_dvs_test", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c55fb-8286-13a8-0e2a-6eba543b8efe",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jwong_dvs_test/jwong_dvs_test.vmx\",
-        \"vmware_ipAddress\": \"10.8.99.210\", \"vmware_guestMemoryUsage\": 20, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500cd6d5-cee7-23ba-dde1-c7e213a58fb0\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1655132712,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 2098,
-        \"ansible_ssh_host\": \"10.8.99.210\", \"vmware_overallStatus\": \"green\",
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 49,
+        \"vmware_hostName\": \"dhcp-8-99-233.example.com\",
+        \"vmware_instanceUuid\": \"500ce4c6-0427-bbd1-ec2d-ffd0820a4512\", \"vmware_distributedCpuEntitlement\":
+        23, \"ansible_ssh_host\": \"10.8.99.233\", \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 179605, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] joev-ldap/joev-ldap.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 4172, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"420c5471-f1af-f5da-16ea-ea1c7a18a596\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 6046923108, \"vmware_name\": \"joev-ldap\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uncommitted\": 15428452352, \"vmware_hostMemoryUsage\": 4017, \"vmware_distributedMemoryEntitlement\":
+        1387, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 6046384657, \"vmware_sharedMemory\": 135}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":6},{"id":6,"type":"host","url":"/api/v1/hosts/6/","related":{"job_host_summaries":"/api/v1/hosts/6/job_host_summaries/","variable_data":"/api/v1/hosts/6/variable_data/","job_events":"/api/v1/hosts/6/job_events/","ad_hoc_commands":"/api/v1/hosts/6/ad_hoc_commands/","fact_versions":"/api/v1/hosts/6/fact_versions/","inventory_sources":"/api/v1/hosts/6/inventory_sources/","groups":"/api/v1/hosts/6/groups/","activity_stream":"/api/v1/hosts/6/activity_stream/","all_groups":"/api/v1/hosts/6/all_groups/","ad_hoc_command_events":"/api/v1/hosts/6/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/9/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":9,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.934Z","modified":"2016-10-12T18:19:16.018Z","name":"JoeV-ManageIQ","description":"imported","inventory":2,"enabled":true,"instance_id":"420cfc95-bb19-405f-413d-7ba19509ec28","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] JoeV-ManageIQ/JoeV-ManageIQ.vmx\", \"vmware_ipAddress\": \"10.8.99.225\",
+        \"vmware_guestMemoryUsage\": 1474, \"vmware_networks\": [\"VM Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 191,
+        \"ansible_ssh_host\": \"10.8.99.225\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        4714955285, \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\":
+        6231, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
         \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"420c55fb-8286-13a8-0e2a-6eba543b8efe\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 922, \"vmware_uncommitted\":
-        41294540800, \"vmware_distributedMemoryEntitlement\": 373, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"MIQ GUID=f054efee-0bed-11e6-9f79-f45c89896441\",
-        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 97, \"vmware_privateMemory\": 390, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        \"420cfc95-bb19-405f-413d-7ba19509ec28\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_uncommitted\": 38234718208, \"vmware_distributedMemoryEntitlement\":
+        2840, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        215, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        200, \"vmware_privateMemory\": 5260, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\": 215, \"vmware_suspendInterval\":
         0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"dhcp-8-99-210.example.com\",
-        \"vmware_uptimeSeconds\": 2485908, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        1655288505, \"vmware_name\": \"jwong_dvs_test\", \"vmware_toolsVersionStatus\":
-        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        445, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 30, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 217, "type": "host", "url": "/api/v1/hosts/217/",
-        "related": {"job_host_summaries": "/api/v1/hosts/217/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/217/variable_data/", "job_events": "/api/v1/hosts/217/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/217/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/217/fact_versions/", "inventory_sources": "/api/v1/hosts/217/inventory_sources/",
-        "groups": "/api/v1/hosts/217/groups/", "activity_stream": "/api/v1/hosts/217/activity_stream/",
-        "all_groups": "/api/v1/hosts/217/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/217/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.469Z", "modified":
-        "2016-04-28T14:28:03.859Z", "name": "jwong-live-dvs", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c5e62-d1b8-49b6-0ac1-708124b932dd",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500c9ffe-489f-8027-37ed-aba6c080ce06\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-live-dvs/jwong-live-dvs.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c5e62-d1b8-49b6-0ac1-708124b932dd\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 2841, \"vmware_name\":
-        \"jwong-live-dvs\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
-        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
-        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=bce91030-0c9d-11e6-bc96-f45c89896441\", \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_unshared\": 502, \"vmware_sharedMemory\": 0}", "has_active_failures":
-        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 267, "type": "host", "url": "/api/v1/hosts/267/", "related":
-        {"job_host_summaries": "/api/v1/hosts/267/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/267/variable_data/", "job_events": "/api/v1/hosts/267/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/267/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/267/fact_versions/", "inventory_sources": "/api/v1/hosts/267/inventory_sources/",
-        "groups": "/api/v1/hosts/267/groups/", "activity_stream": "/api/v1/hosts/267/activity_stream/",
-        "all_groups": "/api/v1/hosts/267/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/267/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.629Z", "modified":
-        "2016-05-25T14:07:46.761Z", "name": "jwong-use-6", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cf32d-328d-3c49-b28c-1418b6e18a43",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostSystem\": \"dev-esxi6hyper1.example.com\",
-        \"vmware_instanceUuid\": \"500c7086-6aa0-7b07-c843-ab8897790770\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-use-6/jwong-use-6.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cf32d-328d-3c49-b28c-1418b6e18a43\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 160370, \"vmware_name\":
-        \"jwong-use-6\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=38eecfd6-1134-11e6-a37b-f45c89896441\", \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}]}'
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-manageiq.jvlcek.redhat.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 1218932,
+        \"vmware_memorySizeMB\": 6144, \"vmware_instanceUuid\": \"500c5d81-f50f-6259-e49a-c25b6020bcc9\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 4715135653,
+        \"vmware_name\": \"JoeV-ManageIQ\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 5373, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 52, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":9},{"id":54,"type":"host","url":"/api/v1/hosts/54/","related":{"job_host_summaries":"/api/v1/hosts/54/job_host_summaries/","variable_data":"/api/v1/hosts/54/variable_data/","job_events":"/api/v1/hosts/54/job_events/","ad_hoc_commands":"/api/v1/hosts/54/ad_hoc_commands/","fact_versions":"/api/v1/hosts/54/fact_versions/","inventory_sources":"/api/v1/hosts/54/inventory_sources/","groups":"/api/v1/hosts/54/groups/","activity_stream":"/api/v1/hosts/54/activity_stream/","all_groups":"/api/v1/hosts/54/all_groups/","ad_hoc_command_events":"/api/v1/hosts/54/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/19/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":19,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.191Z","modified":"2016-10-12T18:19:16.023Z","name":"joev-miq-0824","description":"imported","inventory":2,"enabled":true,"instance_id":"420cca02-fbfe-1d4f-607a-b51ab9648fff","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-miq-0824/joev-miq-0824.vmx\", \"vmware_ipAddress\": \"10.8.99.247\",
+        \"vmware_guestMemoryUsage\": 1351, \"vmware_networks\": [\"VM Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 167,
+        \"ansible_ssh_host\": \"10.8.99.247\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        5397594974, \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\":
+        6240, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420cca02-fbfe-1d4f-607a-b51ab9648fff\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_uncommitted\": 42657099776, \"vmware_distributedMemoryEntitlement\":
+        2385, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        191, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        69, \"vmware_privateMemory\": 4783, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\": 167, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-247.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 7825, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500c2dcd-c5b0-2ba1-c2b8-802452f0ae74\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 11850436345, \"vmware_name\": \"joev-miq-0824\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 4845, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 50, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":19},{"id":55,"type":"host","url":"/api/v1/hosts/55/","related":{"job_host_summaries":"/api/v1/hosts/55/job_host_summaries/","variable_data":"/api/v1/hosts/55/variable_data/","job_events":"/api/v1/hosts/55/job_events/","ad_hoc_commands":"/api/v1/hosts/55/ad_hoc_commands/","fact_versions":"/api/v1/hosts/55/fact_versions/","inventory_sources":"/api/v1/hosts/55/inventory_sources/","groups":"/api/v1/hosts/55/groups/","activity_stream":"/api/v1/hosts/55/activity_stream/","all_groups":"/api/v1/hosts/55/all_groups/","ad_hoc_command_events":"/api/v1/hosts/55/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/15/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":15,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.196Z","modified":"2016-10-12T18:19:16.027Z","name":"joev-miq-23052016-16","description":"imported","inventory":2,"enabled":true,"instance_id":"420c5ac9-c0c4-9492-2da0-cf7d9ed8db59","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-miq-23052016-13_1/joev-miq-23052016-13.vmx\", \"vmware_ipAddress\":
+        \"10.8.97.16\", \"vmware_guestMemoryUsage\": 61, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.97.16\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 7799264115, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 6241, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c5ac9-c0c4-9492-2da0-cf7d9ed8db59\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        39569924096, \"vmware_distributedMemoryEntitlement\": 1163, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 271, \"vmware_privateMemory\": 3159, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-miq16.jvlcek.redhat.com\", \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_uptimeSeconds\": 7993, \"vmware_memorySizeMB\": 6144, \"vmware_instanceUuid\":
+        \"500c30ac-bfdc-e869-e6dd-e0718ad311ea\", \"vmware_compressedMemory\": 0,
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 14253236887, \"vmware_name\": \"joev-miq-23052016-16\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 3288, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 47, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":15},{"id":56,"type":"host","url":"/api/v1/hosts/56/","related":{"job_host_summaries":"/api/v1/hosts/56/job_host_summaries/","variable_data":"/api/v1/hosts/56/variable_data/","job_events":"/api/v1/hosts/56/job_events/","ad_hoc_commands":"/api/v1/hosts/56/ad_hoc_commands/","fact_versions":"/api/v1/hosts/56/fact_versions/","inventory_sources":"/api/v1/hosts/56/inventory_sources/","groups":"/api/v1/hosts/56/groups/","activity_stream":"/api/v1/hosts/56/activity_stream/","all_groups":"/api/v1/hosts/56/all_groups/","ad_hoc_command_events":"/api/v1/hosts/56/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/36/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":36,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.202Z","modified":"2016-10-12T18:19:16.032Z","name":"joev-miq-repmgr-primary","description":"imported","inventory":2,"enabled":true,"instance_id":"420c070d-de88-7912-2e2e-1e7bba9edfd7","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-miq-repmgr-primary/joev-miq-repmgr-primary.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.243\", \"vmware_guestMemoryUsage\": 2150, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 167, \"ansible_ssh_host\": \"10.8.99.243\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 5262636961, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 6231, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c070d-de88-7912-2e2e-1e7bba9edfd7\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        42501545984, \"vmware_distributedMemoryEntitlement\": 2726, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 167, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 1719, \"vmware_privateMemory\": 4425, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        167, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-243.example.com\", \"vmware_product_vendor\":
+        \"ManageIQ\", \"vmware_uptimeSeconds\": 178428, \"vmware_memorySizeMB\": 6144,
+        \"vmware_instanceUuid\": \"500c7f8e-f7b0-2196-666b-a4e16c813db8\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 31072890503, \"vmware_name\": \"joev-miq-repmgr-primary\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 4483, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 53, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":36}]}'
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:25 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:48 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=4
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/hosts/?page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -3455,172 +1849,395 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:25 GMT
+      - Thu, 09 Feb 2017 10:37:47 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.271s
+      - 0.220s
       Content-Length:
-      - '86142'
+      - '91156'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"count": 98, "next": null, "previous": "/api/v1/hosts/?page=3", "results":
-        [{"id": 268, "type": "host", "url": "/api/v1/hosts/268/", "related": {"job_host_summaries":
-        "/api/v1/hosts/268/job_host_summaries/", "variable_data": "/api/v1/hosts/268/variable_data/",
-        "job_events": "/api/v1/hosts/268/job_events/", "ad_hoc_commands": "/api/v1/hosts/268/ad_hoc_commands/",
-        "fact_versions": "/api/v1/hosts/268/fact_versions/", "inventory_sources":
-        "/api/v1/hosts/268/inventory_sources/", "groups": "/api/v1/hosts/268/groups/",
-        "activity_stream": "/api/v1/hosts/268/activity_stream/", "all_groups": "/api/v1/hosts/268/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/268/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name": "Dev
-        VC60", "description": "", "has_active_failures": true, "total_hosts": 69,
-        "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.634Z", "modified":
-        "2016-05-25T15:12:39.184Z", "name": "jwong-use-7", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c3342-c636-948c-02f5-92ba76767bbf",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] jwong-use-7/jwong-use-7.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
-        \"500cee4b-a411-18a3-6895-378619981f31\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 0, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        2114, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"420c3342-c636-948c-02f5-92ba76767bbf\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 2297, \"vmware_uncommitted\":
-        0, \"vmware_distributedMemoryEntitlement\": 252, \"vmware_template\": false,
-        \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
-        0, \"vmware_annotation\": \"MIQ GUID=bff857b4-1138-11e6-aa64-f45c89896441\",
-        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 8, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_uptimeSeconds\": 1904402, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        134929, \"vmware_name\": \"jwong-use-7\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 33, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 25, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 269, "type": "host", "url": "/api/v1/hosts/269/",
-        "related": {"job_host_summaries": "/api/v1/hosts/269/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/269/variable_data/", "job_events": "/api/v1/hosts/269/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/269/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/269/fact_versions/", "inventory_sources": "/api/v1/hosts/269/inventory_sources/",
-        "groups": "/api/v1/hosts/269/groups/", "activity_stream": "/api/v1/hosts/269/activity_stream/",
-        "all_groups": "/api/v1/hosts/269/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/269/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.639Z", "modified":
-        "2016-05-25T14:07:46.770Z", "name": "jwong-use-8", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420c387e-b692-314e-1842-d66a49a453f0",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
-        \"vmware_instanceUuid\": \"500ca104-710b-0e39-288e-4c45825122f2\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-use-8/jwong-use-8.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c387e-b692-314e-1842-d66a49a453f0\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 164443, \"vmware_name\":
-        \"jwong-use-8\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=c2211702-1141-11e6-aa64-f45c89896441\", \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 270, "type":
-        "host", "url": "/api/v1/hosts/270/", "related": {"job_host_summaries": "/api/v1/hosts/270/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/270/variable_data/", "job_events": "/api/v1/hosts/270/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/270/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/270/fact_versions/", "inventory_sources": "/api/v1/hosts/270/inventory_sources/",
-        "groups": "/api/v1/hosts/270/groups/", "activity_stream": "/api/v1/hosts/270/activity_stream/",
-        "all_groups": "/api/v1/hosts/270/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/270/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.644Z", "modified":
-        "2016-05-25T14:07:46.775Z", "name": "jwong-vds-use-5", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420ccdbc-db31-6b13-94d0-780605cb6c8a",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
-        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
-        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
-        \"vmware_instanceUuid\": \"500c2092-4206-f3db-791d-a1901e9699d7\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-vds-use-5/jwong-vds-use-5.vmx\",
-        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ccdbc-db31-6b13-94d0-780605cb6c8a\",
-        \"vmware_installBootRequired\": false, \"vmware_committed\": 160813, \"vmware_name\":
-        \"jwong-vds-use-5\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
-        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
-        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
-        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
-        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        \"MIQ GUID=0359f510-10b9-11e6-818a-f45c89896441\", \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 168, "type":
-        "host", "url": "/api/v1/hosts/168/", "related": {"job_host_summaries": "/api/v1/hosts/168/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/168/variable_data/", "job_events": "/api/v1/hosts/168/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/168/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/168/fact_versions/", "inventory_sources": "/api/v1/hosts/168/inventory_sources/",
-        "groups": "/api/v1/hosts/168/groups/", "activity_stream": "/api/v1/hosts/168/activity_stream/",
-        "all_groups": "/api/v1/hosts/168/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/168/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.846Z", "modified":
-        "2016-03-31T18:43:05.853Z", "name": "lucy_54", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "423307de-ccba-3188-0634-98b295a90aa0",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+      string: '{"count":84,"next":"/api/v1/hosts/?page=4","previous":"/api/v1/hosts/?page=2","results":[{"id":57,"type":"host","url":"/api/v1/hosts/57/","related":{"job_host_summaries":"/api/v1/hosts/57/job_host_summaries/","variable_data":"/api/v1/hosts/57/variable_data/","job_events":"/api/v1/hosts/57/job_events/","ad_hoc_commands":"/api/v1/hosts/57/ad_hoc_commands/","fact_versions":"/api/v1/hosts/57/fact_versions/","inventory_sources":"/api/v1/hosts/57/inventory_sources/","groups":"/api/v1/hosts/57/groups/","activity_stream":"/api/v1/hosts/57/activity_stream/","all_groups":"/api/v1/hosts/57/all_groups/","ad_hoc_command_events":"/api/v1/hosts/57/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/7/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":7,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.207Z","modified":"2016-10-12T18:19:16.036Z","name":"joev-miq-repmgr-sb","description":"imported","inventory":2,"enabled":true,"instance_id":"420c7ee2-6417-deab-0c88-f687036af710","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-miq-repmgr-sb/joev-miq-repmgr-sb.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.235\", \"vmware_guestMemoryUsage\": 122, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.235\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4539793946, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 6241, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c7ee2-6417-deab-0c88-f687036af710\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        38409879552, \"vmware_distributedMemoryEntitlement\": 707, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 82, \"vmware_privateMemory\": 1390, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-235.example.com\", \"vmware_product_vendor\":
+        \"ManageIQ\", \"vmware_uptimeSeconds\": 8071, \"vmware_memorySizeMB\": 6144,
+        \"vmware_instanceUuid\": \"500c22a0-7d5d-ce9d-de7f-93de5bceaec0\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 4540178770, \"vmware_name\": \"joev-miq-repmgr-sb\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 1452, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 43, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":7},{"id":58,"type":"host","url":"/api/v1/hosts/58/","related":{"job_host_summaries":"/api/v1/hosts/58/job_host_summaries/","variable_data":"/api/v1/hosts/58/variable_data/","job_events":"/api/v1/hosts/58/job_events/","ad_hoc_commands":"/api/v1/hosts/58/ad_hoc_commands/","fact_versions":"/api/v1/hosts/58/fact_versions/","inventory_sources":"/api/v1/hosts/58/inventory_sources/","groups":"/api/v1/hosts/58/groups/","activity_stream":"/api/v1/hosts/58/activity_stream/","all_groups":"/api/v1/hosts/58/all_groups/","ad_hoc_command_events":"/api/v1/hosts/58/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.212Z","modified":"2016-08-31T16:59:43.545Z","name":"joev-miq-sb-sb","description":"imported","inventory":2,"enabled":false,"instance_id":"420c1d29-ebfb-b769-d56f-3797a52e59ff","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] joev-miq-sb-sb/joev-miq-sb-sb.vmx\", \"vmware_guestMemoryUsage\":
         0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
-        Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
-        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 5579055969, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c1d29-ebfb-b769-d56f-3797a52e59ff\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 48328527872, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-217.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500cfd3e-4464-c051-0ece-039973a2651b\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 12031710848, \"vmware_name\": \"joev-miq-sb-sb\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":59,"type":"host","url":"/api/v1/hosts/59/","related":{"job_host_summaries":"/api/v1/hosts/59/job_host_summaries/","variable_data":"/api/v1/hosts/59/variable_data/","job_events":"/api/v1/hosts/59/job_events/","ad_hoc_commands":"/api/v1/hosts/59/ad_hoc_commands/","fact_versions":"/api/v1/hosts/59/fact_versions/","inventory_sources":"/api/v1/hosts/59/inventory_sources/","groups":"/api/v1/hosts/59/groups/","activity_stream":"/api/v1/hosts/59/activity_stream/","all_groups":"/api/v1/hosts/59/all_groups/","ad_hoc_command_events":"/api/v1/hosts/59/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/35/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":35,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.218Z","modified":"2016-10-12T18:19:16.041Z","name":"jp-img2","description":"imported","inventory":2,"enabled":true,"instance_id":"420c5b6e-8f7e-2f89-fbd1-0261491d3f1d","variables":"{\"vmware_privateMemory\":
+        1401, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.99.246\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 41,
+        \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_instanceUuid\": \"500c6f11-1d94-18b0-01ca-8072be00d302\", \"vmware_distributedCpuEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.99.246\", \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 179637, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jp-img2/jp-img2.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8317, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\":
+        \"420c5b6e-8f7e-2f89-fbd1-0261491d3f1d\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 39935137014, \"vmware_name\": \"jp-img2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uncommitted\": 67440459776, \"vmware_hostMemoryUsage\": 1464, \"vmware_distributedMemoryEntitlement\":
+        694, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        715, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 39933723153, \"vmware_sharedMemory\": 155}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":35},{"id":60,"type":"host","url":"/api/v1/hosts/60/","related":{"job_host_summaries":"/api/v1/hosts/60/job_host_summaries/","variable_data":"/api/v1/hosts/60/variable_data/","job_events":"/api/v1/hosts/60/job_events/","ad_hoc_commands":"/api/v1/hosts/60/ad_hoc_commands/","fact_versions":"/api/v1/hosts/60/fact_versions/","inventory_sources":"/api/v1/hosts/60/inventory_sources/","groups":"/api/v1/hosts/60/groups/","activity_stream":"/api/v1/hosts/60/activity_stream/","all_groups":"/api/v1/hosts/60/all_groups/","ad_hoc_command_events":"/api/v1/hosts/60/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.223Z","modified":"2016-08-31T16:59:43.554Z","name":"jprause-brewery7","description":"imported","inventory":2,"enabled":false,"instance_id":"420c665e-b42d-26d2-21a2-0a54d4d79cba","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
+        \"jprause-brewery7\", \"vmware_instanceUuid\": \"500c9982-6622-52b4-1301-0c870e7b42ac\",
+        \"vmware_distributedCpuEntitlement\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jprause-brewery7/jprause-brewery7.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c665e-b42d-26d2-21a2-0a54d4d79cba\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 133770352248,
+        \"vmware_name\": \"jprause-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 33908158464, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        2, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
+        VM\", \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 133769327685,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":61,"type":"host","url":"/api/v1/hosts/61/","related":{"job_host_summaries":"/api/v1/hosts/61/job_host_summaries/","variable_data":"/api/v1/hosts/61/variable_data/","job_events":"/api/v1/hosts/61/job_events/","ad_hoc_commands":"/api/v1/hosts/61/ad_hoc_commands/","fact_versions":"/api/v1/hosts/61/fact_versions/","inventory_sources":"/api/v1/hosts/61/inventory_sources/","groups":"/api/v1/hosts/61/groups/","activity_stream":"/api/v1/hosts/61/activity_stream/","all_groups":"/api/v1/hosts/61/all_groups/","ad_hoc_command_events":"/api/v1/hosts/61/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.229Z","modified":"2016-08-31T16:59:43.559Z","name":"jprause-img-factory","description":"imported","inventory":2,"enabled":false,"instance_id":"420c7636-ae0a-6f5e-9792-59774df7924a","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostName\": \"dhcp-8-99-249.example.com\",
+        \"vmware_instanceUuid\": \"500c7a0d-0538-3baf-ba22-fb070f840b89\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jprause-img-factory/jprause-img-factory.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\": \"420c7636-ae0a-6f5e-9792-59774df7924a\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 47246993009,
+        \"vmware_name\": \"jprause-img-factory\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 68911484928, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 47245746717,
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":62,"type":"host","url":"/api/v1/hosts/62/","related":{"job_host_summaries":"/api/v1/hosts/62/job_host_summaries/","variable_data":"/api/v1/hosts/62/variable_data/","job_events":"/api/v1/hosts/62/job_events/","ad_hoc_commands":"/api/v1/hosts/62/ad_hoc_commands/","fact_versions":"/api/v1/hosts/62/fact_versions/","inventory_sources":"/api/v1/hosts/62/inventory_sources/","groups":"/api/v1/hosts/62/groups/","activity_stream":"/api/v1/hosts/62/activity_stream/","all_groups":"/api/v1/hosts/62/all_groups/","ad_hoc_command_events":"/api/v1/hosts/62/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.234Z","modified":"2016-08-31T16:59:43.564Z","name":"jwong-centos7-old","description":"imported","inventory":2,"enabled":false,"instance_id":"420c240f-7d98-98df-14a4-65596827ca25","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
+        \"dhcp-8-99-210.example.com\", \"vmware_instanceUuid\":
+        \"500c871d-ba8d-ef9e-89c0-78095c8f987f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-centos7/jwong-centos7.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c240f-7d98-98df-14a4-65596827ca25\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 4074699488, \"vmware_name\":
+        \"jwong-centos7-old\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 30477475840, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 4074316332, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":63,"type":"host","url":"/api/v1/hosts/63/","related":{"job_host_summaries":"/api/v1/hosts/63/job_host_summaries/","variable_data":"/api/v1/hosts/63/variable_data/","job_events":"/api/v1/hosts/63/job_events/","ad_hoc_commands":"/api/v1/hosts/63/ad_hoc_commands/","fact_versions":"/api/v1/hosts/63/fact_versions/","inventory_sources":"/api/v1/hosts/63/inventory_sources/","groups":"/api/v1/hosts/63/groups/","activity_stream":"/api/v1/hosts/63/activity_stream/","all_groups":"/api/v1/hosts/63/all_groups/","ad_hoc_command_events":"/api/v1/hosts/63/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/20/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":20,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.239Z","modified":"2016-10-12T18:19:16.045Z","name":"jwong-dev","description":"imported","inventory":2,"enabled":true,"instance_id":"420cb104-d414-76e8-996f-fb361acc10d6","variables":"{\"vmware_privateMemory\":
+        475, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        43, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500cd4eb-2647-0faa-e0bd-27d7c09422cb\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 2233053, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] jwong-centos7(2)/jwong-centos7(2).vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        8350, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420cb104-d414-76e8-996f-fb361acc10d6\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 19305259016,
+        \"vmware_name\": \"jwong-dev\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        42831184734, \"vmware_hostMemoryUsage\": 547, \"vmware_distributedMemoryEntitlement\":
+        474, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1918894080, \"vmware_sharedMemory\": 165}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":20},{"id":64,"type":"host","url":"/api/v1/hosts/64/","related":{"job_host_summaries":"/api/v1/hosts/64/job_host_summaries/","variable_data":"/api/v1/hosts/64/variable_data/","job_events":"/api/v1/hosts/64/job_events/","ad_hoc_commands":"/api/v1/hosts/64/ad_hoc_commands/","fact_versions":"/api/v1/hosts/64/fact_versions/","inventory_sources":"/api/v1/hosts/64/inventory_sources/","groups":"/api/v1/hosts/64/groups/","activity_stream":"/api/v1/hosts/64/activity_stream/","all_groups":"/api/v1/hosts/64/all_groups/","ad_hoc_command_events":"/api/v1/hosts/64/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/11/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":11,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.245Z","modified":"2016-10-12T18:19:16.050Z","name":"jwong-esxi1.example.com","description":"imported","inventory":2,"enabled":true,"instance_id":"420cf288-bc81-acd9-78c0-052dc4bb08f8","variables":"{\"vmware_privateMemory\":
+        2680, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.18\",
+        \"vmware_guestMemoryUsage\": 245, \"vmware_overallCpuUsage\": 335, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"VMware
+        ESXi 6.0\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 53,
+        \"vmware_hostName\": \"jwong-esxi1\", \"vmware_instanceUuid\": \"500cbde3-5317-e8d9-2596-957e6469ae2d\",
+        \"vmware_distributedCpuEntitlement\": 215, \"ansible_ssh_host\": \"10.8.97.18\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 179513, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-esxi1.example.com/jwong-esxi1.example.com.vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 12468,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 4, \"vmware_uuid\": \"420cf288-bc81-acd9-78c0-052dc4bb08f8\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2463135919, \"vmware_name\":
+        \"jwong-esxi1.example.com\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uncommitted\": 727682654208, \"vmware_hostMemoryUsage\": 3080, \"vmware_distributedMemoryEntitlement\":
+        1396, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 359, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"vmkernel6Guest\", \"vmware_numVirtualDisks\": 4, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 12288, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 2461788409, \"vmware_sharedMemory\": 2808}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":11},{"id":65,"type":"host","url":"/api/v1/hosts/65/","related":{"job_host_summaries":"/api/v1/hosts/65/job_host_summaries/","variable_data":"/api/v1/hosts/65/variable_data/","job_events":"/api/v1/hosts/65/job_events/","ad_hoc_commands":"/api/v1/hosts/65/ad_hoc_commands/","fact_versions":"/api/v1/hosts/65/fact_versions/","inventory_sources":"/api/v1/hosts/65/inventory_sources/","groups":"/api/v1/hosts/65/groups/","activity_stream":"/api/v1/hosts/65/activity_stream/","all_groups":"/api/v1/hosts/65/all_groups/","ad_hoc_command_events":"/api/v1/hosts/65/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/22/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":22,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.250Z","modified":"2016-10-12T18:19:16.054Z","name":"jwong-esxi2","description":"imported","inventory":2,"enabled":true,"instance_id":"420c67ab-3d87-40a0-a834-b329bdb3d366","variables":"{\"vmware_privateMemory\":
+        2663, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.19\",
+        \"vmware_guestMemoryUsage\": 245, \"vmware_overallCpuUsage\": 503, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"VMware
+        ESXi 6.0\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 54,
+        \"vmware_hostName\": \"jwong-esxi2\", \"vmware_instanceUuid\": \"500c67c1-fc85-bfb9-b612-8d86f266905f\",
+        \"vmware_distributedCpuEntitlement\": 335, \"ansible_ssh_host\": \"10.8.97.19\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 178753, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-esxi2/jwong-esxi2.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 12459, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"420c67ab-3d87-40a0-a834-b329bdb3d366\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 5398514598, \"vmware_name\": \"jwong-esxi2\",
+        \"vmware_toolsVersionStatus\": \"guestToolsCurrent\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 703272427520, \"vmware_hostMemoryUsage\":
+        3135, \"vmware_distributedMemoryEntitlement\": 1300, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        551, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"vmkernel6Guest\", \"vmware_numVirtualDisks\": 3, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 12288, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 5397177909, \"vmware_sharedMemory\": 2793}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":22},{"id":66,"type":"host","url":"/api/v1/hosts/66/","related":{"job_host_summaries":"/api/v1/hosts/66/job_host_summaries/","variable_data":"/api/v1/hosts/66/variable_data/","job_events":"/api/v1/hosts/66/job_events/","ad_hoc_commands":"/api/v1/hosts/66/ad_hoc_commands/","fact_versions":"/api/v1/hosts/66/fact_versions/","inventory_sources":"/api/v1/hosts/66/inventory_sources/","groups":"/api/v1/hosts/66/groups/","activity_stream":"/api/v1/hosts/66/activity_stream/","all_groups":"/api/v1/hosts/66/all_groups/","ad_hoc_command_events":"/api/v1/hosts/66/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/23/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":23,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.255Z","modified":"2016-10-12T18:19:16.059Z","name":"jwong-esxi3","description":"imported","inventory":2,"enabled":true,"instance_id":"420c690c-26c8-fcd1-7413-18cea5be066a","variables":"{\"vmware_privateMemory\":
+        2711, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.20\",
+        \"vmware_guestMemoryUsage\": 122, \"vmware_overallCpuUsage\": 311, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"VMware
+        ESXi 6.0\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 55,
+        \"vmware_hostName\": \"jwong-esxi3\", \"vmware_instanceUuid\": \"500c0d0e-fecc-c475-abab-aa20ca89766f\",
+        \"vmware_distributedCpuEntitlement\": 359, \"ansible_ssh_host\": \"10.8.97.20\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 179442, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-esxi3/jwong-esxi3.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 12459, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"420c690c-26c8-fcd1-7413-18cea5be066a\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 5112921036, \"vmware_name\": \"jwong-esxi3\",
+        \"vmware_toolsVersionStatus\": \"guestToolsCurrent\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 703558037504, \"vmware_hostMemoryUsage\":
+        3217, \"vmware_distributedMemoryEntitlement\": 1400, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        359, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"vmkernel6Guest\", \"vmware_numVirtualDisks\": 3, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 12288, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 5111567925, \"vmware_sharedMemory\": 3003}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":23},{"id":67,"type":"host","url":"/api/v1/hosts/67/","related":{"job_host_summaries":"/api/v1/hosts/67/job_host_summaries/","variable_data":"/api/v1/hosts/67/variable_data/","job_events":"/api/v1/hosts/67/job_events/","ad_hoc_commands":"/api/v1/hosts/67/ad_hoc_commands/","fact_versions":"/api/v1/hosts/67/fact_versions/","inventory_sources":"/api/v1/hosts/67/inventory_sources/","groups":"/api/v1/hosts/67/groups/","activity_stream":"/api/v1/hosts/67/activity_stream/","all_groups":"/api/v1/hosts/67/all_groups/","ad_hoc_command_events":"/api/v1/hosts/67/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/17/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":17,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.261Z","modified":"2016-10-12T18:19:16.063Z","name":"jwong-upstream-appliance","description":"imported","inventory":2,"enabled":true,"instance_id":"420c32cb-14a8-01b1-af26-ff5f1fd26d72","variables":"{\"vmware_vmPathName\":
+        \"[datastore1] jwong-upstream-appliance/jwong-upstream-appliance.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.217\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 23, \"ansible_ssh_host\": \"10.8.99.217\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 43168825344, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8290, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c32cb-14a8-01b1-af26-ff5f1fd26d72\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        42730521445, \"vmware_distributedMemoryEntitlement\": 2329, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 23, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 265, \"vmware_privateMemory\": 7927, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        23, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"upstream\", \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\":
+        492533, \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c712a-265f-f2ac-0852-e303cca74dd7\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 60555090158,
+        \"vmware_name\": \"jwong-upstream-appliance\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        8021, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
+        \"vmware_guestId\": \"rhel6_64Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_ftLatencyStatus\": \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":17},{"id":68,"type":"host","url":"/api/v1/hosts/68/","related":{"job_host_summaries":"/api/v1/hosts/68/job_host_summaries/","variable_data":"/api/v1/hosts/68/variable_data/","job_events":"/api/v1/hosts/68/job_events/","ad_hoc_commands":"/api/v1/hosts/68/ad_hoc_commands/","fact_versions":"/api/v1/hosts/68/fact_versions/","inventory_sources":"/api/v1/hosts/68/inventory_sources/","groups":"/api/v1/hosts/68/groups/","activity_stream":"/api/v1/hosts/68/activity_stream/","all_groups":"/api/v1/hosts/68/all_groups/","ad_hoc_command_events":"/api/v1/hosts/68/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/30/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":30,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.266Z","modified":"2016-10-12T18:19:16.068Z","name":"jwong-vc60","description":"imported","inventory":2,"enabled":true,"instance_id":"4200d0fa-6745-a0d3-a17b-532947ec7453","variables":"{\"vmware_privateMemory\":
+        16172, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.17\",
+        \"vmware_guestMemoryUsage\": 2129, \"vmware_overallCpuUsage\": 1247, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"SUSE
+        Linux Enterprise 11 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 79,
+        \"vmware_hostName\": \"jwong-vc60\", \"vmware_instanceUuid\": \"500015cd-2d52-00b9-d3ec-2c93dd0ef9d3\",
+        \"vmware_distributedCpuEntitlement\": 863, \"ansible_ssh_host\": \"10.8.97.17\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 178410, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-vc60/jwong-vc60.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 16523, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"4200d0fa-6745-a0d3-a17b-532947ec7453\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 17482467517, \"vmware_name\": \"jwong-vc60\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 153664905216, \"vmware_hostMemoryUsage\":
+        16302, \"vmware_distributedMemoryEntitlement\": 6075, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        1343, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\": \"sles11_64Guest\",
+        \"vmware_numVirtualDisks\": 11, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"VMware vCenter Server Appliance\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 17480169426, \"vmware_sharedMemory\": 206}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":30},{"id":1,"type":"host","url":"/api/v1/hosts/1/","related":{"created_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/1/job_host_summaries/","variable_data":"/api/v1/hosts/1/variable_data/","job_events":"/api/v1/hosts/1/job_events/","ad_hoc_commands":"/api/v1/hosts/1/ad_hoc_commands/","fact_versions":"/api/v1/hosts/1/fact_versions/","inventory_sources":"/api/v1/hosts/1/inventory_sources/","groups":"/api/v1/hosts/1/groups/","activity_stream":"/api/v1/hosts/1/activity_stream/","all_groups":"/api/v1/hosts/1/all_groups/","ad_hoc_command_events":"/api/v1/hosts/1/ad_hoc_command_events/","inventory":"/api/v1/inventories/1/","last_job":"/api/v1/jobs/103/","last_job_host_summary":"/api/v1/job_host_summaries/50/"},"summary_fields":{"last_job":{"id":103,"name":"bd-test","description":"","finished":"2017-02-06T15:07:19.588Z","status":"successful","failed":false,"job_template_id":30,"job_template_name":"bd-test"},"last_job_host_summary":{"id":50,"failed":false},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"recent_jobs":[{"status":"successful","finished":"2017-02-06T15:07:19.588Z","id":103,"name":"bd-test"},{"status":"successful","finished":"2016-11-30T16:28:21.612Z","id":69,"name":"bd-test"},{"status":"successful","finished":"2016-11-29T22:14:40.790Z","id":67,"name":"bd-test"},{"status":"successful","finished":"2016-11-29T22:10:39.315Z","id":63,"name":"bd-test"},{"status":"successful","finished":"2016-11-29T21:56:23.738Z","id":61,"name":"bd-test"}]},"created":"2016-08-02T17:57:03.207Z","modified":"2017-02-06T15:07:19.490Z","name":"localhost","description":"","inventory":1,"enabled":true,"instance_id":"","variables":"ansible_connection:
+        local","has_active_failures":false,"has_inventory_sources":false,"last_job":103,"last_job_host_summary":50},{"id":84,"type":"host","url":"/api/v1/hosts/84/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","job_host_summaries":"/api/v1/hosts/84/job_host_summaries/","variable_data":"/api/v1/hosts/84/variable_data/","job_events":"/api/v1/hosts/84/job_events/","ad_hoc_commands":"/api/v1/hosts/84/ad_hoc_commands/","fact_versions":"/api/v1/hosts/84/fact_versions/","inventory_sources":"/api/v1/hosts/84/inventory_sources/","groups":"/api/v1/hosts/84/groups/","activity_stream":"/api/v1/hosts/84/activity_stream/","all_groups":"/api/v1/hosts/84/all_groups/","ad_hoc_command_events":"/api/v1/hosts/84/ad_hoc_command_events/","inventory":"/api/v1/inventories/6/"},"summary_fields":{"inventory":{"id":6,"name":"acme-corp","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"recent_jobs":[]},"created":"2017-01-30T11:28:59.770Z","modified":"2017-01-30T11:28:59.770Z","name":"localhost","description":"","inventory":6,"enabled":true,"instance_id":"","variables":"","has_active_failures":false,"has_inventory_sources":false,"last_job":null,"last_job_host_summary":null},{"id":69,"type":"host","url":"/api/v1/hosts/69/","related":{"job_host_summaries":"/api/v1/hosts/69/job_host_summaries/","variable_data":"/api/v1/hosts/69/variable_data/","job_events":"/api/v1/hosts/69/job_events/","ad_hoc_commands":"/api/v1/hosts/69/ad_hoc_commands/","fact_versions":"/api/v1/hosts/69/fact_versions/","inventory_sources":"/api/v1/hosts/69/inventory_sources/","groups":"/api/v1/hosts/69/groups/","activity_stream":"/api/v1/hosts/69/activity_stream/","all_groups":"/api/v1/hosts/69/all_groups/","ad_hoc_command_events":"/api/v1/hosts/69/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.271Z","modified":"2016-08-31T16:59:43.596Z","name":"lucy_54","description":"imported","inventory":2,"enabled":false,"instance_id":"423307de-ccba-3188-0634-98b295a90aa0","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
+        \"dhcp-8-99-217.example.com\", \"vmware_instanceUuid\":
         \"5033aca6-0e5d-31f7-5921-bf61a3eee024\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] lucy_54/lucy_54.vmx\", \"vmware_guestState\":
         \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
         \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
         4, \"vmware_uuid\": \"423307de-ccba-3188-0634-98b295a90aa0\", \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 8020532055, \"vmware_name\": \"lucy_54\", \"vmware_toolsVersionStatus\":
+        false, \"vmware_committed\": 8243838877, \"vmware_name\": \"lucy_54\", \"vmware_toolsVersionStatus\":
         \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        41568129024, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        41344778240, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
         0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
         \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
         false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
@@ -3628,170 +2245,115 @@ http_interactions:
         \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
         -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
         \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
-        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 8019210767,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 169, "type":
-        "host", "url": "/api/v1/hosts/169/", "related": {"job_host_summaries": "/api/v1/hosts/169/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/169/variable_data/", "job_events": "/api/v1/hosts/169/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/169/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/169/fact_versions/", "inventory_sources": "/api/v1/hosts/169/inventory_sources/",
-        "groups": "/api/v1/hosts/169/groups/", "activity_stream": "/api/v1/hosts/169/activity_stream/",
-        "all_groups": "/api/v1/hosts/169/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/169/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/385/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.851Z",
-        "modified": "2016-05-25T15:12:39.192Z", "name": "lucy_55", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c6c6b-0e6b-f635-b33d-4ce792262eab",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500ccd96-d452-5ea8-12c8-ccab11650f84\", \"vmware_distributedCpuEntitlement\":
-        599, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
-        6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
-        996, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        12288, \"vmware_overallCpuUsage\": 959, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_committed\": 26933273320, \"vmware_product_vendor\": \"Red Hat, Inc.\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"lucy_55\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 1315,
-        \"vmware_overallCpuDemand\": 983, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        49, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
-        lucy_55/lucy_55.vmx\", \"vmware_ipAddress\": \"10.8.99.206\", \"vmware_guestMemoryUsage\":
-        860, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
-        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
-        \"vmware_product_key\": 0, \"vmware_unshared\": 26931889181, \"vmware_staticMemoryEntitlement\":
-        12409, \"ansible_ssh_host\": \"10.8.99.206\", \"vmware_uuid\": \"420c6c6b-0e6b-f635-b33d-4ce792262eab\",
-        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 112654548992,
-        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 103, \"vmware_privateMemory\": 1249,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
-        CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
-        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
-        \"dhcp-8-99-206.example.com\", \"vmware_uptimeSeconds\":
-        87816, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
-        false, \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
-        true, "has_inventory_sources": true, "last_job": 362, "last_job_host_summary":
-        385}, {"id": 271, "type": "host", "url": "/api/v1/hosts/271/", "related":
-        {"job_host_summaries": "/api/v1/hosts/271/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/271/variable_data/", "job_events": "/api/v1/hosts/271/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/271/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/271/fact_versions/", "inventory_sources": "/api/v1/hosts/271/inventory_sources/",
-        "groups": "/api/v1/hosts/271/groups/", "activity_stream": "/api/v1/hosts/271/activity_stream/",
-        "all_groups": "/api/v1/hosts/271/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/271/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.649Z", "modified":
-        "2016-05-25T14:07:46.779Z", "name": "lucy_master_0510", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cce02-b9e7-e67d-16af-048223923a60",
-        "variables": "{\"vmware_vmPathName\": \"[datastore1] lucy_master_0510/lucy_master_0510.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
-        \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960, \"vmware_guestState\":
-        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
-        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
-        \"420cce02-b9e7-e67d-16af-048223923a60\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 6637666814, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
-        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
-        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-243.example.com\",
-        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        6144, \"vmware_instanceUuid\": \"500c7cd8-567f-505f-afbf-4e99fe7ad0fc\", \"vmware_compressedMemory\":
-        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 42949874014, \"vmware_name\": \"lucy_master_0510\",
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 8242561551, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":70,"type":"host","url":"/api/v1/hosts/70/","related":{"job_host_summaries":"/api/v1/hosts/70/job_host_summaries/","variable_data":"/api/v1/hosts/70/variable_data/","job_events":"/api/v1/hosts/70/job_events/","ad_hoc_commands":"/api/v1/hosts/70/ad_hoc_commands/","fact_versions":"/api/v1/hosts/70/fact_versions/","inventory_sources":"/api/v1/hosts/70/inventory_sources/","groups":"/api/v1/hosts/70/groups/","activity_stream":"/api/v1/hosts/70/activity_stream/","all_groups":"/api/v1/hosts/70/all_groups/","ad_hoc_command_events":"/api/v1/hosts/70/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/24/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":24,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.277Z","modified":"2016-10-12T18:19:16.072Z","name":"lucy_555","description":"imported","inventory":2,"enabled":true,"instance_id":"420cfba0-7cc5-212e-3c27-b30eab582690","variables":"{\"vmware_vmPathName\":
+        \"[datastore1] Red Hat CloudForms 4.0/Red Hat CloudForms 4.0.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.207\", \"vmware_guestMemoryUsage\": 2048, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 143, \"ansible_ssh_host\": \"10.8.99.207\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 47244640256, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 8290, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420cfba0-7cc5-212e-3c27-b30eab582690\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"4.0\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\": 1016,
+        \"vmware_distributedMemoryEntitlement\": 3738, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 143, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 48, \"vmware_privateMemory\": 5982, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_overallCpuUsage\":
+        143, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"lucy_555\", \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\":
+        675007, \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c0810-9110-2ffc-4aa3-a93c41decac1\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 56030903778,
+        \"vmware_name\": \"lucy_555\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 6041, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
         -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel6_64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 272, "type": "host", "url": "/api/v1/hosts/272/",
-        "related": {"job_host_summaries": "/api/v1/hosts/272/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/272/variable_data/", "job_events": "/api/v1/hosts/272/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/272/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/272/fact_versions/", "inventory_sources": "/api/v1/hosts/272/inventory_sources/",
-        "groups": "/api/v1/hosts/272/groups/", "activity_stream": "/api/v1/hosts/272/activity_stream/",
-        "all_groups": "/api/v1/hosts/272/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/272/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.654Z", "modified":
-        "2016-05-25T15:12:39.204Z", "name": "miq-brewery7", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cb39d-8c47-fd77-3672-e84d63604f8f",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] miq-brewery7_1/miq-brewery7.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
-        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
-        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
-        \"500c4a95-c6da-e132-efca-11d761282a1c\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 131398219477, \"vmware_guestState\": \"notRunning\",
-        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
-        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420cb39d-8c47-fd77-3672-e84d63604f8f\",
-        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 167677181952, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
-        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"miq-brewery7\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
-        16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
-        false, \"vmware_committed\": 131398900717, \"vmware_name\": \"miq-brewery7\",
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 273, "type": "host", "url": "/api/v1/hosts/273/",
-        "related": {"job_host_summaries": "/api/v1/hosts/273/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/273/variable_data/", "job_events": "/api/v1/hosts/273/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/273/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/273/fact_versions/", "inventory_sources": "/api/v1/hosts/273/inventory_sources/",
-        "groups": "/api/v1/hosts/273/groups/", "activity_stream": "/api/v1/hosts/273/activity_stream/",
-        "all_groups": "/api/v1/hosts/273/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/273/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.659Z", "modified":
-        "2016-05-25T14:07:46.788Z", "name": "mk_centos_7.1", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cf912-fa6d-95ba-eeb8-1f2fc764f296",
-        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 54, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":24},{"id":71,"type":"host","url":"/api/v1/hosts/71/","related":{"job_host_summaries":"/api/v1/hosts/71/job_host_summaries/","variable_data":"/api/v1/hosts/71/variable_data/","job_events":"/api/v1/hosts/71/job_events/","ad_hoc_commands":"/api/v1/hosts/71/ad_hoc_commands/","fact_versions":"/api/v1/hosts/71/fact_versions/","inventory_sources":"/api/v1/hosts/71/inventory_sources/","groups":"/api/v1/hosts/71/groups/","activity_stream":"/api/v1/hosts/71/activity_stream/","all_groups":"/api/v1/hosts/71/all_groups/","ad_hoc_command_events":"/api/v1/hosts/71/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/10/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":10,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.282Z","modified":"2016-10-12T18:19:16.077Z","name":"lucy_561","description":"imported","inventory":2,"enabled":true,"instance_id":"420c1de8-2029-ebf4-2d4d-2dd9a7a9d095","variables":"{\"vmware_vmPathName\":
+        \"[datastore1] Red Hat CloudForms 4.1 Nightly/Red Hat CloudForms 4.1 Nightly.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.215\", \"vmware_guestMemoryUsage\": 2949,
+        \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat
+        Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 359,
+        \"ansible_ssh_host\": \"10.8.99.215\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        47244640256, \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\":
+        8311, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c1de8-2029-ebf4-2d4d-2dd9a7a9d095\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.1-nightly\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_uncommitted\": 1024, \"vmware_distributedMemoryEntitlement\":
+        4361, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        359, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        61, \"vmware_privateMemory\": 6665, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_product_name\": \"Red Hat CloudForms 4.1 Nightly\", \"vmware_overallCpuUsage\":
+        335, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"lucy-56\", \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\":
+        682954, \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500ce219-3a39-5af8-3c81-f0f14241c3fc\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 56030904194,
+        \"vmware_name\": \"lucy_561\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 6728, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 55, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":10},{"id":72,"type":"host","url":"/api/v1/hosts/72/","related":{"job_host_summaries":"/api/v1/hosts/72/job_host_summaries/","variable_data":"/api/v1/hosts/72/variable_data/","job_events":"/api/v1/hosts/72/job_events/","ad_hoc_commands":"/api/v1/hosts/72/ad_hoc_commands/","fact_versions":"/api/v1/hosts/72/fact_versions/","inventory_sources":"/api/v1/hosts/72/inventory_sources/","groups":"/api/v1/hosts/72/groups/","activity_stream":"/api/v1/hosts/72/activity_stream/","all_groups":"/api/v1/hosts/72/all_groups/","ad_hoc_command_events":"/api/v1/hosts/72/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/12/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":12,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.287Z","modified":"2016-10-12T18:19:16.081Z","name":"miq-brewery7","description":"imported","inventory":2,"enabled":true,"instance_id":"420cb39d-8c47-fd77-3672-e84d63604f8f","variables":"{\"vmware_privateMemory\":
+        1816, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.15\",
         \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
         0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
         4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 49,
+        \"vmware_hostName\": \"miq-brewery7\", \"vmware_instanceUuid\": \"500c4a95-c6da-e132-efca-11d761282a1c\",
+        \"vmware_distributedCpuEntitlement\": 23, \"ansible_ssh_host\": \"10.8.97.15\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 91299, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] miq-brewery7_1/miq-brewery7.vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16594,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 4, \"vmware_uuid\": \"420cb39d-8c47-fd77-3672-e84d63604f8f\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 131529230537,
+        \"vmware_name\": \"miq-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        150193582080, \"vmware_hostMemoryUsage\": 1871, \"vmware_distributedMemoryEntitlement\":
+        833, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        1431, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"CentOS 7.2 ImageFactory VM\", \"vmware_maxMemoryUsage\":
+        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 131528189653,
+        \"vmware_sharedMemory\": 110}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":12},{"id":73,"type":"host","url":"/api/v1/hosts/73/","related":{"job_host_summaries":"/api/v1/hosts/73/job_host_summaries/","variable_data":"/api/v1/hosts/73/variable_data/","job_events":"/api/v1/hosts/73/job_events/","ad_hoc_commands":"/api/v1/hosts/73/ad_hoc_commands/","fact_versions":"/api/v1/hosts/73/fact_versions/","inventory_sources":"/api/v1/hosts/73/inventory_sources/","groups":"/api/v1/hosts/73/groups/","activity_stream":"/api/v1/hosts/73/activity_stream/","all_groups":"/api/v1/hosts/73/all_groups/","ad_hoc_command_events":"/api/v1/hosts/73/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.293Z","modified":"2016-08-31T16:59:43.614Z","name":"mk_centos_7.1","description":"imported","inventory":2,"enabled":false,"instance_id":"420cf912-fa6d-95ba-eeb8-1f2fc764f296","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
         0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
         \"vmware_instanceUuid\": \"500cc24a-4e94-db0f-b6e3-e0c162ec4cf8\", \"vmware_distributedCpuEntitlement\":
         0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
         0, \"vmware_vmPathName\": \"[NFS Share] mk_centos_7.1/mk_centos_7.1.vmtx\",
@@ -3809,684 +2371,166 @@ http_interactions:
         -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
         \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
         null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1655067175,
-        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 199, "type":
-        "host", "url": "/api/v1/hosts/199/", "related": {"job_host_summaries": "/api/v1/hosts/199/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/199/variable_data/", "job_events": "/api/v1/hosts/199/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/199/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/199/fact_versions/", "inventory_sources": "/api/v1/hosts/199/inventory_sources/",
-        "groups": "/api/v1/hosts/199/groups/", "activity_stream": "/api/v1/hosts/199/activity_stream/",
-        "all_groups": "/api/v1/hosts/199/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/199/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-18T20:26:31.055Z", "modified":
-        "2016-05-25T15:12:39.211Z", "name": "nc-ManageIQ-pglogical-region-0", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c6f1b-69c3-fd1a-6f41-3f401d7d997f",
-        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
-        \"vmware_instanceUuid\": \"500cac6d-7b48-989b-6726-287430e099c1\", \"vmware_distributedCpuEntitlement\":
-        215, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
-        \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
-        3338, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        6144, \"vmware_overallCpuUsage\": 191, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"ManageIQ\",
-        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
-        \"nc-ManageIQ-pglogical-region-0\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        6034, \"vmware_overallCpuDemand\": 215, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
-        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
-        nc-ManageIQ-pglogical-region-0/nc-ManageIQ-pglogical-region-0.vmx\", \"vmware_ipAddress\":
-        \"10.8.99.201\", \"vmware_guestMemoryUsage\": 1843, \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
-        \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.201\", \"vmware_product_key\":
-        0, \"vmware_unshared\": 8055160832, \"vmware_staticMemoryEntitlement\": 6240,
-        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_uuid\": \"420c6f1b-69c3-fd1a-6f41-3f401d7d997f\",
-        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 39626736529,
-        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 38, \"vmware_privateMemory\": 5976,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
-        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
-        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-201.example.com\",
-        \"vmware_uptimeSeconds\": 3444440, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
-        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 21146166772,
-        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
-        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
-        true, "last_job": null, "last_job_host_summary": null}, {"id": 170, "type":
-        "host", "url": "/api/v1/hosts/170/", "related": {"job_host_summaries": "/api/v1/hosts/170/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/170/variable_data/", "job_events": "/api/v1/hosts/170/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/170/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/170/fact_versions/", "inventory_sources": "/api/v1/hosts/170/inventory_sources/",
-        "groups": "/api/v1/hosts/170/groups/", "activity_stream": "/api/v1/hosts/170/activity_stream/",
-        "all_groups": "/api/v1/hosts/170/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/170/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/382/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.856Z",
-        "modified": "2016-05-25T15:12:39.219Z", "name": "nick-brewery", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] nick-brewery/nick-brewery.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.4\", \"vmware_guestMemoryUsage\": 163, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"50333f3f-9b3e-2e1f-d937-062b14098cde\", \"vmware_distributedCpuEntitlement\":
-        71, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 78089892376,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16602,
-        \"ansible_ssh_host\": \"10.8.97.4\", \"vmware_overallStatus\": \"green\",
-        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 3674, \"vmware_uncommitted\":
-        7809454080, \"vmware_distributedMemoryEntitlement\": 3863, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 71, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"CentOS 7.1 ImageFactory
-        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 3758, \"vmware_privateMemory\": 12626, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 71, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"nick-brewery\", \"vmware_uptimeSeconds\": 1119750,
-        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 78377753305,
-        \"vmware_name\": \"nick-brewery\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 12965, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 109, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 382}, {"id": 171, "type": "host", "url": "/api/v1/hosts/171/",
-        "related": {"job_host_summaries": "/api/v1/hosts/171/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/171/variable_data/", "job_events": "/api/v1/hosts/171/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/171/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/171/fact_versions/", "inventory_sources": "/api/v1/hosts/171/inventory_sources/",
-        "groups": "/api/v1/hosts/171/groups/", "activity_stream": "/api/v1/hosts/171/activity_stream/",
-        "all_groups": "/api/v1/hosts/171/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/171/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/384/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
-        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.861Z",
-        "modified": "2016-05-25T15:12:39.231Z", "name": "satoe-brewery", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "564d25c2-cb51-9434-f647-3ff92cf69192",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] kegerator2/kegerator2.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.6\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Fedora (64-bit)\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
-        \"vmware_instanceUuid\": \"52833b35-2412-2a35-07cb-b5cc79030220\", \"vmware_distributedCpuEntitlement\":
-        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 129356300796,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16605,
-        \"ansible_ssh_host\": \"10.8.97.6\", \"vmware_overallStatus\": \"green\",
-        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"564d25c2-cb51-9434-f647-3ff92cf69192\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\":
-        0, \"vmware_distributedMemoryEntitlement\": 5183, \"vmware_template\": false,
-        \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
-        1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
-        \"inactive\", \"vmware_sharedMemory\": 1693, \"vmware_privateMemory\": 14691,
-        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
-        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
-        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_hostName\": \"satoe-brewery\", \"vmware_uptimeSeconds\": 5136,
-        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 129357552145,
-        \"vmware_name\": \"satoe-brewery\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 15706, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
-        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"fedora64Guest\",
-        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 98, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        362, "last_job_host_summary": 384}, {"id": 172, "type": "host", "url": "/api/v1/hosts/172/",
-        "related": {"job_host_summaries": "/api/v1/hosts/172/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/172/variable_data/", "job_events": "/api/v1/hosts/172/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/172/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/172/fact_versions/", "inventory_sources": "/api/v1/hosts/172/inventory_sources/",
-        "groups": "/api/v1/hosts/172/groups/", "activity_stream": "/api/v1/hosts/172/activity_stream/",
-        "all_groups": "/api/v1/hosts/172/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/172/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/390/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
-        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
-        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
-        "description": "", "has_active_failures": true, "total_hosts": 69, "hosts_with_active_failures":
-        8, "total_groups": 23, "groups_with_active_failures": 14, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
-        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
-        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
-        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
-        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.866Z",
-        "modified": "2016-05-25T15:12:39.243Z", "name": "satoe-build-rhel72", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c776f-d431-d0da-4fe9-8a2a227695ae",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] satoe-build-rhel72/satoe-build-rhel72.vmx\",
-        \"vmware_ipAddress\": \"10.8.97.10\", \"vmware_guestMemoryUsage\": 102, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
-        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"500caa77-7289-699f-af4c-bbe8fc840dd3\", \"vmware_distributedCpuEntitlement\":
-        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 16884781933,
-        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 2107,
-        \"ansible_ssh_host\": \"10.8.97.10\", \"vmware_overallStatus\": \"green\",
-        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
-        \"420c776f-d431-d0da-4fe9-8a2a227695ae\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 922, \"vmware_uncommitted\":
-        10695749632, \"vmware_distributedMemoryEntitlement\": 820, \"vmware_template\":
-        false, \"vmware_overallCpuDemand\": 95, \"vmware_ftSecondaryLatency\": -1,
-        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        438, \"vmware_privateMemory\": 1488, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 71, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"satoe-cfme-build\",
-        \"vmware_uptimeSeconds\": 87520, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        16885965563, \"vmware_name\": \"satoe-build-rhel72\", \"vmware_toolsVersionStatus\":
-        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        1742, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 33, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": true, "has_inventory_sources": true, "last_job": 362,
-        "last_job_host_summary": 390}, {"id": 173, "type": "host", "url": "/api/v1/hosts/173/",
-        "related": {"job_host_summaries": "/api/v1/hosts/173/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/173/variable_data/", "job_events": "/api/v1/hosts/173/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/173/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/173/fact_versions/", "inventory_sources": "/api/v1/hosts/173/inventory_sources/",
-        "groups": "/api/v1/hosts/173/groups/", "activity_stream": "/api/v1/hosts/173/activity_stream/",
-        "all_groups": "/api/v1/hosts/173/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/173/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.871Z", "modified":
-        "2016-04-28T14:28:03.388Z", "name": "test_billya", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "420cb94b-3d65-86a5-ca7e-f3c7c0c6c716",
-        "variables": "{\"vmware_vmPathName\": \"[datastore1] test_billya/test_billya.vmx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host1.example.com\",
-        \"vmware_instanceUuid\": \"500c9705-7ea2-615e-32b4-66a487142f26\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 24117248, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_suspendInterval\":
-        0, \"vmware_uuid\": \"420cb94b-3d65-86a5-ca7e-f3c7c0c6c716\", \"vmware_guestFullName\":
-        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        0, \"vmware_uncommitted\": 19495289331, \"vmware_distributedMemoryEntitlement\":
-        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"Owner: w w\\nEmail:
-        wfitzger@redhat.com\\nSource: ag_rhel7_template\\n\\nMIQ GUID=49daff48-f750-11e5-8377-f45c898c7d55\",
-        \"vmware_maxMemoryUsage\": 877, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
-        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
-        \"vmware_maxCpuUsage\": 2400, \"vmware_committed\": 24275974, \"vmware_numEthernetCards\":
-        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
-        0, \"vmware_name\": \"test_billya\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":74,"type":"host","url":"/api/v1/hosts/74/","related":{"job_host_summaries":"/api/v1/hosts/74/job_host_summaries/","variable_data":"/api/v1/hosts/74/variable_data/","job_events":"/api/v1/hosts/74/job_events/","ad_hoc_commands":"/api/v1/hosts/74/ad_hoc_commands/","fact_versions":"/api/v1/hosts/74/fact_versions/","inventory_sources":"/api/v1/hosts/74/inventory_sources/","groups":"/api/v1/hosts/74/groups/","activity_stream":"/api/v1/hosts/74/activity_stream/","all_groups":"/api/v1/hosts/74/all_groups/","ad_hoc_command_events":"/api/v1/hosts/74/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.298Z","modified":"2016-08-31T16:59:43.619Z","name":"nc-cfme-db-primary","description":"imported","inventory":2,"enabled":false,"instance_id":"420ca140-7057-a964-ad7a-f9fb51e3c8e9","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] nc-cfme-db-primary/nc-cfme-db-primary.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4635002055, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420ca140-7057-a964-ad7a-f9fb51e3c8e9\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.1-rc2.1-nightly\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 49385975808, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 RC2.1 Nightly\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-239.example.com\",
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c7825-5f67-1c20-df2e-a274ec4ee74c\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 21834913162,
+        \"vmware_name\": \"nc-cfme-db-primary\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
         \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
         \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
         \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
         \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 274, "type": "host", "url": "/api/v1/hosts/274/",
-        "related": {"job_host_summaries": "/api/v1/hosts/274/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/274/variable_data/", "job_events": "/api/v1/hosts/274/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/274/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/274/fact_versions/", "inventory_sources": "/api/v1/hosts/274/inventory_sources/",
-        "groups": "/api/v1/hosts/274/groups/", "activity_stream": "/api/v1/hosts/274/activity_stream/",
-        "all_groups": "/api/v1/hosts/274/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/274/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/558/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/446/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
-        "finished": "2016-05-25T15:13:03.777Z", "status": "successful", "failed":
-        false, "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
-        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": [{"status": "successful", "finished": "2016-05-25T15:13:03.777Z",
-        "id": 558, "name": "PackageInfo"}, {"status": "successful", "finished": "2016-05-25T14:24:43.803Z",
-        "id": 550, "name": "PackageInfo"}, {"status": "successful", "finished": "2016-05-25T14:20:35.466Z",
-        "id": 548, "name": "PackageInfo"}, {"status": "successful", "finished": "2016-05-25T14:18:22.686Z",
-        "id": 546, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.664Z",
-        "modified": "2016-05-25T15:13:03.518Z", "name": "test_mkanoor_05_24_16", "description":
-        "imported", "inventory": 17, "enabled": true, "instance_id": "420c358a-4428-baab-205d-9b654d541cca",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] test_mkanoor_05_24_16/test_mkanoor_05_24_16.vmx\",
-        \"vmware_ipAddress\": \"10.8.99.237\", \"vmware_guestMemoryUsage\": 20, \"vmware_networks\":
-        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":75,"type":"host","url":"/api/v1/hosts/75/","related":{"job_host_summaries":"/api/v1/hosts/75/job_host_summaries/","variable_data":"/api/v1/hosts/75/variable_data/","job_events":"/api/v1/hosts/75/job_events/","ad_hoc_commands":"/api/v1/hosts/75/ad_hoc_commands/","fact_versions":"/api/v1/hosts/75/fact_versions/","inventory_sources":"/api/v1/hosts/75/inventory_sources/","groups":"/api/v1/hosts/75/groups/","activity_stream":"/api/v1/hosts/75/activity_stream/","all_groups":"/api/v1/hosts/75/all_groups/","ad_hoc_command_events":"/api/v1/hosts/75/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.303Z","modified":"2016-08-31T16:59:43.623Z","name":"nc-cfme-db-standby1","description":"imported","inventory":2,"enabled":false,"instance_id":"420c899f-a158-4b4f-2f78-33dc61399939","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] cfme-db-standby1/cfme-db-standby1.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
         0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
-        \"vmware_instanceUuid\": \"500c8890-1e81-8c04-3b95-d6ff3cc0d26c\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1885753903, \"vmware_guestState\":
-        \"running\", \"vmware_staticMemoryEntitlement\": 2097, \"ansible_ssh_host\":
-        \"10.8.99.237\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
-        \"intel-sandybridge\", \"vmware_uuid\": \"420c358a-4428-baab-205d-9b654d541cca\",
-        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
-        922, \"vmware_uncommitted\": 41063919616, \"vmware_distributedMemoryEntitlement\":
-        505, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        243, \"vmware_privateMemory\": 825, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4541588327, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c899f-a158-4b4f-2f78-33dc61399939\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.1-rc2.1-nightly\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 49399259136, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 RC2.1 Nightly\",
         \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
-        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-237.example.com\",
-        \"vmware_uptimeSeconds\": 62958, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        1885924841, \"vmware_name\": \"test_mkanoor_05_24_16\", \"vmware_toolsVersionStatus\":
-        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
-        971, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
-        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
-        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
-        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
-        0, \"vmware_consumedOverheadMemory\": 31, \"vmware_ftLatencyStatus\": \"gray\"}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": 558,
-        "last_job_host_summary": 446}, {"id": 210, "type": "host", "url": "/api/v1/hosts/210/",
-        "related": {"job_host_summaries": "/api/v1/hosts/210/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/210/variable_data/", "job_events": "/api/v1/hosts/210/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/210/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/210/fact_versions/", "inventory_sources": "/api/v1/hosts/210/inventory_sources/",
-        "groups": "/api/v1/hosts/210/groups/", "activity_stream": "/api/v1/hosts/210/activity_stream/",
-        "all_groups": "/api/v1/hosts/210/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/210/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-04-21T14:30:25.861Z", "modified":
-        "2016-04-28T14:45:56.036Z", "name": "test_vm_1x4", "description": "imported",
-        "inventory": 17, "enabled": true, "instance_id": "420c2925-2790-67f9-beeb-7d2ed5de734f",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] test_vm_1x4/test_vm_1x4.vmx\",
-        \"vmware_guestMemoryUsage\": 20, \"vmware_networks\": [\"NFS Network\"], \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"dell-r420-06.example.com\",
-        \"vmware_instanceUuid\": \"500c6ff6-7a41-5e91-a8b0-71eca5b6de00\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 1121436147, \"vmware_guestState\": \"notRunning\",
-        \"vmware_staticMemoryEntitlement\": 2141, \"vmware_toolsStatus\": \"toolsNotInstalled\",
-        \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"420c2925-2790-67f9-beeb-7d2ed5de734f\",
-        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
-        2720, \"vmware_uncommitted\": 16058433536, \"vmware_distributedMemoryEntitlement\":
-        807, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
-        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
-        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
-        0, \"vmware_privateMemory\": 2048, \"vmware_resourcePool\": \"Resources\",
-        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
-        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 8796, \"vmware_committed\":
-        1121924610, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 610379,
-        \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
-        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
-        \"vmware_name\": \"test_vm_1x4\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
-        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2089, \"vmware_connectionState\":
-        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
-        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_guestId\":
-        \"rhel7_64Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
-        41, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": false,
-        "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
-        null}, {"id": 146, "type": "host", "url": "/api/v1/hosts/146/", "related":
-        {"job_host_summaries": "/api/v1/hosts/146/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/146/variable_data/", "job_events": "/api/v1/hosts/146/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/146/ad_hoc_commands/", "fact_versions":
-        "/api/v1/hosts/146/fact_versions/", "inventory_sources": "/api/v1/hosts/146/inventory_sources/",
-        "groups": "/api/v1/hosts/146/groups/", "activity_stream": "/api/v1/hosts/146/activity_stream/",
-        "all_groups": "/api/v1/hosts/146/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/146/ad_hoc_command_events/",
-        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.732Z", "modified":
-        "2016-05-25T14:07:45.494Z", "name": "Win2k12DC-template", "description": "imported",
-        "inventory": 17, "enabled": false, "instance_id": "423384ab-4d40-9997-ccd9-e490e8807bc5",
-        "variables": "{\"vmware_vmPathName\": \"[NFS Share] dev-scvmm2k12.vmtx\",
-        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM NFS Network\"],
-        \"vmware_guestFullName\": \"Microsoft Windows Server 2012 (64-bit)\", \"vmware_balloonedMemory\":
-        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
-        \"vmware_instanceUuid\": \"50334b93-08e7-f25e-8da0-dc969e6d675e\", \"vmware_distributedCpuEntitlement\":
-        0, \"vmware_unshared\": 0, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
-        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
-        \"green\", \"vmware_uuid\": \"423384ab-4d40-9997-ccd9-e490e8807bc5\", \"vmware_faultToleranceState\":
-        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
-        4488081408, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
-        true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
-        1, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
-        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
-        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
         false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
-        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
-        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_committed\":
-        2784, \"vmware_name\": \"Win2k12DC-template\", \"vmware_cpuReservation\":
-        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
-        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-223.example.com\",
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c3bb1-3ca0-b84e-49bc-716999210331\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 13142158361,
+        \"vmware_name\": \"nc-cfme-db-standby1\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
         \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
-        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"windows8Server64Guest\",
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
         \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
-        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
-        null, "last_job_host_summary": null}, {"id": 5, "type": "host", "url": "/api/v1/hosts/5/",
-        "related": {"job_host_summaries": "/api/v1/hosts/5/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/5/variable_data/", "job_events": "/api/v1/hosts/5/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/5/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/5/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/5/inventory_sources/", "groups": "/api/v1/hosts/5/groups/",
-        "activity_stream": "/api/v1/hosts/5/activity_stream/", "all_groups": "/api/v1/hosts/5/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/5/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.574Z",
-        "modified": "2015-12-17T22:13:19.027Z", "name": "bill3-cfme-my_instance-vuyhd7qvz6sk",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "aa3a2d28-e364-42ff-bdf4-7d6266c25d46", "variables": "{\"ansible_ssh_host\":
-        \"192.168.200.17\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"private_network\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:f1:ac:b0\",
-        \"version\": 4, \"addr\": \"192.168.200.17\", \"OS-EXT-IPS:type\": \"fixed\"}]},
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"private_network\": [\"192.168.200.17\"]}, \"OS-EXT-STS:vm_state\":
-        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-0000068e\", \"OS-SRV-USG:launched_at\":
-        \"2015-11-19T20:50:57.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"default\"}], \"public_v4\": null, \"progress\": 0, \"OS-EXT-STS:power_state\":
-        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
-        \"ACTIVE\", \"updated\": \"2015-11-19T20:50:57Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": \"userkey\", \"private_v4\": \"192.168.200.17\", \"interface_ip\":
-        \"192.168.200.17\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill3-cfme-my_instance-vuyhd7qvz6sk\", \"created\": \"2015-11-19T20:50:46Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill3-cfme-my_instance-vuyhd7qvz6sk\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 6, "type": "host", "url": "/api/v1/hosts/6/",
-        "related": {"job_host_summaries": "/api/v1/hosts/6/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/6/variable_data/", "job_events": "/api/v1/hosts/6/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/6/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/6/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/6/inventory_sources/", "groups": "/api/v1/hosts/6/groups/",
-        "activity_stream": "/api/v1/hosts/6/activity_stream/", "all_groups": "/api/v1/hosts/6/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/6/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.584Z",
-        "modified": "2015-12-17T22:13:19.034Z", "name": "bill422-1-my_instance-4uckqhihzclr",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "9b03b9fd-2aa6-45ab-be54-e44b82546bba", "variables": "{\"ansible_ssh_host\":
-        \"10.12.0.12\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:36:28:83\", \"version\":
-        4, \"addr\": \"10.12.0.12\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
-        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"public\": [\"10.12.0.12\"]}, \"OS-EXT-STS:vm_state\": \"active\",
-        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-0000065f\", \"OS-SRV-USG:launched_at\":
-        \"2015-04-20T19:31:59.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"default\"}], \"public_v4\": \"10.12.0.12\", \"progress\": 0, \"OS-EXT-STS:power_state\":
-        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
-        \"ACTIVE\", \"updated\": \"2015-04-20T19:31:59Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": null, \"private_v4\": \"10.12.0.12\", \"interface_ip\":
-        \"10.12.0.12\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill422-1-my_instance-4uckqhihzclr\", \"created\": \"2015-04-20T19:31:49Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-1-my_instance-4uckqhihzclr\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 7, "type": "host", "url": "/api/v1/hosts/7/",
-        "related": {"job_host_summaries": "/api/v1/hosts/7/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/7/variable_data/", "job_events": "/api/v1/hosts/7/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/7/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/7/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/7/inventory_sources/", "groups": "/api/v1/hosts/7/groups/",
-        "activity_stream": "/api/v1/hosts/7/activity_stream/", "all_groups": "/api/v1/hosts/7/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/7/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.592Z",
-        "modified": "2015-12-17T22:13:19.040Z", "name": "bill422-3-my_instance-eclvvn5h4loa",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "fac9c8eb-90e7-4d98-a608-78224925163c", "variables": "{\"ansible_ssh_host\":
-        \"10.12.0.13\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:d8:8d:77\", \"version\":
-        4, \"addr\": \"10.12.0.13\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
-        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/fac9c8eb-90e7-4d98-a608-78224925163c\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/fac9c8eb-90e7-4d98-a608-78224925163c\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"public\": [\"10.12.0.13\"]}, \"OS-EXT-STS:vm_state\": \"active\",
-        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000660\", \"OS-SRV-USG:launched_at\":
-        \"2015-04-22T18:14:15.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"fac9c8eb-90e7-4d98-a608-78224925163c\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"default\"}], \"public_v4\": \"10.12.0.13\", \"progress\": 0, \"OS-EXT-STS:power_state\":
-        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
-        \"ACTIVE\", \"updated\": \"2015-04-22T18:14:15Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": null, \"private_v4\": \"10.12.0.13\", \"interface_ip\":
-        \"10.12.0.13\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill422-3-my_instance-eclvvn5h4loa\", \"created\": \"2015-04-22T18:14:06Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-3-my_instance-eclvvn5h4loa\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 8, "type": "host", "url": "/api/v1/hosts/8/",
-        "related": {"job_host_summaries": "/api/v1/hosts/8/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/8/variable_data/", "job_events": "/api/v1/hosts/8/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/8/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/8/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/8/inventory_sources/", "groups": "/api/v1/hosts/8/groups/",
-        "activity_stream": "/api/v1/hosts/8/activity_stream/", "all_groups": "/api/v1/hosts/8/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/8/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.600Z",
-        "modified": "2015-12-17T22:13:19.046Z", "name": "bill422-4-my_instance-qsmfncoidcvb",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "f010f1a5-7b25-4aef-8cab-8f03784aca88", "variables": "{\"ansible_ssh_host\":
-        \"10.12.0.14\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:7f:08:c6\", \"version\":
-        4, \"addr\": \"10.12.0.14\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
-        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/f010f1a5-7b25-4aef-8cab-8f03784aca88\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/f010f1a5-7b25-4aef-8cab-8f03784aca88\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"public\": [\"10.12.0.14\"]}, \"OS-EXT-STS:vm_state\": \"active\",
-        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000661\", \"OS-SRV-USG:launched_at\":
-        \"2015-04-22T18:30:56.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"f010f1a5-7b25-4aef-8cab-8f03784aca88\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"default\"}], \"public_v4\": \"10.12.0.14\", \"progress\": 0, \"OS-EXT-STS:power_state\":
-        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
-        \"ACTIVE\", \"updated\": \"2015-04-22T18:30:56Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": null, \"private_v4\": \"10.12.0.14\", \"interface_ip\":
-        \"10.12.0.14\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill422-4-my_instance-qsmfncoidcvb\", \"created\": \"2015-04-22T18:30:47Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-4-my_instance-qsmfncoidcvb\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 9, "type": "host", "url": "/api/v1/hosts/9/",
-        "related": {"job_host_summaries": "/api/v1/hosts/9/job_host_summaries/", "variable_data":
-        "/api/v1/hosts/9/variable_data/", "job_events": "/api/v1/hosts/9/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/9/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/9/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/9/inventory_sources/", "groups": "/api/v1/hosts/9/groups/",
-        "activity_stream": "/api/v1/hosts/9/activity_stream/", "all_groups": "/api/v1/hosts/9/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/9/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.607Z",
-        "modified": "2015-12-17T22:13:19.053Z", "name": "bill529-1-my_instance-g3zhieqqax46",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "a864027e-f68a-40c8-b0df-3001e7e3710d", "variables": "{\"ansible_ssh_host\":
-        \"192.168.200.5\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"private_network\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:a0:43:1d\",
-        \"version\": 4, \"addr\": \"192.168.200.5\", \"OS-EXT-IPS:type\": \"fixed\"}]},
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/a864027e-f68a-40c8-b0df-3001e7e3710d\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/a864027e-f68a-40c8-b0df-3001e7e3710d\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"private_network\": [\"192.168.200.5\"]}, \"OS-EXT-STS:vm_state\":
-        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000676\", \"OS-SRV-USG:launched_at\":
-        \"2015-06-02T17:51:38.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"a864027e-f68a-40c8-b0df-3001e7e3710d\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"default\"}], \"public_v4\": null, \"progress\": 0, \"OS-EXT-STS:power_state\":
-        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
-        \"ACTIVE\", \"updated\": \"2015-06-02T17:51:38Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": \"userkey\", \"private_v4\": \"192.168.200.5\", \"interface_ip\":
-        \"192.168.200.5\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill529-1-my_instance-g3zhieqqax46\", \"created\": \"2015-06-02T17:51:29Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill529-1-my_instance-g3zhieqqax46\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 10, "type": "host", "url": "/api/v1/hosts/10/",
-        "related": {"job_host_summaries": "/api/v1/hosts/10/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/10/variable_data/", "job_events": "/api/v1/hosts/10/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/10/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/10/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/10/inventory_sources/", "groups": "/api/v1/hosts/10/groups/",
-        "activity_stream": "/api/v1/hosts/10/activity_stream/", "all_groups": "/api/v1/hosts/10/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/10/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
-        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
-        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
-        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.614Z",
-        "modified": "2015-12-17T22:13:19.059Z", "name": "bill817a-my_instance-vqrow5k5u5kj",
-        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
-        "dd21c2df-9f16-417f-9489-bae165cb5e05", "variables": "{\"ansible_ssh_host\":
-        \"10.0.0.7\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
-        {\"private\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:a7:8a:58\", \"version\":
-        4, \"addr\": \"10.0.0.7\", \"OS-EXT-IPS:type\": \"fixed\"}, {\"OS-EXT-IPS-MAC:mac_addr\":
-        \"fa:16:3e:a7:8a:58\", \"version\": 4, \"addr\": \"10.12.0.21\", \"OS-EXT-IPS:type\":
-        \"floating\"}]}, \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/dd21c2df-9f16-417f-9489-bae165cb5e05\",
-        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/dd21c2df-9f16-417f-9489-bae165cb5e05\",
-        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
-        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
-        \"networks\": {\"private\": [\"10.0.0.7\", \"10.12.0.21\"]}, \"OS-EXT-STS:vm_state\":
-        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000683\", \"OS-SRV-USG:launched_at\":
-        \"2015-08-17T02:43:32.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
-        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
-        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
-        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
-        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"dd21c2df-9f16-417f-9489-bae165cb5e05\",
-        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
-        \"web_server_security_group\"}], \"public_v4\": \"10.12.0.21\", \"progress\":
-        0, \"OS-EXT-STS:power_state\": 1, \"OS-EXT-AZ:availability_zone\": \"nova\",
-        \"config_drive\": \"\", \"status\": \"ACTIVE\", \"updated\": \"2015-08-17T02:43:32Z\",
-        \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
-        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
-        null, \"key_name\": \"userkey\", \"private_v4\": \"10.0.0.7\", \"interface_ip\":
-        \"10.0.0.7\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
-        \"name\": \"bill817a-my_instance-vqrow5k5u5kj\", \"created\": \"2015-08-17T02:43:22Z\",
-        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
-        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill817a-my_instance-vqrow5k5u5kj\"}}",
-        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
-        "last_job_host_summary": null}, {"id": 64, "type": "host", "url": "/api/v1/hosts/64/",
-        "related": {"created_by": "/api/v1/users/1/", "job_host_summaries": "/api/v1/hosts/64/job_host_summaries/",
-        "variable_data": "/api/v1/hosts/64/variable_data/", "job_events": "/api/v1/hosts/64/job_events/",
-        "ad_hoc_commands": "/api/v1/hosts/64/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/64/fact_versions/",
-        "inventory_sources": "/api/v1/hosts/64/inventory_sources/", "groups": "/api/v1/hosts/64/groups/",
-        "activity_stream": "/api/v1/hosts/64/activity_stream/", "all_groups": "/api/v1/hosts/64/all_groups/",
-        "ad_hoc_command_events": "/api/v1/hosts/64/ad_hoc_command_events/", "inventory":
-        "/api/v1/inventories/8/", "last_job": "/api/v1/jobs/172/", "last_job_host_summary":
-        "/api/v1/job_host_summaries/215/"}, "summary_fields": {"last_job_host_summary":
-        {"failed": true}, "last_job": {"name": "Install Httpd / Ruby Modules / Start
-        httpd", "description": "db", "finished": "2016-03-24T14:59:03.013Z", "status":
-        "failed", "failed": true, "job_template_id": 147, "job_template_name": "Install
-        Httpd / Ruby Modules / Start httpd"}, "inventory": {"name": "Single AWS Host",
-        "description": "54.86.210.90", "has_active_failures": true, "total_hosts":
-        1, "hosts_with_active_failures": 1, "total_groups": 0, "groups_with_active_failures":
-        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
-        0}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "recent_jobs": [{"status": "failed", "finished": "2016-03-24T14:59:03.013Z",
-        "id": 172, "name": "Install Httpd / Ruby Modules / Start httpd"}]}, "created":
-        "2016-02-01T19:40:08.824Z", "modified": "2016-03-24T14:59:02.929Z", "name":
-        "169.0.0.1", "description": "Test Host", "inventory": 8, "enabled": true,
-        "instance_id": "", "variables": "---", "has_active_failures": true, "has_inventory_sources":
-        false, "last_job": 172, "last_job_host_summary": 215}]}'
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":76,"type":"host","url":"/api/v1/hosts/76/","related":{"job_host_summaries":"/api/v1/hosts/76/job_host_summaries/","variable_data":"/api/v1/hosts/76/variable_data/","job_events":"/api/v1/hosts/76/job_events/","ad_hoc_commands":"/api/v1/hosts/76/ad_hoc_commands/","fact_versions":"/api/v1/hosts/76/fact_versions/","inventory_sources":"/api/v1/hosts/76/inventory_sources/","groups":"/api/v1/hosts/76/groups/","activity_stream":"/api/v1/hosts/76/activity_stream/","all_groups":"/api/v1/hosts/76/all_groups/","ad_hoc_command_events":"/api/v1/hosts/76/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.309Z","modified":"2016-08-31T16:59:43.628Z","name":"nc-cfme-db-standby2","description":"imported","inventory":2,"enabled":false,"instance_id":"420c7d82-dfcf-ff25-1fdb-d1ed2de9d289","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] nc-cfme-db-standby2_1/nc-cfme-db-standby2.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4497724272, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c7d82-dfcf-ff25-1fdb-d1ed2de9d289\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.1-rc2.1-nightly\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 49409482752, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 RC2.1 Nightly\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-215.example.com\",
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500c02aa-7f5c-e726-8425-7a1320c173e3\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 13097884125,
+        \"vmware_name\": \"nc-cfme-db-standby2\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":77,"type":"host","url":"/api/v1/hosts/77/","related":{"job_host_summaries":"/api/v1/hosts/77/job_host_summaries/","variable_data":"/api/v1/hosts/77/variable_data/","job_events":"/api/v1/hosts/77/job_events/","ad_hoc_commands":"/api/v1/hosts/77/ad_hoc_commands/","fact_versions":"/api/v1/hosts/77/fact_versions/","inventory_sources":"/api/v1/hosts/77/inventory_sources/","groups":"/api/v1/hosts/77/groups/","activity_stream":"/api/v1/hosts/77/activity_stream/","all_groups":"/api/v1/hosts/77/all_groups/","ad_hoc_command_events":"/api/v1/hosts/77/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/26/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":26,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.314Z","modified":"2016-10-12T18:19:16.086Z","name":"nick-brewery","description":"imported","inventory":2,"enabled":true,"instance_id":"4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95","variables":"{\"vmware_privateMemory\":
+        10387, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.4\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 78,
+        \"vmware_hostName\": \"nick-brewery\", \"vmware_instanceUuid\": \"50333f3f-9b3e-2e1f-d937-062b14098cde\",
+        \"vmware_distributedCpuEntitlement\": 23, \"ansible_ssh_host\": \"10.8.97.4\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 7875, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] nick-brewery/nick-brewery.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 16594, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 79040635662, \"vmware_name\": \"nick-brewery\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 7804731392, \"vmware_hostMemoryUsage\":
+        11047, \"vmware_distributedMemoryEntitlement\": 3267, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"CentOS 7.1 ImageFactory VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 78094615064, \"vmware_sharedMemory\": 5997}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":26},{"id":7,"type":"host","url":"/api/v1/hosts/7/","related":{"job_host_summaries":"/api/v1/hosts/7/job_host_summaries/","variable_data":"/api/v1/hosts/7/variable_data/","job_events":"/api/v1/hosts/7/job_events/","ad_hoc_commands":"/api/v1/hosts/7/ad_hoc_commands/","fact_versions":"/api/v1/hosts/7/fact_versions/","inventory_sources":"/api/v1/hosts/7/inventory_sources/","groups":"/api/v1/hosts/7/groups/","activity_stream":"/api/v1/hosts/7/activity_stream/","all_groups":"/api/v1/hosts/7/all_groups/","ad_hoc_command_events":"/api/v1/hosts/7/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/34/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":34,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.940Z","modified":"2016-10-12T18:19:16.090Z","name":"Red
+        Hat CloudForms 4.1 Nightly (12-Jul-2016 09","description":"imported","inventory":2,"enabled":true,"instance_id":"","variables":"{}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":34},{"id":78,"type":"host","url":"/api/v1/hosts/78/","related":{"job_host_summaries":"/api/v1/hosts/78/job_host_summaries/","variable_data":"/api/v1/hosts/78/variable_data/","job_events":"/api/v1/hosts/78/job_events/","ad_hoc_commands":"/api/v1/hosts/78/ad_hoc_commands/","fact_versions":"/api/v1/hosts/78/fact_versions/","inventory_sources":"/api/v1/hosts/78/inventory_sources/","groups":"/api/v1/hosts/78/groups/","activity_stream":"/api/v1/hosts/78/activity_stream/","all_groups":"/api/v1/hosts/78/all_groups/","ad_hoc_command_events":"/api/v1/hosts/78/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/28/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":28,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.320Z","modified":"2016-10-12T18:19:16.095Z","name":"satoe-brewery","description":"imported","inventory":2,"enabled":true,"instance_id":"564d25c2-cb51-9434-f647-3ff92cf69192","variables":"{\"vmware_privateMemory\":
+        15119, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"192.168.122.1\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Fedora (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 99,
+        \"vmware_hostName\": \"satoe-brewery\", \"vmware_instanceUuid\": \"52833b35-2412-2a35-07cb-b5cc79030220\",
+        \"vmware_distributedCpuEntitlement\": 23, \"ansible_ssh_host\": \"192.168.122.1\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 91372, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] kegerator2/kegerator2.vmx\", \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 16605, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"564d25c2-cb51-9434-f647-3ff92cf69192\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 231127633926, \"vmware_name\": \"satoe-brewery\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uncommitted\": 27079094272, \"vmware_hostMemoryUsage\":
+        15420, \"vmware_distributedMemoryEntitlement\": 5081, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_overallCpuDemand\":
+        23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\": \"fedora64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 231126225732, \"vmware_sharedMemory\": 1265}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":28}]}'
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:25 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:49 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 301
-      message: MOVED PERMANENTLY
-    headers:
-      Date:
-      - Wed, 12 Oct 2016 16:13:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
-      Location:
-      - https://dev-ansible-tower2.example.com/api/v1/config/
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/html; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:26 GMT
-- request:
-    method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/hosts/?page=4
     body:
       encoding: US-ASCII
       string: ''
@@ -4503,535 +2547,325 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:26 GMT
+      - Thu, 09 Feb 2017 10:37:49 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
-      X-Api-Time:
-      - 0.214s
-      Content-Length:
-      - '2540'
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"eula": "TOWER SOFTWARE END USER LICENSE AGREEMENT\n\nUnless otherwise
-        agreed to, and executed in a definitive agreement, between\nAnsible, Inc.
-        (\u201cAnsible\u201d) and the individual or entity (\u201cCustomer\u201d)
-        signing or\nelectronically accepting these terms of use for the Tower Software
-        (\u201cEULA\u201d),\nall Tower Software, including any and all versions released
-        or made available\nby Ansible, shall be subject to the Ansible Software Subscription
-        and Services\nAgreement found at www.ansible.com/subscription-agreement (\u201cAgreement\u201d).\nAnsible
-        is not responsible for any additional obligations, conditions or\nwarranties
-        agreed to between Customer and an authorized distributor, or\nreseller, of
-        the Tower Software. BY DOWNLOADING AND USING THE TOWER SOFTWARE,\nOR BY CLICKING
-        ON THE \u201cYES\u201d BUTTON OR OTHER BUTTON OR MECHANISM DESIGNED TO\nACKNOWLEDGE
-        CONSENT TO THE TERMS OF AN ELECTRONIC COPY OF THIS EULA, THE\nCUSTOMER HEREBY
-        ACKNOWLEDGES THAT CUSTOMER HAS READ, UNDERSTOOD, AND AGREES TO\nBE BOUND BY
-        THE TERMS OF THIS EULA AND AGREEMENT, INCLUDING ALL TERMS\nINCORPORATED HEREIN
-        BY REFERENCE, AND THAT THIS EULA AND AGREEMENT IS\nEQUIVALENT TO ANY WRITTEN
-        NEGOTIATED AGREEMENT BETWEEN CUSTOMER AND ANSIBLE.\nTHIS EULA AND AGREEMENT
-        IS ENFORCEABLE AGAINST ANY PERSON OR ENTITY THAT USES\nOR AVAILS ITSELF OF
-        THE TOWER SOFTWARE OR ANY PERSON OR ENTITY THAT USES THE OR\nAVAILS ITSELF
-        OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
-        "license_info": {"deployment_id": "6002e746fa4bf7beb33e9fb80a63a9e1f3d3bd77",
-        "subscription_name": "Enterprise Tower 100 Partner NFR", "current_instances":
-        98, "features": {"surveys": true, "multiple_organizations": true, "system_tracking":
-        true, "enterprise_auth": true, "rebranding": true, "activity_streams": true,
-        "ldap": true, "ha": true}, "date_expired": false, "available_instances": 100,
-        "hostname": "27313f9d74884e36a7386f147c70ceae", "free_instances": 2, "instance_count":
-        100, "time_remaining": 8040431, "compliant": true, "grace_period_remaining":
-        10632431, "contact_email": "joesmit@redhat.com", "company_name": "Red Hat,
-        Inc.", "date_warning": false, "license_type": "enterprise", "license_key":
-        "license_key", "license_date":
-        1484329237, "contact_name": "Joe  Smith", "valid_key": true}, "analytics_status":
-        "detailed", "version": "2.4.2", "project_base_dir": "/var/lib/awx/projects",
-        "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
-        []}'
-    http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:26 GMT
-- request:
-    method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 301
-      message: MOVED PERMANENTLY
-    headers:
-      Date:
-      - Wed, 12 Oct 2016 16:13:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
-      Location:
-      - https://dev-ansible-tower2.example.com/api/v1/job_templates/
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/html; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:26 GMT
-- request:
-    method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 12 Oct 2016 16:13:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.198s
+      - 0.112s
       Content-Length:
-      - '33512'
+      - '34249'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"count": 13, "next": null, "previous": null, "results": [{"id": 149,
-        "type": "job_template", "url": "/api/v1/job_templates/149/", "related": {"created_by":
-        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/75/", "last_job": "/api/v1/jobs/119/", "launch":
-        "/api/v1/job_templates/149/launch/", "jobs": "/api/v1/job_templates/149/jobs/",
-        "activity_stream": "/api/v1/job_templates/149/activity_stream/", "schedules":
-        "/api/v1/job_templates/149/schedules/"}, "summary_fields": {"project": {"name":
-        "bd-project", "description": "", "status": "successful"}, "last_job": {"name":
-        "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description", "finished":
-        "2016-02-18T21:52:36.072Z", "status": "failed", "failed": true}, "last_update":
-        {"name": "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description",
-        "status": "failed", "failed": true}, "inventory": {"name": "AWS", "description":
-        "CFME AWS Lab", "has_active_failures": false, "total_hosts": 21, "hosts_with_active_failures":
-        0, "total_groups": 63, "groups_with_active_failures": 0, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
-        "finished": "2016-02-18T21:52:36.072Z", "id": 119}]}, "created": "2016-02-05T23:09:47.943Z",
-        "modified": "2016-10-10T20:52:49.281Z", "name": "Ansible-JobTemplate", "description":
-        "Ansible-JobTemplate-Description", "job_type": "run", "inventory": 2, "project":
-        75, "playbook": "language_features/group_commands.yml", "credential": null,
-        "cloud_credential": null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
-        "abc: 123\n", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-02-18T21:52:36.072Z", "last_job_failed": true, "has_schedules":
-        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 155, "type":
-        "job_template", "url": "/api/v1/job_templates/155/", "related": {"created_by":
-        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/75/", "launch": "/api/v1/job_templates/155/launch/",
-        "jobs": "/api/v1/job_templates/155/jobs/", "activity_stream": "/api/v1/job_templates/155/activity_stream/",
-        "schedules": "/api/v1/job_templates/155/schedules/", "survey_spec": "/api/v1/job_templates/155/survey_spec/"},
-        "summary_fields": {"project": {"name": "bd-project", "description": "", "status":
-        "successful"}, "inventory": {"name": "AWS", "description": "CFME AWS Lab",
-        "has_active_failures": false, "total_hosts": 21, "hosts_with_active_failures":
-        0, "total_groups": 63, "groups_with_active_failures": 0, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": []}, "created": "2016-03-02T22:13:09.055Z", "modified":
-        "2016-03-02T22:13:49.206Z", "name": "Ansible-JobTemplate-Survey", "description":
-        "Ansible-JobTemplate-Description", "job_type": "run", "inventory": 2, "project":
-        75, "playbook": "language_features/group_commands.yml", "credential": null,
-        "cloud_credential": null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
-        "{\n \"abc\": 123\n}", "job_tags": "", "force_handlers": false, "skip_tags":
-        "", "start_at_task": "", "last_job_run": null, "last_job_failed": false, "has_schedules":
-        false, "next_job_run": null, "status": "never updated", "host_config_key":
-        "", "ask_variables_on_launch": false, "survey_enabled": true, "become_enabled":
-        false}, {"id": 94, "type": "job_template", "url": "/api/v1/job_templates/94/",
-        "related": {"created_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
-        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/382/",
-        "launch": "/api/v1/job_templates/94/launch/", "jobs": "/api/v1/job_templates/94/jobs/",
-        "activity_stream": "/api/v1/job_templates/94/activity_stream/", "schedules":
-        "/api/v1/job_templates/94/schedules/"}, "summary_fields": {"credential": {"name":
-        "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false}, "project":
-        {"name": "db-projects", "description": "projects", "status": "successful"},
-        "last_job": {"name": "AWS Provision", "description": "db", "finished": "2016-04-12T21:32:27.620Z",
-        "status": "successful", "failed": false}, "last_update": {"name": "AWS Provision",
-        "description": "db", "status": "successful", "failed": false}, "cloud_credential":
-        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
-        "inventory": {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures":
-        false, "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups":
-        63, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-12T21:32:27.620Z",
-        "id": 382}, {"status": "successful", "finished": "2016-04-05T19:45:02.861Z",
-        "id": 350}, {"status": "successful", "finished": "2016-04-05T19:39:37.767Z",
-        "id": 348}, {"status": "successful", "finished": "2016-03-09T21:20:24.109Z",
-        "id": 149}, {"status": "successful", "finished": "2016-03-02T20:00:12.803Z",
-        "id": 138}, {"status": "successful", "finished": "2016-02-23T22:02:40.397Z",
-        "id": 133}, {"status": "successful", "finished": "2016-02-23T19:28:53.584Z",
-        "id": 121}, {"status": "successful", "finished": "2016-02-11T18:22:49.867Z",
-        "id": 117}, {"status": "successful", "finished": "2016-02-09T22:29:51.728Z",
-        "id": 113}, {"status": "successful", "finished": "2016-02-08T20:26:31.114Z",
-        "id": 111}]}, "created": "2016-01-28T14:31:52.576Z", "modified": "2016-04-12T21:31:26.339Z",
-        "name": "AWS Provision", "description": "db", "job_type": "run", "inventory":
-        2, "project": 93, "playbook": "create_ec2.yml", "credential": 11, "cloud_credential":
-        2, "forks": 0, "limit": "", "verbosity": 0, "extra_vars": "", "job_tags":
-        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
-        "2016-04-12T21:32:27.620Z", "last_job_failed": false, "has_schedules": false,
-        "next_job_run": null, "status": "successful", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 143, "type":
-        "job_template", "url": "/api/v1/job_templates/143/", "related": {"created_by":
-        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
-        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/357/",
-        "launch": "/api/v1/job_templates/143/launch/", "jobs": "/api/v1/job_templates/143/jobs/",
-        "activity_stream": "/api/v1/job_templates/143/activity_stream/", "schedules":
-        "/api/v1/job_templates/143/schedules/", "survey_spec": "/api/v1/job_templates/143/survey_spec/"},
-        "summary_fields": {"credential": {"name": "db", "description": "Drew Bomhof
-        Key", "kind": "ssh", "cloud": false}, "project": {"name": "db-projects", "description":
-        "projects", "status": "successful"}, "last_job": {"name": "AWS State Change",
-        "description": "db (state: present, absent, running, stopped)", "finished":
-        "2016-04-07T16:54:29.339Z", "status": "successful", "failed": false}, "last_update":
-        {"name": "AWS State Change", "description": "db (state: present, absent, running,
-        stopped)", "status": "successful", "failed": false}, "cloud_credential": {"name":
-        "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true}, "inventory":
-        {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": false,
-        "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-07T16:54:29.339Z",
-        "id": 357}, {"status": "failed", "finished": "2016-04-07T16:53:02.493Z", "id":
-        354}, {"status": "failed", "finished": "2016-04-01T21:25:46.816Z", "id": 291},
-        {"status": "failed", "finished": "2016-04-01T21:23:33.943Z", "id": 289}, {"status":
-        "failed", "finished": "2016-03-24T16:15:25.025Z", "id": 179}, {"status": "failed",
-        "finished": "2016-03-15T19:33:02.197Z", "id": 165}, {"status": "failed", "finished":
-        "2016-03-15T19:13:20.395Z", "id": 163}, {"status": "failed", "finished": "2016-03-15T18:49:24.819Z",
-        "id": 161}, {"status": "failed", "finished": "2016-03-11T22:51:33.799Z", "id":
-        159}, {"status": "failed", "finished": "2016-03-11T21:43:39.372Z", "id": 157}]},
-        "created": "2016-01-28T17:12:46.235Z", "modified": "2016-05-24T18:48:43.608Z",
-        "name": "AWS State Change", "description": "db (state: present, absent, running,
-        stopped)", "job_type": "run", "inventory": 2, "project": 93, "playbook": "general_state_ec2.yml",
-        "credential": 11, "cloud_credential": 2, "forks": 90, "limit": "", "verbosity":
-        3, "extra_vars": "instance_ids: []\nregion: us-east-1\nstate: absent\nsubnet_id:
-        subnet-16c70477\n", "job_tags": "", "force_handlers": false, "skip_tags":
-        "", "start_at_task": "", "last_job_run": "2016-04-07T16:54:29.339Z", "last_job_failed":
-        false, "has_schedules": false, "next_job_run": null, "status": "successful",
-        "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
-        true, "become_enabled": false}, {"id": 76, "type": "job_template", "url":
-        "/api/v1/job_templates/76/", "related": {"created_by": "/api/v1/users/1/",
-        "modified_by": "/api/v1/users/1/", "project": "/api/v1/projects/75/", "last_job":
-        "/api/v1/jobs/140/", "launch": "/api/v1/job_templates/76/launch/", "jobs":
-        "/api/v1/job_templates/76/jobs/", "activity_stream": "/api/v1/job_templates/76/activity_stream/",
-        "schedules": "/api/v1/job_templates/76/schedules/"}, "summary_fields": {"project":
-        {"name": "bd-project", "description": "", "status": "successful"}, "last_job":
-        {"name": "bd-test", "description": "", "finished": "2016-03-08T15:07:47.479Z",
-        "status": "failed", "failed": true}, "last_update": {"name": "bd-test", "description":
-        "", "status": "failed", "failed": true}, "created_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "modified_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "failed", "finished": "2016-03-08T15:07:47.479Z",
-        "id": 140}, {"status": "failed", "finished": "2016-02-01T18:56:03.412Z", "id":
-        86}, {"status": "failed", "finished": "2016-01-05T21:04:19.877Z", "id": 16},
-        {"status": "failed", "finished": "2016-01-05T21:02:38.834Z", "id": 15}]},
-        "created": "2016-01-05T21:01:01.678Z", "modified": "2016-03-23T23:25:00.786Z",
-        "name": "bd-test", "description": "", "job_type": "run", "inventory": null,
-        "project": 75, "playbook": "windows/test.yml", "credential": null, "cloud_credential":
-        null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars": "", "job_tags":
-        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
-        "2016-03-08T15:07:47.479Z", "last_job_failed": true, "has_schedules": false,
-        "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 153, "type":
-        "job_template", "url": "/api/v1/job_templates/153/", "related": {"created_by":
-        "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/", "project": "/api/v1/projects/75/",
-        "credential": "/api/v1/credentials/8/", "cloud_credential": "/api/v1/credentials/2/",
-        "last_job": "/api/v1/jobs/762/", "launch": "/api/v1/job_templates/153/launch/",
-        "jobs": "/api/v1/job_templates/153/jobs/", "activity_stream": "/api/v1/job_templates/153/activity_stream/",
-        "schedules": "/api/v1/job_templates/153/schedules/"}, "summary_fields": {"credential":
-        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
-        "project": {"name": "bd-project", "description": "", "status": "successful"},
-        "last_job": {"name": "bill-test", "description": "", "finished": "2016-09-12T21:12:56.077Z",
-        "status": "failed", "failed": true}, "last_update": {"name": "bill-test",
-        "description": "", "status": "failed", "failed": true}, "cloud_credential":
-        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
-        "inventory": {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures":
-        false, "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups":
-        63, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "failed", "finished": "2016-09-12T21:12:56.077Z",
-        "id": 762}, {"status": "failed", "finished": "2016-09-12T20:58:06.232Z", "id":
-        760}, {"status": "failed", "finished": "2016-09-12T20:56:53.361Z", "id": 758},
-        {"status": "failed", "finished": "2016-09-12T20:55:41.015Z", "id": 756}, {"status":
-        "failed", "finished": "2016-08-15T20:26:37.951Z", "id": 753}, {"status": "successful",
-        "finished": "2016-07-25T18:44:24.479Z", "id": 751}, {"status": "successful",
-        "finished": "2016-07-25T18:41:47.992Z", "id": 749}, {"status": "successful",
-        "finished": "2016-07-13T16:09:12.378Z", "id": 734}, {"status": "successful",
-        "finished": "2016-07-13T15:50:45.296Z", "id": 732}, {"status": "failed", "finished":
-        "2016-05-26T07:37:31.163Z", "id": 626}]}, "created": "2016-02-19T22:53:36.623Z",
-        "modified": "2016-09-12T20:58:06.263Z", "name": "bill-test", "description":
-        "", "job_type": "check", "inventory": 2, "project": 75, "playbook": "jboss-standalone/site.yml",
-        "credential": 8, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity":
-        0, "extra_vars": "extra1: val1\nextra2: val2\n", "job_tags": "", "force_handlers":
-        false, "skip_tags": "", "start_at_task": "", "last_job_run": "2016-09-12T21:12:56.077Z",
-        "last_job_failed": true, "has_schedules": false, "next_job_run": null, "status":
-        "failed", "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
-        false, "become_enabled": false}, {"id": 290, "type": "job_template", "url":
-        "/api/v1/job_templates/290/", "related": {"created_by": "/api/v1/users/1/",
-        "inventory": "/api/v1/inventories/2/", "project": "/api/v1/projects/289/",
-        "credential": "/api/v1/credentials/11/", "cloud_credential": "/api/v1/credentials/2/",
-        "last_job": "/api/v1/jobs/721/", "launch": "/api/v1/job_templates/290/launch/",
-        "jobs": "/api/v1/job_templates/290/jobs/", "activity_stream": "/api/v1/job_templates/290/activity_stream/",
-        "schedules": "/api/v1/job_templates/290/schedules/"}, "summary_fields": {"credential":
-        {"name": "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false},
-        "project": {"name": "db-minecraftpe-playbooks", "description": "EC2 PE MP
-        Server", "status": "successful"}, "last_job": {"name": "db-minecraftpe-ec2",
-        "description": "Minecraft Pocket Edition deployment via EC2", "finished":
-        "2016-06-15T19:02:29.460Z", "status": "successful", "failed": false}, "last_update":
-        {"name": "db-minecraftpe-ec2", "description": "Minecraft Pocket Edition deployment
-        via EC2", "status": "successful", "failed": false}, "cloud_credential": {"name":
-        "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true}, "inventory":
-        {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": false,
-        "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "successful",
-        "finished": "2016-06-15T19:02:29.460Z", "id": 721}, {"status": "successful",
-        "finished": "2016-06-15T18:06:41.660Z", "id": 718}, {"status": "successful",
-        "finished": "2016-06-01T22:37:34.183Z", "id": 715}, {"status": "successful",
-        "finished": "2016-06-01T19:30:49.772Z", "id": 712}, {"status": "canceled",
-        "finished": "2016-06-01T19:15:47.575Z", "id": 709}, {"status": "successful",
-        "finished": "2016-06-01T18:45:39.217Z", "id": 706}, {"status": "successful",
-        "finished": "2016-06-01T18:25:17.004Z", "id": 703}, {"status": "successful",
-        "finished": "2016-06-01T16:59:52.150Z", "id": 700}, {"status": "successful",
-        "finished": "2016-06-01T16:33:42.990Z", "id": 697}, {"status": "successful",
-        "finished": "2016-05-31T14:06:28.523Z", "id": 694}]}, "created": "2016-05-23T21:23:10.170Z",
-        "modified": "2016-06-15T18:54:04.941Z", "name": "db-minecraftpe-ec2", "description":
-        "Minecraft Pocket Edition deployment via EC2", "job_type": "run", "inventory":
-        2, "project": 289, "playbook": "minecraftpe-mp-ec2-ansible.yml", "credential":
-        11, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
-        "", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-06-15T19:02:29.460Z", "last_job_failed": false,
-        "has_schedules": false, "next_job_run": null, "status": "successful", "host_config_key":
-        "", "ask_variables_on_launch": false, "survey_enabled": false, "become_enabled":
-        false}, {"id": 309, "type": "job_template", "url": "/api/v1/job_templates/309/",
-        "related": {"created_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/",
-        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/8/",
-        "last_job": "/api/v1/jobs/746/", "launch": "/api/v1/job_templates/309/launch/",
-        "jobs": "/api/v1/job_templates/309/jobs/", "activity_stream": "/api/v1/job_templates/309/activity_stream/",
-        "schedules": "/api/v1/job_templates/309/schedules/"}, "summary_fields": {"credential":
-        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
-        "project": {"name": "db-projects", "description": "projects", "status": "successful"},
-        "last_job": {"name": "db-package-info", "description": "", "finished": "2016-07-22T20:52:47.833Z",
-        "status": "failed", "failed": true}, "last_update": {"name": "db-package-info",
-        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
-        "finished": "2016-07-22T20:52:47.833Z", "id": 746}, {"status": "failed", "finished":
-        "2016-07-22T20:24:05.316Z", "id": 743}, {"status": "failed", "finished": "2016-07-22T20:18:06.722Z",
-        "id": 740}, {"status": "failed", "finished": "2016-07-22T20:00:50.067Z", "id":
-        736}]}, "created": "2016-07-22T19:36:22.509Z", "modified": "2016-07-22T20:52:19.007Z",
-        "name": "db-package-info", "description": "", "job_type": "run", "inventory":
-        17, "project": 93, "playbook": "pkginfo.yml", "credential": 8, "cloud_credential":
-        null, "forks": 0, "limit": "db-centos-7", "verbosity": 3, "extra_vars": "pkg:
-        abrt\nsleep: 15\nuser: root\npassword: \npostgresql_users:\n  - name: test\n    password:
-        test\n", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-07-22T20:52:47.833Z", "last_job_failed": true, "has_schedules":
-        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 158, "type":
-        "job_template", "url": "/api/v1/job_templates/158/", "related": {"created_by":
-        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
-        "cloud_credential": "/api/v1/credentials/2/", "launch": "/api/v1/job_templates/158/launch/",
-        "jobs": "/api/v1/job_templates/158/jobs/", "activity_stream": "/api/v1/job_templates/158/activity_stream/",
-        "schedules": "/api/v1/job_templates/158/schedules/", "survey_spec": "/api/v1/job_templates/158/survey_spec/"},
-        "summary_fields": {"credential": {"name": "db", "description": "Drew Bomhof
-        Key", "kind": "ssh", "cloud": false}, "project": {"name": "db-projects", "description":
-        "projects", "status": "successful"}, "cloud_credential": {"name": "AWS", "description":
-        "AWS Instance", "kind": "aws", "cloud": true}, "inventory": {"name": "AWS",
-        "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
-        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
-        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "modified_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": []}, "created": "2016-03-18T19:58:10.315Z", "modified":
-        "2016-03-18T19:59:27.667Z", "name": "db-survey-spec", "description": "db (state:
-        present, absent, running, stopped)", "job_type": "run", "inventory": 2, "project":
-        93, "playbook": "general_state_ec2.yml", "credential": 11, "cloud_credential":
-        2, "forks": 90, "limit": "test-from-keep", "verbosity": 3, "extra_vars": "instance_ids:
-        []\nregion: us-east-1\nstate: absent\nsubnet_id: subnet-16c70477\n", "job_tags":
-        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
-        null, "last_job_failed": false, "has_schedules": false, "next_job_run": null,
-        "status": "never updated", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": true, "become_enabled": false}, {"id": 147, "type":
-        "job_template", "url": "/api/v1/job_templates/147/", "related": {"created_by":
-        "/api/v1/users/1/", "inventory": "/api/v1/inventories/8/", "project": "/api/v1/projects/93/",
-        "credential": "/api/v1/credentials/11/", "cloud_credential": "/api/v1/credentials/2/",
-        "last_job": "/api/v1/jobs/172/", "launch": "/api/v1/job_templates/147/launch/",
-        "jobs": "/api/v1/job_templates/147/jobs/", "activity_stream": "/api/v1/job_templates/147/activity_stream/",
-        "schedules": "/api/v1/job_templates/147/schedules/"}, "summary_fields": {"credential":
-        {"name": "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false},
-        "project": {"name": "db-projects", "description": "projects", "status": "successful"},
-        "last_job": {"name": "Install Httpd / Ruby Modules / Start httpd", "description":
-        "db", "finished": "2016-03-24T14:59:03.013Z", "status": "failed", "failed":
-        true}, "last_update": {"name": "Install Httpd / Ruby Modules / Start httpd",
-        "description": "db", "status": "failed", "failed": true}, "cloud_credential":
-        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
-        "inventory": {"name": "Single AWS Host", "description": "54.86.210.90", "has_active_failures":
-        true, "total_hosts": 1, "hosts_with_active_failures": 1, "total_groups": 0,
-        "groups_with_active_failures": 0, "has_inventory_sources": false, "total_inventory_sources":
-        0, "inventory_sources_with_failures": 0}, "created_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "failed", "finished": "2016-03-24T14:59:03.013Z",
-        "id": 172}, {"status": "successful", "finished": "2016-01-29T21:28:19.553Z",
-        "id": 82}, {"status": "successful", "finished": "2016-01-29T21:21:34.597Z",
-        "id": 80}, {"status": "failed", "finished": "2016-01-29T21:19:04.267Z", "id":
-        78}]}, "created": "2016-01-29T21:17:18.420Z", "modified": "2016-03-23T23:30:03.345Z",
-        "name": "Install Httpd / Ruby Modules / Start httpd", "description": "db",
-        "job_type": "run", "inventory": 8, "project": 93, "playbook": "yum.yml", "credential":
-        11, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity": 2, "extra_vars":
-        "", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-03-24T14:59:03.013Z", "last_job_failed": true, "has_schedules":
-        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 242, "type":
-        "job_template", "url": "/api/v1/job_templates/242/", "related": {"created_by":
-        "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/", "project": "/api/v1/projects/240/",
-        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/730/", "launch":
-        "/api/v1/job_templates/242/launch/", "jobs": "/api/v1/job_templates/242/jobs/",
-        "activity_stream": "/api/v1/job_templates/242/activity_stream/", "schedules":
-        "/api/v1/job_templates/242/schedules/"}, "summary_fields": {"credential":
-        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
-        "project": {"name": "mkanoor", "description": "", "status": "successful"},
-        "last_job": {"name": "mk_sample", "description": "", "finished": "2016-06-23T18:47:46.680Z",
-        "status": "failed", "failed": true}, "last_update": {"name": "mk_sample",
-        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
-        "finished": "2016-06-23T18:47:46.680Z", "id": 730}, {"status": "successful",
-        "finished": "2016-04-19T14:20:01.028Z", "id": 411}, {"status": "successful",
-        "finished": "2016-04-19T14:00:22.817Z", "id": 407}, {"status": "successful",
-        "finished": "2016-04-19T13:23:45.379Z", "id": 401}, {"status": "successful",
-        "finished": "2016-04-04T19:40:57.514Z", "id": 342}, {"status": "successful",
-        "finished": "2016-04-04T16:10:35.124Z", "id": 329}, {"status": "successful",
-        "finished": "2016-04-04T15:17:42.086Z", "id": 325}, {"status": "successful",
-        "finished": "2016-04-04T14:54:36.057Z", "id": 315}, {"status": "successful",
-        "finished": "2016-04-04T01:21:08.024Z", "id": 311}, {"status": "successful",
-        "finished": "2016-04-02T00:10:57.944Z", "id": 305}]}, "created": "2016-04-01T21:13:52.006Z",
-        "modified": "2016-04-19T14:19:32.027Z", "name": "mk_sample", "description":
-        "", "job_type": "run", "inventory": 17, "project": 240, "playbook": "mk_sample_playbook.yaml",
-        "credential": 8, "cloud_credential": null, "forks": 0, "limit": "test_mkanoor_4_1420",
-        "verbosity": 0, "extra_vars": "{\n \"pkg\": \"abrt\",\n \"user\": \"root\"\n}",
-        "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-06-23T18:47:46.680Z", "last_job_failed": true, "has_schedules":
-        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 241, "type":
-        "job_template", "url": "/api/v1/job_templates/241/", "related": {"created_by":
-        "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/", "project": "/api/v1/projects/240/",
-        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/770/", "launch":
-        "/api/v1/job_templates/241/launch/", "jobs": "/api/v1/job_templates/241/jobs/",
-        "activity_stream": "/api/v1/job_templates/241/activity_stream/", "schedules":
-        "/api/v1/job_templates/241/schedules/"}, "summary_fields": {"credential":
-        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
-        "project": {"name": "mkanoor", "description": "", "status": "successful"},
-        "last_job": {"name": "PackageInfo", "description": "", "finished": "2016-10-11T17:31:45.268Z",
-        "status": "failed", "failed": true}, "last_update": {"name": "PackageInfo",
-        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
-        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
-        69, "hosts_with_active_failures": 8, "total_groups": 23, "groups_with_active_failures":
-        14, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
-        1}, "created_by": {"id": 1, "username": "testuser", "first_name": "", "last_name":
-        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
-        "finished": "2016-10-11T17:31:45.268Z", "id": 770}, {"status": "failed", "finished":
-        "2016-10-11T14:08:51.188Z", "id": 768}, {"status": "failed", "finished": "2016-10-10T21:38:20.277Z",
-        "id": 766}, {"status": "failed", "finished": "2016-10-10T21:29:06.777Z", "id":
-        764}, {"status": "failed", "finished": "2016-06-23T17:52:20.833Z", "id": 728},
-        {"status": "failed", "finished": "2016-06-23T17:43:19.833Z", "id": 726}, {"status":
-        "failed", "finished": "2016-06-23T17:34:05.090Z", "id": 724}, {"status": "successful",
-        "finished": "2016-05-25T15:13:03.777Z", "id": 558}, {"status": "successful",
-        "finished": "2016-05-25T14:24:43.803Z", "id": 550}, {"status": "successful",
-        "finished": "2016-05-25T14:20:35.466Z", "id": 548}]}, "created": "2016-04-01T20:27:22.819Z",
-        "modified": "2016-10-10T21:28:38.625Z", "name": "PackageInfo", "description":
-        "", "job_type": "run", "inventory": 17, "project": 240, "playbook": "pkg_info.yaml",
-        "credential": 8, "cloud_credential": null, "forks": 0, "limit": "test_mkanoor_05_24_16",
-        "verbosity": 0, "extra_vars": "pkg: abrt\nsleep: 15\nuser: root\n", "job_tags":
-        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
-        "2016-10-11T17:31:45.268Z", "last_job_failed": true, "has_schedules": false,
-        "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
-        false, "survey_enabled": false, "become_enabled": false}, {"id": 157, "type":
-        "job_template", "url": "/api/v1/job_templates/157/", "related": {"created_by":
-        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/",
-        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/266/", "launch":
-        "/api/v1/job_templates/157/launch/", "jobs": "/api/v1/job_templates/157/jobs/",
-        "activity_stream": "/api/v1/job_templates/157/activity_stream/", "schedules":
-        "/api/v1/job_templates/157/schedules/"}, "summary_fields": {"credential":
-        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
-        "last_job": {"name": "Sleep and Package Info", "description": "", "finished":
-        "2016-04-01T19:12:20.736Z", "status": "successful", "failed": false}, "last_update":
-        {"name": "Sleep and Package Info", "description": "", "status": "successful",
-        "failed": false}, "inventory": {"name": "Dev VC60", "description": "", "has_active_failures":
-        true, "total_hosts": 69, "hosts_with_active_failures": 8, "total_groups":
-        23, "groups_with_active_failures": 14, "has_inventory_sources": true, "total_inventory_sources":
-        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "modified_by": {"id": 1, "username":
-        "testuser", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
-        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-01T19:12:20.736Z",
-        "id": 266}, {"status": "successful", "finished": "2016-04-01T18:58:46.152Z",
-        "id": 264}, {"status": "successful", "finished": "2016-04-01T18:40:52.071Z",
-        "id": 262}, {"status": "successful", "finished": "2016-04-01T16:00:16.592Z",
-        "id": 260}, {"status": "successful", "finished": "2016-04-01T14:48:22.257Z",
-        "id": 258}, {"status": "successful", "finished": "2016-04-01T13:38:44.674Z",
-        "id": 256}, {"status": "failed", "finished": "2016-04-01T13:34:02.275Z", "id":
-        255}, {"status": "failed", "finished": "2016-04-01T13:28:01.110Z", "id": 254},
-        {"status": "failed", "finished": "2016-03-31T19:52:14.905Z", "id": 252}, {"status":
-        "failed", "finished": "2016-03-31T19:50:14.419Z", "id": 250}]}, "created":
-        "2016-03-08T19:07:48.379Z", "modified": "2016-05-25T14:11:27.070Z", "name":
-        "Sleep and Package Info", "description": "", "job_type": "run", "inventory":
-        17, "project": null, "playbook": "", "credential": 8, "cloud_credential":
-        null, "forks": 0, "limit": "test_mk3_centos_7_1", "verbosity": 0, "extra_vars":
-        "{\n \"host\": \"test_mk3_centos_7_1\",\n \"pkg\": \"abrt\",\n \"sleep\":
-        30,\n \"user\": \"root\"\n}", "job_tags": "", "force_handlers": false, "skip_tags":
-        "", "start_at_task": "", "last_job_run": "2016-04-01T19:12:20.736Z", "last_job_failed":
-        false, "has_schedules": false, "next_job_run": null, "status": "successful",
-        "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
-        false, "become_enabled": false}]}'
+      string: '{"count":84,"next":null,"previous":"/api/v1/hosts/?page=3","results":[{"id":79,"type":"host","url":"/api/v1/hosts/79/","related":{"job_host_summaries":"/api/v1/hosts/79/job_host_summaries/","variable_data":"/api/v1/hosts/79/variable_data/","job_events":"/api/v1/hosts/79/job_events/","ad_hoc_commands":"/api/v1/hosts/79/ad_hoc_commands/","fact_versions":"/api/v1/hosts/79/fact_versions/","inventory_sources":"/api/v1/hosts/79/inventory_sources/","groups":"/api/v1/hosts/79/groups/","activity_stream":"/api/v1/hosts/79/activity_stream/","all_groups":"/api/v1/hosts/79/all_groups/","ad_hoc_command_events":"/api/v1/hosts/79/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/14/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":14,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:40.325Z","modified":"2016-10-12T18:19:16.099Z","name":"satoe-build-rhel72","description":"imported","inventory":2,"enabled":true,"instance_id":"420c776f-d431-d0da-4fe9-8a2a227695ae","variables":"{\"vmware_privateMemory\":
+        1894, \"vmware_resourcePool\": \"Resources\", \"vmware_ipAddress\": \"10.8.97.10\",
+        \"vmware_guestMemoryUsage\": 20, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        34, \"vmware_hostName\": \"satoe-cfme-build\", \"vmware_instanceUuid\": \"500caa77-7289-699f-af4c-bbe8fc840dd3\",
+        \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.97.10\",
+        \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_uptimeSeconds\": 2230610, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] satoe-build-rhel72/satoe-build-rhel72.vmx\",
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 2114,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_overallStatus\": \"green\",
+        \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c776f-d431-d0da-4fe9-8a2a227695ae\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 21751895543,
+        \"vmware_name\": \"satoe-build-rhel72\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uncommitted\":
+        5830225920, \"vmware_hostMemoryUsage\": 1930, \"vmware_distributedMemoryEntitlement\":
+        749, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_staticCpuEntitlement\":
+        362, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOn\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 21750305645, \"vmware_sharedMemory\": 32}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":14},{"id":80,"type":"host","url":"/api/v1/hosts/80/","related":{"job_host_summaries":"/api/v1/hosts/80/job_host_summaries/","variable_data":"/api/v1/hosts/80/variable_data/","job_events":"/api/v1/hosts/80/job_events/","ad_hoc_commands":"/api/v1/hosts/80/ad_hoc_commands/","fact_versions":"/api/v1/hosts/80/fact_versions/","inventory_sources":"/api/v1/hosts/80/inventory_sources/","groups":"/api/v1/hosts/80/groups/","activity_stream":"/api/v1/hosts/80/activity_stream/","all_groups":"/api/v1/hosts/80/all_groups/","ad_hoc_command_events":"/api/v1/hosts/80/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.331Z","modified":"2016-08-31T16:59:43.652Z","name":"test_billya","description":"imported","inventory":2,"enabled":false,"instance_id":"420cb94b-3d65-86a5-ca7e-f3c7c0c6c716","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host1.example.com\",
+        \"vmware_instanceUuid\": \"500c9705-7ea2-615e-32b4-66a487142f26\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] test_billya/test_billya.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420cb94b-3d65-86a5-ca7e-f3c7c0c6c716\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 24275974, \"vmware_name\": \"test_billya\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19495289331, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: w w\\nEmail: wfitzger@redhat.com\\nSource: ag_rhel7_template\\n\\nMIQ
+        GUID=49daff48-f750-11e5-8377-f45c898c7d55\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 24117248, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":81,"type":"host","url":"/api/v1/hosts/81/","related":{"job_host_summaries":"/api/v1/hosts/81/job_host_summaries/","variable_data":"/api/v1/hosts/81/variable_data/","job_events":"/api/v1/hosts/81/job_events/","ad_hoc_commands":"/api/v1/hosts/81/ad_hoc_commands/","fact_versions":"/api/v1/hosts/81/fact_versions/","inventory_sources":"/api/v1/hosts/81/inventory_sources/","groups":"/api/v1/hosts/81/groups/","activity_stream":"/api/v1/hosts/81/activity_stream/","all_groups":"/api/v1/hosts/81/all_groups/","ad_hoc_command_events":"/api/v1/hosts/81/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.336Z","modified":"2016-08-31T16:59:43.656Z","name":"test_mkanoor_05_24_16","description":"imported","inventory":2,"enabled":false,"instance_id":"420c358a-4428-baab-205d-9b654d541cca","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"Resources\", \"vmware_guestMemoryUsage\": 0,
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
+        \"dhcp-8-99-237.example.com\", \"vmware_instanceUuid\":
+        \"500c8890-1e81-8c04-3b95-d6ff3cc0d26c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] test_mkanoor_05_24_16/test_mkanoor_05_24_16.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c358a-4428-baab-205d-9b654d541cca\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1886125283, \"vmware_name\":
+        \"test_mkanoor_05_24_16\", \"vmware_toolsVersionStatus\": \"guestToolsCurrent\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 43403456512, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1885753903, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":11,"type":"host","url":"/api/v1/hosts/11/","related":{"job_host_summaries":"/api/v1/hosts/11/job_host_summaries/","variable_data":"/api/v1/hosts/11/variable_data/","job_events":"/api/v1/hosts/11/job_events/","ad_hoc_commands":"/api/v1/hosts/11/ad_hoc_commands/","fact_versions":"/api/v1/hosts/11/fact_versions/","inventory_sources":"/api/v1/hosts/11/inventory_sources/","groups":"/api/v1/hosts/11/groups/","activity_stream":"/api/v1/hosts/11/activity_stream/","all_groups":"/api/v1/hosts/11/all_groups/","ad_hoc_command_events":"/api/v1/hosts/11/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/38/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":38,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.961Z","modified":"2016-10-12T18:19:16.104Z","name":"Upstream
+        Master 20160628","description":"imported","inventory":2,"enabled":true,"instance_id":"420c18fb-0847-5896-170a-95f6518d88e2","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] Upstream Master 20160628/Upstream Master 20160628.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.226\", \"vmware_guestMemoryUsage\": 61, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.226\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 13553160759, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 6231, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c18fb-0847-5896-170a-95f6518d88e2\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        29396512768, \"vmware_distributedMemoryEntitlement\": 1776, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 5980, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-226.example.com\", \"vmware_product_vendor\":
+        \"ManageIQ\", \"vmware_uptimeSeconds\": 86498, \"vmware_memorySizeMB\": 6144,
+        \"vmware_instanceUuid\": \"500c7906-97fd-e39a-b98f-777a99d85ddf\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 13554614694, \"vmware_name\": \"Upstream Master
+        20160628\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 6031, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 52, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":38},{"id":8,"type":"host","url":"/api/v1/hosts/8/","related":{"job_host_summaries":"/api/v1/hosts/8/job_host_summaries/","variable_data":"/api/v1/hosts/8/variable_data/","job_events":"/api/v1/hosts/8/job_events/","ad_hoc_commands":"/api/v1/hosts/8/ad_hoc_commands/","fact_versions":"/api/v1/hosts/8/fact_versions/","inventory_sources":"/api/v1/hosts/8/inventory_sources/","groups":"/api/v1/hosts/8/groups/","activity_stream":"/api/v1/hosts/8/activity_stream/","all_groups":"/api/v1/hosts/8/all_groups/","ad_hoc_command_events":"/api/v1/hosts/8/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.945Z","modified":"2016-08-31T16:59:43.665Z","name":"Upstream
+        Master 2016-08-19-1","description":"imported","inventory":2,"enabled":false,"instance_id":"420c5b3d-07d2-58f0-95f0-8f99bc72d4c9","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] ManageIQ Upstream 2016-08-19/ManageIQ Upstream 2016-08-19.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4408238651, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c5b3d-07d2-58f0-95f0-8f99bc72d4c9\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 45179101184, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-248.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500c19f6-4c2d-0328-e4c3-b02a6cdebeff\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 4408467124, \"vmware_name\": \"Upstream Master
+        2016-08-19-1\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":9,"type":"host","url":"/api/v1/hosts/9/","related":{"job_host_summaries":"/api/v1/hosts/9/job_host_summaries/","variable_data":"/api/v1/hosts/9/variable_data/","job_events":"/api/v1/hosts/9/job_events/","ad_hoc_commands":"/api/v1/hosts/9/ad_hoc_commands/","fact_versions":"/api/v1/hosts/9/fact_versions/","inventory_sources":"/api/v1/hosts/9/inventory_sources/","groups":"/api/v1/hosts/9/groups/","activity_stream":"/api/v1/hosts/9/activity_stream/","all_groups":"/api/v1/hosts/9/all_groups/","ad_hoc_command_events":"/api/v1/hosts/9/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/","last_job":"/api/v1/jobs/36/","last_job_host_summary":"/api/v1/job_host_summaries/21/"},"summary_fields":{"last_job":{"id":36,"name":"Demo
+        Job Template","description":"","finished":"2016-10-12T18:19:15.491Z","status":"failed","failed":true,"job_template_id":5,"job_template_name":"Demo
+        Job Template"},"last_job_host_summary":{"id":21,"failed":true},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36,"name":"Demo
+        Job Template"}]},"created":"2016-08-31T16:59:39.950Z","modified":"2016-10-12T18:19:16.108Z","name":"Upstream
+        Master 2016-08-19-2","description":"imported","inventory":2,"enabled":true,"instance_id":"420ce26b-10bc-27ef-7032-5c00c829ea42","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] Upstream Master 2016-08-19-2/Upstream Master 2016-08-19-2.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.249\", \"vmware_guestMemoryUsage\": 122, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_product_instanceId\": null, \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_product_classId\":
+        null, \"vmware_distributedCpuEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.249\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4499153467, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 6231, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420ce26b-10bc-27ef-7032-5c00c829ea42\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"master\", \"vmware_staticCpuEntitlement\": 1431, \"vmware_uncommitted\":
+        38450520064, \"vmware_distributedMemoryEntitlement\": 513, \"vmware_product_appUrl\":
+        null, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_product_fullVersion\":
+        null, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 134, \"vmware_privateMemory\": 694, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        1, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-249.example.com\", \"vmware_product_vendor\":
+        \"ManageIQ\", \"vmware_uptimeSeconds\": 524102, \"vmware_memorySizeMB\": 6144,
+        \"vmware_instanceUuid\": \"500c924f-ca30-a041-0453-55990e5f2a46\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 4499729260, \"vmware_name\": \"Upstream Master
+        2016-08-19-2\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 769, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 49, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":true,"has_inventory_sources":true,"last_job":36,"last_job_host_summary":21},{"id":10,"type":"host","url":"/api/v1/hosts/10/","related":{"job_host_summaries":"/api/v1/hosts/10/job_host_summaries/","variable_data":"/api/v1/hosts/10/variable_data/","job_events":"/api/v1/hosts/10/job_events/","ad_hoc_commands":"/api/v1/hosts/10/ad_hoc_commands/","fact_versions":"/api/v1/hosts/10/fact_versions/","inventory_sources":"/api/v1/hosts/10/inventory_sources/","groups":"/api/v1/hosts/10/groups/","activity_stream":"/api/v1/hosts/10/activity_stream/","all_groups":"/api/v1/hosts/10/all_groups/","ad_hoc_command_events":"/api/v1/hosts/10/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.956Z","modified":"2016-08-31T16:59:43.674Z","name":"Upstream
+        Master 2016-08-19-3","description":"imported","inventory":2,"enabled":false,"instance_id":"420cdcea-6a7c-6dae-ce7a-285b0d9ff837","variables":"{\"vmware_vmPathName\":
+        \"[NFS Share] Upstream Master 2016-08-19-3/Upstream Master 2016-08-19-3.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4405457467, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420cdcea-6a7c-6dae-ce7a-285b0d9ff837\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 45181882368, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-212.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500ca844-5d90-10d8-27c8-a7d90baad9d5\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 4405666202, \"vmware_name\": \"Upstream Master
+        2016-08-19-3\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":12,"type":"host","url":"/api/v1/hosts/12/","related":{"job_host_summaries":"/api/v1/hosts/12/job_host_summaries/","variable_data":"/api/v1/hosts/12/variable_data/","job_events":"/api/v1/hosts/12/job_events/","ad_hoc_commands":"/api/v1/hosts/12/ad_hoc_commands/","fact_versions":"/api/v1/hosts/12/fact_versions/","inventory_sources":"/api/v1/hosts/12/inventory_sources/","groups":"/api/v1/hosts/12/groups/","activity_stream":"/api/v1/hosts/12/activity_stream/","all_groups":"/api/v1/hosts/12/all_groups/","ad_hoc_command_events":"/api/v1/hosts/12/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:39.967Z","modified":"2016-08-31T16:59:43.679Z","name":"Win2k12DC-template","description":"imported","inventory":2,"enabled":false,"instance_id":"423384ab-4d40-9997-ccd9-e490e8807bc5","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM NFS Network\"],
+        \"vmware_guestFullName\": \"Microsoft Windows Server 2012 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"50334b93-08e7-f25e-8da0-dc969e6d675e\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] dev-scvmm2k12.vmtx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        2, \"vmware_uuid\": \"423384ab-4d40-9997-ccd9-e490e8807bc5\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2784, \"vmware_name\": \"Win2k12DC-template\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 4488081408, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"windows8Server64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null},{"id":82,"type":"host","url":"/api/v1/hosts/82/","related":{"job_host_summaries":"/api/v1/hosts/82/job_host_summaries/","variable_data":"/api/v1/hosts/82/variable_data/","job_events":"/api/v1/hosts/82/job_events/","ad_hoc_commands":"/api/v1/hosts/82/ad_hoc_commands/","fact_versions":"/api/v1/hosts/82/fact_versions/","inventory_sources":"/api/v1/hosts/82/inventory_sources/","groups":"/api/v1/hosts/82/groups/","activity_stream":"/api/v1/hosts/82/activity_stream/","all_groups":"/api/v1/hosts/82/all_groups/","ad_hoc_command_events":"/api/v1/hosts/82/ad_hoc_command_events/","inventory":"/api/v1/inventories/2/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"recent_jobs":[]},"created":"2016-08-31T16:59:40.342Z","modified":"2016-08-31T16:59:43.684Z","name":"windows_2012_temp","description":"imported","inventory":2,"enabled":false,"instance_id":"420cdbe0-1634-6447-5a48-a7428c66d175","variables":"{\"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Microsoft Windows Server 2012 (64-bit)\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\":
+        \"windows_2012\", \"vmware_instanceUuid\": \"500c5536-1572-080a-b8f2-839df67b3b76\",
+        \"vmware_distributedCpuEntitlement\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] windows_2012_temp/windows_2012_temp.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\": \"420cdbe0-1634-6447-5a48-a7428c66d175\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 10506988130,
+        \"vmware_name\": \"windows_2012_temp\", \"vmware_toolsVersionStatus\": \"guestToolsCurrent\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 56259166208, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"windows8Server64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 10505941525, \"vmware_sharedMemory\": 0}","has_active_failures":false,"has_inventory_sources":true,"last_job":null,"last_job_host_summary":null}]}'
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:26 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:53 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:52 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower3.example.com/api/v1/config/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:37:53 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/config/
     body:
       encoding: US-ASCII
       string: ''
@@ -5048,29 +2882,278 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:26 GMT
+      - Thu, 09 Feb 2017 10:37:52 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.051s
+      - 0.223s
       Content-Length:
-      - '223'
+      - '9766'
       Content-Type:
       - application/json
     body:
-      encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_description":
-        "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
-        "required": false, "variable": "test", "choices": "", "type": "text"}]}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJldWxhIjoiQU5TSUJMRSBUT1dFUiBCWSBSRUQgSEFUIEVORCBVU0VSIExJ
+        Q0VOU0UgQUdSRUVNRU5UXG5cblRoaXMgZW5kIHVzZXIgbGljZW5zZSBhZ3Jl
+        ZW1lbnQgKOKAnEVVTEHigJ0pIGdvdmVybnMgdGhlIHVzZSBvZiB0aGUgQW5z
+        aWJsZSBUb3dlciBzb2Z0d2FyZSBhbmQgYW55IHJlbGF0ZWQgdXBkYXRlcywg
+        dXBncmFkZXMsIHZlcnNpb25zLCBhcHBlYXJhbmNlLCBzdHJ1Y3R1cmUgYW5k
+        IG9yZ2FuaXphdGlvbiAodGhlIOKAnEFuc2libGUgVG93ZXIgU29mdHdhcmXi
+        gJ0pLCByZWdhcmRsZXNzIG9mIHRoZSBkZWxpdmVyeSBtZWNoYW5pc20uICBc
+        blxuMS4gIExpY2Vuc2UgR3JhbnQuICBTdWJqZWN0IHRvIHRoZSB0ZXJtcyBv
+        ZiB0aGlzIEVVTEEsIFJlZCBIYXQsIEluYy4gYW5kIGl0cyBhZmZpbGlhdGVz
+        ICjigJxSZWQgSGF04oCdKSBncmFudCB0byB5b3UgKOKAnFlvdeKAnSkgYSBu
+        b24tdHJhbnNmZXJhYmxlLCBub24tZXhjbHVzaXZlLCB3b3JsZHdpZGUsIG5v
+        bi1zdWJsaWNlbnNhYmxlLCBsaW1pdGVkLCByZXZvY2FibGUgbGljZW5zZSB0
+        byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZm9yIHRoZSB0ZXJt
+        IG9mIHRoZSBhc3NvY2lhdGVkIFJlZCBIYXQgU29mdHdhcmUgU3Vic2NyaXB0
+        aW9uKHMpIGFuZCBpbiBhIHF1YW50aXR5IGVxdWFsIHRvIHRoZSBudW1iZXIg
+        b2YgUmVkIEhhdCBTb2Z0d2FyZSBTdWJzY3JpcHRpb25zIHB1cmNoYXNlZCBm
+        cm9tIFJlZCBIYXQgZm9yIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICji
+        gJxMaWNlbnNl4oCdKSwgZWFjaCBhcyBzZXQgZm9ydGggb24gdGhlIGFwcGxp
+        Y2FibGUgUmVkIEhhdCBvcmRlcmluZyBkb2N1bWVudC4gIFlvdSBhY3F1aXJl
+        IG9ubHkgdGhlIHJpZ2h0IHRvIHVzZSB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0
+        d2FyZSBhbmQgZG8gbm90IGFjcXVpcmUgYW55IHJpZ2h0cyBvZiBvd25lcnNo
+        aXAuIFJlZCBIYXQgcmVzZXJ2ZXMgYWxsIHJpZ2h0cyB0byB0aGUgQW5zaWJs
+        ZSBUb3dlciBTb2Z0d2FyZSBub3QgZXhwcmVzc2x5IGdyYW50ZWQgdG8gWW91
+        LiAgVGhpcyBMaWNlbnNlIGdyYW50IHBlcnRhaW5zIHNvbGVseSB0byBZb3Vy
+        IHVzZSBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXMgbm90
+        IGludGVuZGVkIHRvIGxpbWl0IFlvdXIgcmlnaHRzIHVuZGVyLCBvciBncmFu
+        dCBZb3UgcmlnaHRzIHRoYXQgc3VwZXJzZWRlLCB0aGUgbGljZW5zZSB0ZXJt
+        cyBvZiBhbnkgc29mdHdhcmUgcGFja2FnZXMgd2hpY2ggbWF5IGJlIG1hZGUg
+        YXZhaWxhYmxlIHdpdGggdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgdGhh
+        dCBhcmUgc3ViamVjdCB0byBhbiBvcGVuIHNvdXJjZSBzb2Z0d2FyZSBsaWNl
+        bnNlLiAgXG4gXG4yLiAgSW50ZWxsZWN0dWFsIFByb3BlcnR5IFJpZ2h0cy4g
+        IFRpdGxlIHRvIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIGFuZCBlYWNo
+        IGNvbXBvbmVudCwgY29weSBhbmQgbW9kaWZpY2F0aW9uLCBpbmNsdWRpbmcg
+        YWxsIGRlcml2YXRpdmUgd29ya3Mgd2hldGhlciBtYWRlIGJ5IFJlZCBIYXQs
+        IFlvdSBvciBvbiBSZWQgSGF0J3MgYmVoYWxmLCBpbmNsdWRpbmcgdGhvc2Ug
+        bWFkZSBhdCBZb3VyIHN1Z2dlc3Rpb24gYW5kIGFsbCBhc3NvY2lhdGVkIGlu
+        dGVsbGVjdHVhbCBwcm9wZXJ0eSByaWdodHMsIGFyZSBhbmQgc2hhbGwgcmVt
+        YWluIHRoZSBzb2xlIGFuZCBleGNsdXNpdmUgcHJvcGVydHkgb2YgUmVkIEhh
+        dCBhbmQvb3IgaXQgbGljZW5zb3JzLiAgVGhlIExpY2Vuc2UgZG9lcyBub3Qg
+        YXV0aG9yaXplIFlvdSAobm9yIG1heSBZb3UgYWxsb3cgYW55IHRoaXJkIHBh
+        cnR5LCBzcGVjaWZpY2FsbHkgbm9uLWVtcGxveWVlcyBvZiBZb3VycykgdG86
+        IChhKSBjb3B5LCBkaXN0cmlidXRlLCByZXByb2R1Y2UsIHVzZSBvciBhbGxv
+        dyB0aGlyZCBwYXJ0eSBhY2Nlc3MgdG8gdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgZXhjZXB0IGFzIGV4cHJlc3NseSBhdXRob3JpemVkIGhlcmV1bmRl
+        cjsgKGIpIGRlY29tcGlsZSwgZGlzYXNzZW1ibGUsIHJldmVyc2UgZW5naW5l
+        ZXIsIHRyYW5zbGF0ZSwgbW9kaWZ5LCBjb252ZXJ0IG9yIGFwcGx5IGFueSBw
+        cm9jZWR1cmUgb3IgcHJvY2VzcyB0byB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0
+        d2FyZSBpbiBvcmRlciB0byBhc2NlcnRhaW4sIGRlcml2ZSwgYW5kL29yIGFw
+        cHJvcHJpYXRlIGZvciBhbnkgcmVhc29uIG9yIHB1cnBvc2UsIGluY2x1ZGlu
+        ZyB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBzb3VyY2UgY29kZSBvciBz
+        b3VyY2UgbGlzdGluZ3Mgb3IgYW55IHRyYWRlIHNlY3JldCBpbmZvcm1hdGlv
+        biBvciBwcm9jZXNzIGNvbnRhaW5lZCBpbiB0aGUgQW5zaWJsZSBUb3dlciBT
+        b2Z0d2FyZSAoZXhjZXB0IGFzIHBlcm1pdHRlZCB1bmRlciBhcHBsaWNhYmxl
+        IGxhdyk7IChjKSBleGVjdXRlIG9yIGluY29ycG9yYXRlIG90aGVyIHNvZnR3
+        YXJlIChleGNlcHQgZm9yIGFwcHJvdmVkIHNvZnR3YXJlIGFzIGFwcGVhcnMg
+        aW4gdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZG9jdW1lbnRhdGlvbiBv
+        ciBzcGVjaWZpY2FsbHkgYXBwcm92ZWQgYnkgUmVkIEhhdCBpbiB3cml0aW5n
+        KSBpbnRvIEFuc2libGUgVG93ZXIgU29mdHdhcmUsIG9yIGNyZWF0ZSBhIGRl
+        cml2YXRpdmUgd29yayBvZiBhbnkgcGFydCBvZiB0aGUgQW5zaWJsZSBUb3dl
+        ciBTb2Z0d2FyZTsgKGQpIHJlbW92ZSBhbnkgdHJhZGVtYXJrcywgdHJhZGUg
+        bmFtZXMgb3IgdGl0bGVzLCBjb3B5cmlnaHRzIGxlZ2VuZHMgb3IgYW55IG90
+        aGVyIHByb3ByaWV0YXJ5IG1hcmtpbmcgb24gdGhlIEFuc2libGUgVG93ZXIg
+        U29mdHdhcmU7IChlKSBkaXNjbG9zZSB0aGUgcmVzdWx0cyBvZiBhbnkgYmVu
+        Y2htYXJraW5nIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlICh3aGV0
+        aGVyIG9yIG5vdCBvYnRhaW5lZCB3aXRoIFJlZCBIYXTigJlzIGFzc2lzdGFu
+        Y2UpIHRvIGFueSB0aGlyZCBwYXJ0eTsgKGYpIGF0dGVtcHQgdG8gY2lyY3Vt
+        dmVudCBhbnkgdXNlciBsaW1pdHMgb3Igb3RoZXIgbGljZW5zZSwgdGltaW5n
+        IG9yIHVzZSByZXN0cmljdGlvbnMgdGhhdCBhcmUgYnVpbHQgaW50bywgZGVm
+        aW5lZCBvciBhZ3JlZWQgdXBvbiwgcmVnYXJkaW5nIHRoZSBBbnNpYmxlIFRv
+        d2VyIFNvZnR3YXJlLiBZb3UgYXJlIGhlcmVieSBub3RpZmllZCB0aGF0IHRo
+        ZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG1heSBjb250YWluIHRpbWUtb3V0
+        IGRldmljZXMsIGNvdW50ZXIgZGV2aWNlcywgYW5kL29yIG90aGVyIGRldmlj
+        ZXMgaW50ZW5kZWQgdG8gZW5zdXJlIHRoZSBsaW1pdHMgb2YgdGhlIExpY2Vu
+        c2Ugd2lsbCBub3QgYmUgZXhjZWVkZWQgKOKAnExpbWl0aW5nIERldmljZXPi
+        gJ0pLiAgSWYgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgY29udGFpbnMg
+        TGltaXRpbmcgRGV2aWNlcywgUmVkIEhhdCB3aWxsIHByb3ZpZGUgWW91IG1h
+        dGVyaWFscyBuZWNlc3NhcnkgdG8gdXNlIHRoZSBBbnNpYmxlIFRvd2VyIFNv
+        ZnR3YXJlIHRvIHRoZSBleHRlbnQgcGVybWl0dGVkLiAgWW91IG1heSBub3Qg
+        dGFtcGVyIHdpdGggb3Igb3RoZXJ3aXNlIHRha2UgYW55IGFjdGlvbiB0byBk
+        ZWZlYXQgb3IgY2lyY3VtdmVudCBhIExpbWl0aW5nIERldmljZSBvciBvdGhl
+        ciBjb250cm9sIG1lYXN1cmUsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQg
+        dG8sIHJlc2V0dGluZyB0aGUgdW5pdCBhbW91bnQgb3IgdXNpbmcgZmFsc2Ug
+        aG9zdCBpZGVudGlmaWNhdGlvbiBudW1iZXIgZm9yIHRoZSBwdXJwb3NlIG9m
+        IGV4dGVuZGluZyBhbnkgdGVybSBvZiB0aGUgTGljZW5zZS4gXG5cbjMuICBF
+        dmFsdWF0aW9uIExpY2Vuc2VzLiBVbmxlc3MgWW91IGhhdmUgcHVyY2hhc2Vk
+        IEFuc2libGUgVG93ZXIgU29mdHdhcmUgU3Vic2NyaXB0aW9ucyBmcm9tIFJl
+        ZCBIYXQgb3IgYW4gYXV0aG9yaXplZCByZXNlbGxlciB1bmRlciB0aGUgdGVy
+        bXMgb2YgYSBjb21tZXJjaWFsIGFncmVlbWVudCB3aXRoIFJlZCBIYXQsIGFs
+        bCB1c2Ugb2YgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgc2hhbGwgYmUg
+        bGltaXRlZCB0byB0ZXN0aW5nIHB1cnBvc2VzIGFuZCBub3QgZm9yIHByb2R1
+        Y3Rpb24gdXNlICjigJxFdmFsdWF0aW9u4oCdKS4gVW5sZXNzIG90aGVyd2lz
+        ZSBhZ3JlZWQgYnkgUmVkIEhhdCwgRXZhbHVhdGlvbiBvZiB0aGUgQW5zaWJs
+        ZSBUb3dlciBTb2Z0d2FyZSBzaGFsbCBiZSBsaW1pdGVkIHRvIGFuIGV2YWx1
+        YXRpb24gZW52aXJvbm1lbnQgYW5kIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3
+        YXJlIHNoYWxsIG5vdCBiZSB1c2VkIHRvIG1hbmFnZSBhbnkgc3lzdGVtcyBv
+        ciB2aXJ0dWFsIG1hY2hpbmVzIG9uIG5ldHdvcmtzIGJlaW5nIHVzZWQgaW4g
+        dGhlIG9wZXJhdGlvbiBvZiBZb3VyIGJ1c2luZXNzIG9yIGFueSBvdGhlciBu
+        b24tZXZhbHVhdGlvbiBwdXJwb3NlLiAgVW5sZXNzIG90aGVyd2lzZSBhZ3Jl
+        ZWQgYnkgUmVkIEhhdCwgWW91IHNoYWxsIGxpbWl0IGFsbCBFdmFsdWF0aW9u
+        IHVzZSB0byBhIHNpbmdsZSAzMCBkYXkgZXZhbHVhdGlvbiBwZXJpb2QgYW5k
+        IHNoYWxsIG5vdCBkb3dubG9hZCBvciBvdGhlcndpc2Ugb2J0YWluIGFkZGl0
+        aW9uYWwgY29waWVzIG9mIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlIG9y
+        IGxpY2Vuc2Uga2V5cyBmb3IgRXZhbHVhdGlvbi5cblxuNC4gIExpbWl0ZWQg
+        V2FycmFudHkuICBFeGNlcHQgYXMgc3BlY2lmaWNhbGx5IHN0YXRlZCBpbiB0
+        aGlzIFNlY3Rpb24gNCwgdG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1pdHRl
+        ZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgYW5kIHRoZSBjb21wb25lbnRzIGFyZSBwcm92aWRlZCBhbmQgbGlj
+        ZW5zZWQg4oCcYXMgaXPigJ0gd2l0aG91dCB3YXJyYW50eSBvZiBhbnkga2lu
+        ZCwgZXhwcmVzc2VkIG9yIGltcGxpZWQsIGluY2x1ZGluZyB0aGUgaW1wbGll
+        ZCB3YXJyYW50aWVzIG9mIG1lcmNoYW50YWJpbGl0eSwgbm9uLWluZnJpbmdl
+        bWVudCBvciBmaXRuZXNzIGZvciBhIHBhcnRpY3VsYXIgcHVycG9zZS4gIFJl
+        ZCBIYXQgd2FycmFudHMgc29sZWx5IHRvIFlvdSB0aGF0IHRoZSBtZWRpYSBv
+        biB3aGljaCB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSBtYXkgYmUgZnVy
+        bmlzaGVkIHdpbGwgYmUgZnJlZSBmcm9tIGRlZmVjdHMgaW4gbWF0ZXJpYWxz
+        IGFuZCBtYW51ZmFjdHVyZSB1bmRlciBub3JtYWwgdXNlIGZvciBhIHBlcmlv
+        ZCBvZiB0aGlydHkgKDMwKSBkYXlzIGZyb20gdGhlIGRhdGUgb2YgZGVsaXZl
+        cnkgdG8gWW91LiAgUmVkIEhhdCBkb2VzIG5vdCB3YXJyYW50IHRoYXQgdGhl
+        IGZ1bmN0aW9ucyBjb250YWluZWQgaW4gdGhlIEFuc2libGUgVG93ZXIgU29m
+        dHdhcmUgd2lsbCBtZWV0IFlvdXIgcmVxdWlyZW1lbnRzIG9yIHRoYXQgdGhl
+        IG9wZXJhdGlvbiBvZiB0aGUgQW5zaWJsZSBUb3dlciBTb2Z0d2FyZSB3aWxs
+        IGJlIGVudGlyZWx5IGVycm9yIGZyZWUsIGFwcGVhciBwcmVjaXNlbHkgYXMg
+        ZGVzY3JpYmVkIGluIHRoZSBhY2NvbXBhbnlpbmcgZG9jdW1lbnRhdGlvbiwg
+        b3IgY29tcGx5IHdpdGggcmVndWxhdG9yeSByZXF1aXJlbWVudHMuIFxuXG41
+        LiAgTGltaXRhdGlvbiBvZiBSZW1lZGllcyBhbmQgTGlhYmlsaXR5LiBUbyB0
+        aGUgbWF4aW11bSBleHRlbnQgcGVybWl0dGVkIGJ5IGFwcGxpY2FibGUgbGF3
+        LCBZb3VyIGV4Y2x1c2l2ZSByZW1lZHkgdW5kZXIgdGhpcyBFVUxBIGlzIHRv
+        IHJldHVybiBhbnkgZGVmZWN0aXZlIG1lZGlhIHdpdGhpbiB0aGlydHkgKDMw
+        KSBkYXlzIG9mIGRlbGl2ZXJ5IGFsb25nIHdpdGggYSBjb3B5IG9mIFlvdXIg
+        cGF5bWVudCByZWNlaXB0IGFuZCBSZWQgSGF0LCBhdCBpdHMgb3B0aW9uLCB3
+        aWxsIHJlcGxhY2UgaXQgb3IgcmVmdW5kIHRoZSBtb25leSBwYWlkIGJ5IFlv
+        dSBmb3IgdGhlIG1lZGlhLiAgVG8gdGhlIG1heGltdW0gZXh0ZW50IHBlcm1p
+        dHRlZCB1bmRlciBhcHBsaWNhYmxlIGxhdywgbmVpdGhlciBSZWQgSGF0IG5v
+        ciBhbnkgUmVkIEhhdCBhdXRob3JpemVkIGRpc3RyaWJ1dG9yIHdpbGwgYmUg
+        bGlhYmxlIHRvIFlvdSBmb3IgYW55IGluY2lkZW50YWwgb3IgY29uc2VxdWVu
+        dGlhbCBkYW1hZ2VzLCBpbmNsdWRpbmcgbG9zdCBwcm9maXRzIG9yIGxvc3Qg
+        c2F2aW5ncyBhcmlzaW5nIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0
+        byB1c2UgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgb3IgYW55IGNvbXBv
+        bmVudCwgZXZlbiBpZiBSZWQgSGF0IG9yIHRoZSBhdXRob3JpemVkIGRpc3Ry
+        aWJ1dG9yIGhhcyBiZWVuIGFkdmlzZWQgb2YgdGhlIHBvc3NpYmlsaXR5IG9m
+        IHN1Y2ggZGFtYWdlcy4gIEluIG5vIGV2ZW50IHNoYWxsIFJlZCBIYXQncyBs
+        aWFiaWxpdHkgb3IgYW4gYXV0aG9yaXplZCBkaXN0cmlidXRvcuKAmXMgbGlh
+        YmlsaXR5IGV4Y2VlZCB0aGUgYW1vdW50IHRoYXQgWW91IHBhaWQgdG8gUmVk
+        IEhhdCBmb3IgdGhlIEFuc2libGUgVG93ZXIgU29mdHdhcmUgZHVyaW5nIHRo
+        ZSB0d2VsdmUgbW9udGhzIHByZWNlZGluZyB0aGUgZmlyc3QgZXZlbnQgZ2l2
+        aW5nIHJpc2UgdG8gbGlhYmlsaXR5LlxuXG42LiAgRXhwb3J0IENvbnRyb2wu
+        ICBJbiBhY2NvcmRhbmNlIHdpdGggdGhlIGxhd3Mgb2YgdGhlIFVuaXRlZCBT
+        dGF0ZXMgYW5kIG90aGVyIGNvdW50cmllcywgWW91IHJlcHJlc2VudCBhbmQg
+        d2FycmFudCB0aGF0IFlvdTogKGEpIHVuZGVyc3RhbmQgdGhhdCB0aGUgQW5z
+        aWJsZSBUb3dlciBTb2Z0d2FyZSBhbmQgaXRzIGNvbXBvbmVudHMgbWF5IGJl
+        IHN1YmplY3QgdG8gZXhwb3J0IGNvbnRyb2xzIHVuZGVyIHRoZSBVLlMuIENv
+        bW1lcmNlIERlcGFydG1lbnTigJlzIEV4cG9ydCBBZG1pbmlzdHJhdGlvbiBS
+        ZWd1bGF0aW9ucyAo4oCcRUFS4oCdKTsgKGIpIGFyZSBub3QgbG9jYXRlZCBp
+        biBhbnkgY291bnRyeSBsaXN0ZWQgaW4gQ291bnRyeSBHcm91cCBFOjEgaW4g
+        U3VwcGxlbWVudCBOby4gMSB0byBwYXJ0IDc0MCBvZiB0aGUgRUFSOyAoYykg
+        d2lsbCBub3QgZXhwb3J0LCByZS1leHBvcnQsIG9yIHRyYW5zZmVyIHRoZSBB
+        bnNpYmxlIFRvd2VyIFNvZnR3YXJlIHRvIGFueSBwcm9oaWJpdGVkIGRlc3Rp
+        bmF0aW9uIG9yIHRvIGFueSBlbmQgdXNlciB3aG8gaGFzIGJlZW4gcHJvaGli
+        aXRlZCBmcm9tIHBhcnRpY2lwYXRpbmcgaW4gVVMgZXhwb3J0IHRyYW5zYWN0
+        aW9ucyBieSBhbnkgZmVkZXJhbCBhZ2VuY3kgb2YgdGhlIFVTIGdvdmVybm1l
+        bnQ7ICAoZCkgd2lsbCBub3QgdXNlIG9yIHRyYW5zZmVyIHRoZSBBbnNpYmxl
+        IFRvd2VyIFNvZnR3YXJlIGZvciB1c2UgaW4gY29ubmVjdGlvbiB3aXRoIHRo
+        ZSBkZXNpZ24sIGRldmVsb3BtZW50IG9yIHByb2R1Y3Rpb24gb2YgbnVjbGVh
+        ciwgY2hlbWljYWwgb3IgYmlvbG9naWNhbCB3ZWFwb25zLCBvciByb2NrZXQg
+        c3lzdGVtcywgc3BhY2UgbGF1bmNoIHZlaGljbGVzLCBvciBzb3VuZGluZyBy
+        b2NrZXRzIG9yIHVubWFubmVkIGFpciB2ZWhpY2xlIHN5c3RlbXM7IChlKSB1
+        bmRlcnN0YW5kIGFuZCBhZ3JlZSB0aGF0IGlmIHlvdSBhcmUgaW4gdGhlIFVu
+        aXRlZCBTdGF0ZXMgYW5kIHlvdSBleHBvcnQgb3IgdHJhbnNmZXIgdGhlIEFu
+        c2libGUgVG93ZXIgU29mdHdhcmUgdG8gZWxpZ2libGUgZW5kIHVzZXJzLCB5
+        b3Ugd2lsbCwgdG8gdGhlIGV4dGVudCByZXF1aXJlZCBieSBFQVIgU2VjdGlv
+        biA3NDAuMTcgb2J0YWluIGEgbGljZW5zZSBmb3Igc3VjaCBleHBvcnQgb3Ig
+        dHJhbnNmZXIgYW5kIHdpbGwgc3VibWl0IHNlbWktYW5udWFsIHJlcG9ydHMg
+        dG8gdGhlIENvbW1lcmNlIERlcGFydG1lbnTigJlzIEJ1cmVhdSBvZiBJbmR1
+        c3RyeSBhbmQgU2VjdXJpdHksIHdoaWNoIGluY2x1ZGUgdGhlIG5hbWUgYW5k
+        IGFkZHJlc3MgKGluY2x1ZGluZyBjb3VudHJ5KSBvZiBlYWNoIHRyYW5zZmVy
+        ZWU7IGFuZCAoZikgdW5kZXJzdGFuZCB0aGF0IGNvdW50cmllcyBpbmNsdWRp
+        bmcgdGhlIFVuaXRlZCBTdGF0ZXMgbWF5IHJlc3RyaWN0IHRoZSBpbXBvcnQs
+        IHVzZSwgb3IgZXhwb3J0IG9mIGVuY3J5cHRpb24gcHJvZHVjdHMgKHdoaWNo
+        IG1heSBpbmNsdWRlIHRoZSBBbnNpYmxlIFRvd2VyIFNvZnR3YXJlKSBhbmQg
+        YWdyZWUgdGhhdCB5b3Ugc2hhbGwgYmUgc29sZWx5IHJlc3BvbnNpYmxlIGZv
+        ciBjb21wbGlhbmNlIHdpdGggYW55IHN1Y2ggaW1wb3J0LCB1c2UsIG9yIGV4
+        cG9ydCByZXN0cmljdGlvbnMuXG5cbjcuICBHZW5lcmFsLiAgSWYgYW55IHBy
+        b3Zpc2lvbiBvZiB0aGlzIEVVTEEgaXMgaGVsZCB0byBiZSB1bmVuZm9yY2Vh
+        YmxlLCB0aGF0IHNoYWxsIG5vdCBhZmZlY3QgdGhlIGVuZm9yY2VhYmlsaXR5
+        IG9mIHRoZSByZW1haW5pbmcgcHJvdmlzaW9ucy4gIFRoaXMgYWdyZWVtZW50
+        IHNoYWxsIGJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIG9mIHRoZSBTdGF0ZSBv
+        ZiBOZXcgWW9yayBhbmQgb2YgdGhlIFVuaXRlZCBTdGF0ZXMsIHdpdGhvdXQg
+        cmVnYXJkIHRvIGFueSBjb25mbGljdCBvZiBsYXdzIHByb3Zpc2lvbnMuIFRo
+        ZSByaWdodHMgYW5kIG9ibGlnYXRpb25zIG9mIHRoZSBwYXJ0aWVzIHRvIHRo
+        aXMgRVVMQSBzaGFsbCBub3QgYmUgZ292ZXJuZWQgYnkgdGhlIFVuaXRlZCBO
+        YXRpb25zIENvbnZlbnRpb24gb24gdGhlIEludGVybmF0aW9uYWwgU2FsZSBv
+        ZiBHb29kcy4gXG5cbkNvcHlyaWdodCDCqSAyMDE1IFJlZCBIYXQsIEluYy4g
+        IEFsbCByaWdodHMgcmVzZXJ2ZWQuICBcIlJlZCBIYXRcIiBhbmQg4oCcQW5z
+        aWJsZSBUb3dlcuKAnSBhcmUgcmVnaXN0ZXJlZCB0cmFkZW1hcmtzIG9mIFJl
+        ZCBIYXQsIEluYy4gIEFsbCBvdGhlciB0cmFkZW1hcmtzIGFyZSB0aGUgcHJv
+        cGVydHkgb2YgdGhlaXIgcmVzcGVjdGl2ZSBvd25lcnMuXG4iLCJsaWNlbnNl
+        X2luZm8iOnsiZGVwbG95bWVudF9pZCI6ImEzZGJkYzdmNTRlNDlhNjAzN2M0
+        MzFmYTc4YmZmZTc0NjY3ZmRhY2EiLCJzdWJzY3JpcHRpb25fbmFtZSI6IkFu
+        c2libGUgVG93ZXIgYnkgUmVkIEhhdCwgU3RhbmRhcmQgKDEwMCBNYW5hZ2Vk
+        IE5vZGVzKSIsImN1cnJlbnRfaW5zdGFuY2VzIjo4MywiZmVhdHVyZXMiOnsi
+        c3VydmV5cyI6dHJ1ZSwibXVsdGlwbGVfb3JnYW5pemF0aW9ucyI6dHJ1ZSwi
+        c3lzdGVtX3RyYWNraW5nIjp0cnVlLCJlbnRlcnByaXNlX2F1dGgiOnRydWUs
+        InJlYnJhbmRpbmciOnRydWUsImFjdGl2aXR5X3N0cmVhbXMiOnRydWUsImxk
+        YXAiOnRydWUsImhhIjp0cnVlfSwiZGF0ZV9leHBpcmVkIjpmYWxzZSwiYXZh
+        aWxhYmxlX2luc3RhbmNlcyI6MTAwLCJob3N0bmFtZSI6ImZmNmI5ZTFmNTYx
+        NTRhNjFiZWViNWE0ZGJkY2EzMjFhIiwiZnJlZV9pbnN0YW5jZXMiOjE3LCJp
+        bnN0YW5jZV9jb3VudCI6MTAwLCJ0aW1lX3JlbWFpbmluZyI6MzEyMTExNDcs
+        ImNvbXBsaWFudCI6dHJ1ZSwiZ3JhY2VfcGVyaW9kX3JlbWFpbmluZyI6MzM4
+        MDMxNDcsImNvbnRhY3RfZW1haWwiOiJqb2VzbWl0QHJlZGhhdC5jb20iLCJj
+        b21wYW55X25hbWUiOiJSZWQgSGF0LCBJbmMuIiwiZGF0ZV93YXJuaW5nIjpm
+        YWxzZSwibGljZW5zZV90eXBlIjoiZW50ZXJwcmlzZSIsImNvbnRhY3RfbmFt
+        ZSI6IkpvZSAgU21pdGgiLCJsaWNlbnNlX2RhdGUiOjE1MTc4NDc4MTksImxp
+        Y2Vuc2Vfa2V5IjoiZWQ5ZDAwZjFhMjU0ZTJiMGI3NzBiYWViMmIyNjg4YzQz
+        N2U5ZGVlNDE3OTY2N2RmYmZmY2QxOTNlNTA4YTI2MyIsInZhbGlkX2tleSI6
+        dHJ1ZX0sImFuYWx5dGljc19zdGF0dXMiOiJkZXRhaWxlZCIsInZlcnNpb24i
+        OiIzLjAuMSIsInByb2plY3RfYmFzZV9kaXIiOiIvdmFyL2xpYi9hd3gvcHJv
+        amVjdHMiLCJ0aW1lX3pvbmUiOiJBbWVyaWNhL05ld19Zb3JrIiwiYW5zaWJs
+        ZV92ZXJzaW9uIjoiMi4xLjAuMCIsInByb2plY3RfbG9jYWxfcGF0aHMiOltd
+        fQ==
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:27 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:54 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:53 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower3.example.com/api/v1/job_templates/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:37:55 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/
     body:
       encoding: US-ASCII
       string: ''
@@ -5087,29 +3170,102 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:27 GMT
+      - Thu, 09 Feb 2017 10:37:54 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.060s
+      - 0.192s
       Content-Length:
-      - '223'
+      - '31548'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_description":
-        "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
-        "required": false, "variable": "test", "choices": "", "type": "text"}]}'
+      string: '{"count":11,"next":null,"previous":null,"results":[{"id":76,"type":"job_template","url":"/api/v1/job_templates/76/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/76/labels/","inventory":"/api/v1/inventories/6/","project":"/api/v1/projects/40/","credential":"/api/v1/credentials/6/","notification_templates_error":"/api/v1/job_templates/76/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/76/notification_templates_success/","jobs":"/api/v1/job_templates/76/jobs/","object_roles":"/api/v1/job_templates/76/object_roles/","notification_templates_any":"/api/v1/job_templates/76/notification_templates_any/","access_list":"/api/v1/job_templates/76/access_list/","launch":"/api/v1/job_templates/76/launch/","schedules":"/api/v1/job_templates/76/schedules/","activity_stream":"/api/v1/job_templates/76/activity_stream/","survey_spec":"/api/v1/job_templates/76/survey_spec/"},"summary_fields":{"inventory":{"id":6,"name":"acme-corp","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},"credential":{"id":6,"name":"db_test","description":"","kind":"ssh","cloud":false},"project":{"id":40,"name":"RH-labs","description":"Red
+        Hat innovation Labs","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":224,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":226,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":225,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-08T21:13:37.133Z","modified":"2017-02-08T21:13:37.133Z","name":"432_db_console_provision","description":"test
+        ansible","job_type":"run","inventory":6,"project":40,"playbook":"playbooks/undeploy-service.yaml","credential":6,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":true,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":78,"type":"job_template","url":"/api/v1/job_templates/78/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/78/labels/","inventory":"/api/v1/inventories/6/","project":"/api/v1/projects/40/","credential":"/api/v1/credentials/6/","notification_templates_error":"/api/v1/job_templates/78/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/78/notification_templates_success/","jobs":"/api/v1/job_templates/78/jobs/","object_roles":"/api/v1/job_templates/78/object_roles/","notification_templates_any":"/api/v1/job_templates/78/notification_templates_any/","access_list":"/api/v1/job_templates/78/access_list/","launch":"/api/v1/job_templates/78/launch/","schedules":"/api/v1/job_templates/78/schedules/","activity_stream":"/api/v1/job_templates/78/activity_stream/","survey_spec":"/api/v1/job_templates/78/survey_spec/"},"summary_fields":{"inventory":{"id":6,"name":"acme-corp","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},"credential":{"id":6,"name":"db_test","description":"","kind":"ssh","cloud":false},"project":{"id":40,"name":"RH-labs","description":"Red
+        Hat innovation Labs","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":232,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":234,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":233,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-08T22:05:57.325Z","modified":"2017-02-08T22:05:57.325Z","name":"434_db_console_provision","description":"test
+        ansible","job_type":"run","inventory":6,"project":40,"playbook":"playbooks/undeploy-service.yaml","credential":6,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":true,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":79,"type":"job_template","url":"/api/v1/job_templates/79/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/79/labels/","inventory":"/api/v1/inventories/6/","project":"/api/v1/projects/40/","credential":"/api/v1/credentials/6/","notification_templates_error":"/api/v1/job_templates/79/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/79/notification_templates_success/","jobs":"/api/v1/job_templates/79/jobs/","object_roles":"/api/v1/job_templates/79/object_roles/","notification_templates_any":"/api/v1/job_templates/79/notification_templates_any/","access_list":"/api/v1/job_templates/79/access_list/","launch":"/api/v1/job_templates/79/launch/","schedules":"/api/v1/job_templates/79/schedules/","activity_stream":"/api/v1/job_templates/79/activity_stream/","survey_spec":"/api/v1/job_templates/79/survey_spec/"},"summary_fields":{"inventory":{"id":6,"name":"acme-corp","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},"credential":{"id":6,"name":"db_test","description":"","kind":"ssh","cloud":false},"project":{"id":40,"name":"RH-labs","description":"Red
+        Hat innovation Labs","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":238,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":240,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":239,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-08T22:41:42.178Z","modified":"2017-02-08T22:41:42.178Z","name":"435_db_console_provision","description":"test
+        ansible","job_type":"run","inventory":6,"project":40,"playbook":"playbooks/undeploy-service.yaml","credential":6,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":true,"ask_limit_on_launch":true,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":true,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":80,"type":"job_template","url":"/api/v1/job_templates/80/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/80/labels/","inventory":"/api/v1/inventories/2/","project":"/api/v1/projects/37/","credential":"/api/v1/credentials/1/","cloud_credential":"/api/v1/credentials/2/","network_credential":"/api/v1/credentials/5/","notification_templates_error":"/api/v1/job_templates/80/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/80/notification_templates_success/","jobs":"/api/v1/job_templates/80/jobs/","object_roles":"/api/v1/job_templates/80/object_roles/","notification_templates_any":"/api/v1/job_templates/80/notification_templates_any/","access_list":"/api/v1/job_templates/80/access_list/","launch":"/api/v1/job_templates/80/launch/","schedules":"/api/v1/job_templates/80/schedules/","activity_stream":"/api/v1/job_templates/80/activity_stream/","survey_spec":"/api/v1/job_templates/80/survey_spec/"},"summary_fields":{"network_credential":{"id":5,"name":"Demo
+        Creds 2","description":"test","kind":"net"},"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"cloud_credential":{"id":2,"name":"dev-vc60","description":"","kind":"vmware","cloud":true},"credential":{"id":1,"name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":37,"name":"Test
+        Project","description":"","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":241,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":243,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":242,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-09T09:10:30.744Z","modified":"2017-02-09T10:35:33.484Z","name":"Ansible-JobTemplate","description":"Ansible-JobTemplate-Description","job_type":"run","inventory":2,"project":37,"playbook":"hello_world.yml","credential":1,"cloud_credential":2,"network_credential":5,"forks":0,"limit":"","verbosity":0,"extra_vars":"abc:
+        123","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":81,"type":"job_template","url":"/api/v1/job_templates/81/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/81/labels/","inventory":"/api/v1/inventories/2/","project":"/api/v1/projects/37/","credential":"/api/v1/credentials/1/","notification_templates_error":"/api/v1/job_templates/81/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/81/notification_templates_success/","jobs":"/api/v1/job_templates/81/jobs/","object_roles":"/api/v1/job_templates/81/object_roles/","notification_templates_any":"/api/v1/job_templates/81/notification_templates_any/","access_list":"/api/v1/job_templates/81/access_list/","launch":"/api/v1/job_templates/81/launch/","schedules":"/api/v1/job_templates/81/schedules/","activity_stream":"/api/v1/job_templates/81/activity_stream/","survey_spec":"/api/v1/job_templates/81/survey_spec/"},"summary_fields":{"inventory":{"id":2,"name":"Dev-VC60","description":"","has_active_failures":true,"total_hosts":81,"hosts_with_active_failures":36,"total_groups":22,"groups_with_active_failures":17,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":0},"credential":{"id":1,"name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":37,"name":"Test
+        Project","description":"","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":244,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":246,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":245,"name":"Read"}},"labels":{"count":0,"results":[]},"survey":{"description":"","title":""},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-09T09:11:01.450Z","modified":"2017-02-09T09:42:28.443Z","name":"Ansible-JobTemplate-Survey","description":"Ansible-JobTemplate-Description","job_type":"run","inventory":2,"project":37,"playbook":"hello_world.yml","credential":1,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"abc:
+        123","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":true,"become_enabled":false,"allow_simultaneous":false},{"id":30,"type":"job_template","url":"/api/v1/job_templates/30/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/30/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/103/","notification_templates_error":"/api/v1/job_templates/30/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/30/notification_templates_success/","jobs":"/api/v1/job_templates/30/jobs/","object_roles":"/api/v1/job_templates/30/object_roles/","notification_templates_any":"/api/v1/job_templates/30/notification_templates_any/","access_list":"/api/v1/job_templates/30/access_list/","launch":"/api/v1/job_templates/30/launch/","schedules":"/api/v1/job_templates/30/schedules/","activity_stream":"/api/v1/job_templates/30/activity_stream/","survey_spec":"/api/v1/job_templates/30/survey_spec/"},"summary_fields":{"last_job":{"id":103,"name":"bd-test","description":"","finished":"2017-02-06T15:07:19.588Z","status":"successful","failed":false},"last_update":{"id":103,"name":"bd-test","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"credential":{"id":1,"name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":4,"name":"Demo
+        Project","description":"A great demo","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":38,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":40,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":39,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[{"status":"successful","finished":"2017-02-06T15:07:19.588Z","id":103},{"status":"successful","finished":"2016-11-30T16:28:21.612Z","id":69},{"status":"successful","finished":"2016-11-29T22:14:40.790Z","id":67},{"status":"failed","finished":"2016-11-29T22:11:26.748Z","id":65},{"status":"successful","finished":"2016-11-29T22:10:39.315Z","id":63},{"status":"successful","finished":"2016-11-29T21:56:23.738Z","id":61},{"status":"failed","finished":"2016-11-29T21:43:19.276Z","id":59}]},"created":"2016-11-29T21:42:42.543Z","modified":"2017-02-06T15:06:53.448Z","name":"bd-test","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":"2017-02-06T15:07:19.588779Z","last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":54,"type":"job_template","url":"/api/v1/job_templates/54/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/54/labels/","inventory":"/api/v1/inventories/7/","project":"/api/v1/projects/35/","credential":"/api/v1/credentials/6/","notification_templates_error":"/api/v1/job_templates/54/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/54/notification_templates_success/","jobs":"/api/v1/job_templates/54/jobs/","object_roles":"/api/v1/job_templates/54/object_roles/","notification_templates_any":"/api/v1/job_templates/54/notification_templates_any/","access_list":"/api/v1/job_templates/54/access_list/","launch":"/api/v1/job_templates/54/launch/","schedules":"/api/v1/job_templates/54/schedules/","activity_stream":"/api/v1/job_templates/54/activity_stream/","survey_spec":"/api/v1/job_templates/54/survey_spec/"},"summary_fields":{"inventory":{"id":7,"name":"bill","description":"bill
+        test","has_active_failures":false,"total_hosts":0,"hosts_with_active_failures":0,"total_groups":1,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"credential":{"id":6,"name":"db_test","description":"","kind":"ssh","cloud":false},"project":{"id":35,"name":"DB_Github","description":"DB
+        Playbooks","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":158,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":160,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":159,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-02-03T21:24:16.731Z","modified":"2017-02-08T21:56:29.007Z","name":"bill_playbook_test_provision","description":"playbook
+        service","job_type":"run","inventory":7,"project":35,"playbook":"yum.yml","credential":6,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":38,"type":"job_template","url":"/api/v1/job_templates/38/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/38/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/36/","credential":"/api/v1/credentials/4/","cloud_credential":"/api/v1/credentials/2/","notification_templates_error":"/api/v1/job_templates/38/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/38/notification_templates_success/","jobs":"/api/v1/job_templates/38/jobs/","object_roles":"/api/v1/job_templates/38/object_roles/","notification_templates_any":"/api/v1/job_templates/38/notification_templates_any/","access_list":"/api/v1/job_templates/38/access_list/","launch":"/api/v1/job_templates/38/launch/","schedules":"/api/v1/job_templates/38/schedules/","activity_stream":"/api/v1/job_templates/38/activity_stream/","survey_spec":"/api/v1/job_templates/38/survey_spec/"},"summary_fields":{"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"cloud_credential":{"id":2,"name":"dev-vc60","description":"","kind":"vmware","cloud":true},"credential":{"id":4,"name":"Demo
+        Creds 2","description":"test","kind":"ssh","cloud":false},"project":{"id":36,"name":"jwong-org2","description":"","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":89,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":91,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":90,"name":"Read"}},"labels":{"count":1,"results":[{"id":1,"name":"demo"}]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-01-16T15:53:03.254Z","modified":"2017-01-16T15:53:03.254Z","name":"Demo
+        job template","description":"test","job_type":"run","inventory":1,"project":36,"playbook":"product/charts/miq_reports/vim_perf_daily.yaml","credential":4,"cloud_credential":2,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":true,"allow_simultaneous":false},{"id":5,"type":"job_template","url":"/api/v1/job_templates/5/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/5/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/4/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/56/","notification_templates_error":"/api/v1/job_templates/5/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/5/notification_templates_success/","jobs":"/api/v1/job_templates/5/jobs/","object_roles":"/api/v1/job_templates/5/object_roles/","notification_templates_any":"/api/v1/job_templates/5/notification_templates_any/","access_list":"/api/v1/job_templates/5/access_list/","launch":"/api/v1/job_templates/5/launch/","schedules":"/api/v1/job_templates/5/schedules/","activity_stream":"/api/v1/job_templates/5/activity_stream/","survey_spec":"/api/v1/job_templates/5/survey_spec/"},"summary_fields":{"last_job":{"id":56,"name":"Demo
+        Job Template","description":"","finished":"2016-11-29T21:34:43.185Z","status":"successful","failed":false},"last_update":{"id":56,"name":"Demo
+        Job Template","description":"","status":"successful","failed":false},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"credential":{"id":1,"name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":4,"name":"Demo
+        Project","description":"A great demo","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":20,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":22,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":21,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[{"status":"successful","finished":"2016-11-29T21:34:43.185Z","id":56},{"status":"successful","finished":"2016-10-12T22:11:33.689Z","id":39},{"status":"failed","finished":"2016-10-12T18:19:15.491Z","id":36}]},"created":"2016-08-02T17:57:03.252Z","modified":"2017-01-11T17:48:11.019Z","name":"Demo
+        Job Template","description":"","job_type":"run","inventory":1,"project":4,"playbook":"hello_world.yml","credential":1,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":"2016-11-29T21:34:43.185065Z","last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"successful","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":28,"type":"job_template","url":"/api/v1/job_templates/28/","related":{"created_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/28/labels/","inventory":"/api/v1/inventories/1/","project":"/api/v1/projects/29/","credential":"/api/v1/credentials/1/","last_job":"/api/v1/jobs/58/","notification_templates_error":"/api/v1/job_templates/28/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/28/notification_templates_success/","jobs":"/api/v1/job_templates/28/jobs/","object_roles":"/api/v1/job_templates/28/object_roles/","notification_templates_any":"/api/v1/job_templates/28/notification_templates_any/","access_list":"/api/v1/job_templates/28/access_list/","launch":"/api/v1/job_templates/28/launch/","schedules":"/api/v1/job_templates/28/schedules/","activity_stream":"/api/v1/job_templates/28/activity_stream/","survey_spec":"/api/v1/job_templates/28/survey_spec/"},"summary_fields":{"last_job":{"id":58,"name":"LG
+        Demo Job Template","description":"","finished":"2016-11-29T21:40:58.392Z","status":"failed","failed":true},"last_update":{"id":58,"name":"LG
+        Demo Job Template","description":"","status":"failed","failed":true},"inventory":{"id":1,"name":"Demo
+        Inventory","description":"","has_active_failures":false,"total_hosts":2,"hosts_with_active_failures":0,"total_groups":0,"groups_with_active_failures":0,"has_inventory_sources":false,"total_inventory_sources":0,"inventory_sources_with_failures":0},"credential":{"id":1,"name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false},"project":{"id":29,"name":"lg-project","description":"lg_project","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":31,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":33,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":32,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[{"status":"failed","finished":"2016-11-29T21:40:58.392Z","id":58},{"status":"failed","finished":"2016-10-12T22:03:48.004Z","id":38}]},"created":"2016-09-13T20:42:21.670Z","modified":"2016-11-29T21:40:22.876Z","name":"LG
+        Demo Job Template","description":"","job_type":"check","inventory":1,"project":29,"playbook":"jboss-standalone/site.yml","credential":1,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":"2016-11-29T21:40:58.392051Z","last_job_failed":true,"has_schedules":false,"next_job_run":null,"status":"failed","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":true,"ask_credential_on_launch":false,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false},{"id":41,"type":"job_template","url":"/api/v1/job_templates/41/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","labels":"/api/v1/job_templates/41/labels/","inventory":"/api/v1/inventories/6/","project":"/api/v1/projects/40/","notification_templates_error":"/api/v1/job_templates/41/notification_templates_error/","notification_templates_success":"/api/v1/job_templates/41/notification_templates_success/","jobs":"/api/v1/job_templates/41/jobs/","object_roles":"/api/v1/job_templates/41/object_roles/","notification_templates_any":"/api/v1/job_templates/41/notification_templates_any/","access_list":"/api/v1/job_templates/41/access_list/","launch":"/api/v1/job_templates/41/launch/","schedules":"/api/v1/job_templates/41/schedules/","activity_stream":"/api/v1/job_templates/41/activity_stream/","survey_spec":"/api/v1/job_templates/41/survey_spec/"},"summary_fields":{"inventory":{"id":6,"name":"acme-corp","description":"","has_active_failures":false,"total_hosts":1,"hosts_with_active_failures":0,"total_groups":2,"groups_with_active_failures":0,"has_inventory_sources":true,"total_inventory_sources":1,"inventory_sources_with_failures":1},"project":{"id":40,"name":"RH-labs","description":"Red
+        Hat innovation Labs","status":"successful"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the job template","id":119,"name":"Admin"},"execute_role":{"description":"May
+        run the job template","id":121,"name":"Execute"},"read_role":{"description":"May
+        view settings for the job template","id":120,"name":"Read"}},"labels":{"count":0,"results":[]},"can_copy":true,"can_edit":true,"recent_jobs":[]},"created":"2017-01-30T11:16:59.175Z","modified":"2017-01-30T11:22:01.953Z","name":"rh-labs-test","description":"","job_type":"run","inventory":6,"project":40,"playbook":"playbooks/check-service.yaml","credential":null,"cloud_credential":null,"network_credential":null,"forks":0,"limit":"","verbosity":0,"extra_vars":"","job_tags":"","force_handlers":false,"skip_tags":"","start_at_task":"","last_job_run":null,"last_job_failed":false,"has_schedules":false,"next_job_run":null,"status":"never
+        updated","host_config_key":"","ask_variables_on_launch":false,"ask_limit_on_launch":false,"ask_tags_on_launch":false,"ask_job_type_on_launch":false,"ask_inventory_on_launch":false,"ask_credential_on_launch":true,"survey_enabled":false,"become_enabled":false,"allow_simultaneous":false}]}'
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:27 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:56 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/76/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -5126,32 +3282,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:27 GMT
+      - Thu, 09 Feb 2017 10:37:55 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.052s
+      - 0.033s
       Content-Length:
-      - '456'
+      - '2'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_name":
-        "Instance Id&apos;s", "min": "", "default": "", "max": "", "question_description":
-        "List of Instance Id&apos;s separated by a comma", "required": true, "variable":
-        "instance_ids", "choices": "", "type": "text"}, {"index": 1, "required": true,
-        "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
-        "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
+      string: "{}"
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:27 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:56 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/76/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -5168,32 +3319,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:27 GMT
+      - Thu, 09 Feb 2017 10:37:55 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.051s
+      - 0.034s
       Content-Length:
-      - '456'
+      - '2'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_name":
-        "Instance Id&apos;s", "min": "", "default": "", "max": "", "question_description":
-        "List of Instance Id&apos;s separated by a comma", "required": true, "variable":
-        "instance_ids", "choices": "", "type": "text"}, {"index": 1, "required": true,
-        "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
-        "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
+      string: "{}"
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:27 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:57 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/78/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -5210,29 +3356,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:27 GMT
+      - Thu, 09 Feb 2017 10:37:56 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.051s
+      - 0.036s
       Content-Length:
-      - '189'
+      - '2'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "required": true,
-        "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
-        "variable": "test_id", "type": "integer"}]}'
+      string: "{}"
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:27 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:57 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/78/survey_spec/
     body:
       encoding: US-ASCII
       string: ''
@@ -5249,24 +3393,688 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Oct 2016 16:13:27 GMT
+      - Thu, 09 Feb 2017 10:37:56 GMT
       Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
       - Accept,Cookie
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.053s
+      - 0.033s
       Content-Length:
-      - '189'
+      - '2'
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"description": "", "name": "", "spec": [{"index": 0, "required": true,
-        "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
-        "variable": "test_id", "type": "integer"}]}'
+      string: "{}"
     http_version: 
-  recorded_at: Wed, 12 Oct 2016 16:13:28 GMT
+  recorded_at: Thu, 09 Feb 2017 09:37:58 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/79/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:57 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:37:58 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/79/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:58 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:37:59 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/80/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:58 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.035s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:00 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/80/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:59 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.033s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:00 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/81/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:37:59 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.033s
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description":"","spec":[{"index":1,"required":true,"min":null,"default":"","max":null,"question_description":"Survey","choices":"","variable":"test","question_name":"Survey","type":"text"},{"index":0,"question_description":"","min":0,"default":"","max":1024,"required":true,"choices":"","new_question":true,"variable":"why","question_name":"Why?","type":"text"}],"name":""}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:01 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/81/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:00 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.035s
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description":"","spec":[{"index":1,"required":true,"min":null,"default":"","max":null,"question_description":"Survey","choices":"","variable":"test","question_name":"Survey","type":"text"},{"index":0,"question_description":"","min":0,"default":"","max":1024,"required":true,"choices":"","new_question":true,"variable":"why","question_name":"Why?","type":"text"}],"name":""}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:01 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/30/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:00 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.035s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:02 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/30/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:01 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:02 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/54/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:02 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.033s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:03 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/54/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:02 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:04 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/38/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:03 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:04 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/38/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:03 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.033s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:05 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/5/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:04 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.033s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:05 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/5/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:05 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:06 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/28/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:05 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:06 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/28/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:06 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.035s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:07 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/41/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:06 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:08 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/job_templates/41/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 10:38:07 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.034s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 09:38:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_configuration_script_sources.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_configuration_script_sources.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower2.example.com/api/v1/projects/
+      - https://dev-ansible-tower3.example.com/api/v1/projects/
       Content-Length:
       - '0'
       Content-Type:
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:16 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/
     body:
       encoding: US-ASCII
       string: ''
@@ -109,7 +109,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:17 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/4/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/4/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -146,7 +146,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:18 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/29/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/29/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -183,7 +183,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:18 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/35/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/35/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +220,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:19 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/36/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/36/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -398,7 +398,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:22 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/37/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/37/playbooks/
     body:
       encoding: US-ASCII
       string: ''
@@ -435,7 +435,7 @@ http_interactions:
   recorded_at: Tue, 07 Feb 2017 10:41:22 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/40/playbooks/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/projects/40/playbooks/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
@@ -1,0 +1,9430 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/config/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:30 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.212s
+      Content-Length:
+      - '2548'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"eula": "TOWER SOFTWARE END USER LICENSE AGREEMENT\n\nUnless otherwise
+        agreed to, and executed in a definitive agreement, between\nAnsible, Inc.
+        (\u201cAnsible\u201d) and the individual or entity (\u201cCustomer\u201d)
+        signing or\nelectronically accepting these terms of use for the Tower Software
+        (\u201cEULA\u201d),\nall Tower Software, including any and all versions released
+        or made available\nby Ansible, shall be subject to the Ansible Software Subscription
+        and Services\nAgreement found at www.ansible.com/subscription-agreement (\u201cAgreement\u201d).\nAnsible
+        is not responsible for any additional obligations, conditions or\nwarranties
+        agreed to between Customer and an authorized distributor, or\nreseller, of
+        the Tower Software. BY DOWNLOADING AND USING THE TOWER SOFTWARE,\nOR BY CLICKING
+        ON THE \u201cYES\u201d BUTTON OR OTHER BUTTON OR MECHANISM DESIGNED TO\nACKNOWLEDGE
+        CONSENT TO THE TERMS OF AN ELECTRONIC COPY OF THIS EULA, THE\nCUSTOMER HEREBY
+        ACKNOWLEDGES THAT CUSTOMER HAS READ, UNDERSTOOD, AND AGREES TO\nBE BOUND BY
+        THE TERMS OF THIS EULA AND AGREEMENT, INCLUDING ALL TERMS\nINCORPORATED HEREIN
+        BY REFERENCE, AND THAT THIS EULA AND AGREEMENT IS\nEQUIVALENT TO ANY WRITTEN
+        NEGOTIATED AGREEMENT BETWEEN CUSTOMER AND ANSIBLE.\nTHIS EULA AND AGREEMENT
+        IS ENFORCEABLE AGAINST ANY PERSON OR ENTITY THAT USES\nOR AVAILS ITSELF OF
+        THE TOWER SOFTWARE OR ANY PERSON OR ENTITY THAT USES THE OR\nAVAILS ITSELF
+        OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
+        "license_info": {"deployment_id": "21c7c190b553a923410b8027f7890b8483ba892a",
+        "subscription_name": "Ansible Tower by Red Hat, Self-Support (500 Managed
+        Nodes)", "grace_period_remaining": 6940408, "features": {"surveys": false,
+        "multiple_organizations": false, "system_tracking": false, "enterprise_auth":
+        false, "rebranding": false, "activity_streams": false, "ldap": false, "ha":
+        false}, "date_expired": false, "available_instances": 500, "time_remaining":
+        4348408, "current_instances": 168, "free_instances": 332, "instance_count":
+        500, "trial": false, "compliant": true, "valid_key": true, "contact_email":
+        "matburt@redhat.com", "company_name": "Basic Company", "date_warning": false,
+        "license_type": "basic", "contact_name": "Lumber McLumberjack", "license_date":
+        1491019200, "license_key": "8bf9fdcfe49850186bf5d47103d25a3d67cd59c06977ec1529670b1df6a9ea5b"},
+        "analytics_status": "detailed", "version": "2.4.2", "project_base_dir": "/var/lib/awx/projects",
+        "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
+        []}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:31 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/inventories/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:32 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.080s
+      Content-Length:
+      - '10375'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 8, "next": null, "previous": null, "results": [{"id": 2,
+        "type": "inventory", "url": "/api/v1/inventories/2/", "related": {"created_by":
+        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/2/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/2/variable_data/", "root_groups": "/api/v1/inventories/2/root_groups/",
+        "script": "/api/v1/inventories/2/script/", "ad_hoc_commands": "/api/v1/inventories/2/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/2/tree/", "hosts": "/api/v1/inventories/2/hosts/",
+        "groups": "/api/v1/inventories/2/groups/", "activity_stream": "/api/v1/inventories/2/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/2/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:04:27.635Z", "modified":
+        "2016-08-15T20:26:37.816Z", "name": "AWS", "description": "CFME AWS Lab",
+        "organization": 1, "variables": "---", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, {"id": 6, "type": "inventory", "url": "/api/v1/inventories/6/", "related":
+        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "scan_job_templates":
+        "/api/v1/inventories/6/scan_job_templates/", "variable_data": "/api/v1/inventories/6/variable_data/",
+        "root_groups": "/api/v1/inventories/6/root_groups/", "script": "/api/v1/inventories/6/script/",
+        "ad_hoc_commands": "/api/v1/inventories/6/ad_hoc_commands/", "tree": "/api/v1/inventories/6/tree/",
+        "hosts": "/api/v1/inventories/6/hosts/", "groups": "/api/v1/inventories/6/groups/",
+        "activity_stream": "/api/v1/inventories/6/activity_stream/", "inventory_sources":
+        "/api/v1/inventories/6/inventory_sources/", "organization": "/api/v1/organizations/1/"},
+        "summary_fields": {"organization": {"name": "Default", "description": ""},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-06T22:16:35.875Z", "modified": "2016-01-06T22:16:35.875Z",
+        "name": "bd", "description": "", "organization": 1, "variables": "---", "has_active_failures":
+        false, "total_hosts": 0, "hosts_with_active_failures": 0, "total_groups":
+        0, "groups_with_active_failures": 0, "has_inventory_sources": false, "total_inventory_sources":
+        0, "inventory_sources_with_failures": 0}, {"id": 9, "type": "inventory", "url":
+        "/api/v1/inventories/9/", "related": {"created_by": "/api/v1/users/1/", "modified_by":
+        "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/9/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/9/variable_data/", "root_groups": "/api/v1/inventories/9/root_groups/",
+        "script": "/api/v1/inventories/9/script/", "ad_hoc_commands": "/api/v1/inventories/9/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/9/tree/", "hosts": "/api/v1/inventories/9/hosts/",
+        "groups": "/api/v1/inventories/9/groups/", "activity_stream": "/api/v1/inventories/9/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/9/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2016-02-01T19:44:58.850Z", "modified":
+        "2016-02-09T22:39:26.451Z", "name": "db-test-inventory-put", "description":
+        "", "organization": 1, "variables": "---", "has_active_failures": false, "total_hosts":
+        1, "hosts_with_active_failures": 0, "total_groups": 1, "groups_with_active_failures":
+        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
+        0}, {"id": 17, "type": "inventory", "url": "/api/v1/inventories/17/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/17/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/17/variable_data/", "root_groups": "/api/v1/inventories/17/root_groups/",
+        "script": "/api/v1/inventories/17/script/", "ad_hoc_commands": "/api/v1/inventories/17/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/17/tree/", "hosts": "/api/v1/inventories/17/hosts/",
+        "groups": "/api/v1/inventories/17/groups/", "activity_stream": "/api/v1/inventories/17/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/17/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2016-03-31T18:42:30.808Z", "modified":
+        "2016-12-07T16:24:27.762Z", "name": "Dev VC60", "description": "", "organization":
+        1, "variables": "---", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        {"id": 19, "type": "inventory", "url": "/api/v1/inventories/19/", "related":
+        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "scan_job_templates":
+        "/api/v1/inventories/19/scan_job_templates/", "variable_data": "/api/v1/inventories/19/variable_data/",
+        "root_groups": "/api/v1/inventories/19/root_groups/", "script": "/api/v1/inventories/19/script/",
+        "ad_hoc_commands": "/api/v1/inventories/19/ad_hoc_commands/", "tree": "/api/v1/inventories/19/tree/",
+        "hosts": "/api/v1/inventories/19/hosts/", "groups": "/api/v1/inventories/19/groups/",
+        "activity_stream": "/api/v1/inventories/19/activity_stream/", "inventory_sources":
+        "/api/v1/inventories/19/inventory_sources/", "organization": "/api/v1/organizations/1/"},
+        "summary_fields": {"organization": {"name": "Default", "description": ""},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2017-01-04T23:08:14.212Z", "modified": "2017-01-04T23:08:14.212Z",
+        "name": "jwong", "description": "", "organization": 1, "variables": "---",
+        "has_active_failures": false, "total_hosts": 0, "hosts_with_active_failures":
+        0, "total_groups": 0, "groups_with_active_failures": 0, "has_inventory_sources":
+        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0},
+        {"id": 1, "type": "inventory", "url": "/api/v1/inventories/1/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/1/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/1/variable_data/", "root_groups": "/api/v1/inventories/1/root_groups/",
+        "script": "/api/v1/inventories/1/script/", "ad_hoc_commands": "/api/v1/inventories/1/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/1/tree/", "hosts": "/api/v1/inventories/1/hosts/",
+        "groups": "/api/v1/inventories/1/groups/", "activity_stream": "/api/v1/inventories/1/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/1/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T16:51:16.902Z", "modified":
+        "2015-12-17T16:56:21.511Z", "name": "Openstack", "description": "", "organization":
+        1, "variables": "---", "has_active_failures": false, "total_hosts": 0, "hosts_with_active_failures":
+        0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        {"id": 3, "type": "inventory", "url": "/api/v1/inventories/3/", "related":
+        {"created_by": "/api/v1/users/1/", "scan_job_templates": "/api/v1/inventories/3/scan_job_templates/",
+        "variable_data": "/api/v1/inventories/3/variable_data/", "root_groups": "/api/v1/inventories/3/root_groups/",
+        "script": "/api/v1/inventories/3/script/", "ad_hoc_commands": "/api/v1/inventories/3/ad_hoc_commands/",
+        "tree": "/api/v1/inventories/3/tree/", "hosts": "/api/v1/inventories/3/hosts/",
+        "groups": "/api/v1/inventories/3/groups/", "activity_stream": "/api/v1/inventories/3/activity_stream/",
+        "inventory_sources": "/api/v1/inventories/3/inventory_sources/", "organization":
+        "/api/v1/organizations/1/"}, "summary_fields": {"organization": {"name": "Default",
+        "description": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:08:49.861Z", "modified":
+        "2016-01-15T21:12:24.696Z", "name": "Openstack RH Support", "description":
+        "RH Support Openstack Hosts", "organization": 1, "variables": "---", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, {"id": 8, "type": "inventory", "url":
+        "/api/v1/inventories/8/", "related": {"created_by": "/api/v1/users/1/", "scan_job_templates":
+        "/api/v1/inventories/8/scan_job_templates/", "variable_data": "/api/v1/inventories/8/variable_data/",
+        "root_groups": "/api/v1/inventories/8/root_groups/", "script": "/api/v1/inventories/8/script/",
+        "ad_hoc_commands": "/api/v1/inventories/8/ad_hoc_commands/", "tree": "/api/v1/inventories/8/tree/",
+        "hosts": "/api/v1/inventories/8/hosts/", "groups": "/api/v1/inventories/8/groups/",
+        "activity_stream": "/api/v1/inventories/8/activity_stream/", "inventory_sources":
+        "/api/v1/inventories/8/inventory_sources/", "organization": "/api/v1/organizations/1/"},
+        "summary_fields": {"organization": {"name": "Default", "description": ""},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-29T21:15:35.295Z", "modified": "2016-03-24T14:59:02.954Z",
+        "name": "Single AWS Host", "description": "54.86.210.90", "organization":
+        1, "variables": "---", "has_active_failures": true, "total_hosts": 1, "hosts_with_active_failures":
+        1, "total_groups": 0, "groups_with_active_failures": 0, "has_inventory_sources":
+        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:32 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/hosts/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:33 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.273s
+      Content-Length:
+      - '75817'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=2", "previous": null, "results":
+        [{"id": 222, "type": "host", "url": "/api/v1/hosts/222/", "related": {"job_host_summaries":
+        "/api/v1/hosts/222/job_host_summaries/", "variable_data": "/api/v1/hosts/222/variable_data/",
+        "job_events": "/api/v1/hosts/222/job_events/", "ad_hoc_commands": "/api/v1/hosts/222/ad_hoc_commands/",
+        "fact_versions": "/api/v1/hosts/222/fact_versions/", "inventory_sources":
+        "/api/v1/hosts/222/inventory_sources/", "groups": "/api/v1/hosts/222/groups/",
+        "activity_stream": "/api/v1/hosts/222/activity_stream/", "all_groups": "/api/v1/hosts/222/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/222/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name": "AWS",
+        "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-24T21:50:46.601Z", "modified":
+        "2016-05-24T21:50:47.108Z", "name": "184.72.116.213", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-fef21b62", "variables":
+        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-fef21b62\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-26.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.26\", \"ec2_security_group_names\":
+        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
+        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
+        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-24T20:43:22.000Z\", \"ec2_ip_address\":
+        \"184.72.116.213\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
+        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
+        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 194, "type": "host", "url": "/api/v1/hosts/194/",
+        "related": {"job_host_summaries": "/api/v1/hosts/194/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/194/variable_data/", "job_events": "/api/v1/hosts/194/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/194/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/194/fact_versions/", "inventory_sources": "/api/v1/hosts/194/inventory_sources/",
+        "groups": "/api/v1/hosts/194/groups/", "activity_stream": "/api/v1/hosts/194/activity_stream/",
+        "all_groups": "/api/v1/hosts/194/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/194/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-05T19:44:30.739Z", "modified":
+        "2016-04-05T19:44:31.009Z", "name": "52.20.255.156", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-8b5739f2", "variables":
+        "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-8b5739f2\", \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-254.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.254\", \"ec2_security_group_names\":
+        \"EmsRefreshSpec-SecurityGroup-VPC\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-VPC\", \"ec2_architecture\":
+        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\",
+        \"ec2_client_token\": \"aPCzL1379967112359\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\":
+        \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\": \"/dev/sda1\",
+        \"ec2_subnet_id\": \"subnet-f849ff96\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
+        \"sg-80f755ef\", \"ec2_placement\": \"us-east-1e\", \"ec2_launch_time\": \"2013-09-23T20:11:52.000Z\",
+        \"ec2_ip_address\": \"52.20.255.156\", \"ec2_image_id\": \"ami-5769193e\",
+        \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\": \"paravirtual\",
+        \"ec2_monitored\": false, \"ec2_dns_name\": \"\", \"ec2_previous_state\":
+        \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\":
+        \"\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 221, "type": "host", "url": "/api/v1/hosts/221/",
+        "related": {"job_host_summaries": "/api/v1/hosts/221/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/221/variable_data/", "job_events": "/api/v1/hosts/221/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/221/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/221/fact_versions/", "inventory_sources": "/api/v1/hosts/221/inventory_sources/",
+        "groups": "/api/v1/hosts/221/groups/", "activity_stream": "/api/v1/hosts/221/activity_stream/",
+        "all_groups": "/api/v1/hosts/221/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/221/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-24T19:02:15.148Z", "modified":
+        "2016-05-24T19:02:15.435Z", "name": "52.90.6.108", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-d5608e49", "variables":
+        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-d5608e49\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-68.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.68\", \"ec2_security_group_names\":
+        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
+        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
+        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-24T18:47:02.000Z\", \"ec2_ip_address\":
+        \"52.90.6.108\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
+        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
+        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 195, "type": "host", "url": "/api/v1/hosts/195/",
+        "related": {"job_host_summaries": "/api/v1/hosts/195/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/195/variable_data/", "job_events": "/api/v1/hosts/195/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/195/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/195/fact_versions/", "inventory_sources": "/api/v1/hosts/195/inventory_sources/",
+        "groups": "/api/v1/hosts/195/groups/", "activity_stream": "/api/v1/hosts/195/activity_stream/",
+        "all_groups": "/api/v1/hosts/195/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/195/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-05T19:47:32.266Z", "modified":
+        "2016-04-05T19:47:32.550Z", "name": "52.91.186.182", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-1d3c2387", "variables":
+        "{\"ec2_kernel\": \"\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-1d3c2387\", \"ec2_instance_type\": \"t2.nano\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-183.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.183\", \"ec2_security_group_names\":
+        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"db-test-provision\", \"ec2_architecture\": \"x86_64\",
+        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
+        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/xvda\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-04-05T19:44:35.000Z\", \"ec2_ip_address\":
+        \"52.91.186.182\", \"ec2_image_id\": \"ami-60b6c60a\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"hvm\", \"ec2_monitored\": false, \"ec2_dns_name\":
+        \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 275, "type":
+        "host", "url": "/api/v1/hosts/275/", "related": {"job_host_summaries": "/api/v1/hosts/275/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/275/variable_data/", "job_events": "/api/v1/hosts/275/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/275/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/275/fact_versions/", "inventory_sources": "/api/v1/hosts/275/inventory_sources/",
+        "groups": "/api/v1/hosts/275/groups/", "activity_stream": "/api/v1/hosts/275/activity_stream/",
+        "all_groups": "/api/v1/hosts/275/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/275/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-26T07:37:27.657Z", "modified":
+        "2016-05-26T07:37:28.214Z", "name": "54.165.209.179", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-3eef18a2", "variables":
+        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-3eef18a2\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-224.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.224\", \"ec2_security_group_names\":
+        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
+        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
+        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-25T21:51:56.000Z\", \"ec2_ip_address\":
+        \"54.165.209.179\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
+        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
+        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 220, "type": "host", "url": "/api/v1/hosts/220/",
+        "related": {"job_host_summaries": "/api/v1/hosts/220/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/220/variable_data/", "job_events": "/api/v1/hosts/220/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/220/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/220/fact_versions/", "inventory_sources": "/api/v1/hosts/220/inventory_sources/",
+        "groups": "/api/v1/hosts/220/groups/", "activity_stream": "/api/v1/hosts/220/activity_stream/",
+        "all_groups": "/api/v1/hosts/220/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/220/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-23T21:24:21.556Z", "modified":
+        "2016-05-23T21:24:21.828Z", "name": "54.173.189.199", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-fb694e66", "variables":
+        "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-fb694e66\", \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-109.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.109\", \"ec2_security_group_names\":
+        \"EmsRefreshSpec-SecurityGroup-VPC\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"VMstate-8\", \"ec2_architecture\": \"x86_64\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"uBCLe1462913797292\",
+        \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\": \"\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-80f755ef\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-11T19:53:18.000Z\", \"ec2_ip_address\":
+        \"54.173.189.199\", \"ec2_image_id\": \"ami-5769193e\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
+        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
+        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 276, "type": "host", "url": "/api/v1/hosts/276/",
+        "related": {"job_host_summaries": "/api/v1/hosts/276/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/276/variable_data/", "job_events": "/api/v1/hosts/276/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/276/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/276/fact_versions/", "inventory_sources": "/api/v1/hosts/276/inventory_sources/",
+        "groups": "/api/v1/hosts/276/groups/", "activity_stream": "/api/v1/hosts/276/activity_stream/",
+        "all_groups": "/api/v1/hosts/276/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/276/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-27T20:49:25.335Z", "modified":
+        "2016-05-27T20:49:25.614Z", "name": "54.210.127.55", "description": "imported",
+        "inventory": 2, "enabled": true, "instance_id": "i-3d04fda1", "variables":
+        "{\"ec2_kernel\": \"aki-919dcaf8\", \"ec2_state\": \"running\", \"ec2_ami_launch_index\":
+        \"0\", \"ec2_id\": \"i-3d04fda1\", \"ec2_instance_type\": \"m1.small\", \"ec2_platform\":
+        \"\", \"ec2_sourceDestCheck\": \"true\", \"ec2_private_dns_name\": \"ip-10-0-0-125.ec2.internal\",
+        \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\": \"10.0.0.125\", \"ec2_security_group_names\":
+        \"launch-wizard-13\", \"ec2_vpc_id\": \"vpc-ff49ff91\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"minecraftpe-mp\", \"ec2_architecture\": \"x86_64\",
+        \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\",
+        \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"db\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"\", \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"subnet-f849ff96\",
+        \"ec2_item\": \"\", \"ec2_security_group_ids\": \"sg-dfe6c6a6\", \"ec2_placement\":
+        \"us-east-1e\", \"ec2_launch_time\": \"2016-05-27T20:35:16.000Z\", \"ec2_ip_address\":
+        \"54.210.127.55\", \"ec2_image_id\": \"ami-bcb853d1\", \"ec2_root_device_type\":
+        \"ebs\", \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\":
+        false, \"ec2_dns_name\": \"\", \"ec2_previous_state\": \"\", \"ec2_ramdisk\":
+        \"\", \"ec2__in_monitoring_element\": false, \"ec2_requester_id\": \"\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 386, "type": "host", "url": "/api/v1/hosts/386/",
+        "related": {"job_host_summaries": "/api/v1/hosts/386/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/386/variable_data/", "job_events": "/api/v1/hosts/386/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/386/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/386/fact_versions/", "inventory_sources": "/api/v1/hosts/386/inventory_sources/",
+        "groups": "/api/v1/hosts/386/groups/", "activity_stream": "/api/v1/hosts/386/activity_stream/",
+        "all_groups": "/api/v1/hosts/386/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/386/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.408Z", "modified":
+        "2016-07-25T18:41:44.864Z", "name": "ec2-174-129-183-120.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-cf7144b4", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-cf7144b4\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-141-134-252.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.141.134.252\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"VMWorld_001\", \"ec2_architecture\":
+        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"bill\", \"ec2_client_token\":
+        \"cd854056-ec87-11e1-853b-005056b25af6\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"ec2-174-129-183-120.compute-1.amazonaws.com\", \"ec2_persistent\": false,
+        \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\":
+        \"\", \"ec2_subnet_id\": \"\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
+        \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1b\", \"ec2_launch_time\": \"2012-08-22T18:33:01.000Z\",
+        \"ec2_ip_address\": \"174.129.183.120\", \"ec2_image_id\": \"ami-edaa1f84\",
+        \"ec2_root_device_type\": \"instance-store\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-174-129-183-120.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 387, "type":
+        "host", "url": "/api/v1/hosts/387/", "related": {"job_host_summaries": "/api/v1/hosts/387/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/387/variable_data/", "job_events": "/api/v1/hosts/387/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/387/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/387/fact_versions/", "inventory_sources": "/api/v1/hosts/387/inventory_sources/",
+        "groups": "/api/v1/hosts/387/groups/", "activity_stream": "/api/v1/hosts/387/activity_stream/",
+        "all_groups": "/api/v1/hosts/387/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/387/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.424Z", "modified":
+        "2016-07-25T18:41:44.871Z", "name": "ec2-184-169-243-31.us-west-1.compute.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-fdd815a4", "variables": "{\"ec2_kernel\": \"aki-99a0f1dc\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-fdd815a4\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-160-177-126.us-west-1.compute.internal\", \"ec2_eventsSet\": \"\",
+        \"ec2_private_ip_address\": \"10.160.177.126\", \"ec2_security_group_names\":
+        \"default\", \"ec2_vpc_id\": \"\", \"ec2_state_code\": 272, \"ec2_architecture\":
+        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_key_name\": \"\", \"ec2_client_token\":
+        \"5bfd4308-0bf3-11e2-96b9-a4b197fffe9a\", \"ec2_region\": \"us-west-1\", \"ec2_public_dns_name\":
+        \"ec2-184-169-243-31.us-west-1.compute.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-e94055ac\", \"ec2_placement\": \"us-west-1a\",
+        \"ec2_launch_time\": \"2012-10-01T18:11:04.000Z\", \"ec2_ip_address\": \"184.169.243.31\",
+        \"ec2_image_id\": \"ami-3bc9997e\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-184-169-243-31.us-west-1.compute.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 388, "type":
+        "host", "url": "/api/v1/hosts/388/", "related": {"job_host_summaries": "/api/v1/hosts/388/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/388/variable_data/", "job_events": "/api/v1/hosts/388/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/388/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/388/fact_versions/", "inventory_sources": "/api/v1/hosts/388/inventory_sources/",
+        "groups": "/api/v1/hosts/388/groups/", "activity_stream": "/api/v1/hosts/388/activity_stream/",
+        "all_groups": "/api/v1/hosts/388/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/388/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.429Z", "modified":
+        "2016-07-25T18:41:44.875Z", "name": "ec2-204-236-137-154.us-west-1.compute.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-dc1ee486", "variables": "{\"ec2_kernel\": \"aki-36b79b73\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-dc1ee486\",
+        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-191-129-95.us-west-1.compute.internal\", \"ec2_eventsSet\": \"\",
+        \"ec2_private_ip_address\": \"10.191.129.95\", \"ec2_security_group_names\":
+        \"EmsRefreshSpec-SecurityGroup-OtherRegion\", \"ec2_vpc_id\": \"\", \"ec2_state_code\":
+        16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-OtherRegion\", \"ec2_architecture\":
+        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair-OtherRegion\", \"ec2_client_token\": \"TYBNt1377907963036\",
+        \"ec2_region\": \"us-west-1\", \"ec2_public_dns_name\": \"ec2-204-236-137-154.us-west-1.compute.amazonaws.com\",
+        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-2b87746f\", \"ec2_placement\": \"us-west-1a\",
+        \"ec2_launch_time\": \"2013-08-31T00:12:43.000Z\", \"ec2_ip_address\": \"204.236.137.154\",
+        \"ec2_image_id\": \"ami-183e175d\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-204-236-137-154.us-west-1.compute.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 381, "type":
+        "host", "url": "/api/v1/hosts/381/", "related": {"job_host_summaries": "/api/v1/hosts/381/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/381/variable_data/", "job_events": "/api/v1/hosts/381/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/381/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/381/fact_versions/", "inventory_sources": "/api/v1/hosts/381/inventory_sources/",
+        "groups": "/api/v1/hosts/381/groups/", "activity_stream": "/api/v1/hosts/381/activity_stream/",
+        "all_groups": "/api/v1/hosts/381/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/381/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.069Z", "modified":
+        "2016-07-13T15:50:39.590Z", "name": "ec2-54-157-236-18.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-6c1526f0", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-6c1526f0\",
+        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-181-210-78.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.181.210.78\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-157-236-18.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-07-01T17:52:29.000Z\", \"ec2_ip_address\": \"54.157.236.18\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-157-236-18.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 277, "type":
+        "host", "url": "/api/v1/hosts/277/", "related": {"job_host_summaries": "/api/v1/hosts/277/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/277/variable_data/", "job_events": "/api/v1/hosts/277/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/277/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/277/fact_versions/", "inventory_sources": "/api/v1/hosts/277/inventory_sources/",
+        "groups": "/api/v1/hosts/277/groups/", "activity_stream": "/api/v1/hosts/277/activity_stream/",
+        "all_groups": "/api/v1/hosts/277/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/277/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.139Z", "modified":
+        "2016-06-15T17:59:10.737Z", "name": "ec2-54-161-192-82.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-9c68fe00", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-9c68fe00\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-235-82-38.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.235.82.38\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-161-192-82.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-06-13T18:56:08.000Z\", \"ec2_ip_address\": \"54.161.192.82\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-161-192-82.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 382, "type":
+        "host", "url": "/api/v1/hosts/382/", "related": {"job_host_summaries": "/api/v1/hosts/382/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/382/variable_data/", "job_events": "/api/v1/hosts/382/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/382/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/382/fact_versions/", "inventory_sources": "/api/v1/hosts/382/inventory_sources/",
+        "groups": "/api/v1/hosts/382/groups/", "activity_stream": "/api/v1/hosts/382/activity_stream/",
+        "all_groups": "/api/v1/hosts/382/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/382/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.078Z", "modified":
+        "2016-07-13T15:50:39.594Z", "name": "ec2-54-167-151-39.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-f7b2a36b", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-f7b2a36b\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-180-170-159.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.180.170.159\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_mkanoor_0707_1653\",
+        \"ec2_architecture\": \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
+        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
+        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
+        \"\", \"ec2_key_name\": \"mk\", \"ec2_client_token\": \"\", \"ec2_region\":
+        \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-167-151-39.compute-1.amazonaws.com\",
+        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-07-07T20:54:44.000Z\", \"ec2_ip_address\": \"54.167.151.39\",
+        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
+        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
+        \"ec2-54-167-151-39.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
+        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
+        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 383, "type":
+        "host", "url": "/api/v1/hosts/383/", "related": {"job_host_summaries": "/api/v1/hosts/383/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/383/variable_data/", "job_events": "/api/v1/hosts/383/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/383/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/383/fact_versions/", "inventory_sources": "/api/v1/hosts/383/inventory_sources/",
+        "groups": "/api/v1/hosts/383/groups/", "activity_stream": "/api/v1/hosts/383/activity_stream/",
+        "all_groups": "/api/v1/hosts/383/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/383/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.085Z", "modified":
+        "2016-07-13T15:50:39.599Z", "name": "ec2-54-197-137-38.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-291708b5", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-291708b5\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-123-174-181.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.123.174.181\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_billyx_instance-store\",
+        \"ec2_architecture\": \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
+        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
+        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
+        \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\":
+        \"\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-197-137-38.compute-1.amazonaws.com\",
+        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-07-08T20:26:12.000Z\", \"ec2_ip_address\": \"54.197.137.38\",
+        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
+        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
+        \"ec2-54-197-137-38.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
+        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
+        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 278, "type":
+        "host", "url": "/api/v1/hosts/278/", "related": {"job_host_summaries": "/api/v1/hosts/278/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/278/variable_data/", "job_events": "/api/v1/hosts/278/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/278/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/278/fact_versions/", "inventory_sources": "/api/v1/hosts/278/inventory_sources/",
+        "groups": "/api/v1/hosts/278/groups/", "activity_stream": "/api/v1/hosts/278/activity_stream/",
+        "all_groups": "/api/v1/hosts/278/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/278/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.146Z", "modified":
+        "2016-06-15T17:59:10.742Z", "name": "ec2-54-204-178-162.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-60805cfc", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-60805cfc\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-182-240-219.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.182.240.219\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-204-178-162.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-06-02T13:53:30.000Z\", \"ec2_ip_address\": \"54.204.178.162\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-204-178-162.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 384, "type":
+        "host", "url": "/api/v1/hosts/384/", "related": {"job_host_summaries": "/api/v1/hosts/384/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/384/variable_data/", "job_events": "/api/v1/hosts/384/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/384/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/384/fact_versions/", "inventory_sources": "/api/v1/hosts/384/inventory_sources/",
+        "groups": "/api/v1/hosts/384/groups/", "activity_stream": "/api/v1/hosts/384/activity_stream/",
+        "all_groups": "/api/v1/hosts/384/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/384/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.090Z", "modified":
+        "2016-07-13T15:50:39.604Z", "name": "ec2-54-204-235-7.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-81e5d51d", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-81e5d51d\",
+        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-182-185-68.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.182.185.68\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-204-235-7.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-07-01T14:29:04.000Z\", \"ec2_ip_address\": \"54.204.235.7\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-204-235-7.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 385, "type":
+        "host", "url": "/api/v1/hosts/385/", "related": {"job_host_summaries": "/api/v1/hosts/385/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/385/variable_data/", "job_events": "/api/v1/hosts/385/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/385/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/385/fact_versions/", "inventory_sources": "/api/v1/hosts/385/inventory_sources/",
+        "groups": "/api/v1/hosts/385/groups/", "activity_stream": "/api/v1/hosts/385/activity_stream/",
+        "all_groups": "/api/v1/hosts/385/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/385/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-13T15:50:39.094Z", "modified":
+        "2016-07-13T15:50:39.608Z", "name": "ec2-54-211-15-200.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-2f4858b3", "variables": "{\"ec2_kernel\": \"aki-a71cf9ce\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-2f4858b3\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-43-148-212.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.43.148.212\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-211-15-200.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-07-07T21:38:29.000Z\", \"ec2_ip_address\": \"54.211.15.200\",
+        \"ec2_image_id\": \"ami-edaa1f84\", \"ec2_root_device_type\": \"instance-store\",
+        \"ec2_virtualization_type\": \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\":
+        \"ec2-54-211-15-200.compute-1.amazonaws.com\", \"ec2_previous_state\": \"\",
+        \"ec2_ramdisk\": \"ari-a51cf9cc\", \"ec2__in_monitoring_element\": false,
+        \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 279, "type":
+        "host", "url": "/api/v1/hosts/279/", "related": {"job_host_summaries": "/api/v1/hosts/279/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/279/variable_data/", "job_events": "/api/v1/hosts/279/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/279/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/279/fact_versions/", "inventory_sources": "/api/v1/hosts/279/inventory_sources/",
+        "groups": "/api/v1/hosts/279/groups/", "activity_stream": "/api/v1/hosts/279/activity_stream/",
+        "all_groups": "/api/v1/hosts/279/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/279/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.151Z", "modified":
+        "2016-06-15T17:59:10.750Z", "name": "ec2-54-211-165-245.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-7f45c6e3", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-7f45c6e3\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-230-44-55.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.230.44.55\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_architecture\": \"i386\", \"ec2_monitoring\":
+        \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\":
+        \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\": false,
+        \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-211-165-245.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-06-10T17:34:32.000Z\", \"ec2_ip_address\": \"54.211.165.245\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-211-165-245.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 389, "type":
+        "host", "url": "/api/v1/hosts/389/", "related": {"job_host_summaries": "/api/v1/hosts/389/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/389/variable_data/", "job_events": "/api/v1/hosts/389/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/389/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/389/fact_versions/", "inventory_sources": "/api/v1/hosts/389/inventory_sources/",
+        "groups": "/api/v1/hosts/389/groups/", "activity_stream": "/api/v1/hosts/389/activity_stream/",
+        "all_groups": "/api/v1/hosts/389/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/389/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.434Z", "modified":
+        "2016-07-25T18:41:44.880Z", "name": "ec2-54-221-202-53.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-680071e9", "variables": "{\"ec2_kernel\": \"aki-1eceaf77\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-680071e9\",
+        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-65-160-22.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.65.160.22\", \"ec2_security_group_names\": \"EmsRefreshSpec-SecurityGroup1,EmsRefreshSpec-SecurityGroup2\",
+        \"ec2_vpc_id\": \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"EmsRefreshSpec-PoweredOn-Basic3\",
+        \"ec2_architecture\": \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\":
+        \"\", \"ec2_hypervisor\": \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\":
+        \"\", \"ec2_ebs_optimized\": false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\":
+        \"\", \"ec2_key_name\": \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\":
+        \"JwNdr1452196715903\", \"ec2_region\": \"us-east-1\", \"ec2_public_dns_name\":
+        \"ec2-54-221-202-53.compute-1.amazonaws.com\", \"ec2_persistent\": false,
+        \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\": 0, \"ec2_root_device_name\":
+        \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\": \"\", \"ec2_security_group_ids\":
+        \"sg-038e8a69,sg-12898d78\", \"ec2_placement\": \"us-east-1e\", \"ec2_launch_time\":
+        \"2016-03-29T07:49:56.000Z\", \"ec2_ip_address\": \"54.221.202.53\", \"ec2_image_id\":
+        \"ami-5769193e\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-221-202-53.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 390, "type":
+        "host", "url": "/api/v1/hosts/390/", "related": {"job_host_summaries": "/api/v1/hosts/390/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/390/variable_data/", "job_events": "/api/v1/hosts/390/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/390/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/390/fact_versions/", "inventory_sources": "/api/v1/hosts/390/inventory_sources/",
+        "groups": "/api/v1/hosts/390/groups/", "activity_stream": "/api/v1/hosts/390/activity_stream/",
+        "all_groups": "/api/v1/hosts/390/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/390/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-07-25T18:41:44.439Z", "modified":
+        "2016-07-25T18:41:44.884Z", "name": "ec2-54-224-129-8.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-10b27f76", "variables": "{\"ec2_kernel\": \"aki-08ed0761\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-10b27f76\",
+        \"ec2_instance_type\": \"t1.micro\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-185-241-50.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.185.241.50\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"WP_WEB_06\", \"ec2_architecture\":
+        \"x86_64\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"miq\", \"ec2_client_token\": \"95bdee84-5d1a-11e3-a53a-005056b25643\", \"ec2_region\":
+        \"us-east-1\", \"ec2_public_dns_name\": \"ec2-54-224-129-8.compute-1.amazonaws.com\",
+        \"ec2_persistent\": false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1d\",
+        \"ec2_launch_time\": \"2014-11-10T23:12:06.000Z\", \"ec2_ip_address\": \"54.224.129.8\",
+        \"ec2_image_id\": \"ami-bda014d4\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-224-129-8.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 280, "type":
+        "host", "url": "/api/v1/hosts/280/", "related": {"job_host_summaries": "/api/v1/hosts/280/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/280/variable_data/", "job_events": "/api/v1/hosts/280/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/280/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/280/fact_versions/", "inventory_sources": "/api/v1/hosts/280/inventory_sources/",
+        "groups": "/api/v1/hosts/280/groups/", "activity_stream": "/api/v1/hosts/280/activity_stream/",
+        "all_groups": "/api/v1/hosts/280/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/280/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/2/"}, "summary_fields": {"inventory": {"name":
+        "AWS", "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-06-15T17:59:10.158Z", "modified":
+        "2016-06-15T17:59:10.767Z", "name": "ec2-54-92-246-63.compute-1.amazonaws.com",
+        "description": "imported", "inventory": 2, "enabled": true, "instance_id":
+        "i-cda32951", "variables": "{\"ec2_kernel\": \"aki-36ed075f\", \"ec2_state\":
+        \"running\", \"ec2_ami_launch_index\": \"0\", \"ec2_id\": \"i-cda32951\",
+        \"ec2_instance_type\": \"m1.small\", \"ec2_platform\": \"\", \"ec2_private_dns_name\":
+        \"ip-10-91-187-140.ec2.internal\", \"ec2_eventsSet\": \"\", \"ec2_private_ip_address\":
+        \"10.91.187.140\", \"ec2_security_group_names\": \"default\", \"ec2_vpc_id\":
+        \"\", \"ec2_state_code\": 16, \"ec2_tag_Name\": \"test_billya_0008\", \"ec2_architecture\":
+        \"i386\", \"ec2_monitoring\": \"\", \"ec2_group_name\": \"\", \"ec2_hypervisor\":
+        \"xen\", \"ec2_reason\": \"\", \"ec2_spot_instance_request_id\": \"\", \"ec2_ebs_optimized\":
+        false, \"ec2_instance_profile\": \"\", \"ec2_state_reason\": \"\", \"ec2_key_name\":
+        \"EmsRefreshSpec-KeyPair\", \"ec2_client_token\": \"\", \"ec2_region\": \"us-east-1\",
+        \"ec2_public_dns_name\": \"ec2-54-92-246-63.compute-1.amazonaws.com\", \"ec2_persistent\":
+        false, \"ec2_monitoring_state\": \"disabled\", \"ec2_previous_state_code\":
+        0, \"ec2_root_device_name\": \"/dev/sda1\", \"ec2_subnet_id\": \"\", \"ec2_item\":
+        \"\", \"ec2_security_group_ids\": \"sg-347f9b5d\", \"ec2_placement\": \"us-east-1e\",
+        \"ec2_launch_time\": \"2016-06-12T23:10:58.000Z\", \"ec2_ip_address\": \"54.92.246.63\",
+        \"ec2_image_id\": \"ami-63ac180a\", \"ec2_root_device_type\": \"ebs\", \"ec2_virtualization_type\":
+        \"paravirtual\", \"ec2_monitored\": false, \"ec2_dns_name\": \"ec2-54-92-246-63.compute-1.amazonaws.com\",
+        \"ec2_previous_state\": \"\", \"ec2_ramdisk\": \"\", \"ec2__in_monitoring_element\":
+        false, \"ec2_requester_id\": \"\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 65, "type":
+        "host", "url": "/api/v1/hosts/65/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "job_host_summaries": "/api/v1/hosts/65/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/65/variable_data/", "job_events": "/api/v1/hosts/65/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/65/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/65/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/65/inventory_sources/", "groups": "/api/v1/hosts/65/groups/",
+        "activity_stream": "/api/v1/hosts/65/activity_stream/", "all_groups": "/api/v1/hosts/65/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/65/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/9/"}, "summary_fields": {"inventory": {"name": "db-test-inventory-put",
+        "description": "", "has_active_failures": false, "total_hosts": 1, "hosts_with_active_failures":
+        0, "total_groups": 1, "groups_with_active_failures": 0, "has_inventory_sources":
+        false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "recent_jobs": []}, "created": "2016-02-01T19:47:45.695Z", "modified":
+        "2016-02-01T19:47:45.695Z", "name": "127.0.0.1", "description": "db-test-host",
+        "inventory": 9, "enabled": true, "instance_id": "", "variables": "", "has_active_failures":
+        false, "has_inventory_sources": false, "last_job": null, "last_job_host_summary":
+        null}, {"id": 147, "type": "host", "url": "/api/v1/hosts/147/", "related":
+        {"job_host_summaries": "/api/v1/hosts/147/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/147/variable_data/", "job_events": "/api/v1/hosts/147/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/147/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/147/fact_versions/", "inventory_sources": "/api/v1/hosts/147/inventory_sources/",
+        "groups": "/api/v1/hosts/147/groups/", "activity_stream": "/api/v1/hosts/147/activity_stream/",
+        "all_groups": "/api/v1/hosts/147/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/147/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1464/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.737Z",
+        "modified": "2016-11-17T17:56:26.542Z", "name": "aab-brewery7", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "564d5056-49ea-a5aa-a71d-cf9b8138430b",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-brewery7/aab-brewery7.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.1\", \"vmware_guestMemoryUsage\": 163, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"52ec15d3-0467-1880-8fc6-f91416816ad6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 341385339791,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16594,
+        \"ansible_ssh_host\": \"10.8.97.1\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"564d5056-49ea-a5aa-a71d-cf9b8138430b\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 150168002560, \"vmware_distributedMemoryEntitlement\":
+        784, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
+        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 100, \"vmware_privateMemory\": 1616, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 392943550827, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"aab-brewery7\", \"vmware_uptimeSeconds\": 5522794,
+        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"aab-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 1673, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 49, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1464}, {"id": 148, "type": "host", "url": "/api/v1/hosts/148/",
+        "related": {"job_host_summaries": "/api/v1/hosts/148/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/148/variable_data/", "job_events": "/api/v1/hosts/148/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/148/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/148/fact_versions/", "inventory_sources": "/api/v1/hosts/148/inventory_sources/",
+        "groups": "/api/v1/hosts/148/groups/", "activity_stream": "/api/v1/hosts/148/activity_stream/",
+        "all_groups": "/api/v1/hosts/148/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/148/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1456/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.742Z",
+        "modified": "2016-11-17T17:56:26.558Z", "name": "aab-idp", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "4233467e-9249-f495-f348-3ca09711bac1",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-idp/aab-idp.vmx\",
+        \"vmware_ipAddress\": \"192.168.122.1\", \"vmware_guestMemoryUsage\": 81,
+        \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat
+        Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"503399f4-212d-055a-556e-75cc9026f15d\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 9512372107,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4180,
+        \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"4233467e-9249-f495-f348-3ca09711bac1\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 717, \"vmware_uncommitted\":
+        42184114176, \"vmware_distributedMemoryEntitlement\": 986, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"SAML Provider\\n-
+        Keycloak\", \"vmware_maxMemoryUsage\": 4096, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 1597, \"vmware_privateMemory\": 2499,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"aab-idp.aabsaml.redhat.com\", \"vmware_uptimeSeconds\":
+        1986597, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        2, \"vmware_installBootRequired\": false, \"vmware_committed\": 26732483320,
+        \"vmware_name\": \"aab-idp\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2570, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 43, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1456}, {"id": 149, "type": "host", "url": "/api/v1/hosts/149/",
+        "related": {"job_host_summaries": "/api/v1/hosts/149/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/149/variable_data/", "job_events": "/api/v1/hosts/149/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/149/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/149/fact_versions/", "inventory_sources": "/api/v1/hosts/149/inventory_sources/",
+        "groups": "/api/v1/hosts/149/groups/", "activity_stream": "/api/v1/hosts/149/activity_stream/",
+        "all_groups": "/api/v1/hosts/149/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/149/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1451/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.747Z",
+        "modified": "2016-11-17T17:56:26.572Z", "name": "aab-ipaserver7", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "564d8be8-84bf-03ab-c421-a503da6db700",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-ipaserver7/aab-ipaserver7.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.9\", \"vmware_guestMemoryUsage\": 163, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"52605f18-24e2-1a63-46c8-2dd79ee2469f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 9841623597, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 4165, \"ansible_ssh_host\":
+        \"10.8.97.9\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"564d8be8-84bf-03ab-c421-a503da6db700\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        717, \"vmware_uncommitted\": 11633213440, \"vmware_distributedMemoryEntitlement\":
+        1296, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        73, \"vmware_privateMemory\": 3895, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_committed\":
+        9843228345, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"aab-ipaserver7.aabipa.redhat.com\",
+        \"vmware_uptimeSeconds\": 6837379, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"aab-ipaserver7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3946, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 37, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1451}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:34 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.283s
+      Content-Length:
+      - '96525'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=3", "previous": "/api/v1/hosts/?page=1",
+        "results": [{"id": 830, "type": "host", "url": "/api/v1/hosts/830/", "related":
+        {"job_host_summaries": "/api/v1/hosts/830/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/830/variable_data/", "job_events": "/api/v1/hosts/830/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/830/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/830/fact_versions/", "inventory_sources": "/api/v1/hosts/830/inventory_sources/",
+        "groups": "/api/v1/hosts/830/groups/", "activity_stream": "/api/v1/hosts/830/activity_stream/",
+        "all_groups": "/api/v1/hosts/830/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/830/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1471/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.421Z",
+        "modified": "2016-11-17T17:56:26.583Z", "name": "aab-ldap", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c8f0d-4a8f-0b6d-fc3a-0c3cfab7b33f",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-ldap/aab-ldap.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.22\", \"vmware_guestMemoryUsage\": 122, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c1916-2acd-2e09-90bf-4db1d8dec048\", \"vmware_distributedCpuEntitlement\":
+        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 10349052455,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4157,
+        \"ansible_ssh_host\": \"10.8.97.22\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c8f0d-4a8f-0b6d-fc3a-0c3cfab7b33f\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 717, \"vmware_uncommitted\":
+        11125784576, \"vmware_distributedMemoryEntitlement\": 1351, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        69, \"vmware_privateMemory\": 3899, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 47, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"aab-ldap\", \"vmware_uptimeSeconds\":
+        6754095, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        2, \"vmware_installBootRequired\": false, \"vmware_committed\": 10349902125,
+        \"vmware_name\": \"aab-ldap\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3940, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 37, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1471}, {"id": 150, "type": "host", "url": "/api/v1/hosts/150/",
+        "related": {"job_host_summaries": "/api/v1/hosts/150/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/150/variable_data/", "job_events": "/api/v1/hosts/150/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/150/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/150/fact_versions/", "inventory_sources": "/api/v1/hosts/150/inventory_sources/",
+        "groups": "/api/v1/hosts/150/groups/", "activity_stream": "/api/v1/hosts/150/activity_stream/",
+        "all_groups": "/api/v1/hosts/150/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/150/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1459/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.752Z",
+        "modified": "2016-11-17T17:56:26.595Z", "name": "aab-miq-saml", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "42332064-1b21-3bc2-ee0b-09ae0799bc3b",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] aab-miq-saml/aab-miq-saml.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.8\", \"vmware_guestMemoryUsage\": 2129, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"50332797-ee3a-a583-9dbc-02a5f6c24815\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 15840109449,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16548,
+        \"ansible_ssh_host\": \"10.8.97.8\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"42332064-1b21-3bc2-ee0b-09ae0799bc3b\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 31434903552, \"vmware_distributedMemoryEntitlement\":
+        3820, \"vmware_template\": false, \"vmware_overallCpuDemand\": 191, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"ManageIQ SAML
+        External Auth Prototype\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 103, \"vmware_privateMemory\": 7857,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 191, \"vmware_overallStatus\":
+        \"green\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 15841920551, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"aab-miq-saml.aabsaml.redhat.com\", \"vmware_uptimeSeconds\":
+        2500467, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"aab-miq-saml\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 7947, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 66, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1459}, {"id": 249, "type": "host", "url": "/api/v1/hosts/249/",
+        "related": {"job_host_summaries": "/api/v1/hosts/249/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/249/variable_data/", "job_events": "/api/v1/hosts/249/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/249/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/249/fact_versions/", "inventory_sources": "/api/v1/hosts/249/inventory_sources/",
+        "groups": "/api/v1/hosts/249/groups/", "activity_stream": "/api/v1/hosts/249/activity_stream/",
+        "all_groups": "/api/v1/hosts/249/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/249/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.522Z", "modified":
+        "2016-05-25T14:07:46.673Z", "name": "ag-centos-3", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cef80-3008-d177-3d38-b3f4ade5e8e3",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500c4a54-021e-b5dc-d347-a147abd0aa36\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] ag-centos-3/ag-centos-3.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 16, \"vmware_uuid\": \"420cef80-3008-d177-3d38-b3f4ade5e8e3\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1956827680, \"vmware_name\":
+        \"ag-centos-3\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18652246016, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource: db-centos-7-template\\n\\nMIQ
+        GUID=303298f2-12e5-11e6-972c-52540020383c\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1956815880, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 250, "type": "host", "url": "/api/v1/hosts/250/",
+        "related": {"job_host_summaries": "/api/v1/hosts/250/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/250/variable_data/", "job_events": "/api/v1/hosts/250/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/250/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/250/fact_versions/", "inventory_sources": "/api/v1/hosts/250/inventory_sources/",
+        "groups": "/api/v1/hosts/250/groups/", "activity_stream": "/api/v1/hosts/250/activity_stream/",
+        "all_groups": "/api/v1/hosts/250/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/250/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.527Z", "modified":
+        "2016-05-25T14:07:46.677Z", "name": "ag-centos-4", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c3542-3bbb-1bc1-9f49-a1b43bfc9781",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500cd634-3e8e-7fa2-1022-873b72df686c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] ag-centos-4/ag-centos-4.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 16, \"vmware_uuid\": \"420c3542-3bbb-1bc1-9f49-a1b43bfc9781\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1956827681, \"vmware_name\":
+        \"ag-centos-4\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18652246016, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource: db-centos-7-template\\n\\nMIQ
+        GUID=c40aeb50-139f-11e6-97b3-52540020383c\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1956815880, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 151, "type": "host", "url": "/api/v1/hosts/151/",
+        "related": {"job_host_summaries": "/api/v1/hosts/151/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/151/variable_data/", "job_events": "/api/v1/hosts/151/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/151/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/151/fact_versions/", "inventory_sources": "/api/v1/hosts/151/inventory_sources/",
+        "groups": "/api/v1/hosts/151/groups/", "activity_stream": "/api/v1/hosts/151/activity_stream/",
+        "all_groups": "/api/v1/hosts/151/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/151/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1415/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.757Z",
+        "modified": "2016-11-17T17:56:26.607Z", "name": "ag_cfme_5.5", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "4233b56a-db5f-66a0-f701-734b406046b1",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] CFME (Agrare)/CFME (Agrare).vmx\",
+        \"vmware_ipAddress\": \"10.8.99.221\", \"vmware_guestMemoryUsage\": 2990,
+        \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"50336b48-19a0-91bb-5f74-3da27ef38d57\", \"vmware_distributedCpuEntitlement\":
+        983, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 33256118350,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4172,
+        \"ansible_ssh_host\": \"10.8.99.221\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"4233b56a-db5f-66a0-f701-734b406046b1\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 169062191104, \"vmware_distributedMemoryEntitlement\":
+        3691, \"vmware_template\": false, \"vmware_overallCpuDemand\": 2686, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        33, \"vmware_privateMemory\": 3937, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 2351, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
+        33257658300, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-221.example.com\",
+        \"vmware_uptimeSeconds\": 4487391, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"ag_cfme_5.5\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3987, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 46, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1415}, {"id": 196, "type": "host", "url": "/api/v1/hosts/196/",
+        "related": {"job_host_summaries": "/api/v1/hosts/196/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/196/variable_data/", "job_events": "/api/v1/hosts/196/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/196/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/196/fact_versions/", "inventory_sources": "/api/v1/hosts/196/inventory_sources/",
+        "groups": "/api/v1/hosts/196/groups/", "activity_stream": "/api/v1/hosts/196/activity_stream/",
+        "all_groups": "/api/v1/hosts/196/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/196/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1428/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-08T13:22:58.967Z",
+        "modified": "2016-11-17T17:25:55.124Z", "name": "ag_cfme_5.5.2.4", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cffcd-39ca-d9f6-8882-074070e680c2",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c78d4-ecde-df05-725b-a7432327e3ba\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"running\", \"vmware_guestFullName\": \"Red Hat
+        Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        363, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2045253895, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"ag_cfme_5.5.2.4\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        857, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        43, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        cfme-5.5.2.4/cfme-5.5.2.4.vmx\", \"vmware_ipAddress\": \"10.8.99.210\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 2045015083, \"vmware_staticMemoryEntitlement\":
+        8311, \"ansible_ssh_host\": \"10.8.99.210\", \"vmware_uuid\": \"420cffcd-39ca-d9f6-8882-074070e680c2\",
+        \"vmware_staticCpuEntitlement\": 2901, \"vmware_uncommitted\": 75264397312,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 814, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"dhcp-8-99-210.example.com\",
+        \"vmware_uptimeSeconds\": 1062063, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1428}, {"id": 152, "type":
+        "host", "url": "/api/v1/hosts/152/", "related": {"job_host_summaries": "/api/v1/hosts/152/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/152/variable_data/", "job_events": "/api/v1/hosts/152/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/152/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/152/fact_versions/", "inventory_sources": "/api/v1/hosts/152/inventory_sources/",
+        "groups": "/api/v1/hosts/152/groups/", "activity_stream": "/api/v1/hosts/152/activity_stream/",
+        "all_groups": "/api/v1/hosts/152/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/152/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.762Z", "modified":
+        "2016-03-31T18:43:05.774Z", "name": "ag_cfme_5.5_clone", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c5dee-c354-5713-10df-9ec3de4fd88b",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostName\": \"dhcp-8-99-218.example.com\",
+        \"vmware_instanceUuid\": \"500c466e-9533-f7ec-6766-3a4963b79c64\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_cfme_5.5_clone/ag_cfme_5.5_clone.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c5dee-c354-5713-10df-9ec3de4fd88b\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 14664741287,
+        \"vmware_name\": \"ag_cfme_5.5_clone\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 173436108800,
+        \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\": 0,
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource VM: ag_cfme_5.5\\n\\nMIQ
+        GUID=e435d0b2-d98d-11e5-864d-52540056dab7\", \"vmware_maxMemoryUsage\": 4096,
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 14663926893,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 198, "type":
+        "host", "url": "/api/v1/hosts/198/", "related": {"job_host_summaries": "/api/v1/hosts/198/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/198/variable_data/", "job_events": "/api/v1/hosts/198/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/198/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/198/fact_versions/", "inventory_sources": "/api/v1/hosts/198/inventory_sources/",
+        "groups": "/api/v1/hosts/198/groups/", "activity_stream": "/api/v1/hosts/198/activity_stream/",
+        "all_groups": "/api/v1/hosts/198/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/198/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-18T20:26:31.050Z", "modified":
+        "2016-04-18T20:26:31.250Z", "name": "ag_cfme_5.5_template", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c30ff-0d3d-501e-78da-35a68515d7d6",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c9dd7-01fd-6da9-77d1-6c94d6f4e978\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_cfme_5.5_template/ag_cfme_5.5_template.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c30ff-0d3d-501e-78da-35a68515d7d6\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 15267197573,
+        \"vmware_name\": \"ag_cfme_5.5_template\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        172832849920, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: Adam Grare\\nEmail: agrare@redhat.com\\nSource Template: ag_cfme_5.5\\n\\nMIQ
+        GUID=29d020a0-fd97-11e5-b063-5254006ea507\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 15267185779, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 251, "type": "host", "url": "/api/v1/hosts/251/",
+        "related": {"job_host_summaries": "/api/v1/hosts/251/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/251/variable_data/", "job_events": "/api/v1/hosts/251/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/251/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/251/fact_versions/", "inventory_sources": "/api/v1/hosts/251/inventory_sources/",
+        "groups": "/api/v1/hosts/251/groups/", "activity_stream": "/api/v1/hosts/251/activity_stream/",
+        "all_groups": "/api/v1/hosts/251/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/251/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1457/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.532Z",
+        "modified": "2016-11-17T17:25:55.712Z", "name": "agrare-centos", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cf83c-ed2f-38c6-8e24-7cec6866bea2",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] agrare-centos/agrare-centos.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.228\", \"vmware_guestMemoryUsage\": 61, \"vmware_networks\":
+        [\"DPortGroup\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"dev-esxi6hyper1.example.com\",
+        \"vmware_instanceUuid\": \"500cb091-4426-4298-6b7d-210e8733426a\", \"vmware_distributedCpuEntitlement\":
+        68, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1956815884,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 1083,
+        \"ansible_ssh_host\": \"10.8.99.228\", \"vmware_overallStatus\": \"green\",
+        \"vmware_uuid\": \"420cf83c-ed2f-38c6-8e24-7cec6866bea2\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 9188, \"vmware_uncommitted\":
+        17370537984, \"vmware_distributedMemoryEntitlement\": 382, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 68, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=cb683378-12cb-11e6-8c90-54ee753e66dc\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 362, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 68, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 7166, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 1731009, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1956991403, \"vmware_name\": \"agrare-centos\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        398, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 36, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1457}, {"id": 212, "type": "host", "url": "/api/v1/hosts/212/",
+        "related": {"job_host_summaries": "/api/v1/hosts/212/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/212/variable_data/", "job_events": "/api/v1/hosts/212/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/212/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/212/fact_versions/", "inventory_sources": "/api/v1/hosts/212/inventory_sources/",
+        "groups": "/api/v1/hosts/212/groups/", "activity_stream": "/api/v1/hosts/212/activity_stream/",
+        "all_groups": "/api/v1/hosts/212/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/212/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.443Z", "modified":
+        "2016-05-25T14:07:45.279Z", "name": "agrare-dvs-test", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c6a2d-108c-91c5-6aaa-391e18d8215c",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] agrare-dvs-test/agrare-dvs-test.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper2.example.com\", \"vmware_instanceUuid\":
+        \"500caaac-ac35-3c7b-161c-c7d8e20103c0\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 503, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_uuid\": \"420c6a2d-108c-91c5-6aaa-391e18d8215c\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19519406080, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 316860, \"vmware_name\": \"agrare-dvs-test\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 252, "type": "host", "url": "/api/v1/hosts/252/",
+        "related": {"job_host_summaries": "/api/v1/hosts/252/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/252/variable_data/", "job_events": "/api/v1/hosts/252/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/252/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/252/fact_versions/", "inventory_sources": "/api/v1/hosts/252/inventory_sources/",
+        "groups": "/api/v1/hosts/252/groups/", "activity_stream": "/api/v1/hosts/252/activity_stream/",
+        "all_groups": "/api/v1/hosts/252/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/252/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.537Z", "modified":
+        "2016-05-25T14:07:46.687Z", "name": "agrare-dvs-test-1", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ca3a3-3e75-b8cf-4a26-82f4d6e5d452",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup_1\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper2.example.com\", \"vmware_instanceUuid\":
+        \"500c831a-ecc3-7478-5397-b5fad6ec94b0\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] agrare-dvs-test-1/agrare-dvs-test-1.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ca3a3-3e75-b8cf-4a26-82f4d6e5d452\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2634, \"vmware_name\":
+        \"agrare-dvs-test-1\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 505,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 154, "type":
+        "host", "url": "/api/v1/hosts/154/", "related": {"job_host_summaries": "/api/v1/hosts/154/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/154/variable_data/", "job_events": "/api/v1/hosts/154/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/154/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/154/fact_versions/", "inventory_sources": "/api/v1/hosts/154/inventory_sources/",
+        "groups": "/api/v1/hosts/154/groups/", "activity_stream": "/api/v1/hosts/154/activity_stream/",
+        "all_groups": "/api/v1/hosts/154/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/154/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/374/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
+        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
+        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
+        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
+        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.772Z",
+        "modified": "2016-05-25T14:07:45.505Z", "name": "ag_rhel_7", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7162-30ec-7368-6e4f-89238167d850",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] ag_rhel_7/ag_rhel_7.vmtx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500cb016-33eb-e588-c30a-80f2e2b63bcd\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 497, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_uuid\": \"420c7162-30ec-7368-6e4f-89238167d850\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19519406080, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
+        true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
+        1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 11089, \"vmware_name\": \"ag_rhel_7\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 362,
+        "last_job_host_summary": 374}, {"id": 831, "type": "host", "url": "/api/v1/hosts/831/",
+        "related": {"job_host_summaries": "/api/v1/hosts/831/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/831/variable_data/", "job_events": "/api/v1/hosts/831/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/831/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/831/fact_versions/", "inventory_sources": "/api/v1/hosts/831/inventory_sources/",
+        "groups": "/api/v1/hosts/831/groups/", "activity_stream": "/api/v1/hosts/831/activity_stream/",
+        "all_groups": "/api/v1/hosts/831/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/831/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.426Z", "modified":
+        "2016-10-14T13:37:12.102Z", "name": "ag_rhel_7_template", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ccf7d-cf55-2d33-f70e-8b07ed54ced3",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c7a10-141a-bbad-e145-4b53d70d09cd\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] ag_rhel_7_template/ag_rhel_7_template.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ccf7d-cf55-2d33-f70e-8b07ed54ced3\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 11039, \"vmware_name\":
+        \"ag_rhel_7_template\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 9318858752, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        512, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 506,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 153, "type":
+        "host", "url": "/api/v1/hosts/153/", "related": {"job_host_summaries": "/api/v1/hosts/153/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/153/variable_data/", "job_events": "/api/v1/hosts/153/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/153/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/153/fact_versions/", "inventory_sources": "/api/v1/hosts/153/inventory_sources/",
+        "groups": "/api/v1/hosts/153/groups/", "activity_stream": "/api/v1/hosts/153/activity_stream/",
+        "all_groups": "/api/v1/hosts/153/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/153/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.767Z", "modified":
+        "2016-03-31T18:43:05.783Z", "name": "ag_rhel7_template", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c638c-3ab6-9c76-d202-c3046d7f4d70",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c5927-fc20-5833-b042-c747d3305bbe\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] ag_rhel7_template/ag_rhel7_template.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c638c-3ab6-9c76-d202-c3046d7f4d70\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 24128453, \"vmware_name\":
+        \"ag_rhel7_template\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19498471952, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\", \"NFS Share\"], \"vmware_cpuReservation\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 24117248,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 878, "type":
+        "host", "url": "/api/v1/hosts/878/", "related": {"job_host_summaries": "/api/v1/hosts/878/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/878/variable_data/", "job_events": "/api/v1/hosts/878/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/878/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/878/fact_versions/", "inventory_sources": "/api/v1/hosts/878/inventory_sources/",
+        "groups": "/api/v1/hosts/878/groups/", "activity_stream": "/api/v1/hosts/878/activity_stream/",
+        "all_groups": "/api/v1/hosts/878/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/878/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1461/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-24T19:13:46.822Z",
+        "modified": "2016-11-17T17:25:55.784Z", "name": "ag_test_1", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420ccea6-fce8-6f11-7d4c-1016efcabb60",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] ag_test_1_2/ag_test_1.vmx\",
+        \"vmware_guestMemoryUsage\": 10, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c0fce-87fe-0af6-e708-ee74f7047328\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1116840433, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 1068, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420ccea6-fce8-6f11-7d4c-1016efcabb60\", \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        394, \"vmware_uncommitted\": 16063029248, \"vmware_distributedMemoryEntitlement\":
+        319, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        1024, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        20, \"vmware_privateMemory\": 316, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_committed\":
+        1117975536, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 348147,
+        \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"ag_test_1\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 347, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_guestId\":
+        \"rhel7_64Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        29, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1461}, {"id": 832, "type":
+        "host", "url": "/api/v1/hosts/832/", "related": {"job_host_summaries": "/api/v1/hosts/832/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/832/variable_data/", "job_events": "/api/v1/hosts/832/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/832/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/832/fact_versions/", "inventory_sources": "/api/v1/hosts/832/inventory_sources/",
+        "groups": "/api/v1/hosts/832/groups/", "activity_stream": "/api/v1/hosts/832/activity_stream/",
+        "all_groups": "/api/v1/hosts/832/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/832/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/810/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1124/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-10-24T20:41:58.883Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T14:09:39.286Z",
+        "id": 802, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.431Z",
+        "modified": "2016-10-28T14:56:16.084Z", "name": "akrzos-rhel7-performance",
+        "description": "imported", "inventory": 17, "enabled": false, "instance_id":
+        "420c207c-baad-fae1-9bd6-8da00edab68d", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] akrzos-rhel7-performance/akrzos-rhel7-performance.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c33be-6d66-9c60-41d8-7be3d9f1b81b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 8472773496, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420c207c-baad-fae1-9bd6-8da00edab68d\", \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 56752136192, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_committed\":
+        8474104378, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\":
+        false, \"vmware_numMksConnections\": 0, \"vmware_name\": \"akrzos-rhel7-performance\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        810, "last_job_host_summary": 1124}, {"id": 833, "type": "host", "url": "/api/v1/hosts/833/",
+        "related": {"job_host_summaries": "/api/v1/hosts/833/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/833/variable_data/", "job_events": "/api/v1/hosts/833/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/833/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/833/fact_versions/", "inventory_sources": "/api/v1/hosts/833/inventory_sources/",
+        "groups": "/api/v1/hosts/833/groups/", "activity_stream": "/api/v1/hosts/833/activity_stream/",
+        "all_groups": "/api/v1/hosts/833/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/833/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.437Z", "modified":
+        "2016-10-20T19:42:03.852Z", "name": "akrzos-test-cfme-5612", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c6bba-c438-7e64-400a-07e67394c91b",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c3779-3198-9948-9ee3-7d3737a79e98\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"akrzos-test-cfme-5612\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        akrzos-test-cfme-5612/akrzos-test-cfme-5612.vmx\", \"vmware_ipAddress\": \"10.8.99.227\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\": \"Red Hat Enterprise
+        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"ansible_ssh_host\": \"10.8.99.227\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        3480061682, \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_uuid\": \"420c6bba-c438-7e64-400a-07e67394c91b\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 71770263552, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"akrzos-test-cfme-5612\", \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 3481337029, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 145, "type": "host", "url": "/api/v1/hosts/145/", "related":
+        {"job_host_summaries": "/api/v1/hosts/145/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/145/variable_data/", "job_events": "/api/v1/hosts/145/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/145/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/145/fact_versions/", "inventory_sources": "/api/v1/hosts/145/inventory_sources/",
+        "groups": "/api/v1/hosts/145/groups/", "activity_stream": "/api/v1/hosts/145/activity_stream/",
+        "all_groups": "/api/v1/hosts/145/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/145/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.725Z", "modified":
+        "2016-03-31T18:43:05.788Z", "name": "Ansible-Host", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "4233080d-7467-de61-76c9-c8307b6e4830",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"test-vc60-host2.example.com\", \"vmware_instanceUuid\":
+        \"50337917-876b-364f-6c3e-030ab9411b7e\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] Ansible-Host/Ansible-Host.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"4233080d-7467-de61-76c9-c8307b6e4830\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2431, \"vmware_name\": \"Ansible-Host\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        3376017408, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 498,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 155, "type":
+        "host", "url": "/api/v1/hosts/155/", "related": {"job_host_summaries": "/api/v1/hosts/155/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/155/variable_data/", "job_events": "/api/v1/hosts/155/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/155/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/155/fact_versions/", "inventory_sources": "/api/v1/hosts/155/inventory_sources/",
+        "groups": "/api/v1/hosts/155/groups/", "activity_stream": "/api/v1/hosts/155/activity_stream/",
+        "all_groups": "/api/v1/hosts/155/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/155/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.777Z", "modified":
+        "2016-04-04T18:20:26.291Z", "name": "ansible-stupid-test", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e",
+        "variables": "vmware_annotation: null\nvmware_balloonedMemory: 0\nvmware_committed:
+        2461\nvmware_compressedMemory: 0\nvmware_connectionState: connected\nvmware_consumedOverheadMemory:
+        0\nvmware_cpuReservation: 0\nvmware_datastores:\n  - NFS Share\nvmware_distributedCpuEntitlement:
+        0\nvmware_distributedMemoryEntitlement: 0\nvmware_faultToleranceState: notConfigured\nvmware_ftLatencyStatus:
+        gray\nvmware_ftLogBandwidth: -1\nvmware_ftSecondaryLatency: -1\nvmware_guestFullName:
+        Red Hat Enterprise Linux 7 (64-bit)\nvmware_guestHeartbeatStatus: gray\nvmware_guestId:
+        rhel7_64Guest\nvmware_guestMemoryUsage: 0\nvmware_guestState: notRunning\nvmware_hostMemoryUsage:
+        0\nvmware_hostSystem: test-vc60-host2.example.com\nvmware_installBootRequired:
+        false\nvmware_instanceUuid: 500cb691-6d91-b961-c9da-7e23a1b1833d\nvmware_memoryReservation:
+        0\nvmware_memorySizeMB: 2048\nvmware_name: ansible-stupid-test\nvmware_networks:\n  -
+        VM Network\nvmware_numCpu: 1\nvmware_numEthernetCards: 1\nvmware_numMksConnections:
+        0\nvmware_numVirtualDisks: 1\nvmware_overallCpuDemand: 0\nvmware_overallCpuUsage:
+        0\nvmware_overallStatus: green\nvmware_powerState: poweredOff\nvmware_privateMemory:
+        0\nvmware_recordReplayState: inactive\nvmware_resourcePool: Resources\nvmware_sharedMemory:
+        0\nvmware_staticCpuEntitlement: 0\nvmware_staticMemoryEntitlement: 0\nvmware_suspendInterval:
+        0\nvmware_swappedMemory: 0\nvmware_template: false\nvmware_toolsInstallerMounted:
+        false\nvmware_toolsRunningStatus: guestToolsNotRunning\nvmware_toolsStatus:
+        toolsNotInstalled\nvmware_toolsVersionStatus: guestToolsNotInstalled\nvmware_uncommitted:
+        19482144768\nvmware_unshared: 507\nvmware_uptimeSeconds: 0\nvmware_uuid: 420cc84e-d8b9-5a6b-2ae9-f2dbe08d475e\nvmware_vmPathName:
+        \"[NFS Share] ansible-stupid-test/ansible-stupid-test.vmx\"\n", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 156, "type": "host", "url": "/api/v1/hosts/156/", "related":
+        {"job_host_summaries": "/api/v1/hosts/156/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/156/variable_data/", "job_events": "/api/v1/hosts/156/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/156/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/156/fact_versions/", "inventory_sources": "/api/v1/hosts/156/inventory_sources/",
+        "groups": "/api/v1/hosts/156/groups/", "activity_stream": "/api/v1/hosts/156/activity_stream/",
+        "all_groups": "/api/v1/hosts/156/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/156/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.782Z", "modified":
+        "2016-10-14T13:37:10.146Z", "name": "bd-brewery7", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "423335cd-4f1c-debe-1a7d-4d8279336b70",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] bd-brewery7/bd-brewery7.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"50335907-ffa8-7d93-7118-88e1d719219b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 75161002519, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"423335cd-4f1c-debe-1a7d-4d8279336b70\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 28091973632, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"CentOS 7.1 ImageFactory
+        VM\", \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_committed\": 75161199723,
+        \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_numMksConnections\": 0, \"vmware_name\": \"bd-brewery7\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 253, "type": "host", "url": "/api/v1/hosts/253/",
+        "related": {"job_host_summaries": "/api/v1/hosts/253/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/253/variable_data/", "job_events": "/api/v1/hosts/253/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/253/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/253/fact_versions/", "inventory_sources": "/api/v1/hosts/253/inventory_sources/",
+        "groups": "/api/v1/hosts/253/groups/", "activity_stream": "/api/v1/hosts/253/activity_stream/",
+        "all_groups": "/api/v1/hosts/253/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/253/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.542Z", "modified":
+        "2016-05-25T14:07:46.691Z", "name": "bd-emptyTemplate", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cda47-986f-cf2f-d0ce-5f9564163ea8",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"test-vc60-host2.example.com\", \"vmware_instanceUuid\":
+        \"500cd702-268a-fc97-b839-197438a6d7f4\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] bd-emptyTemplate/bd-emptyTemplate.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cda47-986f-cf2f-d0ce-5f9564163ea8\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2615, \"vmware_name\":
+        \"bd-emptyTemplate\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 3376017408, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"MIQ GUID=1a6b069c-1783-11e6-892d-0242afe60688\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 502, \"vmware_sharedMemory\":
+        0}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 254, "type": "host", "url": "/api/v1/hosts/254/",
+        "related": {"job_host_summaries": "/api/v1/hosts/254/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/254/variable_data/", "job_events": "/api/v1/hosts/254/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/254/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/254/fact_versions/", "inventory_sources": "/api/v1/hosts/254/inventory_sources/",
+        "groups": "/api/v1/hosts/254/groups/", "activity_stream": "/api/v1/hosts/254/activity_stream/",
+        "all_groups": "/api/v1/hosts/254/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/254/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.547Z", "modified":
+        "2016-05-25T14:07:46.696Z", "name": "bd-test-publish-vm-1", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420ca0c6-8346-5304-1fb7-e8069923ce02",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c2862-e777-fed8-d890-460be68723de\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] bd-test-publish-vm-1/bd-test-publish-vm-1.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420ca0c6-8346-5304-1fb7-e8069923ce02\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 75071761854,
+        \"vmware_name\": \"bd-test-publish-vm-1\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        28181226039, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=9ecf6998-16eb-11e6-bd50-024267aede97\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 75071750144, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 255, "type": "host", "url": "/api/v1/hosts/255/",
+        "related": {"job_host_summaries": "/api/v1/hosts/255/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/255/variable_data/", "job_events": "/api/v1/hosts/255/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/255/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/255/fact_versions/", "inventory_sources": "/api/v1/hosts/255/inventory_sources/",
+        "groups": "/api/v1/hosts/255/groups/", "activity_stream": "/api/v1/hosts/255/activity_stream/",
+        "all_groups": "/api/v1/hosts/255/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/255/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.552Z", "modified":
+        "2016-11-08T22:23:35.554Z", "name": "bdunne-VmEmpty", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c4091-3ea0-6031-88e2-bf3086cd0ec5",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] bdunne-VmEmpty/bdunne-VmEmpty.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM NFS Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c49be-365b-6d6f-eb35-283590a82d38\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 13854, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_uuid\": \"420c4091-3ea0-6031-88e2-bf3086cd0ec5\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        3377074176, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        2, \"vmware_installBootRequired\": false, \"vmware_committed\": 47641, \"vmware_name\":
+        \"bdunne-VmEmpty\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 157, "type": "host", "url": "/api/v1/hosts/157/",
+        "related": {"job_host_summaries": "/api/v1/hosts/157/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/157/variable_data/", "job_events": "/api/v1/hosts/157/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/157/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/157/fact_versions/", "inventory_sources": "/api/v1/hosts/157/inventory_sources/",
+        "groups": "/api/v1/hosts/157/groups/", "activity_stream": "/api/v1/hosts/157/activity_stream/",
+        "all_groups": "/api/v1/hosts/157/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/157/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.787Z", "modified":
+        "2016-10-14T13:37:10.162Z", "name": "bm-cfme-5.5.2.4", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c55e6-9917-0d86-b47c-e9e716c3b133",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c352d-8daf-465f-8bf1-7ff5557f7fd8\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 13948858122, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"bm-cfme-5.5.2.4\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        bm-cfme-5.5.2.4/bm-cfme-5.5.2.4.vmx\", \"vmware_ipAddress\": \"10.8.99.207\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_product_key\": 0, \"vmware_unshared\": 13947265556,
+        \"vmware_staticMemoryEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.207\",
+        \"vmware_uuid\": \"420c55e6-9917-0d86-b47c-e9e716c3b133\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 37787557888, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0,
+        \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-207.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 158, "type":
+        "host", "url": "/api/v1/hosts/158/", "related": {"job_host_summaries": "/api/v1/hosts/158/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/158/variable_data/", "job_events": "/api/v1/hosts/158/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/158/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/158/fact_versions/", "inventory_sources": "/api/v1/hosts/158/inventory_sources/",
+        "groups": "/api/v1/hosts/158/groups/", "activity_stream": "/api/v1/hosts/158/activity_stream/",
+        "all_groups": "/api/v1/hosts/158/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/158/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.793Z", "modified":
+        "2016-04-01T13:26:56.491Z", "name": "bm-cfme-5.5.4.2-2", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c3c2f-6dcd-bcc9-044e-03501d2781df",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c5607-7423-28d2-b335-93aa98bea917\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 42949940500, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"bm-cfme-5.5.4.2-2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        bm-cfme-5.5.4.2-2/bm-cfme-5.5.4.2-2.vmx\", \"vmware_ipAddress\": \"10.8.99.241\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960,
+        \"vmware_staticMemoryEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.241\",
+        \"vmware_uuid\": \"420c3c2f-6dcd-bcc9-044e-03501d2781df\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 8785150486, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0,
+        \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-241.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:35 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.309s
+      Content-Length:
+      - '96385'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=4", "previous": "/api/v1/hosts/?page=2",
+        "results": [{"id": 871, "type": "host", "url": "/api/v1/hosts/871/", "related":
+        {"job_host_summaries": "/api/v1/hosts/871/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/871/variable_data/", "job_events": "/api/v1/hosts/871/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/871/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/871/fact_versions/", "inventory_sources": "/api/v1/hosts/871/inventory_sources/",
+        "groups": "/api/v1/hosts/871/groups/", "activity_stream": "/api/v1/hosts/871/activity_stream/",
+        "all_groups": "/api/v1/hosts/871/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/871/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1478/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-20T19:42:04.207Z",
+        "modified": "2016-11-17T17:56:26.642Z", "name": "bundle_servers_for_drew_1",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c04a5-0c11-e11a-0684-d467d294b2dc", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] bundle_servers_for_drew_1/bundle_servers_for_drew_1.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.232\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c4ffc-e8a3-b91f-22ae-1b4db37b7d0b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1951822930, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1068, \"ansible_ssh_host\":
+        \"10.8.99.232\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c04a5-0c11-e11a-0684-d467d294b2dc\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        358, \"vmware_uncommitted\": 17375531008, \"vmware_distributedMemoryEntitlement\":
+        343, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-rebuild-request\\n\\nMIQ GUID=b773f832-9568-11e6-94b3-a45e60f1b905\\n\\nParent
+        Service: bundle_servers_for_drew (c59ba470-9566-11e6-94b3-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 430, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 2399, \"vmware_committed\": 1953151373, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 764141, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"bundle_servers_for_drew_1\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        459, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 29, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1478}, {"id": 872, "type": "host", "url": "/api/v1/hosts/872/",
+        "related": {"job_host_summaries": "/api/v1/hosts/872/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/872/variable_data/", "job_events": "/api/v1/hosts/872/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/872/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/872/fact_versions/", "inventory_sources": "/api/v1/hosts/872/inventory_sources/",
+        "groups": "/api/v1/hosts/872/groups/", "activity_stream": "/api/v1/hosts/872/activity_stream/",
+        "all_groups": "/api/v1/hosts/872/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/872/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1476/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-20T19:42:04.212Z",
+        "modified": "2016-11-17T17:56:26.654Z", "name": "bundle_servers_for_drew_2",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c6feb-3a7f-55be-60cc-a800ec537d8b", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] bundle_servers_for_drew_2/bundle_servers_for_drew_2.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.249\", \"vmware_guestMemoryUsage\": 30, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c6975-6416-32a3-0098-dc33f463a6db\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1951822930, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1084, \"ansible_ssh_host\":
+        \"10.8.99.249\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c6feb-3a7f-55be-60cc-a800ec537d8b\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        358, \"vmware_uncommitted\": 17375531008, \"vmware_distributedMemoryEntitlement\":
+        359, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-rebuild-request\\n\\nMIQ GUID=ad8a302c-956b-11e6-94b3-a45e60f1b905\\n\\nParent
+        Service: bundle_servers_for_drew (cae71950-9566-11e6-94b3-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 34, \"vmware_privateMemory\": 392, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 762830, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1953151797, \"vmware_name\": \"bundle_servers_for_drew_2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        427, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 29, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1476}, {"id": 873, "type": "host", "url": "/api/v1/hosts/873/",
+        "related": {"job_host_summaries": "/api/v1/hosts/873/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/873/variable_data/", "job_events": "/api/v1/hosts/873/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/873/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/873/fact_versions/", "inventory_sources": "/api/v1/hosts/873/inventory_sources/",
+        "groups": "/api/v1/hosts/873/groups/", "activity_stream": "/api/v1/hosts/873/activity_stream/",
+        "all_groups": "/api/v1/hosts/873/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/873/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/784/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/583/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-10-20T22:15:35.524Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-10-20T22:15:35.524Z",
+        "id": 784, "name": "PackageInfo"}]}, "created": "2016-10-20T19:42:04.217Z",
+        "modified": "2016-11-08T23:02:45.269Z", "name": "bundle_servers_for_drew_3",
+        "description": "imported", "inventory": 17, "enabled": false, "instance_id":
+        "420ccc2c-6a18-388c-b0a5-c9873e7675f2", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] bundle_servers_for_drew_3/bundle_servers_for_drew_3.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.225\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c2042-fcac-3f84-304c-25a12ba455eb\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 1951822930,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.99.225\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420ccc2c-6a18-388c-b0a5-c9873e7675f2\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18644508672, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-template\\n\\nMIQ GUID=40413c06-956e-11e6-94b3-a45e60f1b905\\n\\nParent
+        Service: bundle_servers_for_drew (cf5cde16-9566-11e6-94b3-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 1953200132, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"bundle_servers_for_drew_3\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 784,
+        "last_job_host_summary": 583}, {"id": 834, "type": "host", "url": "/api/v1/hosts/834/",
+        "related": {"job_host_summaries": "/api/v1/hosts/834/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/834/variable_data/", "job_events": "/api/v1/hosts/834/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/834/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/834/fact_versions/", "inventory_sources": "/api/v1/hosts/834/inventory_sources/",
+        "groups": "/api/v1/hosts/834/groups/", "activity_stream": "/api/v1/hosts/834/activity_stream/",
+        "all_groups": "/api/v1/hosts/834/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/834/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.442Z", "modified":
+        "2016-10-14T13:37:12.116Z", "name": "centos7_temp", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c37c4-1c29-d28b-1154-0a45081236f6",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c4372-559a-e757-7348-9f564eaa5482\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] centos7_temp/centos7_temp.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c37c4-1c29-d28b-1154-0a45081236f6\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1031529385, \"vmware_name\":
+        \"centos7_temp\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 33520832512, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1030959604, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 881, "type": "host", "url": "/api/v1/hosts/881/",
+        "related": {"job_host_summaries": "/api/v1/hosts/881/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/881/variable_data/", "job_events": "/api/v1/hosts/881/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/881/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/881/fact_versions/", "inventory_sources": "/api/v1/hosts/881/inventory_sources/",
+        "groups": "/api/v1/hosts/881/groups/", "activity_stream": "/api/v1/hosts/881/activity_stream/",
+        "all_groups": "/api/v1/hosts/881/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/881/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-11-08T22:23:36.123Z", "modified":
+        "2016-11-08T22:23:36.430Z", "name": "cfme023", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c1844-c56c-2fd6-4ebc-3bdbfcd84eca",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500cc8d9-4d37-a496-8f81-407821ae8579\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] cfme023/cfme023.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420c1844-c56c-2fd6-4ebc-3bdbfcd84eca\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 1951834545, \"vmware_name\": \"cfme023\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        18641326080, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner:  \\nEmail: \\nSource: db-centos-7-rebuild-request\\n\\nMIQ GUID=800fb64e-a218-11e6-910b-b8e856429d10\\n\\nParent
+        Service: Bundle of VMWare Servers2 (2ffcd092-a218-11e6-910b-b8e856429d10)\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951822894,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 820, "type":
+        "host", "url": "/api/v1/hosts/820/", "related": {"job_host_summaries": "/api/v1/hosts/820/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/820/variable_data/", "job_events": "/api/v1/hosts/820/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/820/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/820/fact_versions/", "inventory_sources": "/api/v1/hosts/820/inventory_sources/",
+        "groups": "/api/v1/hosts/820/groups/", "activity_stream": "/api/v1/hosts/820/activity_stream/",
+        "all_groups": "/api/v1/hosts/820/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/820/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1425/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.371Z",
+        "modified": "2016-11-17T17:56:26.666Z", "name": "ChrisK_MIQ_Server", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cbcfc-f4f5-78d8-e8cc-fd5b881a366b",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] ChrisK_MIQ_Server/ChrisK_MIQ_Server.vmx\",
+        \"vmware_guestMemoryUsage\": 1133, \"vmware_networks\": [\"VM Network\"],
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c2e8b-0083-5102-f636-046f6d1b3e8a\", \"vmware_distributedCpuEntitlement\":
+        47, \"vmware_unshared\": 26616869709, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 8230, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420cbcfc-f4f5-78d8-e8cc-fd5b881a366b\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 717, \"vmware_uncommitted\":
+        153088307200, \"vmware_distributedMemoryEntitlement\": 2905, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        105, \"vmware_privateMemory\": 7863, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 47, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 5522802, \"vmware_memorySizeMB\":
+        8096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 26618304494, \"vmware_name\": \"ChrisK_MIQ_Server\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 7926, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 53, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1425}, {"id": 256, "type": "host", "url": "/api/v1/hosts/256/",
+        "related": {"job_host_summaries": "/api/v1/hosts/256/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/256/variable_data/", "job_events": "/api/v1/hosts/256/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/256/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/256/fact_versions/", "inventory_sources": "/api/v1/hosts/256/inventory_sources/",
+        "groups": "/api/v1/hosts/256/groups/", "activity_stream": "/api/v1/hosts/256/activity_stream/",
+        "all_groups": "/api/v1/hosts/256/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/256/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1450/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.562Z",
+        "modified": "2016-11-17T17:56:26.678Z", "name": "console_test1", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c2d64-33d1-9cdf-9e59-10456729d89e",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] console_test1/console_test1.vmx\",
+        \"vmware_guestMemoryUsage\": 61, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500ced40-5440-06c7-5f6a-a2965aa9d088\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1037894133, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 2093, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420c2d64-33d1-9cdf-9e59-10456729d89e\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 360, \"vmware_uncommitted\":
+        16141975552, \"vmware_distributedMemoryEntitlement\": 319, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 396, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 265945, \"vmware_memorySizeMB\":
+        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 1038967935, \"vmware_name\": \"console_test1\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 418, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 23, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1450}, {"id": 257, "type": "host", "url": "/api/v1/hosts/257/",
+        "related": {"job_host_summaries": "/api/v1/hosts/257/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/257/variable_data/", "job_events": "/api/v1/hosts/257/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/257/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/257/fact_versions/", "inventory_sources": "/api/v1/hosts/257/inventory_sources/",
+        "groups": "/api/v1/hosts/257/groups/", "activity_stream": "/api/v1/hosts/257/activity_stream/",
+        "all_groups": "/api/v1/hosts/257/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/257/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1474/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.568Z",
+        "modified": "2016-11-17T17:56:26.690Z", "name": "console_test2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c36c5-f6f0-2788-8a92-ab545196b6d8",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] console_test2/console_test2.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cff60-e993-de9a-aedb-0beca8e6ec75\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1034510860, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 2110, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420c36c5-f6f0-2788-8a92-ab545196b6d8\", \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\": 358, \"vmware_uncommitted\":
+        16145358848, \"vmware_distributedMemoryEntitlement\": 328, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 394, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_committed\":
+        1035252772, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 252568,
+        \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"console_test2\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 416, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 23, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1474}, {"id": 258, "type": "host", "url": "/api/v1/hosts/258/",
+        "related": {"job_host_summaries": "/api/v1/hosts/258/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/258/variable_data/", "job_events": "/api/v1/hosts/258/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/258/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/258/fact_versions/", "inventory_sources": "/api/v1/hosts/258/inventory_sources/",
+        "groups": "/api/v1/hosts/258/groups/", "activity_stream": "/api/v1/hosts/258/activity_stream/",
+        "all_groups": "/api/v1/hosts/258/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/258/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1458/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.572Z",
+        "modified": "2016-11-17T17:56:26.702Z", "name": "console_test3", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420ca0fe-b0c3-3285-46ab-e50f7094d073",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] console_test3/console_test3.vmx\",
+        \"vmware_guestMemoryUsage\": 20, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c856f-41a9-79d7-4270-b6148c030d20\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1027760652, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 2093, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420ca0fe-b0c3-3285-46ab-e50f7094d073\", \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\": 358, \"vmware_uncommitted\":
+        16152109056, \"vmware_distributedMemoryEntitlement\": 313, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 390, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_committed\":
+        1028355081, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 252571,
+        \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"console_test3\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 413, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 23, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1458}, {"id": 159, "type": "host", "url": "/api/v1/hosts/159/",
+        "related": {"job_host_summaries": "/api/v1/hosts/159/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/159/variable_data/", "job_events": "/api/v1/hosts/159/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/159/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/159/fact_versions/", "inventory_sources": "/api/v1/hosts/159/inventory_sources/",
+        "groups": "/api/v1/hosts/159/groups/", "activity_stream": "/api/v1/hosts/159/activity_stream/",
+        "all_groups": "/api/v1/hosts/159/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/159/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.798Z", "modified":
+        "2016-10-14T13:37:10.191Z", "name": "db-centos-7", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c132a-40df-d4fa-7b08-c4352c3450c4",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] db-rhel-7/db-rhel-7.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.228\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c5397-47c9-d319-6cf6-08dea1250db5\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 1961248216,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.99.228\", \"vmware_suspendInterval\": 0, \"vmware_uuid\":
+        \"420c132a-40df-d4fa-7b08-c4352c3450c4\", \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        20245696512, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 3, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
+        \"vmware_maxMemoryUsage\": 512, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 8796, \"vmware_committed\": 1962862717, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"db-centos-7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 836, "type": "host", "url": "/api/v1/hosts/836/",
+        "related": {"job_host_summaries": "/api/v1/hosts/836/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/836/variable_data/", "job_events": "/api/v1/hosts/836/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/836/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/836/fact_versions/", "inventory_sources": "/api/v1/hosts/836/inventory_sources/",
+        "groups": "/api/v1/hosts/836/groups/", "activity_stream": "/api/v1/hosts/836/activity_stream/",
+        "all_groups": "/api/v1/hosts/836/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/836/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.452Z", "modified":
+        "2016-10-14T13:37:12.125Z", "name": "db-centos-7-rebuild-request", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c68c3-38ce-2ea8-93b0-9440e529811d",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c3ceb-025b-dcde-517f-8e7d06fbcb8e\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-centos-7-rebuild-request/db-centos-7-rebuild-request.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c68c3-38ce-2ea8-93b0-9440e529811d\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1951834603, \"vmware_name\":
+        \"db-centos-7-rebuild-request\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 18641326080, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        2, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"Owner: D B\\nEmail:
+        db@rh.com\\nSource: db-centos-7-template\\n\\nMIQ GUID=74b8599c-2d86-11e6-a875-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951822934,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 259, "type":
+        "host", "url": "/api/v1/hosts/259/", "related": {"job_host_summaries": "/api/v1/hosts/259/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/259/variable_data/", "job_events": "/api/v1/hosts/259/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/259/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/259/fact_versions/", "inventory_sources": "/api/v1/hosts/259/inventory_sources/",
+        "groups": "/api/v1/hosts/259/groups/", "activity_stream": "/api/v1/hosts/259/activity_stream/",
+        "all_groups": "/api/v1/hosts/259/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/259/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.577Z", "modified":
+        "2016-10-14T13:37:10.199Z", "name": "db-centos-7-template", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c2024-ecc0-3f93-4ed6-c8fe897ec8f2",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] db-centos-7-template/db-centos-7-template.vmtx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c5cc7-d345-bfcb-0ddc-523db3d350d5\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1951822920, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420c2024-ecc0-3f93-4ed6-c8fe897ec8f2\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18107637760, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\":
+        0, \"vmware_resourcePool\": \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 1951834502,
+        \"vmware_name\": \"db-centos-7-template\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 838, "type": "host", "url": "/api/v1/hosts/838/",
+        "related": {"job_host_summaries": "/api/v1/hosts/838/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/838/variable_data/", "job_events": "/api/v1/hosts/838/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/838/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/838/fact_versions/", "inventory_sources": "/api/v1/hosts/838/inventory_sources/",
+        "groups": "/api/v1/hosts/838/groups/", "activity_stream": "/api/v1/hosts/838/activity_stream/",
+        "all_groups": "/api/v1/hosts/838/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/838/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.462Z", "modified":
+        "2016-10-14T13:37:12.130Z", "name": "db_cfme_5.5", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cdf52-153a-b5e4-22f9-a62e4aacd51c",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c5ba2-3a7c-0159-d2d0-df42dcc15d6f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db_cfme_5.5/db_cfme_5.5.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420cdf52-153a-b5e4-22f9-a62e4aacd51c\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 16793979593, \"vmware_name\": \"db_cfme_5.5\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 171306475520, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 2, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 16793560154,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 260, "type":
+        "host", "url": "/api/v1/hosts/260/", "related": {"job_host_summaries": "/api/v1/hosts/260/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/260/variable_data/", "job_events": "/api/v1/hosts/260/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/260/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/260/fact_versions/", "inventory_sources": "/api/v1/hosts/260/inventory_sources/",
+        "groups": "/api/v1/hosts/260/groups/", "activity_stream": "/api/v1/hosts/260/activity_stream/",
+        "all_groups": "/api/v1/hosts/260/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/260/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.582Z", "modified":
+        "2016-10-14T13:37:10.206Z", "name": "db-test-from-vc60", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c40b7-6ad1-28d9-e890-7ce150599d5c",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] db-test-from-vc60/db-test-from-vc60.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c5399-55d1-e563-9f51-4dabcbf6a297\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1951822914, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420c40b7-6ad1-28d9-e890-7ce150599d5c\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18107637760, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=63bae348-ea1b-11e5-a1a7-a45e60f1b905\",
+        \"vmware_maxMemoryUsage\": 512, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 8796, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 512, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1952206634, \"vmware_name\": \"db-test-from-vc60\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 837, "type": "host", "url": "/api/v1/hosts/837/",
+        "related": {"job_host_summaries": "/api/v1/hosts/837/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/837/variable_data/", "job_events": "/api/v1/hosts/837/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/837/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/837/fact_versions/", "inventory_sources": "/api/v1/hosts/837/inventory_sources/",
+        "groups": "/api/v1/hosts/837/groups/", "activity_stream": "/api/v1/hosts/837/activity_stream/",
+        "all_groups": "/api/v1/hosts/837/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/837/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.457Z", "modified":
+        "2016-10-14T13:37:12.135Z", "name": "db-test-log-1", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cbbc9-c5ce-a7be-e73b-3e1a2b3a4daf",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500ca136-6092-c918-c935-b18466ab709b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] db-test-log-1/db-test-log-1.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420cbbc9-c5ce-a7be-e73b-3e1a2b3a4daf\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1951835249, \"vmware_name\":
+        \"db-test-log-1\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 20791992320, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        3, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"Owner: d b\\nEmail:
+        db@rh.com\\nSource VM: db-centos-7\\n\\nMIQ GUID=55f9fa04-84f9-11e6-a648-a45e60f1b905\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 1951823430,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 197, "type":
+        "host", "url": "/api/v1/hosts/197/", "related": {"job_host_summaries": "/api/v1/hosts/197/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/197/variable_data/", "job_events": "/api/v1/hosts/197/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/197/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/197/fact_versions/", "inventory_sources": "/api/v1/hosts/197/inventory_sources/",
+        "groups": "/api/v1/hosts/197/groups/", "activity_stream": "/api/v1/hosts/197/activity_stream/",
+        "all_groups": "/api/v1/hosts/197/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/197/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-18T20:26:31.045Z", "modified":
+        "2016-10-14T13:37:10.213Z", "name": "Dev-IPA2", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c8a2f-dd0c-b175-6749-11c0278be69c",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] Dev-IPA2/Dev-IPA2.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.12\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500ca199-37a8-318a-e712-11c20210eab6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 3419329754,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.97.12\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c8a2f-dd0c-b175-6749-11c0278be69c\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        36268908544, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"Dev-IPA2.ipatesting.lab.redhat.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        12030052484, \"vmware_name\": \"Dev-IPA2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 839, "type": "host", "url": "/api/v1/hosts/839/",
+        "related": {"job_host_summaries": "/api/v1/hosts/839/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/839/variable_data/", "job_events": "/api/v1/hosts/839/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/839/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/839/fact_versions/", "inventory_sources": "/api/v1/hosts/839/inventory_sources/",
+        "groups": "/api/v1/hosts/839/groups/", "activity_stream": "/api/v1/hosts/839/activity_stream/",
+        "all_groups": "/api/v1/hosts/839/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/839/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1439/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.467Z",
+        "modified": "2016-11-17T17:56:27.212Z", "name": "djm", "description": "imported",
+        "inventory": 17, "enabled": true, "instance_id": "", "variables": "{}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1439}, {"id": 885, "type": "host", "url": "/api/v1/hosts/885/", "related":
+        {"job_host_summaries": "/api/v1/hosts/885/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/885/variable_data/", "job_events": "/api/v1/hosts/885/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/885/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/885/fact_versions/", "inventory_sources": "/api/v1/hosts/885/inventory_sources/",
+        "groups": "/api/v1/hosts/885/groups/", "activity_stream": "/api/v1/hosts/885/activity_stream/",
+        "all_groups": "/api/v1/hosts/885/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/885/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1424/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}]}, "created": "2016-11-15T13:52:07.259Z",
+        "modified": "2016-11-17T17:56:26.716Z", "name": "Downstream 4.2 Beta3 - Ansible
+        Integration", "description": "imported", "inventory": 17, "enabled": true,
+        "instance_id": "420cbab4-568f-7a0b-eb69-16cccdeafc88", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c4262-3b52-8f31-71c7-c2db6e4a8978\", \"vmware_distributedCpuEntitlement\":
+        407, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.2-beta3\", \"vmware_distributedMemoryEntitlement\":
+        4164, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 383, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 3397137372, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Downstream 4.2 Beta3 - Ansible Integration\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 7558, \"vmware_overallCpuDemand\": 407, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        58, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        Red Hat CloudForms 4.2 Beta3/Red Hat CloudForms 4.2 Beta3.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.103\", \"vmware_guestMemoryUsage\": 2867, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        3396956708, \"vmware_staticMemoryEntitlement\": 8290, \"ansible_ssh_host\":
+        \"10.8.99.103\", \"vmware_uuid\": \"420cbab4-568f-7a0b-eb69-16cccdeafc88\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 39552716800,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 225, \"vmware_privateMemory\": 7399,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.2 Beta3\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-103.example.com\",
+        \"vmware_uptimeSeconds\": 271773, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1424}, {"id": 835, "type":
+        "host", "url": "/api/v1/hosts/835/", "related": {"job_host_summaries": "/api/v1/hosts/835/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/835/variable_data/", "job_events": "/api/v1/hosts/835/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/835/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/835/fact_versions/", "inventory_sources": "/api/v1/hosts/835/inventory_sources/",
+        "groups": "/api/v1/hosts/835/groups/", "activity_stream": "/api/v1/hosts/835/activity_stream/",
+        "all_groups": "/api/v1/hosts/835/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/835/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.447Z", "modified":
+        "2016-10-14T13:37:12.144Z", "name": "d_vm_template", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c30d1-dbbd-60dd-464f-3ffeb0c661c2",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c863c-a4c7-37b0-895d-bd86d4401e47\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] d_vm_prov001/d_vm_prov001.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c30d1-dbbd-60dd-464f-3ffeb0c661c2\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 4482493, \"vmware_name\":
+        \"d_vm_template\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": \"MIQ GUID=c4c4143e-33d6-11e6-96fa-34363bc9458e\",
+        \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0, \"vmware_sharedMemory\":
+        0}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 160, "type": "host", "url": "/api/v1/hosts/160/",
+        "related": {"job_host_summaries": "/api/v1/hosts/160/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/160/variable_data/", "job_events": "/api/v1/hosts/160/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/160/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/160/fact_versions/", "inventory_sources": "/api/v1/hosts/160/inventory_sources/",
+        "groups": "/api/v1/hosts/160/groups/", "activity_stream": "/api/v1/hosts/160/activity_stream/",
+        "all_groups": "/api/v1/hosts/160/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/160/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.802Z", "modified":
+        "2016-03-31T18:43:05.816Z", "name": "gm-diskless-template", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420cfe93-0fa8-a8ca-b5e8-2fe63bc9986c",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c51bf-409b-1e00-38a7-deaec2daa35a\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] gm-diskless-template1/gm-diskless-template1.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cfe93-0fa8-a8ca-b5e8-2fe63bc9986c\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1956, \"vmware_name\":
+        \"gm-diskless-template\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2302275584, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        true, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 162, "type":
+        "host", "url": "/api/v1/hosts/162/", "related": {"job_host_summaries": "/api/v1/hosts/162/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/162/variable_data/", "job_events": "/api/v1/hosts/162/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/162/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/162/fact_versions/", "inventory_sources": "/api/v1/hosts/162/inventory_sources/",
+        "groups": "/api/v1/hosts/162/groups/", "activity_stream": "/api/v1/hosts/162/activity_stream/",
+        "all_groups": "/api/v1/hosts/162/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/162/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.813Z", "modified":
+        "2016-03-31T18:43:05.820Z", "name": "gm_disk_test", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ca9fd-3a50-b271-f6d9-64b7b0d21dc0",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"NFS Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500cda7c-6c37-8bd2-c8a9-2a8f7aabe0f8\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] gm_disk_test/gm_disk_test.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420ca9fd-3a50-b271-f6d9-64b7b0d21dc0\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2640, \"vmware_name\": \"gm_disk_test\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19482144768, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 523,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 161, "type":
+        "host", "url": "/api/v1/hosts/161/", "related": {"job_host_summaries": "/api/v1/hosts/161/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/161/variable_data/", "job_events": "/api/v1/hosts/161/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/161/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/161/fact_versions/", "inventory_sources": "/api/v1/hosts/161/inventory_sources/",
+        "groups": "/api/v1/hosts/161/groups/", "activity_stream": "/api/v1/hosts/161/activity_stream/",
+        "all_groups": "/api/v1/hosts/161/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/161/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.808Z", "modified":
+        "2016-10-14T13:37:10.221Z", "name": "gm-empty-template", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c4d7c-58ee-6d40-f01c-fa2659943824",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] gm-empty-template/gm-empty-template.vmtx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c9646-394a-f37a-de3a-c5c4b43249aa\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 505, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_suspendInterval\":
+        0, \"vmware_uuid\": \"420c4d7c-58ee-6d40-f01c-fa2659943824\", \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 19482144768, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2454, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"gm-empty-template\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 841, "type": "host", "url": "/api/v1/hosts/841/",
+        "related": {"job_host_summaries": "/api/v1/hosts/841/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/841/variable_data/", "job_events": "/api/v1/hosts/841/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/841/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/841/fact_versions/", "inventory_sources": "/api/v1/hosts/841/inventory_sources/",
+        "groups": "/api/v1/hosts/841/groups/", "activity_stream": "/api/v1/hosts/841/activity_stream/",
+        "all_groups": "/api/v1/hosts/841/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/841/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.477Z", "modified":
+        "2016-10-14T13:37:12.149Z", "name": "gm_test_001", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c5708-8ab6-56f6-3ba0-fc85e0983f26",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c7bc0-fc9d-9ce4-52e1-ac7a1813f8e4\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] gm_test_001/gm_test_001.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420c5708-8ab6-56f6-3ba0-fc85e0983f26\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2580, \"vmware_name\": \"gm_test_001\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19482144768, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 522,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 842, "type":
+        "host", "url": "/api/v1/hosts/842/", "related": {"job_host_summaries": "/api/v1/hosts/842/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/842/variable_data/", "job_events": "/api/v1/hosts/842/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/842/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/842/fact_versions/", "inventory_sources": "/api/v1/hosts/842/inventory_sources/",
+        "groups": "/api/v1/hosts/842/groups/", "activity_stream": "/api/v1/hosts/842/activity_stream/",
+        "all_groups": "/api/v1/hosts/842/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/842/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1435/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.481Z",
+        "modified": "2016-11-17T17:56:26.729Z", "name": "gs-server-poweron-1", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c5605-f7b7-ddde-8c51-08a93138224f",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] gs-server-poweron-1/gs-server-poweron-1.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.230\", \"vmware_guestMemoryUsage\": 51, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c732f-ddc0-deba-0f72-fbc4fcf7cbc2\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1951822918, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1068, \"ansible_ssh_host\":
+        \"10.8.99.230\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c5605-f7b7-ddde-8c51-08a93138224f\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        358, \"vmware_uncommitted\": 17375531008, \"vmware_distributedMemoryEntitlement\":
+        362, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-rebuild-request\\n\\nMIQ GUID=edeb969c-8670-11e6-aaa5-a45e60f1b905\\n\\nParent
+        Service: bundle_of_3_with_all_power_ops (9a9dc5f0-8670-11e6-aaa5-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 468, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 2311156, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1953142856, \"vmware_name\": \"gs-server-poweron-1\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        497, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 29, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1435}, {"id": 843, "type": "host", "url": "/api/v1/hosts/843/",
+        "related": {"job_host_summaries": "/api/v1/hosts/843/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/843/variable_data/", "job_events": "/api/v1/hosts/843/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/843/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/843/fact_versions/", "inventory_sources": "/api/v1/hosts/843/inventory_sources/",
+        "groups": "/api/v1/hosts/843/groups/", "activity_stream": "/api/v1/hosts/843/activity_stream/",
+        "all_groups": "/api/v1/hosts/843/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/843/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1436/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.486Z",
+        "modified": "2016-11-17T17:56:26.741Z", "name": "gs-server-poweron-3", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cedf7-dddc-34de-c4d9-ba2f679bafd9",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] gs-server-poweron-3/gs-server-poweron-3.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.216\", \"vmware_guestMemoryUsage\": 10, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c146f-c041-9b29-4542-f631ae2685e6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1951822918, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1083, \"ansible_ssh_host\":
+        \"10.8.99.216\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420cedf7-dddc-34de-c4d9-ba2f679bafd9\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 17375531008, \"vmware_distributedMemoryEntitlement\":
+        361, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-template\\n\\nMIQ GUID=af484c1c-8672-11e6-aaa5-a45e60f1b905\\n\\nParent
+        Service: bundle_of_3_with_all_power_ops (9d83e38a-8670-11e6-aaa5-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 26, \"vmware_privateMemory\": 442, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 2310782, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1953166728, \"vmware_name\": \"gs-server-poweron-3\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        478, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 36, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1436}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:36 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.310s
+      Content-Length:
+      - '112298'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=5", "previous": "/api/v1/hosts/?page=3",
+        "results": [{"id": 844, "type": "host", "url": "/api/v1/hosts/844/", "related":
+        {"job_host_summaries": "/api/v1/hosts/844/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/844/variable_data/", "job_events": "/api/v1/hosts/844/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/844/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/844/fact_versions/", "inventory_sources": "/api/v1/hosts/844/inventory_sources/",
+        "groups": "/api/v1/hosts/844/groups/", "activity_stream": "/api/v1/hosts/844/activity_stream/",
+        "all_groups": "/api/v1/hosts/844/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/844/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1467/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.492Z",
+        "modified": "2016-11-17T17:56:26.753Z", "name": "gs-servier-poweron-2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c939c-67bb-4cac-e272-90368c57ac60",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] gs-servier-poweron-2/gs-servier-poweron-2.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.212\", \"vmware_guestMemoryUsage\": 20, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cc13b-5797-4572-a47b-ffedf4958d50\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1993618504, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1084, \"ansible_ssh_host\":
+        \"10.8.99.212\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c939c-67bb-4cac-e272-90368c57ac60\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        358, \"vmware_uncommitted\": 17333735424, \"vmware_distributedMemoryEntitlement\":
+        373, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner:  \\nEmail:
+        \\nSource: db-centos-7-rebuild-request\\n\\nMIQ GUID=d86a50fa-8671-11e6-aaa5-a45e60f1b905\\n\\nParent
+        Service: bundle_of_3_with_all_power_ops (9c22f2ba-8670-11e6-aaa5-a45e60f1b905)\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 549, \"vmware_privateMemory\": 475, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 2311027, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1994843505, \"vmware_name\": \"gs-servier-poweron-2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        511, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 30, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1467}, {"id": 840, "type": "host", "url": "/api/v1/hosts/840/",
+        "related": {"job_host_summaries": "/api/v1/hosts/840/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/840/variable_data/", "job_events": "/api/v1/hosts/840/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/840/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/840/fact_versions/", "inventory_sources": "/api/v1/hosts/840/inventory_sources/",
+        "groups": "/api/v1/hosts/840/groups/", "activity_stream": "/api/v1/hosts/840/activity_stream/",
+        "all_groups": "/api/v1/hosts/840/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/840/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.472Z", "modified":
+        "2016-10-14T13:37:12.167Z", "name": "g_vm_prov009", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cc1a2-ba54-4c18-eb9b-47999a4b121b",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500cd202-2d1b-b97c-1c31-664ca41963eb\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] g_vm_prov009/g_vm_prov009.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420cc1a2-ba54-4c18-eb9b-47999a4b121b\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 11055, \"vmware_name\": \"g_vm_prov009\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\",
+        \"NFS Share\"], \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 0, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 248, "type": "host", "url": "/api/v1/hosts/248/", "related":
+        {"job_host_summaries": "/api/v1/hosts/248/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/248/variable_data/", "job_events": "/api/v1/hosts/248/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/248/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/248/fact_versions/", "inventory_sources": "/api/v1/hosts/248/inventory_sources/",
+        "groups": "/api/v1/hosts/248/groups/", "activity_stream": "/api/v1/hosts/248/activity_stream/",
+        "all_groups": "/api/v1/hosts/248/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/248/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.517Z", "modified":
+        "2016-10-14T13:37:10.228Z", "name": "James-cfme", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c419a-52bd-046e-7a05-4341e44c3f29",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cb5bf-aa2e-b4d6-c4a3-a236ee3dbce5\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 6, \"vmware_name\":
+        \"James-cfme\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        James-cfme/James-cfme.vmx\", \"vmware_ipAddress\": \"10.8.99.212\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.212\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 13693518674, \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c419a-52bd-046e-7a05-4341e44c3f29\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 50841702400, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"dhcp-8-99-212.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 22294531224,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 163, "type":
+        "host", "url": "/api/v1/hosts/163/", "related": {"job_host_summaries": "/api/v1/hosts/163/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/163/variable_data/", "job_events": "/api/v1/hosts/163/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/163/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/163/fact_versions/", "inventory_sources": "/api/v1/hosts/163/inventory_sources/",
+        "groups": "/api/v1/hosts/163/groups/", "activity_stream": "/api/v1/hosts/163/activity_stream/",
+        "all_groups": "/api/v1/hosts/163/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/163/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.818Z", "modified":
+        "2016-10-14T13:37:10.235Z", "name": "jason-brewery", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "42332ec3-7555-5c9c-d4c1-b0a88332a8c7",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jason-brewery/jason-brewery.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"50336f60-16ec-53e2-2329-c7b3914c216b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 78033679207, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"42332ec3-7555-5c9c-d4c1-b0a88332a8c7\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 102245875712, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"CentOS 7.1 ImageFactory
+        VM\", \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        95220407662, \"vmware_name\": \"jason-brewery\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 821, "type": "host", "url": "/api/v1/hosts/821/",
+        "related": {"job_host_summaries": "/api/v1/hosts/821/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/821/variable_data/", "job_events": "/api/v1/hosts/821/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/821/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/821/fact_versions/", "inventory_sources": "/api/v1/hosts/821/inventory_sources/",
+        "groups": "/api/v1/hosts/821/groups/", "activity_stream": "/api/v1/hosts/821/activity_stream/",
+        "all_groups": "/api/v1/hosts/821/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/821/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1449/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.375Z",
+        "modified": "2016-11-17T17:56:26.766Z", "name": "JOEV50", "description": "imported",
+        "inventory": 17, "enabled": true, "instance_id": "420cac28-5a70-7e00-a9b5-1d82e66a2d3e",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c5eef-dd41-e3bd-d3f8-ff60cc15c7c7\", \"vmware_distributedCpuEntitlement\":
+        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        2639, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 10966455047, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"JOEV50\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 4731,
+        \"vmware_overallCpuDemand\": 167, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        ManageIQ/ManageIQ.vmx\", \"vmware_ipAddress\": \"10.8.99.238\", \"vmware_guestMemoryUsage\":
+        1781, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 4512798657, \"vmware_staticMemoryEntitlement\":
+        6240, \"ansible_ssh_host\": \"10.8.99.238\", \"vmware_uuid\": \"420cac28-5a70-7e00-a9b5-1d82e66a2d3e\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 70271315968,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 1482, \"vmware_privateMemory\": 4662,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-238.example.com\",
+        \"vmware_uptimeSeconds\": 1290801, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1449}, {"id": 879, "type":
+        "host", "url": "/api/v1/hosts/879/", "related": {"job_host_summaries": "/api/v1/hosts/879/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/879/variable_data/", "job_events": "/api/v1/hosts/879/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/879/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/879/fact_versions/", "inventory_sources": "/api/v1/hosts/879/inventory_sources/",
+        "groups": "/api/v1/hosts/879/groups/", "activity_stream": "/api/v1/hosts/879/activity_stream/",
+        "all_groups": "/api/v1/hosts/879/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/879/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1414/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-11-08T22:23:36.112Z",
+        "modified": "2016-11-17T17:56:26.778Z", "name": "JoeV_5.7.0.7-1_25.10.2016",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c0d16-f67e-0fd7-6437-70fd4f02cd9e", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c3cf9-f680-0d1f-a560-568a4a486015\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.2-beta1\", \"vmware_distributedMemoryEntitlement\":
+        2278, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 19694101635, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"JoeV_5.7.0.7-1_25.10.2016\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        4809, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        52, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        JoeV_5.7.0.7-1_25.10.2016/JoeV_5.7.0.7-1_25.10.2016.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.202\", \"vmware_guestMemoryUsage\": 2129, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        2494003678, \"vmware_staticMemoryEntitlement\": 8294, \"ansible_ssh_host\":
+        \"10.8.99.202\", \"vmware_uuid\": \"420c0d16-f67e-0fd7-6437-70fd4f02cd9e\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 64066785280,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 71, \"vmware_privateMemory\": 4737,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.2 Beta1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"joev-57071.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
+        1199689, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1414}, {"id": 845, "type": "host", "url": "/api/v1/hosts/845/", "related":
+        {"job_host_summaries": "/api/v1/hosts/845/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/845/variable_data/", "job_events": "/api/v1/hosts/845/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/845/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/845/fact_versions/", "inventory_sources": "/api/v1/hosts/845/inventory_sources/",
+        "groups": "/api/v1/hosts/845/groups/", "activity_stream": "/api/v1/hosts/845/activity_stream/",
+        "all_groups": "/api/v1/hosts/845/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/845/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1419/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.497Z",
+        "modified": "2016-11-17T17:56:26.790Z", "name": "joev-apache-openldap", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c67c7-50d4-95be-7c65-a8f5f4be5ebb",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-apache-openldap/joev-apache-openldap.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_instanceUuid\":
+        \"500ca39f-7fbc-f357-b7e0-eda686864da6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 2345316860, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 4181, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420c67c7-50d4-95be-7c65-a8f5f4be5ebb\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        19129520128, \"vmware_distributedMemoryEntitlement\": 685, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        178, \"vmware_privateMemory\": 1560, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 6837445, \"vmware_memorySizeMB\":
+        4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2346488029, \"vmware_name\": \"joev-apache-openldap\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 1645, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 42, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1419}, {"id": 164, "type": "host", "url": "/api/v1/hosts/164/",
+        "related": {"job_host_summaries": "/api/v1/hosts/164/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/164/variable_data/", "job_events": "/api/v1/hosts/164/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/164/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/164/fact_versions/", "inventory_sources": "/api/v1/hosts/164/inventory_sources/",
+        "groups": "/api/v1/hosts/164/groups/", "activity_stream": "/api/v1/hosts/164/activity_stream/",
+        "all_groups": "/api/v1/hosts/164/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/164/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1447/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.823Z",
+        "modified": "2016-11-17T17:56:26.802Z", "name": "joev-brewery-centos-72",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c0d63-5270-443c-61b9-8270a876db16", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] joev-brewery-centos-72/joev-brewery-centos-72.vmx\", \"vmware_ipAddress\":
+        \"192.168.122.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM
+        Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500ca211-c5fe-3cbf-d6ef-a0794c1377f9\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 96210874935,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16607,
+        \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c0d63-5270-443c-61b9-8270a876db16\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 118537490432, \"vmware_distributedMemoryEntitlement\":
+        4491, \"vmware_template\": false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        1030, \"vmware_privateMemory\": 15354, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 23, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
+        96212276981, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-brewery\",
+        \"vmware_uptimeSeconds\": 4492703, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"joev-brewery-centos-72\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        15899, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 87, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1447}, {"id": 882, "type": "host", "url": "/api/v1/hosts/882/",
+        "related": {"job_host_summaries": "/api/v1/hosts/882/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/882/variable_data/", "job_events": "/api/v1/hosts/882/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/882/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/882/fact_versions/", "inventory_sources": "/api/v1/hosts/882/inventory_sources/",
+        "groups": "/api/v1/hosts/882/groups/", "activity_stream": "/api/v1/hosts/882/activity_stream/",
+        "all_groups": "/api/v1/hosts/882/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/882/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1455/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-11-08T22:23:36.128Z",
+        "modified": "2016-11-17T17:56:26.814Z", "name": "joev_cfme_5622-1", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c0e42-54a5-a15b-53af-d11d79dc7fcd",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c0788-791a-5017-6a2c-febb93af1631\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.1\", \"vmware_distributedMemoryEntitlement\":
+        2269, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2831228739, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev_cfme_5622-1\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        4038, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        50, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev_cfme_5622-1/joev_cfme_5622-1.vmx\", \"vmware_ipAddress\": \"10.8.99.208\",
+        \"vmware_guestMemoryUsage\": 1310, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 2830844978, \"vmware_staticMemoryEntitlement\":
+        8290, \"ansible_ssh_host\": \"10.8.99.208\", \"vmware_uuid\": \"420c0e42-54a5-a15b-53af-d11d79dc7fcd\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 57298698240,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 59, \"vmware_privateMemory\": 3983,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
+        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-cfme5622.jvlcek.redhat.com\", \"vmware_uptimeSeconds\": 670389, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
+        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1455}, {"id": 884, "type": "host", "url": "/api/v1/hosts/884/", "related":
+        {"job_host_summaries": "/api/v1/hosts/884/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/884/variable_data/", "job_events": "/api/v1/hosts/884/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/884/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/884/fact_versions/", "inventory_sources": "/api/v1/hosts/884/inventory_sources/",
+        "groups": "/api/v1/hosts/884/groups/", "activity_stream": "/api/v1/hosts/884/activity_stream/",
+        "all_groups": "/api/v1/hosts/884/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/884/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1432/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-11-11T23:12:08.865Z",
+        "modified": "2016-11-17T17:56:26.826Z", "name": "joev_cfme_5622-1d", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cbd84-00dc-3804-8f8e-3a93dc9b39bf",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c66f3-cb7c-1549-8450-d4a6c047d26b\", \"vmware_distributedCpuEntitlement\":
+        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.1\", \"vmware_distributedMemoryEntitlement\":
+        2410, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 46552139127, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev_cfme_5622-1d\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        5096, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev_cfme_5622-1d/joev_cfme_5622-1d.vmx\", \"vmware_ipAddress\": \"10.8.97.16\",
+        \"vmware_guestMemoryUsage\": 1966, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 3552743818, \"vmware_staticMemoryEntitlement\":
+        8294, \"ansible_ssh_host\": \"10.8.97.16\", \"vmware_uuid\": \"420cbd84-00dc-3804-8f8e-3a93dc9b39bf\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 59646803968,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 44, \"vmware_privateMemory\": 5032,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
+        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-cfme-16.jvlcek.redhat.com\", \"vmware_uptimeSeconds\": 598520, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
+        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1432}, {"id": 880, "type": "host", "url": "/api/v1/hosts/880/", "related":
+        {"job_host_summaries": "/api/v1/hosts/880/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/880/variable_data/", "job_events": "/api/v1/hosts/880/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/880/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/880/fact_versions/", "inventory_sources": "/api/v1/hosts/880/inventory_sources/",
+        "groups": "/api/v1/hosts/880/groups/", "activity_stream": "/api/v1/hosts/880/activity_stream/",
+        "all_groups": "/api/v1/hosts/880/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/880/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-11-08T22:23:36.117Z", "modified":
+        "2016-11-08T22:23:36.444Z", "name": "JoeV_cfme_5622-1-IPA_OTP_test", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c4564-afd6-f6e4-0f45-b7081f751939",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_product_instanceId\": null,
+        \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_product_key\": 0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        8192, \"vmware_instanceUuid\": \"500cc57f-3161-95bb-e366-a3040a62ec54\", \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] JoeV_cfme_5622-1-IPA_OTP_test/JoeV_cfme_5622-1-IPA_OTP_test.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_overallStatus\": \"green\",
+        \"vmware_consumedOverheadMemory\": 0, \"vmware_numCpu\": 4, \"vmware_uuid\":
+        \"420c4564-afd6-f6e4-0f45-b7081f751939\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2004600648, \"vmware_numVirtualDisks\": 1, \"vmware_product_version\":
+        \"4.1\", \"vmware_name\": \"JoeV_cfme_5622-1-IPA_OTP_test\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_memoryReservation\": 0, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_uncommitted\": 50374471680,
+        \"vmware_product_fullVersion\": null, \"vmware_ftLatencyStatus\": \"gray\",
+        \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\": \"poweredOff\",
+        \"vmware_guestId\": \"rhel6_64Guest\", \"vmware_product_appUrl\": null, \"vmware_swappedMemory\":
+        0, \"vmware_annotation\": null, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 2004599301, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 883, "type": "host", "url": "/api/v1/hosts/883/", "related":
+        {"job_host_summaries": "/api/v1/hosts/883/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/883/variable_data/", "job_events": "/api/v1/hosts/883/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/883/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/883/fact_versions/", "inventory_sources": "/api/v1/hosts/883/inventory_sources/",
+        "groups": "/api/v1/hosts/883/groups/", "activity_stream": "/api/v1/hosts/883/activity_stream/",
+        "all_groups": "/api/v1/hosts/883/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/883/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1417/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-11-10T15:47:11.909Z",
+        "modified": "2016-11-17T17:56:26.838Z", "name": "joev_cfme_5630-2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c3633-98f4-9d67-ea2f-57b3c2efafcf",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c2f4f-75c5-05a5-570c-8513bf5d6391\", \"vmware_distributedCpuEntitlement\":
+        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.1\", \"vmware_distributedMemoryEntitlement\":
+        2964, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 11875975091, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev_cfme_5630-2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        5435, \"vmware_overallCpuDemand\": 167, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev_cfme_5630-2/joev_cfme_5630-2.vmx\", \"vmware_ipAddress\": \"10.8.99.225\",
+        \"vmware_guestMemoryUsage\": 901, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 3271739092, \"vmware_staticMemoryEntitlement\":
+        8294, \"ansible_ssh_host\": \"10.8.99.225\", \"vmware_uuid\": \"420c3633-98f4-9d67-ea2f-57b3c2efafcf\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 59751354368,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 2817, \"vmware_privateMemory\": 5375,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
+        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-cfme5630.jvlcek.redhat.com\", \"vmware_uptimeSeconds\": 99765, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
+        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1417}, {"id": 887, "type": "host", "url": "/api/v1/hosts/887/", "related":
+        {"job_host_summaries": "/api/v1/hosts/887/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/887/variable_data/", "job_events": "/api/v1/hosts/887/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/887/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/887/fact_versions/", "inventory_sources": "/api/v1/hosts/887/inventory_sources/",
+        "groups": "/api/v1/hosts/887/groups/", "activity_stream": "/api/v1/hosts/887/activity_stream/",
+        "all_groups": "/api/v1/hosts/887/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/887/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1446/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}]}, "created": "2016-11-17T17:22:08.920Z",
+        "modified": "2016-11-17T17:56:26.849Z", "name": "joev-cfme-57011-1", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cbe6b-7c1b-14a9-044e-64ccb255308d",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500cf30d-97cc-a5f3-4ea7-631ed11738b1\", \"vmware_distributedCpuEntitlement\":
+        2375, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.2-rc1\", \"vmware_distributedMemoryEntitlement\":
+        962, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 2231, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2562314561, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-cfme-57011-1\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        1823, \"vmware_overallCpuDemand\": 2399, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        46, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-cfme-57011-1/joev-cfme-57011-1.vmx\", \"vmware_ipAddress\": \"10.8.99.115\",
+        \"vmware_guestMemoryUsage\": 245, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 2562130996, \"vmware_staticMemoryEntitlement\":
+        8311, \"ansible_ssh_host\": \"10.8.99.115\", \"vmware_uuid\": \"420cbe6b-7c1b-14a9-044e-64ccb255308d\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 57567412224,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 1778,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.2 RC1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-115.example.com\",
+        \"vmware_uptimeSeconds\": 7274, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1446}, {"id": 888, "type":
+        "host", "url": "/api/v1/hosts/888/", "related": {"job_host_summaries": "/api/v1/hosts/888/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/888/variable_data/", "job_events": "/api/v1/hosts/888/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/888/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/888/fact_versions/", "inventory_sources": "/api/v1/hosts/888/inventory_sources/",
+        "groups": "/api/v1/hosts/888/groups/", "activity_stream": "/api/v1/hosts/888/activity_stream/",
+        "all_groups": "/api/v1/hosts/888/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/888/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-11-17T17:22:08.924Z", "modified":
+        "2016-11-17T17:56:26.861Z", "name": "joev-cfme-57011-1_B", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cd150-cff1-e194-8695-bdea541302f5",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c073e-c49f-97b9-71db-e3280c8e8a53\", \"vmware_distributedCpuEntitlement\":
+        143, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.2-rc1\", \"vmware_distributedMemoryEntitlement\":
+        1189, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 239, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-cfme-57011-1_B\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        938, \"vmware_overallCpuDemand\": 263, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-cfme-57011-1_B/joev-cfme-57011-1_B.vmx\", \"vmware_ipAddress\": \"10.8.99.118\",
+        \"vmware_guestMemoryUsage\": 4669, \"vmware_guestFullName\": \"Red Hat Enterprise
+        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"ansible_ssh_host\": \"10.8.99.118\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        2651240866, \"vmware_staticMemoryEntitlement\": 8311, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_uuid\": \"420cd150-cff1-e194-8695-bdea541302f5\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 60128088064, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 7313,
+        \"vmware_privateMemory\": 879, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"Red Hat CloudForms 4.2 RC1\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-118.example.com\",
+        \"vmware_uptimeSeconds\": 382, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 19858987641,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 874, "type":
+        "host", "url": "/api/v1/hosts/874/", "related": {"job_host_summaries": "/api/v1/hosts/874/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/874/variable_data/", "job_events": "/api/v1/hosts/874/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/874/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/874/fact_versions/", "inventory_sources": "/api/v1/hosts/874/inventory_sources/",
+        "groups": "/api/v1/hosts/874/groups/", "activity_stream": "/api/v1/hosts/874/activity_stream/",
+        "all_groups": "/api/v1/hosts/874/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/874/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/810/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1108/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-10-24T20:41:58.883Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T14:09:39.286Z",
+        "id": 802, "name": "PackageInfo"}]}, "created": "2016-10-20T19:42:04.222Z",
+        "modified": "2016-11-08T22:23:35.712Z", "name": "joev_cfme_5705-1_20161017",
+        "description": "imported", "inventory": 17, "enabled": false, "instance_id":
+        "420c037b-741c-5860-ecd9-86a3392a2aac", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c44c6-d3a3-aa24-e2a6-b6791fe9b210\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.2-alpha2\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 3, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev_cfme_5705-1_20161017\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev_cfme_5705-1_20161017/joev_cfme_5705-1_20161017.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.232\", \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.232\", \"vmware_product_key\":
+        0, \"vmware_unshared\": 3399840959, \"vmware_staticMemoryEntitlement\": 0,
+        \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c037b-741c-5860-ecd9-86a3392a2aac\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 86091440128, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.2 Alpha2\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-232.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 37800250201,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 810, "last_job_host_summary": 1108}, {"id": 209, "type":
+        "host", "url": "/api/v1/hosts/209/", "related": {"job_host_summaries": "/api/v1/hosts/209/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/209/variable_data/", "job_events": "/api/v1/hosts/209/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/209/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/209/fact_versions/", "inventory_sources": "/api/v1/hosts/209/inventory_sources/",
+        "groups": "/api/v1/hosts/209/groups/", "activity_stream": "/api/v1/hosts/209/activity_stream/",
+        "all_groups": "/api/v1/hosts/209/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/209/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1470/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-20T19:46:07.486Z",
+        "modified": "2016-11-17T17:56:26.869Z", "name": "joev-ipa14", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cf66e-39ca-eb2b-4b42-dd543f800b54",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-ipa-rhel7/joev-ipa-rhel7.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.14\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c9f91-a013-73e0-c4ca-87b2ab696b8b\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 4605396829,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16528,
+        \"ansible_ssh_host\": \"10.8.97.14\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420cf66e-39ca-eb2b-4b42-dd543f800b54\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 213492465664, \"vmware_distributedMemoryEntitlement\":
+        1434, \"vmware_template\": false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        307, \"vmware_privateMemory\": 4325, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 23, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
+        73365468920, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-ipa14.jvlcek.redhat.com\",
+        \"vmware_uptimeSeconds\": 5522788, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"joev-ipa14\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 4417, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 60, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1470}, {"id": 165, "type": "host", "url": "/api/v1/hosts/165/",
+        "related": {"job_host_summaries": "/api/v1/hosts/165/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/165/variable_data/", "job_events": "/api/v1/hosts/165/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/165/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/165/fact_versions/", "inventory_sources": "/api/v1/hosts/165/inventory_sources/",
+        "groups": "/api/v1/hosts/165/groups/", "activity_stream": "/api/v1/hosts/165/activity_stream/",
+        "all_groups": "/api/v1/hosts/165/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/165/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/370/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
+        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
+        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
+        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
+        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.830Z",
+        "modified": "2016-05-25T14:07:45.391Z", "name": "joev-ipa-ad", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c299f-aa19-c7ee-05a6-ef86163464a6",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-ipa-ad/joev-ipa-ad.vmx\",
+        \"vmware_ipAddress\": \"192.168.122.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500ce8fc-49c2-24fb-d3c3-6d65553bcebc\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 76356796972,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_suspendInterval\": 0,
+        \"vmware_uuid\": \"420c299f-aa19-c7ee-05a6-ef86163464a6\", \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 155766673408, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 8796, \"vmware_committed\":
+        76357108972, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"joev-ipa-ad.jvlcek.redhat.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"joev-ipa-ad\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        362, "last_job_host_summary": 370}, {"id": 846, "type": "host", "url": "/api/v1/hosts/846/",
+        "related": {"job_host_summaries": "/api/v1/hosts/846/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/846/variable_data/", "job_events": "/api/v1/hosts/846/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/846/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/846/fact_versions/", "inventory_sources": "/api/v1/hosts/846/inventory_sources/",
+        "groups": "/api/v1/hosts/846/groups/", "activity_stream": "/api/v1/hosts/846/activity_stream/",
+        "all_groups": "/api/v1/hosts/846/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/846/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/810/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1092/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-10-24T20:41:58.883Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T14:09:39.286Z",
+        "id": 802, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.502Z",
+        "modified": "2016-11-11T23:12:08.466Z", "name": "joev-ldap", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c5471-f1af-f5da-16ea-ea1c7a18a596",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-ldap/joev-ldap.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.233\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500ce4c6-0427-bbd1-ec2d-ffd0820a4512\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 7662903825,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.99.233\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c5471-f1af-f5da-16ea-ea1c7a18a596\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 18302136320, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_committed\":
+        7663818369, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-233.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"joev-ldap\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        810, "last_job_host_summary": 1092}, {"id": 822, "type": "host", "url": "/api/v1/hosts/822/",
+        "related": {"job_host_summaries": "/api/v1/hosts/822/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/822/variable_data/", "job_events": "/api/v1/hosts/822/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/822/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/822/fact_versions/", "inventory_sources": "/api/v1/hosts/822/inventory_sources/",
+        "groups": "/api/v1/hosts/822/groups/", "activity_stream": "/api/v1/hosts/822/activity_stream/",
+        "all_groups": "/api/v1/hosts/822/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/822/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1416/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.381Z",
+        "modified": "2016-11-17T17:25:54.709Z", "name": "JoeV-ManageIQ", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cfc95-bb19-405f-413d-7ba19509ec28",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c5d81-f50f-6259-e49a-c25b6020bcc9\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        3310, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 5153463694, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"JoeV-ManageIQ\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        5931, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        JoeV-ManageIQ/JoeV-ManageIQ.vmx\", \"vmware_ipAddress\": \"10.8.99.225\",
+        \"vmware_guestMemoryUsage\": 2457, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 5152875029, \"vmware_staticMemoryEntitlement\":
+        6231, \"ansible_ssh_host\": \"10.8.99.225\", \"vmware_uuid\": \"420cfc95-bb19-405f-413d-7ba19509ec28\",
+        \"vmware_staticCpuEntitlement\": 1475, \"vmware_uncommitted\": 37796798464,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 184, \"vmware_privateMemory\": 5828,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-manageiq.jvlcek.redhat.com\",
+        \"vmware_uptimeSeconds\": 3195752, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1416}, {"id": 166, "type":
+        "host", "url": "/api/v1/hosts/166/", "related": {"job_host_summaries": "/api/v1/hosts/166/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/166/variable_data/", "job_events": "/api/v1/hosts/166/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/166/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/166/fact_versions/", "inventory_sources": "/api/v1/hosts/166/inventory_sources/",
+        "groups": "/api/v1/hosts/166/groups/", "activity_stream": "/api/v1/hosts/166/activity_stream/",
+        "all_groups": "/api/v1/hosts/166/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/166/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1413/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.836Z",
+        "modified": "2016-11-17T17:25:54.591Z", "name": "joev-miq", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c1eaa-1df4-00b3-e93d-4902edb3f496",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500cb184-a71e-c566-562e-263e0e4a1ec7\", \"vmware_distributedCpuEntitlement\":
+        71, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        1599, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 71, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 49588606995, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 4984,
+        \"vmware_overallCpuDemand\": 71, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        52, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        joev-miq/joev-miq.vmx\", \"vmware_ipAddress\": \"10.8.99.206\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960, \"vmware_staticMemoryEntitlement\":
+        6252, \"ansible_ssh_host\": \"10.8.99.206\", \"vmware_uuid\": \"420c1eaa-1df4-00b3-e93d-4902edb3f496\",
+        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 502, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 1696, \"vmware_privateMemory\": 4318, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"joev-miq.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
+        4897979, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"red\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1413}, {"id": 847, "type": "host", "url": "/api/v1/hosts/847/", "related":
+        {"job_host_summaries": "/api/v1/hosts/847/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/847/variable_data/", "job_events": "/api/v1/hosts/847/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/847/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/847/fact_versions/", "inventory_sources": "/api/v1/hosts/847/inventory_sources/",
+        "groups": "/api/v1/hosts/847/groups/", "activity_stream": "/api/v1/hosts/847/activity_stream/",
+        "all_groups": "/api/v1/hosts/847/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/847/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1440/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.506Z",
+        "modified": "2016-11-17T17:25:55.405Z", "name": "joev-miq-0824", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cca02-fbfe-1d4f-607a-b51ab9648fff",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c2dcd-c5b0-2ba1-c2b8-802452f0ae74\", \"vmware_distributedCpuEntitlement\":
+        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        3126, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 12927008505, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq-0824\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        6047, \"vmware_overallCpuDemand\": 167, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-miq-0824/joev-miq-0824.vmx\", \"vmware_ipAddress\": \"10.8.99.247\",
+        \"vmware_guestMemoryUsage\": 1536, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 6474167134, \"vmware_staticMemoryEntitlement\":
+        6240, \"ansible_ssh_host\": \"10.8.99.247\", \"vmware_uuid\": \"420cca02-fbfe-1d4f-607a-b51ab9648fff\",
+        \"vmware_staticCpuEntitlement\": 1475, \"vmware_uncommitted\": 41580527616,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 35, \"vmware_privateMemory\": 5989,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-247.example.com\",
+        \"vmware_uptimeSeconds\": 3806545, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1440}, {"id": 213, "type":
+        "host", "url": "/api/v1/hosts/213/", "related": {"job_host_summaries": "/api/v1/hosts/213/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/213/variable_data/", "job_events": "/api/v1/hosts/213/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/213/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/213/fact_versions/", "inventory_sources": "/api/v1/hosts/213/inventory_sources/",
+        "groups": "/api/v1/hosts/213/groups/", "activity_stream": "/api/v1/hosts/213/activity_stream/",
+        "all_groups": "/api/v1/hosts/213/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/213/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.448Z", "modified":
+        "2016-05-25T14:07:45.414Z", "name": "joev-miq13_OLD", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c162b-c940-7f7a-e979-c46bf1618d2d",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c9ed1-0284-53e1-6cb4-0043c63f4e65\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq13_OLD\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-miq13_1/joev-miq13.vmx\", \"vmware_ipAddress\": \"10.8.97.13\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.97.13\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 5653742444, \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c162b-c940-7f7a-e979-c46bf1618d2d\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 49587249152, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 8796, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"joev-miq13.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 5654356315, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 849, "type": "host", "url": "/api/v1/hosts/849/", "related":
+        {"job_host_summaries": "/api/v1/hosts/849/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/849/variable_data/", "job_events": "/api/v1/hosts/849/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/849/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/849/fact_versions/", "inventory_sources": "/api/v1/hosts/849/inventory_sources/",
+        "groups": "/api/v1/hosts/849/groups/", "activity_stream": "/api/v1/hosts/849/activity_stream/",
+        "all_groups": "/api/v1/hosts/849/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/849/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1469/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.517Z",
+        "modified": "2016-11-17T17:56:26.881Z", "name": "joev-miq16b", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c5283-b3e3-e9c8-072a-52094041ef17",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c13fd-75ac-d3a1-debc-ab882f2d8d78\", \"vmware_distributedCpuEntitlement\":
+        167, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        2786, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 167, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 12942708466, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq16b\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        6040, \"vmware_overallCpuDemand\": 167, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-miq16b/joev-miq16b.vmx\", \"vmware_ipAddress\": \"10.8.99.240\", \"vmware_guestMemoryUsage\":
+        1536, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 6489662298, \"vmware_staticMemoryEntitlement\":
+        6240, \"ansible_ssh_host\": \"10.8.99.240\", \"vmware_uuid\": \"420c5283-b3e3-e9c8-072a-52094041ef17\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 50843058176,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 32, \"vmware_privateMemory\": 5982,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"bob.the.builder.com\",
+        \"vmware_uptimeSeconds\": 3105184, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1469}, {"id": 167, "type":
+        "host", "url": "/api/v1/hosts/167/", "related": {"job_host_summaries": "/api/v1/hosts/167/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/167/variable_data/", "job_events": "/api/v1/hosts/167/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/167/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/167/fact_versions/", "inventory_sources": "/api/v1/hosts/167/inventory_sources/",
+        "groups": "/api/v1/hosts/167/groups/", "activity_stream": "/api/v1/hosts/167/activity_stream/",
+        "all_groups": "/api/v1/hosts/167/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/167/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/362/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/371/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-04-08T13:43:38.776Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-04-08T13:43:38.776Z",
+        "id": 362, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-08T13:25:19.926Z",
+        "id": 360, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:45:36.361Z",
+        "id": 282, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-04-01T20:34:20.468Z",
+        "id": 278, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.841Z",
+        "modified": "2016-05-25T14:07:45.421Z", "name": "joev-miq2", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7cbd-06ae-20a6-e3d5-0225e02bc245",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c26de-061e-2bf8-6327-e3d24e6d6724\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"master\",
+        \"vmware_distributedMemoryEntitlement\": 0, \"vmware_product_appUrl\": null,
+        \"vmware_product_fullVersion\": null, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 6144, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\":
+        \"green\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_committed\": 42950239702, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0,
+        \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        joev-miq-20160329/joev-miq-20160329.vmx\", \"vmware_ipAddress\": \"10.8.99.226\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960,
+        \"vmware_staticMemoryEntitlement\": 0, \"ansible_ssh_host\": \"10.8.99.226\",
+        \"vmware_uuid\": \"420c7cbd-06ae-20a6-e3d5-0225e02bc245\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 6637666838, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 0,
+        \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"ManageIQ\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
+        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"joev-miq2.jvlcek.redhat.com\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
+        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": 362, "last_job_host_summary":
+        371}, {"id": 889, "type": "host", "url": "/api/v1/hosts/889/", "related":
+        {"job_host_summaries": "/api/v1/hosts/889/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/889/variable_data/", "job_events": "/api/v1/hosts/889/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/889/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/889/fact_versions/", "inventory_sources": "/api/v1/hosts/889/inventory_sources/",
+        "groups": "/api/v1/hosts/889/groups/", "activity_stream": "/api/v1/hosts/889/activity_stream/",
+        "all_groups": "/api/v1/hosts/889/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/889/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1433/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}]}, "created": "2016-11-17T17:22:08.929Z",
+        "modified": "2016-11-17T17:56:26.892Z", "name": "joev-miq-201611152000", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cb67a-8cc7-aebc-90bb-cdb25c54a88a",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c07f0-7f30-80c4-bb17-8fee9f7ee407\", \"vmware_distributedCpuEntitlement\":
+        215, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        2231, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 215, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 10250439536, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq-201611152000\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        4722, \"vmware_overallCpuDemand\": 239, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-miq-201611152000/joev-miq-201611152000.vmx\", \"vmware_ipAddress\": \"10.8.99.112\",
+        \"vmware_guestMemoryUsage\": 1781, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 3797807992, \"vmware_staticMemoryEntitlement\":
+        6235, \"ansible_ssh_host\": \"10.8.99.112\", \"vmware_uuid\": \"420cb67a-8cc7-aebc-90bb-cdb25c54a88a\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 53393371136,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 1486, \"vmware_privateMemory\": 4658,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-miq-20161115.jvlcek.redhat.com\",
+        \"vmware_uptimeSeconds\": 92879, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1433}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:38 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.330s
+      Content-Length:
+      - '101439'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=6", "previous": "/api/v1/hosts/?page=4",
+        "results": [{"id": 261, "type": "host", "url": "/api/v1/hosts/261/", "related":
+        {"job_host_summaries": "/api/v1/hosts/261/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/261/variable_data/", "job_events": "/api/v1/hosts/261/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/261/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/261/fact_versions/", "inventory_sources": "/api/v1/hosts/261/inventory_sources/",
+        "groups": "/api/v1/hosts/261/groups/", "activity_stream": "/api/v1/hosts/261/activity_stream/",
+        "all_groups": "/api/v1/hosts/261/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/261/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/810/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1109/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-10-24T20:41:58.883Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T14:09:39.286Z",
+        "id": 802, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.587Z",
+        "modified": "2016-11-11T23:12:08.496Z", "name": "joev-miq-23052016-16", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c5ac9-c0c4-9492-2da0-cf7d9ed8db59",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c30ac-bfdc-e869-e6dd-e0718ad311ea\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"joev-miq-23052016-16\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        joev-miq-23052016-13_1/joev-miq-23052016-13.vmx\", \"vmware_ipAddress\": \"10.8.97.16\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\": \"Red Hat Enterprise
+        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"ansible_ssh_host\": \"10.8.97.16\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        10807792499, \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_uuid\": \"420c5ac9-c0c4-9492-2da0-cf7d9ed8db59\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 43199062016, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"joev-miq16.jvlcek.redhat.com\", \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 17261853471, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 810, "last_job_host_summary":
+        1109}, {"id": 262, "type": "host", "url": "/api/v1/hosts/262/", "related":
+        {"job_host_summaries": "/api/v1/hosts/262/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/262/variable_data/", "job_events": "/api/v1/hosts/262/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/262/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/262/fact_versions/", "inventory_sources": "/api/v1/hosts/262/inventory_sources/",
+        "groups": "/api/v1/hosts/262/groups/", "activity_stream": "/api/v1/hosts/262/activity_stream/",
+        "all_groups": "/api/v1/hosts/262/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/262/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.592Z", "modified":
+        "2016-05-25T14:07:46.738Z", "name": "joev-miq-5-13", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c460b-11e1-4858-978a-971e8d8f0202",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-miq-5-13/joev-miq-5-13.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 11148903262, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c460b-11e1-4858-978a-971e8d8f0202\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 42810253312, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"joev-miq13.jvlcek.redhat.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500c98cb-ccfb-316f-c779-453c3a959bd6\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 17602705266, \"vmware_name\": \"joev-miq-5-13\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 848, "type": "host", "url": "/api/v1/hosts/848/",
+        "related": {"job_host_summaries": "/api/v1/hosts/848/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/848/variable_data/", "job_events": "/api/v1/hosts/848/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/848/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/848/fact_versions/", "inventory_sources": "/api/v1/hosts/848/inventory_sources/",
+        "groups": "/api/v1/hosts/848/groups/", "activity_stream": "/api/v1/hosts/848/activity_stream/",
+        "all_groups": "/api/v1/hosts/848/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/848/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.512Z", "modified":
+        "2016-10-14T13:37:12.200Z", "name": "joev-miq-sb-sb", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c1d29-ebfb-b769-d56f-3797a52e59ff",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] joev-miq-sb-sb/joev-miq-sb-sb.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 5579055969, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c1d29-ebfb-b769-d56f-3797a52e59ff\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 48328527872, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"ManageIQ\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-217.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500cfd3e-4464-c051-0ece-039973a2651b\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 12031710848, \"vmware_name\": \"joev-miq-sb-sb\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 263, "type": "host", "url": "/api/v1/hosts/263/",
+        "related": {"job_host_summaries": "/api/v1/hosts/263/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/263/variable_data/", "job_events": "/api/v1/hosts/263/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/263/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/263/fact_versions/", "inventory_sources": "/api/v1/hosts/263/inventory_sources/",
+        "groups": "/api/v1/hosts/263/groups/", "activity_stream": "/api/v1/hosts/263/activity_stream/",
+        "all_groups": "/api/v1/hosts/263/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/263/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1468/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.597Z",
+        "modified": "2016-11-17T17:56:26.904Z", "name": "jp-img2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c5b6e-8f7e-2f89-fbd1-0261491d3f1d",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jp-img2/jp-img2.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.246\", \"vmware_guestMemoryUsage\": 81, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c6f11-1d94-18b0-01ca-8072be00d302\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 39933723153,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 8317,
+        \"ansible_ssh_host\": \"10.8.99.246\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c5b6e-8f7e-2f89-fbd1-0261491d3f1d\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        717, \"vmware_uncommitted\": 67440459776, \"vmware_distributedMemoryEntitlement\":
+        891, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        126, \"vmware_privateMemory\": 2050, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_committed\":
+        39935149954, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 5714929, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"jp-img2\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2119, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 43, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1468}, {"id": 264, "type": "host", "url": "/api/v1/hosts/264/",
+        "related": {"job_host_summaries": "/api/v1/hosts/264/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/264/variable_data/", "job_events": "/api/v1/hosts/264/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/264/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/264/fact_versions/", "inventory_sources": "/api/v1/hosts/264/inventory_sources/",
+        "groups": "/api/v1/hosts/264/groups/", "activity_stream": "/api/v1/hosts/264/activity_stream/",
+        "all_groups": "/api/v1/hosts/264/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/264/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.602Z", "modified":
+        "2016-10-14T13:37:10.276Z", "name": "jprause-brewery7", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c665e-b42d-26d2-21a2-0a54d4d79cba",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jprause-brewery7/jprause-brewery7.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.220\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c9982-6622-52b4-1301-0c870e7b42ac\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_unshared\": 133769327685,
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"ansible_ssh_host\": \"10.8.99.220\", \"vmware_suspendInterval\": 0, \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c665e-b42d-26d2-21a2-0a54d4d79cba\",
+        \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 33908158464, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
+        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_committed\": 133770352248, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"jprause-brewery7\", \"vmware_uptimeSeconds\": 0,
+        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"jprause-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 265, "type": "host", "url": "/api/v1/hosts/265/",
+        "related": {"job_host_summaries": "/api/v1/hosts/265/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/265/variable_data/", "job_events": "/api/v1/hosts/265/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/265/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/265/fact_versions/", "inventory_sources": "/api/v1/hosts/265/inventory_sources/",
+        "groups": "/api/v1/hosts/265/groups/", "activity_stream": "/api/v1/hosts/265/activity_stream/",
+        "all_groups": "/api/v1/hosts/265/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/265/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.607Z", "modified":
+        "2016-10-14T13:37:10.283Z", "name": "jprause-img-factory", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c7636-ae0a-6f5e-9792-59774df7924a",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jprause-img-factory/jprause-img-factory.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c7a0d-0538-3baf-ba22-fb070f840b89\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 47245746717, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420c7636-ae0a-6f5e-9792-59774df7924a\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 68911484928, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-249.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        47246993009, \"vmware_name\": \"jprause-img-factory\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 850, "type": "host", "url": "/api/v1/hosts/850/",
+        "related": {"job_host_summaries": "/api/v1/hosts/850/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/850/variable_data/", "job_events": "/api/v1/hosts/850/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/850/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/850/fact_versions/", "inventory_sources": "/api/v1/hosts/850/inventory_sources/",
+        "groups": "/api/v1/hosts/850/groups/", "activity_stream": "/api/v1/hosts/850/activity_stream/",
+        "all_groups": "/api/v1/hosts/850/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/850/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.522Z", "modified":
+        "2016-10-14T13:37:12.205Z", "name": "jwong-centos7-old", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c240f-7d98-98df-14a4-65596827ca25",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"dhcp-8-99-210.example.com\",
+        \"vmware_instanceUuid\": \"500c871d-ba8d-ef9e-89c0-78095c8f987f\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] jwong-centos7/jwong-centos7.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c240f-7d98-98df-14a4-65596827ca25\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 4074699488, \"vmware_name\":
+        \"jwong-centos7-old\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 30477475840, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 4074316332, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 851, "type": "host", "url": "/api/v1/hosts/851/",
+        "related": {"job_host_summaries": "/api/v1/hosts/851/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/851/variable_data/", "job_events": "/api/v1/hosts/851/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/851/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/851/fact_versions/", "inventory_sources": "/api/v1/hosts/851/inventory_sources/",
+        "groups": "/api/v1/hosts/851/groups/", "activity_stream": "/api/v1/hosts/851/activity_stream/",
+        "all_groups": "/api/v1/hosts/851/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/851/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1441/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.527Z",
+        "modified": "2016-11-17T17:56:26.917Z", "name": "jwong-dev", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cb104-d414-76e8-996f-fb361acc10d6",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] jwong-centos7(2)/jwong-centos7(2).vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500cd4eb-2647-0faa-e0bd-27d7c09422cb\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1918894080, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 8350, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420cb104-d414-76e8-996f-fb361acc10d6\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        42831184757, \"vmware_distributedMemoryEntitlement\": 481, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        169, \"vmware_privateMemory\": 505, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 8979230, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 19305314236, \"vmware_name\": \"jwong-dev\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 577, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 44, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1441}, {"id": 214, "type": "host", "url": "/api/v1/hosts/214/",
+        "related": {"job_host_summaries": "/api/v1/hosts/214/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/214/variable_data/", "job_events": "/api/v1/hosts/214/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/214/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/214/fact_versions/", "inventory_sources": "/api/v1/hosts/214/inventory_sources/",
+        "groups": "/api/v1/hosts/214/groups/", "activity_stream": "/api/v1/hosts/214/activity_stream/",
+        "all_groups": "/api/v1/hosts/214/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/214/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.453Z", "modified":
+        "2016-04-28T14:28:03.840Z", "name": "jwong-dvs", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ced0b-e0c4-19e1-d6ce-0b3e3e27b951",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500c7dde-7806-a68b-4beb-8c159d577b5a\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs/jwong-dvs.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420ced0b-e0c4-19e1-d6ce-0b3e3e27b951\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 2637, \"vmware_name\": \"jwong-dvs\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19482144768, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=8c9d6da2-0beb-11e6-9f79-f45c89896441\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 497, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 215, "type": "host", "url": "/api/v1/hosts/215/", "related":
+        {"job_host_summaries": "/api/v1/hosts/215/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/215/variable_data/", "job_events": "/api/v1/hosts/215/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/215/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/215/fact_versions/", "inventory_sources": "/api/v1/hosts/215/inventory_sources/",
+        "groups": "/api/v1/hosts/215/groups/", "activity_stream": "/api/v1/hosts/215/activity_stream/",
+        "all_groups": "/api/v1/hosts/215/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/215/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.459Z", "modified":
+        "2016-04-28T14:28:03.844Z", "name": "jwong-dvs-3", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ce9fa-088d-dc4d-bda2-c3ccf9940c59",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
+        \"vmware_instanceUuid\": \"500ca6d1-803e-0267-330b-8a5fe6bf2581\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-3/jwong-dvs-3.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ce9fa-088d-dc4d-bda2-c3ccf9940c59\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1657843239, \"vmware_name\":
+        \"jwong-dvs-3\", \"vmware_toolsVersionStatus\": \"guestToolsNeedUpgrade\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 43631378432, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=092ccea0-0bef-11e6-9f79-f45c89896441\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1657831950, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 216, "type": "host", "url": "/api/v1/hosts/216/",
+        "related": {"job_host_summaries": "/api/v1/hosts/216/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/216/variable_data/", "job_events": "/api/v1/hosts/216/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/216/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/216/fact_versions/", "inventory_sources": "/api/v1/hosts/216/inventory_sources/",
+        "groups": "/api/v1/hosts/216/groups/", "activity_stream": "/api/v1/hosts/216/activity_stream/",
+        "all_groups": "/api/v1/hosts/216/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/216/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1475/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-28T14:28:03.464Z",
+        "modified": "2016-11-17T17:25:56.037Z", "name": "jwong-dvs-4", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c2537-c895-afd7-3507-1d09da2896e6",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-4/jwong-dvs-4.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500cf709-a129-7cd4-3b95-870a28f47e18\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 499, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        2114, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_uuid\": \"420c2537-c895-afd7-3507-1d09da2896e6\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 2297, \"vmware_uncommitted\":
+        17179869184, \"vmware_distributedMemoryEntitlement\": 67, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 6, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 142083, \"vmware_memorySizeMB\":
+        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 137207, \"vmware_name\": \"jwong-dvs-4\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        23, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 17, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1475}, {"id": 266, "type": "host", "url": "/api/v1/hosts/266/",
+        "related": {"job_host_summaries": "/api/v1/hosts/266/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/266/variable_data/", "job_events": "/api/v1/hosts/266/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/266/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/266/fact_versions/", "inventory_sources": "/api/v1/hosts/266/inventory_sources/",
+        "groups": "/api/v1/hosts/266/groups/", "activity_stream": "/api/v1/hosts/266/activity_stream/",
+        "all_groups": "/api/v1/hosts/266/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/266/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.624Z", "modified":
+        "2016-05-25T14:07:46.756Z", "name": "jwong-dvs-re-fix", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c2e04-8e26-2344-b100-d20f97098ce6",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
+        \"vmware_instanceUuid\": \"500c1d49-da1d-84eb-36e1-60b02a4eba1c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-dvs-re-fix/jwong-dvs-re-fix.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c2e04-8e26-2344-b100-d20f97098ce6\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 161316, \"vmware_name\":
+        \"jwong-dvs-re-fix\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=ab2163a6-12f2-11e6-8713-f45c89896441\", \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 218, "type":
+        "host", "url": "/api/v1/hosts/218/", "related": {"job_host_summaries": "/api/v1/hosts/218/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/218/variable_data/", "job_events": "/api/v1/hosts/218/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/218/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/218/fact_versions/", "inventory_sources": "/api/v1/hosts/218/inventory_sources/",
+        "groups": "/api/v1/hosts/218/groups/", "activity_stream": "/api/v1/hosts/218/activity_stream/",
+        "all_groups": "/api/v1/hosts/218/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/218/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1437/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-28T14:28:03.474Z",
+        "modified": "2016-11-17T17:25:55.350Z", "name": "jwong_dvs_test", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c55fb-8286-13a8-0e2a-6eba543b8efe",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jwong_dvs_test/jwong_dvs_test.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.210\", \"vmware_guestMemoryUsage\": 20, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500cd6d5-cee7-23ba-dde1-c7e213a58fb0\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1655132712,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 2098,
+        \"ansible_ssh_host\": \"10.8.99.210\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c55fb-8286-13a8-0e2a-6eba543b8efe\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 922, \"vmware_uncommitted\":
+        41294540800, \"vmware_distributedMemoryEntitlement\": 373, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"MIQ GUID=f054efee-0bed-11e6-9f79-f45c89896441\",
+        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 97, \"vmware_privateMemory\": 390, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-210.example.com\",
+        \"vmware_uptimeSeconds\": 2485908, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1655288505, \"vmware_name\": \"jwong_dvs_test\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        445, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 30, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1437}, {"id": 852, "type": "host", "url": "/api/v1/hosts/852/",
+        "related": {"job_host_summaries": "/api/v1/hosts/852/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/852/variable_data/", "job_events": "/api/v1/hosts/852/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/852/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/852/fact_versions/", "inventory_sources": "/api/v1/hosts/852/inventory_sources/",
+        "groups": "/api/v1/hosts/852/groups/", "activity_stream": "/api/v1/hosts/852/activity_stream/",
+        "all_groups": "/api/v1/hosts/852/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/852/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1420/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.532Z",
+        "modified": "2016-11-17T17:56:26.929Z", "name": "jwong-esxi1.example.com",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420cf288-bc81-acd9-78c0-052dc4bb08f8", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] jwong-esxi1.example.com/jwong-esxi1.example.com.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.18\", \"vmware_guestMemoryUsage\": 368, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"VMware ESXi 6.0\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500cbde3-5317-e8d9-2596-957e6469ae2d\", \"vmware_distributedCpuEntitlement\":
+        263, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 6322137337,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 12468,
+        \"ansible_ssh_host\": \"10.8.97.18\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420cf288-bc81-acd9-78c0-052dc4bb08f8\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        723822305280, \"vmware_distributedMemoryEntitlement\": 1382, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 335, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 4, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        12288, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        3082, \"vmware_privateMemory\": 2635, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 311, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"jwong-esxi1\", \"vmware_uptimeSeconds\":
+        5714963, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 6323471178,
+        \"vmware_name\": \"jwong-esxi1.example.com\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        3241, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"vmkernel6Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 54, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1420}, {"id": 853, "type": "host", "url": "/api/v1/hosts/853/",
+        "related": {"job_host_summaries": "/api/v1/hosts/853/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/853/variable_data/", "job_events": "/api/v1/hosts/853/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/853/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/853/fact_versions/", "inventory_sources": "/api/v1/hosts/853/inventory_sources/",
+        "groups": "/api/v1/hosts/853/groups/", "activity_stream": "/api/v1/hosts/853/activity_stream/",
+        "all_groups": "/api/v1/hosts/853/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/853/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1443/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.537Z",
+        "modified": "2016-11-17T17:56:26.941Z", "name": "jwong-esxi2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c67ab-3d87-40a0-a834-b329bdb3d366",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jwong-esxi2/jwong-esxi2.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.19\", \"vmware_guestMemoryUsage\": 122, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"VMware ESXi 6.0\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c67c1-fc85-bfb9-b612-8d86f266905f\", \"vmware_distributedCpuEntitlement\":
+        263, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 11792995893,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 12459,
+        \"ansible_ssh_host\": \"10.8.97.19\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c67ab-3d87-40a0-a834-b329bdb3d366\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        696876609536, \"vmware_distributedMemoryEntitlement\": 1321, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 263, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 3, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        12288, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        3182, \"vmware_privateMemory\": 2704, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 263, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"jwong-esxi2\", \"vmware_uptimeSeconds\":
+        6924913, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 11794333414,
+        \"vmware_name\": \"jwong-esxi2\", \"vmware_toolsVersionStatus\": \"guestToolsCurrent\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3326, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_guestId\":
+        \"vmkernel6Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        55, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1443}, {"id": 854, "type":
+        "host", "url": "/api/v1/hosts/854/", "related": {"job_host_summaries": "/api/v1/hosts/854/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/854/variable_data/", "job_events": "/api/v1/hosts/854/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/854/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/854/fact_versions/", "inventory_sources": "/api/v1/hosts/854/inventory_sources/",
+        "groups": "/api/v1/hosts/854/groups/", "activity_stream": "/api/v1/hosts/854/activity_stream/",
+        "all_groups": "/api/v1/hosts/854/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/854/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1431/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.542Z",
+        "modified": "2016-11-17T17:56:26.952Z", "name": "jwong-esxi3", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c690c-26c8-fcd1-7413-18cea5be066a",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jwong-esxi3/jwong-esxi3.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.20\", \"vmware_guestMemoryUsage\": 368, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"VMware ESXi 6.0\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c0d0e-fecc-c475-abab-aa20ca89766f\", \"vmware_distributedCpuEntitlement\":
+        239, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 8595469877,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 12459,
+        \"ansible_ssh_host\": \"10.8.97.20\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c690c-26c8-fcd1-7413-18cea5be066a\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        700074135552, \"vmware_distributedMemoryEntitlement\": 1399, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 383, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 3, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        12288, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        3090, \"vmware_privateMemory\": 2634, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 359, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"jwong-esxi3\", \"vmware_uptimeSeconds\":
+        4926877, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 8596761751,
+        \"vmware_name\": \"jwong-esxi3\", \"vmware_toolsVersionStatus\": \"guestToolsCurrent\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 3223, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_guestId\":
+        \"vmkernel6Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        54, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1431}, {"id": 217, "type":
+        "host", "url": "/api/v1/hosts/217/", "related": {"job_host_summaries": "/api/v1/hosts/217/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/217/variable_data/", "job_events": "/api/v1/hosts/217/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/217/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/217/fact_versions/", "inventory_sources": "/api/v1/hosts/217/inventory_sources/",
+        "groups": "/api/v1/hosts/217/groups/", "activity_stream": "/api/v1/hosts/217/activity_stream/",
+        "all_groups": "/api/v1/hosts/217/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/217/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-04-28T14:28:03.469Z", "modified":
+        "2016-04-28T14:28:03.859Z", "name": "jwong-live-dvs", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c5e62-d1b8-49b6-0ac1-708124b932dd",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500c9ffe-489f-8027-37ed-aba6c080ce06\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-live-dvs/jwong-live-dvs.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c5e62-d1b8-49b6-0ac1-708124b932dd\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 2841, \"vmware_name\":
+        \"jwong-live-dvs\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19482144768, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_cpuReservation\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=bce91030-0c9d-11e6-bc96-f45c89896441\", \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 502, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 857, "type": "host", "url": "/api/v1/hosts/857/", "related":
+        {"job_host_summaries": "/api/v1/hosts/857/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/857/variable_data/", "job_events": "/api/v1/hosts/857/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/857/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/857/fact_versions/", "inventory_sources": "/api/v1/hosts/857/inventory_sources/",
+        "groups": "/api/v1/hosts/857/groups/", "activity_stream": "/api/v1/hosts/857/activity_stream/",
+        "all_groups": "/api/v1/hosts/857/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/857/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1434/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.557Z",
+        "modified": "2016-11-17T17:56:26.964Z", "name": "jwong_test_2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c0b99-6aab-c647-cf34-c7868cef3ed8",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] jwong_test_2/jwong_test_2.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c5d86-cf23-07ff-ee3f-3715a49af529\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1800404992, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 8328, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_uuid\": \"420c0b99-6aab-c647-cf34-c7868cef3ed8\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        41149268491, \"vmware_distributedMemoryEntitlement\": 458, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"MIQ GUID=48dc5daa-79e9-11e6-bf9e-54ee753e66dc\",
+        \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 161, \"vmware_privateMemory\": 497, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_uptimeSeconds\": 5609675, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        10586594783, \"vmware_name\": \"jwong_test_2\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        565, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\"],
+        \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        43, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1434}, {"id": 855, "type":
+        "host", "url": "/api/v1/hosts/855/", "related": {"job_host_summaries": "/api/v1/hosts/855/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/855/variable_data/", "job_events": "/api/v1/hosts/855/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/855/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/855/fact_versions/", "inventory_sources": "/api/v1/hosts/855/inventory_sources/",
+        "groups": "/api/v1/hosts/855/groups/", "activity_stream": "/api/v1/hosts/855/activity_stream/",
+        "all_groups": "/api/v1/hosts/855/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/855/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1438/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.547Z",
+        "modified": "2016-11-17T17:56:26.976Z", "name": "jwong-upstream-appliance",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c32cb-14a8-01b1-af26-ff5f1fd26d72", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c712a-265f-f2ac-0852-e303cca74dd7\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        2283, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 23, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 60706085280, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"jwong-upstream-appliance\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        7968, \"vmware_overallCpuDemand\": 23, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        59, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        jwong-upstream-appliance/jwong-upstream-appliance.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.217\", \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        43319820288, \"vmware_staticMemoryEntitlement\": 8290, \"ansible_ssh_host\":
+        \"10.8.99.217\", \"vmware_uuid\": \"420c32cb-14a8-01b1-af26-ff5f1fd26d72\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 42579526501,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 363, \"vmware_privateMemory\": 7829,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"upstream\",
+        \"vmware_uptimeSeconds\": 7238711, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1438}, {"id": 267, "type":
+        "host", "url": "/api/v1/hosts/267/", "related": {"job_host_summaries": "/api/v1/hosts/267/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/267/variable_data/", "job_events": "/api/v1/hosts/267/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/267/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/267/fact_versions/", "inventory_sources": "/api/v1/hosts/267/inventory_sources/",
+        "groups": "/api/v1/hosts/267/groups/", "activity_stream": "/api/v1/hosts/267/activity_stream/",
+        "all_groups": "/api/v1/hosts/267/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/267/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.629Z", "modified":
+        "2016-05-25T14:07:46.761Z", "name": "jwong-use-6", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cf32d-328d-3c49-b28c-1418b6e18a43",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"NFSPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"dev-esxi6hyper1.example.com\",
+        \"vmware_instanceUuid\": \"500c7086-6aa0-7b07-c843-ab8897790770\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-use-6/jwong-use-6.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420cf32d-328d-3c49-b28c-1418b6e18a43\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 160370, \"vmware_name\":
+        \"jwong-use-6\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=38eecfd6-1134-11e6-a37b-f45c89896441\", \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 268, "type":
+        "host", "url": "/api/v1/hosts/268/", "related": {"job_host_summaries": "/api/v1/hosts/268/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/268/variable_data/", "job_events": "/api/v1/hosts/268/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/268/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/268/fact_versions/", "inventory_sources": "/api/v1/hosts/268/inventory_sources/",
+        "groups": "/api/v1/hosts/268/groups/", "activity_stream": "/api/v1/hosts/268/activity_stream/",
+        "all_groups": "/api/v1/hosts/268/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/268/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1445/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.634Z",
+        "modified": "2016-11-17T17:25:55.496Z", "name": "jwong-use-7", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c3342-c636-948c-02f5-92ba76767bbf",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Datastore] jwong-use-7/jwong-use-7.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"dev-esxi6hyper1.example.com\", \"vmware_instanceUuid\":
+        \"500cee4b-a411-18a3-6895-378619981f31\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 0, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        2114, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_uuid\": \"420c3342-c636-948c-02f5-92ba76767bbf\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 2297, \"vmware_uncommitted\":
+        0, \"vmware_distributedMemoryEntitlement\": 252, \"vmware_template\": false,
+        \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1, \"vmware_numVirtualDisks\":
+        0, \"vmware_annotation\": \"MIQ GUID=bff857b4-1138-11e6-aa64-f45c89896441\",
+        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 8, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_uptimeSeconds\": 1904402, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        134929, \"vmware_name\": \"jwong-use-7\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 33, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Datastore\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 25, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1445}, {"id": 269, "type": "host", "url": "/api/v1/hosts/269/",
+        "related": {"job_host_summaries": "/api/v1/hosts/269/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/269/variable_data/", "job_events": "/api/v1/hosts/269/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/269/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/269/fact_versions/", "inventory_sources": "/api/v1/hosts/269/inventory_sources/",
+        "groups": "/api/v1/hosts/269/groups/", "activity_stream": "/api/v1/hosts/269/activity_stream/",
+        "all_groups": "/api/v1/hosts/269/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/269/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.639Z", "modified":
+        "2016-05-25T14:07:46.770Z", "name": "jwong-use-8", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c387e-b692-314e-1842-d66a49a453f0",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
+        \"vmware_instanceUuid\": \"500ca104-710b-0e39-288e-4c45825122f2\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-use-8/jwong-use-8.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c387e-b692-314e-1842-d66a49a453f0\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 164443, \"vmware_name\":
+        \"jwong-use-8\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=c2211702-1141-11e6-aa64-f45c89896441\", \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 856, "type":
+        "host", "url": "/api/v1/hosts/856/", "related": {"job_host_summaries": "/api/v1/hosts/856/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/856/variable_data/", "job_events": "/api/v1/hosts/856/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/856/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/856/fact_versions/", "inventory_sources": "/api/v1/hosts/856/inventory_sources/",
+        "groups": "/api/v1/hosts/856/groups/", "activity_stream": "/api/v1/hosts/856/activity_stream/",
+        "all_groups": "/api/v1/hosts/856/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/856/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1453/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.552Z",
+        "modified": "2016-11-17T17:56:26.988Z", "name": "jwong-vc60", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "4200d0fa-6745-a0d3-a17b-532947ec7453",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] jwong-vc60/jwong-vc60.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.17\", \"vmware_guestMemoryUsage\": 2621, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"SUSE Linux Enterprise 11 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500015cd-2d52-00b9-d3ec-2c93dd0ef9d3\", \"vmware_distributedCpuEntitlement\":
+        959, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 18827667410,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16523,
+        \"ansible_ssh_host\": \"10.8.97.17\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"4200d0fa-6745-a0d3-a17b-532947ec7453\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        152317407232, \"vmware_distributedMemoryEntitlement\": 6565, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 1487, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 11, \"vmware_annotation\": \"VMware vCenter Server
+        Appliance\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 108, \"vmware_privateMemory\": 16270,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\": 1391,
+        \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"jwong-vc60\", \"vmware_uptimeSeconds\": 6924588,
+        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 18830002830,
+        \"vmware_name\": \"jwong-vc60\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 16352, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"sles11_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 79, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1453}, {"id": 270, "type": "host", "url": "/api/v1/hosts/270/",
+        "related": {"job_host_summaries": "/api/v1/hosts/270/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/270/variable_data/", "job_events": "/api/v1/hosts/270/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/270/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/270/fact_versions/", "inventory_sources": "/api/v1/hosts/270/inventory_sources/",
+        "groups": "/api/v1/hosts/270/groups/", "activity_stream": "/api/v1/hosts/270/activity_stream/",
+        "all_groups": "/api/v1/hosts/270/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/270/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.644Z", "modified":
+        "2016-05-25T14:07:46.775Z", "name": "jwong-vds-use-5", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ccdbc-db31-6b13-94d0-780605cb6c8a",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"DPortGroup\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2297, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"dev-esxi6hyper2.example.com\",
+        \"vmware_instanceUuid\": \"500c2092-4206-f3db-791d-a1901e9699d7\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Datastore] jwong-vds-use-5/jwong-vds-use-5.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420ccdbc-db31-6b13-94d0-780605cb6c8a\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 160813, \"vmware_name\":
+        \"jwong-vds-use-5\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        2339536896, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Datastore\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 0, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"MIQ GUID=0359f510-10b9-11e6-818a-f45c89896441\", \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_unshared\": 0,
+        \"vmware_sharedMemory\": 0}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 858, "type":
+        "host", "url": "/api/v1/hosts/858/", "related": {"job_host_summaries": "/api/v1/hosts/858/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/858/variable_data/", "job_events": "/api/v1/hosts/858/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/858/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/858/fact_versions/", "inventory_sources": "/api/v1/hosts/858/inventory_sources/",
+        "groups": "/api/v1/hosts/858/groups/", "activity_stream": "/api/v1/hosts/858/activity_stream/",
+        "all_groups": "/api/v1/hosts/858/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/858/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1462/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.562Z",
+        "modified": "2016-11-17T17:56:27.000Z", "name": "lg_win12", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cd5ca-b184-9e42-aaa8-5fc7a01a3122",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] lg_win12/lg_win12.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.204\", \"vmware_guestMemoryUsage\": 245, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Microsoft Windows Server 2012
+        (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500cd5db-8b81-5b76-7748-00fdf3822091\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 15261581859,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 4179,
+        \"ansible_ssh_host\": \"10.8.99.204\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420cd5ca-b184-9e42-aaa8-5fc7a01a3122\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 717, \"vmware_uncommitted\":
+        47015444480, \"vmware_distributedMemoryEntitlement\": 1466, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        162, \"vmware_privateMemory\": 3934, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"windows_2012\",
+        \"vmware_uptimeSeconds\": 3912464, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 2, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        15262024648, \"vmware_name\": \"lg_win12\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        3970, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"windows8Server64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 37, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1462}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:39 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.303s
+      Content-Length:
+      - '106639'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": "/api/v1/hosts/?page=7", "previous": "/api/v1/hosts/?page=5",
+        "results": [{"id": 168, "type": "host", "url": "/api/v1/hosts/168/", "related":
+        {"job_host_summaries": "/api/v1/hosts/168/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/168/variable_data/", "job_events": "/api/v1/hosts/168/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/168/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/168/fact_versions/", "inventory_sources": "/api/v1/hosts/168/inventory_sources/",
+        "groups": "/api/v1/hosts/168/groups/", "activity_stream": "/api/v1/hosts/168/activity_stream/",
+        "all_groups": "/api/v1/hosts/168/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/168/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1472/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.846Z",
+        "modified": "2016-11-17T17:56:27.012Z", "name": "lucy_54", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "423307de-ccba-3188-0634-98b295a90aa0",
+        "variables": "{\"vmware_vmPathName\": \"[nfs41_svm] lucy_54/lucy_54.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.117\", \"vmware_guestMemoryUsage\": 1413,
+        \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat
+        Enterprise Linux 6 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-03.example.com\", \"vmware_instanceUuid\":
+        \"5033aca6-0e5d-31f7-5921-bf61a3eee024\", \"vmware_distributedCpuEntitlement\":
+        215, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 8255906342,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 6226,
+        \"ansible_ssh_host\": \"10.8.99.117\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"423307de-ccba-3188-0634-98b295a90aa0\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1075, \"vmware_uncommitted\":
+        34693767168, \"vmware_distributedMemoryEntitlement\": 2615, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 215, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 4446, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 215, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 7197, \"vmware_numMksConnections\":
+        1, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-117.example.com\",
+        \"vmware_uptimeSeconds\": 6321, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 3, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        8257147191, \"vmware_name\": \"lucy_54\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 4485, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"nfs41_svm\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 40, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1472}, {"id": 859, "type": "host", "url": "/api/v1/hosts/859/",
+        "related": {"job_host_summaries": "/api/v1/hosts/859/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/859/variable_data/", "job_events": "/api/v1/hosts/859/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/859/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/859/fact_versions/", "inventory_sources": "/api/v1/hosts/859/inventory_sources/",
+        "groups": "/api/v1/hosts/859/groups/", "activity_stream": "/api/v1/hosts/859/activity_stream/",
+        "all_groups": "/api/v1/hosts/859/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/859/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.567Z", "modified":
+        "2016-10-14T13:37:12.247Z", "name": "lucy_54_clone", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420ce6ae-bb31-6b98-e508-ad52e1a89a0e",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostName\": \"localhost.localdomain\", \"vmware_instanceUuid\":
+        \"500c3955-faed-b7ee-55a6-66116cda5f46\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] lucy_a/lucy_a.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        4, \"vmware_uuid\": \"420ce6ae-bb31-6b98-e508-ad52e1a89a0e\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 15022732934, \"vmware_name\": \"lucy_54_clone\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 29196075008, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        \"Owner: a a\\nEmail: a@a.com\\nSource VM: lucy_54\\n\\nMIQ GUID=f324aa06-871d-11e6-950f-005056b396fc\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 15022555685, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 169, "type": "host", "url": "/api/v1/hosts/169/", "related":
+        {"job_host_summaries": "/api/v1/hosts/169/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/169/variable_data/", "job_events": "/api/v1/hosts/169/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/169/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/169/fact_versions/", "inventory_sources": "/api/v1/hosts/169/inventory_sources/",
+        "groups": "/api/v1/hosts/169/groups/", "activity_stream": "/api/v1/hosts/169/activity_stream/",
+        "all_groups": "/api/v1/hosts/169/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/169/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1473/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.851Z",
+        "modified": "2016-11-17T17:25:56.000Z", "name": "lucy_55", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c6c6b-0e6b-f635-b33d-4ce792262eab",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500ccd96-d452-5ea8-12c8-ccab11650f84\", \"vmware_distributedCpuEntitlement\":
+        599, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        996, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        12288, \"vmware_overallCpuUsage\": 959, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 26933273320, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"lucy_55\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 1315,
+        \"vmware_overallCpuDemand\": 983, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        49, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        lucy_55/lucy_55.vmx\", \"vmware_ipAddress\": \"10.8.99.206\", \"vmware_guestMemoryUsage\":
+        860, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 26931889181, \"vmware_staticMemoryEntitlement\":
+        12409, \"ansible_ssh_host\": \"10.8.99.206\", \"vmware_uuid\": \"420c6c6b-0e6b-f635-b33d-4ce792262eab\",
+        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 112654548992,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 103, \"vmware_privateMemory\": 1249,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.0\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596,
+        \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"dhcp-8-99-206.example.com\", \"vmware_uptimeSeconds\":
+        87816, \"vmware_memorySizeMB\": 12288, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\":
+        false, \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        true, "has_inventory_sources": true, "last_job": 852, "last_job_host_summary":
+        1473}, {"id": 860, "type": "host", "url": "/api/v1/hosts/860/", "related":
+        {"job_host_summaries": "/api/v1/hosts/860/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/860/variable_data/", "job_events": "/api/v1/hosts/860/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/860/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/860/fact_versions/", "inventory_sources": "/api/v1/hosts/860/inventory_sources/",
+        "groups": "/api/v1/hosts/860/groups/", "activity_stream": "/api/v1/hosts/860/activity_stream/",
+        "all_groups": "/api/v1/hosts/860/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/860/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.572Z", "modified":
+        "2016-11-08T22:23:35.882Z", "name": "lucy_555", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cfba0-7cc5-212e-3c27-b30eab582690",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c0810-9110-2ffc-4aa3-a93c41decac1\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\": \"4.0\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2900269676, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"lucy_555\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0,
+        \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"nfs41_svm\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[nfs41_svm]
+        lucy_555/lucy_555.vmx\", \"vmware_guestMemoryUsage\": 0, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"vmware_product_key\": 0, \"vmware_unshared\": 2899997776, \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420cfba0-7cc5-212e-3c27-b30eab582690\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 53129793536, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.0\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"lucy_555\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        8192, \"vmware_compressedMemory\": 0, \"vmware_installBootRequired\": false,
+        \"vmware_numMksConnections\": 0, \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel6_64Guest\"}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 861, "type": "host", "url": "/api/v1/hosts/861/", "related":
+        {"job_host_summaries": "/api/v1/hosts/861/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/861/variable_data/", "job_events": "/api/v1/hosts/861/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/861/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/861/fact_versions/", "inventory_sources": "/api/v1/hosts/861/inventory_sources/",
+        "groups": "/api/v1/hosts/861/groups/", "activity_stream": "/api/v1/hosts/861/activity_stream/",
+        "all_groups": "/api/v1/hosts/861/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/861/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1418/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.577Z",
+        "modified": "2016-11-17T17:56:27.025Z", "name": "lucy_561", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c1de8-2029-ebf4-2d4d-2dd9a7a9d095",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500ce219-3a39-5af8-3c81-f0f14241c3fc\", \"vmware_distributedCpuEntitlement\":
+        359, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1-nightly\", \"vmware_distributedMemoryEntitlement\":
+        5400, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 359, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 2, \"vmware_name\":
+        \"lucy_561\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 8078,
+        \"vmware_overallCpuDemand\": 359, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        Red Hat CloudForms 4.1 Nightly/Red Hat CloudForms 4.1 Nightly.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.215\", \"vmware_guestMemoryUsage\": 4997, \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_product_key\":
+        0, \"vmware_unshared\": 47244640256, \"vmware_staticMemoryEntitlement\": 8298,
+        \"ansible_ssh_host\": \"10.8.99.215\", \"vmware_uuid\": \"420c1de8-2029-ebf4-2d4d-2dd9a7a9d095\",
+        \"vmware_staticCpuEntitlement\": 717, \"vmware_uncommitted\": 1070, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 55, \"vmware_privateMemory\": 8007, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 Nightly\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 4798, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"lucy-56\",
+        \"vmware_uptimeSeconds\": 1135429, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 56029219805,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1418}, {"id": 862, "type":
+        "host", "url": "/api/v1/hosts/862/", "related": {"job_host_summaries": "/api/v1/hosts/862/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/862/variable_data/", "job_events": "/api/v1/hosts/862/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/862/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/862/fact_versions/", "inventory_sources": "/api/v1/hosts/862/inventory_sources/",
+        "groups": "/api/v1/hosts/862/groups/", "activity_stream": "/api/v1/hosts/862/activity_stream/",
+        "all_groups": "/api/v1/hosts/862/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/862/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.582Z", "modified":
+        "2016-10-20T19:42:04.053Z", "name": "lucy_5612", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c19d8-91f5-f2ec-5bc6-d863c302b1c5",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c385d-df83-a6c4-1edb-c253ffc1bc8a\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"lucy_5612\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0,
+        \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        lucy_5612/lucy_5612.vmx\", \"vmware_ipAddress\": \"10.8.99.248\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.248\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 60129542144, \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c19d8-91f5-f2ec-5bc6-d863c302b1c5\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 8785150960, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"dhcp-8-99-248.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 60130273849,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 863, "type":
+        "host", "url": "/api/v1/hosts/863/", "related": {"job_host_summaries": "/api/v1/hosts/863/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/863/variable_data/", "job_events": "/api/v1/hosts/863/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/863/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/863/fact_versions/", "inventory_sources": "/api/v1/hosts/863/inventory_sources/",
+        "groups": "/api/v1/hosts/863/groups/", "activity_stream": "/api/v1/hosts/863/activity_stream/",
+        "all_groups": "/api/v1/hosts/863/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/863/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.587Z", "modified":
+        "2016-10-14T13:37:12.265Z", "name": "lucy_56_a", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c9404-b02e-1078-ba1e-df25bf22df6f",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] lucy_56_a/lucy_56_a.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 13055943710, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420c9404-b02e-1078-ba1e-df25bf22df6f\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"4.1-nightly\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 42973847552, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"Owner: a a\\nEmail:
+        a@a.com\\nSource VM: lucy_561\\n\\nMIQ GUID=6b3d180a-8973-11e6-8057-0050568c7416\",
+        \"vmware_maxMemoryUsage\": 8192, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 Nightly\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null, \"vmware_hostName\":
+        \"lucy-56\", \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 8192, \"vmware_instanceUuid\": \"500cc955-7f76-8edb-8715-738eb51ec77f\",
+        \"vmware_compressedMemory\": 0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 13056156018,
+        \"vmware_name\": \"lucy_56_a\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 823, "type": "host", "url": "/api/v1/hosts/823/",
+        "related": {"job_host_summaries": "/api/v1/hosts/823/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/823/variable_data/", "job_events": "/api/v1/hosts/823/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/823/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/823/fact_versions/", "inventory_sources": "/api/v1/hosts/823/inventory_sources/",
+        "groups": "/api/v1/hosts/823/groups/", "activity_stream": "/api/v1/hosts/823/activity_stream/",
+        "all_groups": "/api/v1/hosts/823/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/823/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1423/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.386Z",
+        "modified": "2016-11-17T17:56:27.038Z", "name": "Lucy_57", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c12de-7739-f2f5-afcd-6a510496b5a4",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c395f-7e68-f8ef-1d45-671c2f75e4ea\", \"vmware_distributedCpuEntitlement\":
+        263, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.2\", \"vmware_distributedMemoryEntitlement\":
+        3921, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 239, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Lucy_57\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 7456,
+        \"vmware_overallCpuDemand\": 263, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        57, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        Lucy_57/Lucy_57.vmx\", \"vmware_ipAddress\": \"10.8.99.248\", \"vmware_guestMemoryUsage\":
+        1720, \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 85899345920, \"vmware_staticMemoryEntitlement\":
+        8311, \"ansible_ssh_host\": \"10.8.99.248\", \"vmware_uuid\": \"420c12de-7739-f2f5-afcd-6a510496b5a4\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 1050, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 67, \"vmware_privateMemory\": 7379, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.2\", \"vmware_suspendInterval\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\":
+        null, \"vmware_hostName\": \"dhcp-8-99-248.example.com\",
+        \"vmware_uptimeSeconds\": 1304932, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 94685917693,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1423}, {"id": 271, "type":
+        "host", "url": "/api/v1/hosts/271/", "related": {"job_host_summaries": "/api/v1/hosts/271/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/271/variable_data/", "job_events": "/api/v1/hosts/271/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/271/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/271/fact_versions/", "inventory_sources": "/api/v1/hosts/271/inventory_sources/",
+        "groups": "/api/v1/hosts/271/groups/", "activity_stream": "/api/v1/hosts/271/activity_stream/",
+        "all_groups": "/api/v1/hosts/271/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/271/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.649Z", "modified":
+        "2016-05-25T14:07:46.779Z", "name": "lucy_master_0510", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cce02-b9e7-e67d-16af-048223923a60",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] lucy_master_0510/lucy_master_0510.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_product_classId\": null, \"vmware_distributedCpuEntitlement\": 0,
+        \"vmware_product_key\": 0, \"vmware_unshared\": 42949672960, \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_overallStatus\": \"green\", \"vmware_uuid\":
+        \"420cce02-b9e7-e67d-16af-048223923a60\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_version\": \"master\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 6637666814, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_template\": false, \"vmware_overallCpuDemand\":
+        0, \"vmware_product_fullVersion\": null, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"ManageIQ\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0,
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-243.example.com\",
+        \"vmware_product_vendor\": \"ManageIQ\", \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        6144, \"vmware_instanceUuid\": \"500c7cd8-567f-505f-afbf-4e99fe7ad0fc\", \"vmware_compressedMemory\":
+        0, \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 42949874014, \"vmware_name\": \"lucy_master_0510\",
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel6_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 272, "type": "host", "url": "/api/v1/hosts/272/",
+        "related": {"job_host_summaries": "/api/v1/hosts/272/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/272/variable_data/", "job_events": "/api/v1/hosts/272/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/272/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/272/fact_versions/", "inventory_sources": "/api/v1/hosts/272/inventory_sources/",
+        "groups": "/api/v1/hosts/272/groups/", "activity_stream": "/api/v1/hosts/272/activity_stream/",
+        "all_groups": "/api/v1/hosts/272/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/272/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1422/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.654Z",
+        "modified": "2016-11-17T17:56:27.049Z", "name": "miq-brewery7", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420cb39d-8c47-fd77-3672-e84d63604f8f",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] miq-brewery7_1/miq-brewery7.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.15\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c4a95-c6da-e132-efca-11d761282a1c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 131565975253,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16594,
+        \"ansible_ssh_host\": \"10.8.97.15\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420cb39d-8c47-fd77-3672-e84d63604f8f\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        150155796480, \"vmware_distributedMemoryEntitlement\": 942, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"CentOS 7.2 ImageFactory
+        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 122, \"vmware_privateMemory\": 2074, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"miq-brewery7\", \"vmware_uptimeSeconds\": 6837455,
+        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 131567016137,
+        \"vmware_name\": \"miq-brewery7\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2142, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 50, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1422}, {"id": 273, "type": "host", "url": "/api/v1/hosts/273/",
+        "related": {"job_host_summaries": "/api/v1/hosts/273/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/273/variable_data/", "job_events": "/api/v1/hosts/273/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/273/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/273/fact_versions/", "inventory_sources": "/api/v1/hosts/273/inventory_sources/",
+        "groups": "/api/v1/hosts/273/groups/", "activity_stream": "/api/v1/hosts/273/activity_stream/",
+        "all_groups": "/api/v1/hosts/273/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/273/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-05-25T14:07:45.659Z", "modified":
+        "2016-10-14T13:37:10.305Z", "name": "mk_centos_7.1", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cf912-fa6d-95ba-eeb8-1f2fc764f296",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] mk_centos_7.1/mk_centos_7.1.vmtx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500cc24a-4e94-db0f-b6e3-e0c162ec4cf8\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1655067175, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotRunning\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420cf912-fa6d-95ba-eeb8-1f2fc764f296\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 43634143232, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1655078419, \"vmware_name\": \"mk_centos_7.1\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 876, "type": "host", "url": "/api/v1/hosts/876/",
+        "related": {"job_host_summaries": "/api/v1/hosts/876/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/876/variable_data/", "job_events": "/api/v1/hosts/876/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/876/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/876/fact_versions/", "inventory_sources": "/api/v1/hosts/876/inventory_sources/",
+        "groups": "/api/v1/hosts/876/groups/", "activity_stream": "/api/v1/hosts/876/activity_stream/",
+        "all_groups": "/api/v1/hosts/876/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/876/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1430/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-21T16:43:41.909Z",
+        "modified": "2016-11-17T17:56:27.062Z", "name": "nc-catalog-provision-test0001",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c4b31-bdc4-64d8-0d38-4d4a09e20416", "variables": "{\"vmware_vmPathName\":
+        \"[NFS Share] nc-catalog-provision-test0001/nc-catalog-provision-test0001.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-04.example.com\", \"vmware_instanceUuid\":
+        \"500c3cf7-5904-cfb2-d80b-fdd216c034d2\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 540, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        2097, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c4b31-bdc4-64d8-0d38-4d4a09e20416\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 358, \"vmware_uncommitted\":
+        17179869184, \"vmware_distributedMemoryEntitlement\": 233, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"MIQ GUID=bbb586c0-97a4-11e6-9d06-000c29014b69\\n\\nParent
+        Service: Catalog Item (9d672f3e-97a4-11e6-9d06-000c29014b69)\", \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        5, \"vmware_privateMemory\": 3, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 2340665, \"vmware_memorySizeMB\":
+        2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 146692, \"vmware_name\": \"nc-catalog-provision-test0001\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 28, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 26, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1430}, {"id": 864, "type": "host", "url": "/api/v1/hosts/864/",
+        "related": {"job_host_summaries": "/api/v1/hosts/864/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/864/variable_data/", "job_events": "/api/v1/hosts/864/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/864/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/864/fact_versions/", "inventory_sources": "/api/v1/hosts/864/inventory_sources/",
+        "groups": "/api/v1/hosts/864/groups/", "activity_stream": "/api/v1/hosts/864/activity_stream/",
+        "all_groups": "/api/v1/hosts/864/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/864/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1452/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.592Z",
+        "modified": "2016-11-17T17:56:27.074Z", "name": "nc-db-primary", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420ca140-7057-a964-ad7a-f9fb51e3c8e9",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c7825-5f67-1c20-df2e-a274ec4ee74c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_version\":
+        \"4.1-rc2.1-nightly\", \"vmware_distributedMemoryEntitlement\": 989, \"vmware_product_appUrl\":
+        null, \"vmware_product_fullVersion\": null, \"vmware_numVirtualDisks\": 1,
+        \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 8192, \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_numMksConnections\": 0, \"vmware_product_vendor\":
+        \"Red Hat, Inc.\", \"vmware_product_vendorUrl\": null, \"vmware_numCpu\":
+        4, \"vmware_name\": \"nc-db-primary\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        2267, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        48, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        nc-cfme-db-primary/nc-cfme-db-primary.vmx\", \"vmware_ipAddress\": \"10.8.99.207\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\": \"Red Hat Enterprise
+        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"ansible_ssh_host\": \"10.8.99.207\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        5372769479, \"vmware_staticMemoryEntitlement\": 8290, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_uuid\": \"420ca140-7057-a964-ad7a-f9fb51e3c8e9\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 39863058432, \"vmware_template\": false, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\": 1562,
+        \"vmware_privateMemory\": 1302, \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\":
+        \"Red Hat CloudForms 4.1 RC2.1 Nightly\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-207.example.com\",
+        \"vmware_uptimeSeconds\": 2343681, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 22573621234,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1452}, {"id": 865, "type":
+        "host", "url": "/api/v1/hosts/865/", "related": {"job_host_summaries": "/api/v1/hosts/865/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/865/variable_data/", "job_events": "/api/v1/hosts/865/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/865/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/865/fact_versions/", "inventory_sources": "/api/v1/hosts/865/inventory_sources/",
+        "groups": "/api/v1/hosts/865/groups/", "activity_stream": "/api/v1/hosts/865/activity_stream/",
+        "all_groups": "/api/v1/hosts/865/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/865/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.597Z", "modified":
+        "2016-10-28T14:56:16.474Z", "name": "nc-db-standby1", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c899f-a158-4b4f-2f78-33dc61399939",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c3bb1-3ca0-b84e-49bc-716999210331\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1-rc2.1-nightly\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"nc-db-standby1\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        cfme-db-standby1/cfme-db-standby1.vmx\", \"vmware_ipAddress\": \"10.8.99.215\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\": \"Red Hat Enterprise
+        Linux 6 (64-bit)\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"ansible_ssh_host\": \"10.8.99.215\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        4714845031, \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotRunning\", \"vmware_uuid\": \"420c899f-a158-4b4f-2f78-33dc61399939\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 42783551488, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 RC2.1 Nightly\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-215.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 13315612260,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": null, "last_job_host_summary": null}, {"id": 866, "type":
+        "host", "url": "/api/v1/hosts/866/", "related": {"job_host_summaries": "/api/v1/hosts/866/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/866/variable_data/", "job_events": "/api/v1/hosts/866/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/866/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/866/fact_versions/", "inventory_sources": "/api/v1/hosts/866/inventory_sources/",
+        "groups": "/api/v1/hosts/866/groups/", "activity_stream": "/api/v1/hosts/866/activity_stream/",
+        "all_groups": "/api/v1/hosts/866/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/866/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1429/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.602Z",
+        "modified": "2016-11-17T17:56:27.087Z", "name": "nc-db-standby2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c7d82-dfcf-ff25-1fdb-d1ed2de9d289",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c02aa-7f5c-e726-8425-7a1320c173e3\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_version\":
+        \"4.1-rc2.1-nightly\", \"vmware_distributedMemoryEntitlement\": 1047, \"vmware_product_appUrl\":
+        null, \"vmware_product_fullVersion\": null, \"vmware_numVirtualDisks\": 1,
+        \"vmware_annotation\": null, \"vmware_maxMemoryUsage\": 8192, \"vmware_overallCpuUsage\":
+        0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_committed\": 14364092610,
+        \"vmware_product_vendor\": \"Red Hat, Inc.\", \"vmware_product_vendorUrl\":
+        null, \"vmware_numCpu\": 4, \"vmware_name\": \"nc-db-standby2\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 2877, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        48, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        nc-cfme-db-standby2_1/nc-cfme-db-standby2.vmx\", \"vmware_ipAddress\": \"10.8.99.213\",
+        \"vmware_guestMemoryUsage\": 81, \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_instanceId\": null, \"vmware_product_classId\": null, \"vmware_toolsStatus\":
+        \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\": 5763359600, \"vmware_staticMemoryEntitlement\":
+        8290, \"ansible_ssh_host\": \"10.8.99.213\", \"vmware_uuid\": \"420c7d82-dfcf-ff25-1fdb-d1ed2de9d289\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 39358697472,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 75, \"vmware_privateMemory\": 2807,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"Red Hat
+        CloudForms 4.1 RC2.1 Nightly\", \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\":
+        9596, \"vmware_numEthernetCards\": 1, \"vmware_product_productUrl\": null,
+        \"vmware_hostName\": \"dhcp-8-99-213.example.com\",
+        \"vmware_uptimeSeconds\": 2671470, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1429}, {"id": 199, "type":
+        "host", "url": "/api/v1/hosts/199/", "related": {"job_host_summaries": "/api/v1/hosts/199/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/199/variable_data/", "job_events": "/api/v1/hosts/199/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/199/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/199/fact_versions/", "inventory_sources": "/api/v1/hosts/199/inventory_sources/",
+        "groups": "/api/v1/hosts/199/groups/", "activity_stream": "/api/v1/hosts/199/activity_stream/",
+        "all_groups": "/api/v1/hosts/199/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/199/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1477/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-18T20:26:31.055Z",
+        "modified": "2016-11-17T17:25:56.073Z", "name": "nc-ManageIQ-pglogical-region-0",
+        "description": "imported", "inventory": 17, "enabled": true, "instance_id":
+        "420c6f1b-69c3-fd1a-6f41-3f401d7d997f", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500cac6d-7b48-989b-6726-287430e099c1\", \"vmware_distributedCpuEntitlement\":
+        215, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        3338, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 191, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"nc-ManageIQ-pglogical-region-0\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        6034, \"vmware_overallCpuDemand\": 215, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"datastore1\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[datastore1]
+        nc-ManageIQ-pglogical-region-0/nc-ManageIQ-pglogical-region-0.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.201\", \"vmware_guestMemoryUsage\": 1843, \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.201\", \"vmware_product_key\":
+        0, \"vmware_unshared\": 8055160832, \"vmware_staticMemoryEntitlement\": 6240,
+        \"vmware_toolsStatus\": \"toolsOk\", \"vmware_uuid\": \"420c6f1b-69c3-fd1a-6f41-3f401d7d997f\",
+        \"vmware_staticCpuEntitlement\": 3679, \"vmware_uncommitted\": 39626736529,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 38, \"vmware_privateMemory\": 5976,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-201.example.com\",
+        \"vmware_uptimeSeconds\": 3444440, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 21146166772,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1477}, {"id": 877, "type":
+        "host", "url": "/api/v1/hosts/877/", "related": {"job_host_summaries": "/api/v1/hosts/877/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/877/variable_data/", "job_events": "/api/v1/hosts/877/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/877/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/877/fact_versions/", "inventory_sources": "/api/v1/hosts/877/inventory_sources/",
+        "groups": "/api/v1/hosts/877/groups/", "activity_stream": "/api/v1/hosts/877/activity_stream/",
+        "all_groups": "/api/v1/hosts/877/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/877/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-21T16:43:41.914Z", "modified":
+        "2016-10-21T16:43:42.160Z", "name": "nc-the-test-vm", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c9817-9024-c492-56bf-19167f34cbb7",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500ccb48-ce10-cf1e-cf47-935612484428\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] nc-the-test-vm/nc-the-test-vm.vmx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 1, \"vmware_uuid\": \"420c9817-9024-c492-56bf-19167f34cbb7\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 171091, \"vmware_name\":
+        \"nc-the-test-vm\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 19519406080, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": false, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": \"MIQ GUID=126f61d2-97a2-11e6-9d06-000c29014b69\",
+        \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 525, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 170, "type": "host", "url": "/api/v1/hosts/170/", "related":
+        {"job_host_summaries": "/api/v1/hosts/170/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/170/variable_data/", "job_events": "/api/v1/hosts/170/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/170/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/170/fact_versions/", "inventory_sources": "/api/v1/hosts/170/inventory_sources/",
+        "groups": "/api/v1/hosts/170/groups/", "activity_stream": "/api/v1/hosts/170/activity_stream/",
+        "all_groups": "/api/v1/hosts/170/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/170/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1448/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.856Z",
+        "modified": "2016-11-17T17:56:27.099Z", "name": "nick-brewery", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] nick-brewery/nick-brewery.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.4\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"50333f3f-9b3e-2e1f-d937-062b14098cde\", \"vmware_distributedCpuEntitlement\":
+        23, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 78160818712,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16594,
+        \"ansible_ssh_host\": \"10.8.97.4\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"4233fd3a-a0b6-a4b3-2ceb-fec1b6f57c95\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        7738527744, \"vmware_distributedMemoryEntitlement\": 4465, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 23, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"CentOS 7.1 ImageFactory
+        VM\", \"vmware_maxMemoryUsage\": 16384, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 27, \"vmware_privateMemory\": 16357, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 23, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"nick-brewery\", \"vmware_uptimeSeconds\": 1202639,
+        \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_committed\": 78906002702,
+        \"vmware_name\": \"nick-brewery\", \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 16463, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_guestId\": \"centos64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 106, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1448}, {"id": 867, "type": "host", "url": "/api/v1/hosts/867/",
+        "related": {"job_host_summaries": "/api/v1/hosts/867/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/867/variable_data/", "job_events": "/api/v1/hosts/867/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/867/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/867/fact_versions/", "inventory_sources": "/api/v1/hosts/867/inventory_sources/",
+        "groups": "/api/v1/hosts/867/groups/", "activity_stream": "/api/v1/hosts/867/activity_stream/",
+        "all_groups": "/api/v1/hosts/867/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/867/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.607Z", "modified":
+        "2016-10-14T13:37:12.288Z", "name": "pblaho-test", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420c5a6d-95b3-ae81-dc4c-bad9af44cb86",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM NFS Network\"], \"vmware_guestFullName\": \"Red
+        Hat Enterprise Linux 7 (64-bit)\", \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\": 1, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c950d-8fe0-ee5e-b1b5-45d44039f4c6\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] pblaho-test/pblaho-test.vmx\", \"vmware_guestState\":
+        \"notRunning\", \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\":
+        \"toolsNotInstalled\", \"vmware_overallStatus\": \"green\", \"vmware_numCpu\":
+        1, \"vmware_uuid\": \"420c5a6d-95b3-ae81-dc4c-bad9af44cb86\", \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 435587, \"vmware_name\": \"pblaho-test\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\":
+        19519365120, \"vmware_hostMemoryUsage\": 0, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_template\":
+        false, \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_overallCpuDemand\":
+        0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS Share\"],
+        \"vmware_cpuReservation\": 0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_numVirtualDisks\": 1, \"vmware_swappedMemory\": 0, \"vmware_annotation\":
+        null, \"vmware_maxMemoryUsage\": 2048, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_unshared\": 165653, \"vmware_sharedMemory\": 0}", "has_active_failures":
+        false, "has_inventory_sources": true, "last_job": null, "last_job_host_summary":
+        null}, {"id": 868, "type": "host", "url": "/api/v1/hosts/868/", "related":
+        {"job_host_summaries": "/api/v1/hosts/868/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/868/variable_data/", "job_events": "/api/v1/hosts/868/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/868/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/868/fact_versions/", "inventory_sources": "/api/v1/hosts/868/inventory_sources/",
+        "groups": "/api/v1/hosts/868/groups/", "activity_stream": "/api/v1/hosts/868/activity_stream/",
+        "all_groups": "/api/v1/hosts/868/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/868/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1444/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.612Z",
+        "modified": "2016-11-17T17:56:27.111Z", "name": "rblanco_testing", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c6d28-a887-0e62-aca5-0f0478eb8492",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] rblanco_testing/rblanco_testing.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.214\", \"vmware_guestMemoryUsage\": 51, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500ce1f7-f3c8-ae3a-74f8-80712d525f26\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1951929406, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 1083, \"ansible_ssh_host\":
+        \"10.8.99.214\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c6d28-a887-0e62-aca5-0f0478eb8492\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        1434, \"vmware_uncommitted\": 17375424512, \"vmware_distributedMemoryEntitlement\":
+        389, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 2, \"vmware_annotation\": \"MIQ GUID=16bb760a-7a55-11e6-90d4-28d2447badab\",
+        \"vmware_maxMemoryUsage\": 1024, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 26, \"vmware_privateMemory\": 464, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 5563250, \"vmware_memorySizeMB\": 1024, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1952115569, \"vmware_name\": \"rblanco_testing\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        501, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 36, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1444}, {"id": 825, "type": "host", "url": "/api/v1/hosts/825/",
+        "related": {"job_host_summaries": "/api/v1/hosts/825/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/825/variable_data/", "job_events": "/api/v1/hosts/825/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/825/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/825/fact_versions/", "inventory_sources": "/api/v1/hosts/825/inventory_sources/",
+        "groups": "/api/v1/hosts/825/groups/", "activity_stream": "/api/v1/hosts/825/activity_stream/",
+        "all_groups": "/api/v1/hosts/825/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/825/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/840/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1204/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-11T23:16:04.755Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.396Z",
+        "modified": "2016-11-15T13:52:07.133Z", "name": "Red Hat CloudForms 4.1 Nightly
+        1", "description": "imported", "inventory": 17, "enabled": false, "instance_id":
+        "420c7e0e-a521-874c-563e-fc3c2bf70875", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500ce32a-91b4-feb4-3f52-98726afe4191\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1-nightly\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Red Hat CloudForms 4.1 Nightly 1\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"Prod_ISOs_NFS\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[Prod_ISOs_NFS]
+        Red Hat CloudForms 4.1 Nightly/Red Hat CloudForms 4.1 Nightly.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.209\", \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.209\", \"vmware_product_key\":
+        0, \"vmware_unshared\": 2744386086, \"vmware_staticMemoryEntitlement\": 0,
+        \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420c7e0e-a521-874c-563e-fc3c2bf70875\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 48990437376, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 Nightly\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-209.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 2744798363,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 840, "last_job_host_summary": 1204}, {"id": 824, "type":
+        "host", "url": "/api/v1/hosts/824/", "related": {"job_host_summaries": "/api/v1/hosts/824/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/824/variable_data/", "job_events": "/api/v1/hosts/824/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/824/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/824/fact_versions/", "inventory_sources": "/api/v1/hosts/824/inventory_sources/",
+        "groups": "/api/v1/hosts/824/groups/", "activity_stream": "/api/v1/hosts/824/activity_stream/",
+        "all_groups": "/api/v1/hosts/824/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/824/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1426/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.391Z",
+        "modified": "2016-11-17T17:56:27.223Z", "name": "Red Hat CloudForms 4.1 Nightly
+        (12-Jul-2016 09", "description": "imported", "inventory": 17, "enabled": true,
+        "instance_id": "", "variables": "{}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1426}, {"id": 826, "type":
+        "host", "url": "/api/v1/hosts/826/", "related": {"job_host_summaries": "/api/v1/hosts/826/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/826/variable_data/", "job_events": "/api/v1/hosts/826/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/826/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/826/fact_versions/", "inventory_sources": "/api/v1/hosts/826/inventory_sources/",
+        "groups": "/api/v1/hosts/826/groups/", "activity_stream": "/api/v1/hosts/826/activity_stream/",
+        "all_groups": "/api/v1/hosts/826/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/826/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/840/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1176/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-11T23:16:04.755Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T20:41:58.883Z",
+        "id": 810, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:48:49.352Z",
+        "id": 808, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T19:16:11.926Z",
+        "id": 806, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-10-24T15:02:32.612Z",
+        "id": 804, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.401Z",
+        "modified": "2016-11-15T13:52:07.145Z", "name": "Red Hat CloudForms 4.1Nightly
+        2", "description": "imported", "inventory": 17, "enabled": false, "instance_id":
+        "420cacbd-aef0-9348-4f0c-e9e0efb4844a", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c29af-9eda-88d4-72e4-1254e966377c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_guestState\": \"notRunning\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_faultToleranceState\": \"notConfigured\",
+        \"vmware_product_version\": \"4.1-nightly\", \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        8192, \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_numMksConnections\": 0, \"vmware_product_vendor\": \"Red Hat, Inc.\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Red Hat CloudForms 4.1Nightly 2\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        0, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        Red Hat CloudForms 4.1Nightly 2/Red Hat CloudForms 4.1Nightly 2.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.219\", \"vmware_guestMemoryUsage\": 0, \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 6 (64-bit)\", \"vmware_product_instanceId\": null,
+        \"vmware_product_classId\": null, \"ansible_ssh_host\": \"10.8.99.219\", \"vmware_product_key\":
+        0, \"vmware_unshared\": 4198953534, \"vmware_staticMemoryEntitlement\": 0,
+        \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_uuid\": \"420cacbd-aef0-9348-4f0c-e9e0efb4844a\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 47535869952, \"vmware_template\":
+        false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_product_name\": \"Red Hat CloudForms 4.1 Nightly\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-219.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_committed\": 4199367840,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 840, "last_job_host_summary": 1176}, {"id": 171, "type":
+        "host", "url": "/api/v1/hosts/171/", "related": {"job_host_summaries": "/api/v1/hosts/171/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/171/variable_data/", "job_events": "/api/v1/hosts/171/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/171/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/171/fact_versions/", "inventory_sources": "/api/v1/hosts/171/inventory_sources/",
+        "groups": "/api/v1/hosts/171/groups/", "activity_stream": "/api/v1/hosts/171/activity_stream/",
+        "all_groups": "/api/v1/hosts/171/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/171/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1466/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.861Z",
+        "modified": "2016-11-17T17:56:27.124Z", "name": "satoe-brewery", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "564d25c2-cb51-9434-f647-3ff92cf69192",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] kegerator2/kegerator2.vmx\",
+        \"vmware_ipAddress\": \"192.168.122.1\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Fedora (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"52833b35-2412-2a35-07cb-b5cc79030220\", \"vmware_distributedCpuEntitlement\":
+        47, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 242804769604,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 16605,
+        \"ansible_ssh_host\": \"192.168.122.1\", \"vmware_overallStatus\": \"green\",
+        \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"564d25c2-cb51-9434-f647-3ff92cf69192\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\":
+        15400550400, \"vmware_distributedMemoryEntitlement\": 5228, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 47, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        16384, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        63, \"vmware_privateMemory\": 16321, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 47, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"satoe-brewery\",
+        \"vmware_uptimeSeconds\": 2681115, \"vmware_memorySizeMB\": 16384, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 4, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        242806175566, \"vmware_name\": \"satoe-brewery\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        16472, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"fedora64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 138, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1466}, {"id": 172, "type": "host", "url": "/api/v1/hosts/172/",
+        "related": {"job_host_summaries": "/api/v1/hosts/172/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/172/variable_data/", "job_events": "/api/v1/hosts/172/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/172/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/172/fact_versions/", "inventory_sources": "/api/v1/hosts/172/inventory_sources/",
+        "groups": "/api/v1/hosts/172/groups/", "activity_stream": "/api/v1/hosts/172/activity_stream/",
+        "all_groups": "/api/v1/hosts/172/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/172/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1463/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-03-31T18:43:04.866Z",
+        "modified": "2016-11-17T17:56:27.136Z", "name": "satoe-build-rhel72", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c776f-d431-d0da-4fe9-8a2a227695ae",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] satoe-build-rhel72/satoe-build-rhel72.vmx\",
+        \"vmware_ipAddress\": \"10.8.97.10\", \"vmware_guestMemoryUsage\": 40, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\",
+        \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500caa77-7289-699f-af4c-bbe8fc840dd3\", \"vmware_distributedCpuEntitlement\":
+        2375, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 24262447981,
+        \"vmware_guestState\": \"running\", \"vmware_staticMemoryEntitlement\": 2107,
+        \"ansible_ssh_host\": \"10.8.97.10\", \"vmware_overallStatus\": \"red\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c776f-d431-d0da-4fe9-8a2a227695ae\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        363, \"vmware_uncommitted\": 3318083584, \"vmware_distributedMemoryEntitlement\":
+        745, \"vmware_template\": false, \"vmware_overallCpuDemand\": 2375, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        26, \"vmware_privateMemory\": 1899, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 2375, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"satoe-cfme-build\",
+        \"vmware_uptimeSeconds\": 99069, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        24263892886, \"vmware_name\": \"satoe-build-rhel72\", \"vmware_toolsVersionStatus\":
+        \"guestToolsUnmanaged\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        1935, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"rhel7_64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 34, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
+        "last_job_host_summary": 1463}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:40 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.239s
+      Content-Length:
+      - '70229'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 168, "next": null, "previous": "/api/v1/hosts/?page=6", "results":
+        [{"id": 869, "type": "host", "url": "/api/v1/hosts/869/", "related": {"job_host_summaries":
+        "/api/v1/hosts/869/job_host_summaries/", "variable_data": "/api/v1/hosts/869/variable_data/",
+        "job_events": "/api/v1/hosts/869/job_events/", "ad_hoc_commands": "/api/v1/hosts/869/ad_hoc_commands/",
+        "fact_versions": "/api/v1/hosts/869/fact_versions/", "inventory_sources":
+        "/api/v1/hosts/869/inventory_sources/", "groups": "/api/v1/hosts/869/groups/",
+        "activity_stream": "/api/v1/hosts/869/activity_stream/", "all_groups": "/api/v1/hosts/869/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/869/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name": "Dev
+        VC60", "description": "", "has_active_failures": true, "total_hosts": 139,
+        "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.617Z", "modified":
+        "2016-10-14T13:37:12.312Z", "name": "template_with_storage_policy", "description":
+        "imported", "inventory": 17, "enabled": false, "instance_id": "420c5e69-f56b-2802-3fd6-ff8b68ed313b",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"CentOS
+        4/5/6/7 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-01.example.com\",
+        \"vmware_instanceUuid\": \"500c63fb-9873-3fc3-7af1-8f6a347ed081\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 8192, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[datastore1] template_with_storage_policy/template_with_storage_policy.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 4, \"vmware_uuid\": \"420c5e69-f56b-2802-3fd6-ff8b68ed313b\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 1800416395, \"vmware_name\":
+        \"template_with_storage_policy\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 49934438939, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"centos64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 1800404992, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 173, "type": "host", "url": "/api/v1/hosts/173/",
+        "related": {"job_host_summaries": "/api/v1/hosts/173/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/173/variable_data/", "job_events": "/api/v1/hosts/173/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/173/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/173/fact_versions/", "inventory_sources": "/api/v1/hosts/173/inventory_sources/",
+        "groups": "/api/v1/hosts/173/groups/", "activity_stream": "/api/v1/hosts/173/activity_stream/",
+        "all_groups": "/api/v1/hosts/173/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/173/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.871Z", "modified":
+        "2016-04-28T14:28:03.388Z", "name": "test_billya", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cb94b-3d65-86a5-ca7e-f3c7c0c6c716",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] test_billya/test_billya.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"test-vc60-host1.example.com\",
+        \"vmware_instanceUuid\": \"500c9705-7ea2-615e-32b4-66a487142f26\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 24117248, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_suspendInterval\":
+        0, \"vmware_uuid\": \"420cb94b-3d65-86a5-ca7e-f3c7c0c6c716\", \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 19495289331, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"Owner: w w\\nEmail:
+        wfitzger@redhat.com\\nSource: ag_rhel7_template\\n\\nMIQ GUID=49daff48-f750-11e5-8377-f45c898c7d55\",
+        \"vmware_maxMemoryUsage\": 877, \"vmware_recordReplayState\": \"inactive\",
+        \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"Resources\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_maxCpuUsage\": 2400, \"vmware_committed\": 24275974, \"vmware_numEthernetCards\":
+        1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\":
+        0, \"vmware_name\": \"test_billya\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOff\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
+        null, "last_job_host_summary": null}, {"id": 875, "type": "host", "url": "/api/v1/hosts/875/",
+        "related": {"job_host_summaries": "/api/v1/hosts/875/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/875/variable_data/", "job_events": "/api/v1/hosts/875/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/875/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/875/fact_versions/", "inventory_sources": "/api/v1/hosts/875/inventory_sources/",
+        "groups": "/api/v1/hosts/875/groups/", "activity_stream": "/api/v1/hosts/875/activity_stream/",
+        "all_groups": "/api/v1/hosts/875/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/875/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1460/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-20T22:10:31.592Z",
+        "modified": "2016-11-17T17:25:55.766Z", "name": "test_billy_svc_r2", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c53ee-5f1c-41dc-56b7-05fd7690f16a",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] test_billy_svc_r2/test_billy_svc_r2.vmx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\":
+        \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c393d-8ac7-54bc-1f82-aaa6d2ce251d\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 0, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        1068, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_overallStatus\":
+        \"green\", \"vmware_minRequiredEVCModeKey\": \"intel-sandybridge\", \"vmware_uuid\":
+        \"420c53ee-5f1c-41dc-56b7-05fd7690f16a\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_staticCpuEntitlement\": 394, \"vmware_uncommitted\":
+        8589935120, \"vmware_distributedMemoryEntitlement\": 228, \"vmware_template\":
+        false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\": -1,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": \"Owner: Bill Fitzgerald\\nEmail:
+        wfitzger@redhat.com\\nSource: ag_rhel_7_template\\n\\nMIQ GUID=aef133c8-970c-11e6-a6df-f45c898c7d55\\n\\nParent
+        Service: test_billy (04e1413e-970c-11e6-a6df-f45c898c7d55)\", \"vmware_maxMemoryUsage\":
+        1024, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        5, \"vmware_privateMemory\": 3, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 1014822, \"vmware_memorySizeMB\":
+        1024, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 1266825395, \"vmware_name\": \"test_billy_svc_r2\",
+        \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 26, \"vmware_connectionState\": \"connected\",
+        \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"datastore1\"], \"vmware_guestId\": \"rhel7_64Guest\",
+        \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\": 24, \"vmware_ftLatencyStatus\":
+        \"gray\"}", "has_active_failures": true, "has_inventory_sources": true, "last_job":
+        852, "last_job_host_summary": 1460}, {"id": 274, "type": "host", "url": "/api/v1/hosts/274/",
+        "related": {"job_host_summaries": "/api/v1/hosts/274/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/274/variable_data/", "job_events": "/api/v1/hosts/274/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/274/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/274/fact_versions/", "inventory_sources": "/api/v1/hosts/274/inventory_sources/",
+        "groups": "/api/v1/hosts/274/groups/", "activity_stream": "/api/v1/hosts/274/activity_stream/",
+        "all_groups": "/api/v1/hosts/274/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/274/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/854/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1479/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:56:50.088Z", "status": "successful", "failed":
+        false, "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "successful", "finished": "2016-11-17T17:56:50.088Z",
+        "id": 854, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}]}, "created": "2016-05-25T14:07:45.664Z",
+        "modified": "2016-11-17T17:56:49.863Z", "name": "test_mkanoor_05_24_16", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c358a-4428-baab-205d-9b654d541cca",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] test_mkanoor_05_24_16/test_mkanoor_05_24_16.vmx\",
+        \"vmware_ipAddress\": \"10.8.99.243\", \"vmware_guestMemoryUsage\": 0, \"vmware_networks\":
+        [\"VM Network\"], \"vmware_guestFullName\": \"CentOS 4/5/6/7 (64-bit)\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500c8890-1e81-8c04-3b95-d6ff3cc0d26c\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_unshared\": 1885757999, \"vmware_guestState\":
+        \"running\", \"vmware_staticMemoryEntitlement\": 2114, \"ansible_ssh_host\":
+        \"10.8.99.243\", \"vmware_overallStatus\": \"green\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_uuid\": \"420c358a-4428-baab-205d-9b654d541cca\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        358, \"vmware_uncommitted\": 41063915520, \"vmware_distributedMemoryEntitlement\":
+        430, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        79, \"vmware_privateMemory\": 611, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_hostName\": \"dhcp-8-99-243.example.com\",
+        \"vmware_uptimeSeconds\": 3269930, \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\":
+        0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\": false, \"vmware_committed\":
+        1886279634, \"vmware_name\": \"test_mkanoor_05_24_16\", \"vmware_toolsVersionStatus\":
+        \"guestToolsCurrent\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        665, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"green\", \"vmware_toolsRunningStatus\": \"guestToolsRunning\", \"vmware_powerState\":
+        \"poweredOn\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"centos64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 30, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": 854,
+        "last_job_host_summary": 1479}, {"id": 210, "type": "host", "url": "/api/v1/hosts/210/",
+        "related": {"job_host_summaries": "/api/v1/hosts/210/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/210/variable_data/", "job_events": "/api/v1/hosts/210/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/210/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/210/fact_versions/", "inventory_sources": "/api/v1/hosts/210/inventory_sources/",
+        "groups": "/api/v1/hosts/210/groups/", "activity_stream": "/api/v1/hosts/210/activity_stream/",
+        "all_groups": "/api/v1/hosts/210/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/210/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1421/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "PackageInfo", "description": "", "finished":
+        "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true, "job_template_id":
+        241, "job_template_name": "PackageInfo"}, "inventory": {"name": "Dev VC60",
+        "description": "", "has_active_failures": true, "total_hosts": 139, "hosts_with_active_failures":
+        47, "total_groups": 28, "groups_with_active_failures": 24, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-04-21T14:30:25.861Z",
+        "modified": "2016-11-17T17:25:54.935Z", "name": "test_vm_1x4", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c2925-2790-67f9-beeb-7d2ed5de734f",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] test_vm_1x4/test_vm_1x4.vmx\",
+        \"vmware_guestMemoryUsage\": 20, \"vmware_networks\": [\"NFS Network\"], \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"dell-r420-06.example.com\",
+        \"vmware_instanceUuid\": \"500c6ff6-7a41-5e91-a8b0-71eca5b6de00\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 1121436147, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 2141, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_suspendInterval\": 0, \"vmware_uuid\": \"420c2925-2790-67f9-beeb-7d2ed5de734f\",
+        \"vmware_guestFullName\": \"Red Hat Enterprise Linux 7 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        2720, \"vmware_uncommitted\": 16058433536, \"vmware_distributedMemoryEntitlement\":
+        807, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        2048, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 2048, \"vmware_resourcePool\": \"Resources\",
+        \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\", \"vmware_toolsInstallerMounted\":
+        false, \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 8796, \"vmware_committed\":
+        1121924610, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 610379,
+        \"vmware_memorySizeMB\": 2048, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        4, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"test_vm_1x4\", \"vmware_toolsVersionStatus\": \"guestToolsNotInstalled\",
+        \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\": 2089, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"Prod_ISOs_NFS\", \"NFS Share\"], \"vmware_guestId\":
+        \"rhel7_64Guest\", \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        41, \"vmware_ftLatencyStatus\": \"gray\"}", "has_active_failures": true, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1421}, {"id": 886, "type":
+        "host", "url": "/api/v1/hosts/886/", "related": {"job_host_summaries": "/api/v1/hosts/886/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/886/variable_data/", "job_events": "/api/v1/hosts/886/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/886/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/886/fact_versions/", "inventory_sources": "/api/v1/hosts/886/inventory_sources/",
+        "groups": "/api/v1/hosts/886/groups/", "activity_stream": "/api/v1/hosts/886/activity_stream/",
+        "all_groups": "/api/v1/hosts/886/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/886/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-11-17T17:22:08.915Z", "modified":
+        "2016-11-17T17:56:27.160Z", "name": "UFEI", "description": "imported", "inventory":
+        17, "enabled": false, "instance_id": "420c4499-a8c8-2790-cb26-253f75314f44",
+        "variables": "{\"vmware_vmPathName\": \"[datastore1] UFEI/UFEI.vmx\", \"vmware_guestMemoryUsage\":
+        0, \"vmware_networks\": [\"VM NFS Network\"], \"vmware_guestFullName\": \"Microsoft
+        Windows Server 2008 R2 (64-bit)\", \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\":
+        \"ibm-x3550m4-01.example.com\", \"vmware_instanceUuid\":
+        \"500c5bb3-5fcb-d2c0-9b92-70674b2b389b\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 42949672960, \"vmware_guestState\": \"notRunning\",
+        \"vmware_staticMemoryEntitlement\": 0, \"vmware_toolsStatus\": \"toolsNotInstalled\",
+        \"vmware_overallStatus\": \"green\", \"vmware_uuid\": \"420c4499-a8c8-2790-cb26-253f75314f44\",
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 4487021010, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": false, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        4096, \"vmware_recordReplayState\": \"inactive\", \"vmware_sharedMemory\":
+        0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"Resources\", \"vmware_overallCpuUsage\":
+        0, \"vmware_suspendInterval\": 0, \"vmware_toolsInstallerMounted\": false,
+        \"vmware_memoryReservation\": 0, \"vmware_maxCpuUsage\": 2399, \"vmware_numMksConnections\":
+        0, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\":
+        4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\": 1, \"vmware_installBootRequired\":
+        false, \"vmware_committed\": 42950233611, \"vmware_name\": \"UFEI\", \"vmware_toolsVersionStatus\":
+        \"guestToolsNotInstalled\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"datastore1\",
+        \"Prod_ISOs_NFS\"], \"vmware_guestId\": \"windows7Server64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 827, "type": "host", "url": "/api/v1/hosts/827/",
+        "related": {"job_host_summaries": "/api/v1/hosts/827/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/827/variable_data/", "job_events": "/api/v1/hosts/827/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/827/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/827/fact_versions/", "inventory_sources": "/api/v1/hosts/827/inventory_sources/",
+        "groups": "/api/v1/hosts/827/groups/", "activity_stream": "/api/v1/hosts/827/activity_stream/",
+        "all_groups": "/api/v1/hosts/827/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/827/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1427/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.406Z",
+        "modified": "2016-11-17T17:56:27.168Z", "name": "Upstream 20161011 for Central
+        Admin Region 1", "description": "imported", "inventory": 17, "enabled": true,
+        "instance_id": "420cd4ed-7ba1-5068-c5c0-eeaf072aa053", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"500cea71-3a20-fb48-b834-82e6ea0ba65f\", \"vmware_distributedCpuEntitlement\":
+        143, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        2932, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 143, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 3823827589, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Upstream 20161011 for Central Admin Region 1\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 6036, \"vmware_overallCpuDemand\": 143, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        54, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        Upstream 20161011 for Central Admin Region 1/Upstream 20161011 for Central
+        Admin Region 1.vmx\", \"vmware_ipAddress\": \"10.8.99.235\", \"vmware_guestMemoryUsage\":
+        1351, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 3823440437, \"vmware_staticMemoryEntitlement\":
+        6241, \"ansible_ssh_host\": \"10.8.99.235\", \"vmware_uuid\": \"420cd4ed-7ba1-5068-c5c0-eeaf072aa053\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 49863651328,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 38, \"vmware_privateMemory\": 5976,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-235.example.com\",
+        \"vmware_uptimeSeconds\": 3168867, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1427}, {"id": 828, "type":
+        "host", "url": "/api/v1/hosts/828/", "related": {"job_host_summaries": "/api/v1/hosts/828/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/828/variable_data/", "job_events": "/api/v1/hosts/828/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/828/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/828/fact_versions/", "inventory_sources": "/api/v1/hosts/828/inventory_sources/",
+        "groups": "/api/v1/hosts/828/groups/", "activity_stream": "/api/v1/hosts/828/activity_stream/",
+        "all_groups": "/api/v1/hosts/828/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/828/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1465/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.411Z",
+        "modified": "2016-11-17T17:56:27.180Z", "name": "Upstream 20161011 for Central
+        Admin Region 99", "description": "imported", "inventory": 17, "enabled": true,
+        "instance_id": "420cf6e7-ada0-9b49-49f9-1da8448cd9f7", "variables": "{\"vmware_networks\":
+        [\"VM Network\"], \"vmware_balloonedMemory\": 0, \"vmware_hostSystem\": \"ibm-x3550m4-03.example.com\",
+        \"vmware_instanceUuid\": \"500c0dbd-17b3-046e-6a11-c61bf07bec17\", \"vmware_distributedCpuEntitlement\":
+        191, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        3025, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 191, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 3797287787, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Upstream 20161011 for Central Admin Region 99\", \"vmware_cpuReservation\":
+        0, \"vmware_hostMemoryUsage\": 6037, \"vmware_overallCpuDemand\": 191, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        Upstream 20161011 for Central Admin Region 99/Upstream 20161011 for Central
+        Admin Region 99.vmx\", \"vmware_ipAddress\": \"10.8.99.234\", \"vmware_guestMemoryUsage\":
+        1167, \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_product_instanceId\":
+        null, \"vmware_product_classId\": null, \"vmware_toolsStatus\": \"toolsOk\",
+        \"vmware_product_key\": 0, \"vmware_unshared\": 3796898381, \"vmware_staticMemoryEntitlement\":
+        6241, \"ansible_ssh_host\": \"10.8.99.234\", \"vmware_uuid\": \"420cf6e7-ada0-9b49-49f9-1da8448cd9f7\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 49890193408,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 36, \"vmware_privateMemory\": 5978,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-234.example.com\",
+        \"vmware_uptimeSeconds\": 3178131, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1465}, {"id": 829, "type":
+        "host", "url": "/api/v1/hosts/829/", "related": {"job_host_summaries": "/api/v1/hosts/829/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/829/variable_data/", "job_events": "/api/v1/hosts/829/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/829/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/829/fact_versions/", "inventory_sources": "/api/v1/hosts/829/inventory_sources/",
+        "groups": "/api/v1/hosts/829/groups/", "activity_stream": "/api/v1/hosts/829/activity_stream/",
+        "all_groups": "/api/v1/hosts/829/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/829/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/", "last_job": "/api/v1/jobs/852/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/1442/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": false}, "last_job": {"name": "PackageInfo", "description": "",
+        "finished": "2016-11-17T17:25:55.010Z", "status": "failed", "failed": true,
+        "job_template_id": 241, "job_template_name": "PackageInfo"}, "inventory":
+        {"name": "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": [{"status": "failed", "finished": "2016-11-17T17:25:55.010Z",
+        "id": 852, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T18:39:41.601Z",
+        "id": 848, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T15:33:35.359Z",
+        "id": 846, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-15T13:55:57.252Z",
+        "id": 844, "name": "PackageInfo"}, {"status": "failed", "finished": "2016-11-11T23:16:04.755Z",
+        "id": 840, "name": "PackageInfo"}]}, "created": "2016-10-14T13:37:10.416Z",
+        "modified": "2016-11-17T17:56:27.192Z", "name": "Upstream C&U 20160628", "description":
+        "imported", "inventory": 17, "enabled": true, "instance_id": "420c18fb-0847-5896-170a-95f6518d88e2",
+        "variables": "{\"vmware_networks\": [\"VM Network\"], \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-02.example.com\",
+        \"vmware_instanceUuid\": \"500c7906-97fd-e39a-b98f-777a99d85ddf\", \"vmware_distributedCpuEntitlement\":
+        527, \"vmware_guestState\": \"running\", \"vmware_minRequiredEVCModeKey\":
+        \"intel-sandybridge\", \"vmware_guestFullName\": \"Red Hat Enterprise Linux
+        6 (64-bit)\", \"vmware_product_version\": \"master\", \"vmware_distributedMemoryEntitlement\":
+        4621, \"vmware_product_appUrl\": null, \"vmware_product_fullVersion\": null,
+        \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_maxMemoryUsage\":
+        6144, \"vmware_overallCpuUsage\": 503, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 15058671722, \"vmware_product_vendor\": \"ManageIQ\",
+        \"vmware_product_vendorUrl\": null, \"vmware_numCpu\": 4, \"vmware_name\":
+        \"Upstream C&U 20160628\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        6042, \"vmware_overallCpuDemand\": 527, \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\":
+        [\"NFS Share\"], \"vmware_swappedMemory\": 0, \"vmware_consumedOverheadMemory\":
+        53, \"vmware_ftLatencyStatus\": \"gray\", \"vmware_vmPathName\": \"[NFS Share]
+        Upstream Master 20160628/Upstream Master 20160628.vmx\", \"vmware_ipAddress\":
+        \"10.8.99.226\", \"vmware_guestMemoryUsage\": 3809, \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_product_instanceId\": null, \"vmware_product_classId\":
+        null, \"vmware_toolsStatus\": \"toolsOk\", \"vmware_product_key\": 0, \"vmware_unshared\":
+        15057011255, \"vmware_staticMemoryEntitlement\": 6231, \"ansible_ssh_host\":
+        \"10.8.99.226\", \"vmware_uuid\": \"420c18fb-0847-5896-170a-95f6518d88e2\",
+        \"vmware_staticCpuEntitlement\": 1434, \"vmware_uncommitted\": 27892662272,
+        \"vmware_template\": false, \"vmware_ftSecondaryLatency\": -1, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 29, \"vmware_privateMemory\": 5985,
+        \"vmware_resourcePool\": \"Resources\", \"vmware_product_name\": \"ManageIQ\",
+        \"vmware_suspendInterval\": 0, \"vmware_maxCpuUsage\": 9596, \"vmware_numEthernetCards\":
+        1, \"vmware_product_productUrl\": null, \"vmware_hostName\": \"dhcp-8-99-226.example.com\",
+        \"vmware_uptimeSeconds\": 3600373, \"vmware_memorySizeMB\": 6144, \"vmware_compressedMemory\":
+        0, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_toolsVersionStatus\": \"guestToolsUnmanaged\", \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"green\", \"vmware_toolsRunningStatus\":
+        \"guestToolsRunning\", \"vmware_powerState\": \"poweredOn\", \"vmware_guestId\":
+        \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
+        true, "last_job": 852, "last_job_host_summary": 1442}, {"id": 146, "type":
+        "host", "url": "/api/v1/hosts/146/", "related": {"job_host_summaries": "/api/v1/hosts/146/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/146/variable_data/", "job_events": "/api/v1/hosts/146/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/146/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/146/fact_versions/", "inventory_sources": "/api/v1/hosts/146/inventory_sources/",
+        "groups": "/api/v1/hosts/146/groups/", "activity_stream": "/api/v1/hosts/146/activity_stream/",
+        "all_groups": "/api/v1/hosts/146/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/146/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-03-31T18:43:04.732Z", "modified":
+        "2016-10-14T13:37:10.359Z", "name": "Win2k12DC-template", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "423384ab-4d40-9997-ccd9-e490e8807bc5",
+        "variables": "{\"vmware_vmPathName\": \"[NFS Share] dev-scvmm2k12.vmtx\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_networks\": [\"VM NFS Network\"],
+        \"vmware_faultToleranceState\": \"notConfigured\", \"vmware_balloonedMemory\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_instanceUuid\": \"50334b93-08e7-f25e-8da0-dc969e6d675e\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_unshared\": 0, \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotInstalled\", \"vmware_suspendInterval\":
+        0, \"vmware_uuid\": \"423384ab-4d40-9997-ccd9-e490e8807bc5\", \"vmware_guestFullName\":
+        \"Microsoft Windows Server 2012 (64-bit)\", \"vmware_staticCpuEntitlement\":
+        0, \"vmware_uncommitted\": 4488081408, \"vmware_distributedMemoryEntitlement\":
+        0, \"vmware_template\": true, \"vmware_overallCpuDemand\": 0, \"vmware_ftSecondaryLatency\":
+        -1, \"vmware_numVirtualDisks\": 1, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_sharedMemory\": 0, \"vmware_privateMemory\": 0, \"vmware_resourcePool\":
+        \"\", \"vmware_overallCpuUsage\": 0, \"vmware_overallStatus\": \"green\",
+        \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\": 0,
+        \"vmware_committed\": 2784, \"vmware_numEthernetCards\": 1, \"vmware_uptimeSeconds\":
+        0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\": 0, \"vmware_numCpu\":
+        2, \"vmware_installBootRequired\": false, \"vmware_numMksConnections\": 0,
+        \"vmware_name\": \"Win2k12DC-template\", \"vmware_cpuReservation\": 0, \"vmware_hostMemoryUsage\":
+        0, \"vmware_connectionState\": \"connected\", \"vmware_guestHeartbeatStatus\":
+        \"gray\", \"vmware_toolsRunningStatus\": \"guestToolsNotRunning\", \"vmware_powerState\":
+        \"poweredOff\", \"vmware_ftLogBandwidth\": -1, \"vmware_datastores\": [\"NFS
+        Share\"], \"vmware_guestId\": \"windows8Server64Guest\", \"vmware_swappedMemory\":
+        0, \"vmware_consumedOverheadMemory\": 0, \"vmware_ftLatencyStatus\": \"gray\"}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 870, "type": "host", "url": "/api/v1/hosts/870/",
+        "related": {"job_host_summaries": "/api/v1/hosts/870/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/870/variable_data/", "job_events": "/api/v1/hosts/870/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/870/ad_hoc_commands/", "fact_versions":
+        "/api/v1/hosts/870/fact_versions/", "inventory_sources": "/api/v1/hosts/870/inventory_sources/",
+        "groups": "/api/v1/hosts/870/groups/", "activity_stream": "/api/v1/hosts/870/activity_stream/",
+        "all_groups": "/api/v1/hosts/870/all_groups/", "ad_hoc_command_events": "/api/v1/hosts/870/ad_hoc_command_events/",
+        "inventory": "/api/v1/inventories/17/"}, "summary_fields": {"inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "recent_jobs": []}, "created": "2016-10-14T13:37:10.622Z", "modified":
+        "2016-10-14T13:37:12.331Z", "name": "windows_2012_temp", "description": "imported",
+        "inventory": 17, "enabled": false, "instance_id": "420cdbe0-1634-6447-5a48-a7428c66d175",
+        "variables": "{\"vmware_privateMemory\": 0, \"vmware_resourcePool\": \"\",
+        \"vmware_guestMemoryUsage\": 0, \"vmware_overallCpuUsage\": 0, \"vmware_suspendInterval\":
+        0, \"vmware_networks\": [\"VM Network\"], \"vmware_guestFullName\": \"Microsoft
+        Windows Server 2012 (64-bit)\", \"vmware_toolsInstallerMounted\": false, \"vmware_memoryReservation\":
+        0, \"vmware_numMksConnections\": 0, \"vmware_balloonedMemory\": 0, \"vmware_numEthernetCards\":
+        1, \"vmware_consumedOverheadMemory\": 0, \"vmware_hostName\": \"windows_2012\",
+        \"vmware_instanceUuid\": \"500c5536-1572-080a-b8f2-839df67b3b76\", \"vmware_distributedCpuEntitlement\":
+        0, \"vmware_hostSystem\": \"ibm-x3550m4-04.example.com\",
+        \"vmware_uptimeSeconds\": 0, \"vmware_memorySizeMB\": 4096, \"vmware_compressedMemory\":
+        0, \"vmware_vmPathName\": \"[NFS Share] windows_2012_temp/windows_2012_temp.vmtx\",
+        \"vmware_guestState\": \"notRunning\", \"vmware_staticMemoryEntitlement\":
+        0, \"vmware_toolsStatus\": \"toolsNotRunning\", \"vmware_overallStatus\":
+        \"green\", \"vmware_numCpu\": 2, \"vmware_uuid\": \"420cdbe0-1634-6447-5a48-a7428c66d175\",
+        \"vmware_installBootRequired\": false, \"vmware_committed\": 10506988130,
+        \"vmware_name\": \"windows_2012_temp\", \"vmware_toolsVersionStatus\": \"guestToolsCurrent\",
+        \"vmware_staticCpuEntitlement\": 0, \"vmware_uncommitted\": 56259166208, \"vmware_hostMemoryUsage\":
+        0, \"vmware_distributedMemoryEntitlement\": 0, \"vmware_connectionState\":
+        \"connected\", \"vmware_guestHeartbeatStatus\": \"gray\", \"vmware_faultToleranceState\":
+        \"notConfigured\", \"vmware_template\": true, \"vmware_toolsRunningStatus\":
+        \"guestToolsNotRunning\", \"vmware_overallCpuDemand\": 0, \"vmware_ftLogBandwidth\":
+        -1, \"vmware_datastores\": [\"NFS Share\"], \"vmware_cpuReservation\": 0,
+        \"vmware_ftLatencyStatus\": \"gray\", \"vmware_ftSecondaryLatency\": -1, \"vmware_powerState\":
+        \"poweredOff\", \"vmware_guestId\": \"windows8Server64Guest\", \"vmware_numVirtualDisks\":
+        1, \"vmware_swappedMemory\": 0, \"vmware_annotation\": null, \"vmware_recordReplayState\":
+        \"inactive\", \"vmware_unshared\": 10505941525, \"vmware_sharedMemory\": 0}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 5, "type": "host", "url": "/api/v1/hosts/5/",
+        "related": {"job_host_summaries": "/api/v1/hosts/5/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/5/variable_data/", "job_events": "/api/v1/hosts/5/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/5/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/5/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/5/inventory_sources/", "groups": "/api/v1/hosts/5/groups/",
+        "activity_stream": "/api/v1/hosts/5/activity_stream/", "all_groups": "/api/v1/hosts/5/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/5/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.574Z",
+        "modified": "2015-12-17T22:13:19.027Z", "name": "bill3-cfme-my_instance-vuyhd7qvz6sk",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "aa3a2d28-e364-42ff-bdf4-7d6266c25d46", "variables": "{\"ansible_ssh_host\":
+        \"192.168.200.17\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"private_network\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:f1:ac:b0\",
+        \"version\": 4, \"addr\": \"192.168.200.17\", \"OS-EXT-IPS:type\": \"fixed\"}]},
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"private_network\": [\"192.168.200.17\"]}, \"OS-EXT-STS:vm_state\":
+        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-0000068e\", \"OS-SRV-USG:launched_at\":
+        \"2015-11-19T20:50:57.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"aa3a2d28-e364-42ff-bdf4-7d6266c25d46\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"default\"}], \"public_v4\": null, \"progress\": 0, \"OS-EXT-STS:power_state\":
+        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
+        \"ACTIVE\", \"updated\": \"2015-11-19T20:50:57Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": \"userkey\", \"private_v4\": \"192.168.200.17\", \"interface_ip\":
+        \"192.168.200.17\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill3-cfme-my_instance-vuyhd7qvz6sk\", \"created\": \"2015-11-19T20:50:46Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill3-cfme-my_instance-vuyhd7qvz6sk\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 6, "type": "host", "url": "/api/v1/hosts/6/",
+        "related": {"job_host_summaries": "/api/v1/hosts/6/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/6/variable_data/", "job_events": "/api/v1/hosts/6/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/6/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/6/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/6/inventory_sources/", "groups": "/api/v1/hosts/6/groups/",
+        "activity_stream": "/api/v1/hosts/6/activity_stream/", "all_groups": "/api/v1/hosts/6/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/6/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.584Z",
+        "modified": "2015-12-17T22:13:19.034Z", "name": "bill422-1-my_instance-4uckqhihzclr",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "9b03b9fd-2aa6-45ab-be54-e44b82546bba", "variables": "{\"ansible_ssh_host\":
+        \"10.12.0.12\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:36:28:83\", \"version\":
+        4, \"addr\": \"10.12.0.12\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
+        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"public\": [\"10.12.0.12\"]}, \"OS-EXT-STS:vm_state\": \"active\",
+        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-0000065f\", \"OS-SRV-USG:launched_at\":
+        \"2015-04-20T19:31:59.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"9b03b9fd-2aa6-45ab-be54-e44b82546bba\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"default\"}], \"public_v4\": \"10.12.0.12\", \"progress\": 0, \"OS-EXT-STS:power_state\":
+        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
+        \"ACTIVE\", \"updated\": \"2015-04-20T19:31:59Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": null, \"private_v4\": \"10.12.0.12\", \"interface_ip\":
+        \"10.12.0.12\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill422-1-my_instance-4uckqhihzclr\", \"created\": \"2015-04-20T19:31:49Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-1-my_instance-4uckqhihzclr\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 7, "type": "host", "url": "/api/v1/hosts/7/",
+        "related": {"job_host_summaries": "/api/v1/hosts/7/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/7/variable_data/", "job_events": "/api/v1/hosts/7/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/7/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/7/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/7/inventory_sources/", "groups": "/api/v1/hosts/7/groups/",
+        "activity_stream": "/api/v1/hosts/7/activity_stream/", "all_groups": "/api/v1/hosts/7/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/7/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.592Z",
+        "modified": "2015-12-17T22:13:19.040Z", "name": "bill422-3-my_instance-eclvvn5h4loa",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "fac9c8eb-90e7-4d98-a608-78224925163c", "variables": "{\"ansible_ssh_host\":
+        \"10.12.0.13\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:d8:8d:77\", \"version\":
+        4, \"addr\": \"10.12.0.13\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
+        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/fac9c8eb-90e7-4d98-a608-78224925163c\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/fac9c8eb-90e7-4d98-a608-78224925163c\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"public\": [\"10.12.0.13\"]}, \"OS-EXT-STS:vm_state\": \"active\",
+        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000660\", \"OS-SRV-USG:launched_at\":
+        \"2015-04-22T18:14:15.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"fac9c8eb-90e7-4d98-a608-78224925163c\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"default\"}], \"public_v4\": \"10.12.0.13\", \"progress\": 0, \"OS-EXT-STS:power_state\":
+        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
+        \"ACTIVE\", \"updated\": \"2015-04-22T18:14:15Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": null, \"private_v4\": \"10.12.0.13\", \"interface_ip\":
+        \"10.12.0.13\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill422-3-my_instance-eclvvn5h4loa\", \"created\": \"2015-04-22T18:14:06Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-3-my_instance-eclvvn5h4loa\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 8, "type": "host", "url": "/api/v1/hosts/8/",
+        "related": {"job_host_summaries": "/api/v1/hosts/8/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/8/variable_data/", "job_events": "/api/v1/hosts/8/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/8/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/8/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/8/inventory_sources/", "groups": "/api/v1/hosts/8/groups/",
+        "activity_stream": "/api/v1/hosts/8/activity_stream/", "all_groups": "/api/v1/hosts/8/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/8/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.600Z",
+        "modified": "2015-12-17T22:13:19.046Z", "name": "bill422-4-my_instance-qsmfncoidcvb",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "f010f1a5-7b25-4aef-8cab-8f03784aca88", "variables": "{\"ansible_ssh_host\":
+        \"10.12.0.14\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"public\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:7f:08:c6\", \"version\":
+        4, \"addr\": \"10.12.0.14\", \"OS-EXT-IPS:type\": \"fixed\"}]}, \"links\":
+        [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/f010f1a5-7b25-4aef-8cab-8f03784aca88\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/f010f1a5-7b25-4aef-8cab-8f03784aca88\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"public\": [\"10.12.0.14\"]}, \"OS-EXT-STS:vm_state\": \"active\",
+        \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000661\", \"OS-SRV-USG:launched_at\":
+        \"2015-04-22T18:30:56.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"1\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/1\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.tiny\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"f010f1a5-7b25-4aef-8cab-8f03784aca88\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"default\"}], \"public_v4\": \"10.12.0.14\", \"progress\": 0, \"OS-EXT-STS:power_state\":
+        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
+        \"ACTIVE\", \"updated\": \"2015-04-22T18:30:56Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": null, \"private_v4\": \"10.12.0.14\", \"interface_ip\":
+        \"10.12.0.14\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill422-4-my_instance-qsmfncoidcvb\", \"created\": \"2015-04-22T18:30:47Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill422-4-my_instance-qsmfncoidcvb\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 9, "type": "host", "url": "/api/v1/hosts/9/",
+        "related": {"job_host_summaries": "/api/v1/hosts/9/job_host_summaries/", "variable_data":
+        "/api/v1/hosts/9/variable_data/", "job_events": "/api/v1/hosts/9/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/9/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/9/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/9/inventory_sources/", "groups": "/api/v1/hosts/9/groups/",
+        "activity_stream": "/api/v1/hosts/9/activity_stream/", "all_groups": "/api/v1/hosts/9/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/9/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.607Z",
+        "modified": "2015-12-17T22:13:19.053Z", "name": "bill529-1-my_instance-g3zhieqqax46",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "a864027e-f68a-40c8-b0df-3001e7e3710d", "variables": "{\"ansible_ssh_host\":
+        \"192.168.200.5\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"private_network\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:a0:43:1d\",
+        \"version\": 4, \"addr\": \"192.168.200.5\", \"OS-EXT-IPS:type\": \"fixed\"}]},
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/a864027e-f68a-40c8-b0df-3001e7e3710d\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/a864027e-f68a-40c8-b0df-3001e7e3710d\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"private_network\": [\"192.168.200.5\"]}, \"OS-EXT-STS:vm_state\":
+        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000676\", \"OS-SRV-USG:launched_at\":
+        \"2015-06-02T17:51:38.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"a864027e-f68a-40c8-b0df-3001e7e3710d\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"default\"}], \"public_v4\": null, \"progress\": 0, \"OS-EXT-STS:power_state\":
+        1, \"OS-EXT-AZ:availability_zone\": \"nova\", \"config_drive\": \"\", \"status\":
+        \"ACTIVE\", \"updated\": \"2015-06-02T17:51:38Z\", \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": \"userkey\", \"private_v4\": \"192.168.200.5\", \"interface_ip\":
+        \"192.168.200.5\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill529-1-my_instance-g3zhieqqax46\", \"created\": \"2015-06-02T17:51:29Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill529-1-my_instance-g3zhieqqax46\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 10, "type": "host", "url": "/api/v1/hosts/10/",
+        "related": {"job_host_summaries": "/api/v1/hosts/10/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/10/variable_data/", "job_events": "/api/v1/hosts/10/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/10/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/10/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/10/inventory_sources/", "groups": "/api/v1/hosts/10/groups/",
+        "activity_stream": "/api/v1/hosts/10/activity_stream/", "all_groups": "/api/v1/hosts/10/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/10/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/3/"}, "summary_fields": {"inventory": {"name": "Openstack
+        RH Support", "description": "RH Support Openstack Hosts", "has_active_failures":
+        false, "total_hosts": 6, "hosts_with_active_failures": 0, "total_groups":
+        15, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "recent_jobs": []}, "created": "2015-12-17T22:13:18.614Z",
+        "modified": "2015-12-17T22:13:19.059Z", "name": "bill817a-my_instance-vqrow5k5u5kj",
+        "description": "imported", "inventory": 3, "enabled": true, "instance_id":
+        "dd21c2df-9f16-417f-9489-bae165cb5e05", "variables": "{\"ansible_ssh_host\":
+        \"10.0.0.7\", \"openstack\": {\"OS-EXT-STS:task_state\": null, \"addresses\":
+        {\"private\": [{\"OS-EXT-IPS-MAC:mac_addr\": \"fa:16:3e:a7:8a:58\", \"version\":
+        4, \"addr\": \"10.0.0.7\", \"OS-EXT-IPS:type\": \"fixed\"}, {\"OS-EXT-IPS-MAC:mac_addr\":
+        \"fa:16:3e:a7:8a:58\", \"version\": 4, \"addr\": \"10.12.0.21\", \"OS-EXT-IPS:type\":
+        \"floating\"}]}, \"links\": [{\"href\": \"http://10.13.214.218:8774/v2/9ae6444ca2d1470ea94b5c956ebf8b83/servers/dd21c2df-9f16-417f-9489-bae165cb5e05\",
+        \"rel\": \"self\"}, {\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/servers/dd21c2df-9f16-417f-9489-bae165cb5e05\",
+        \"rel\": \"bookmark\"}], \"image\": {\"id\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/images/77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\",
+        \"rel\": \"bookmark\"}], \"name\": \"77ed0ac8-bb7b-46b9-b785-0dacc43fb7a8\"},
+        \"networks\": {\"private\": [\"10.0.0.7\", \"10.12.0.21\"]}, \"OS-EXT-STS:vm_state\":
+        \"active\", \"OS-EXT-SRV-ATTR:instance_name\": \"instance-00000683\", \"OS-SRV-USG:launched_at\":
+        \"2015-08-17T02:43:32.000000\", \"NAME_ATTR\": \"name\", \"flavor\": {\"id\":
+        \"2\", \"links\": [{\"href\": \"http://10.13.214.218:8774/9ae6444ca2d1470ea94b5c956ebf8b83/flavors/2\",
+        \"rel\": \"bookmark\"}], \"name\": \"m1.small\"}, \"az\": \"nova\", \"HUMAN_ID\":
+        true, \"cloud\": \"devstack\", \"user_id\": \"aee421cd3dea4ca289796e15c56e119e\",
+        \"OS-DCF:diskConfig\": \"MANUAL\", \"id\": \"dd21c2df-9f16-417f-9489-bae165cb5e05\",
+        \"accessIPv4\": \"\", \"accessIPv6\": \"\", \"security_groups\": [{\"name\":
+        \"web_server_security_group\"}], \"public_v4\": \"10.12.0.21\", \"progress\":
+        0, \"OS-EXT-STS:power_state\": 1, \"OS-EXT-AZ:availability_zone\": \"nova\",
+        \"config_drive\": \"\", \"status\": \"ACTIVE\", \"updated\": \"2015-08-17T02:43:32Z\",
+        \"hostId\": \"5804b4b90662411a50c803a9d7e84f582f8b9e932905f0dc49ea642f\",
+        \"OS-EXT-SRV-ATTR:host\": \"skynet-cloud.usersys.redhat.com\", \"OS-SRV-USG:terminated_at\":
+        null, \"key_name\": \"userkey\", \"private_v4\": \"10.0.0.7\", \"interface_ip\":
+        \"10.0.0.7\", \"OS-EXT-SRV-ATTR:hypervisor_hostname\": \"skynet-cloud.usersys.redhat.com\",
+        \"name\": \"bill817a-my_instance-vqrow5k5u5kj\", \"created\": \"2015-08-17T02:43:22Z\",
+        \"tenant_id\": \"9ae6444ca2d1470ea94b5c956ebf8b83\", \"region\": \"\", \"os-extended-volumes:volumes_attached\":
+        [], \"volumes\": [], \"metadata\": {}, \"human_id\": \"bill817a-my_instance-vqrow5k5u5kj\"}}",
+        "has_active_failures": false, "has_inventory_sources": true, "last_job": null,
+        "last_job_host_summary": null}, {"id": 64, "type": "host", "url": "/api/v1/hosts/64/",
+        "related": {"created_by": "/api/v1/users/1/", "job_host_summaries": "/api/v1/hosts/64/job_host_summaries/",
+        "variable_data": "/api/v1/hosts/64/variable_data/", "job_events": "/api/v1/hosts/64/job_events/",
+        "ad_hoc_commands": "/api/v1/hosts/64/ad_hoc_commands/", "fact_versions": "/api/v1/hosts/64/fact_versions/",
+        "inventory_sources": "/api/v1/hosts/64/inventory_sources/", "groups": "/api/v1/hosts/64/groups/",
+        "activity_stream": "/api/v1/hosts/64/activity_stream/", "all_groups": "/api/v1/hosts/64/all_groups/",
+        "ad_hoc_command_events": "/api/v1/hosts/64/ad_hoc_command_events/", "inventory":
+        "/api/v1/inventories/8/", "last_job": "/api/v1/jobs/172/", "last_job_host_summary":
+        "/api/v1/job_host_summaries/215/"}, "summary_fields": {"last_job_host_summary":
+        {"failed": true}, "last_job": {"name": "Install Httpd / Ruby Modules / Start
+        httpd", "description": "db", "finished": "2016-03-24T14:59:03.013Z", "status":
+        "failed", "failed": true, "job_template_id": 147, "job_template_name": "Install
+        Httpd / Ruby Modules / Start httpd"}, "inventory": {"name": "Single AWS Host",
+        "description": "54.86.210.90", "has_active_failures": true, "total_hosts":
+        1, "hosts_with_active_failures": 1, "total_groups": 0, "groups_with_active_failures":
+        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
+        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "recent_jobs": [{"status": "failed", "finished": "2016-03-24T14:59:03.013Z",
+        "id": 172, "name": "Install Httpd / Ruby Modules / Start httpd"}]}, "created":
+        "2016-02-01T19:40:08.824Z", "modified": "2016-03-24T14:59:02.929Z", "name":
+        "169.0.0.1", "description": "Test Host", "inventory": 8, "enabled": true,
+        "instance_id": "", "variables": "---", "has_active_failures": true, "has_inventory_sources":
+        false, "last_job": 172, "last_job_host_summary": 215}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:42 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/config/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:42 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.204s
+      Content-Length:
+      - '2548'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"eula": "TOWER SOFTWARE END USER LICENSE AGREEMENT\n\nUnless otherwise
+        agreed to, and executed in a definitive agreement, between\nAnsible, Inc.
+        (\u201cAnsible\u201d) and the individual or entity (\u201cCustomer\u201d)
+        signing or\nelectronically accepting these terms of use for the Tower Software
+        (\u201cEULA\u201d),\nall Tower Software, including any and all versions released
+        or made available\nby Ansible, shall be subject to the Ansible Software Subscription
+        and Services\nAgreement found at www.ansible.com/subscription-agreement (\u201cAgreement\u201d).\nAnsible
+        is not responsible for any additional obligations, conditions or\nwarranties
+        agreed to between Customer and an authorized distributor, or\nreseller, of
+        the Tower Software. BY DOWNLOADING AND USING THE TOWER SOFTWARE,\nOR BY CLICKING
+        ON THE \u201cYES\u201d BUTTON OR OTHER BUTTON OR MECHANISM DESIGNED TO\nACKNOWLEDGE
+        CONSENT TO THE TERMS OF AN ELECTRONIC COPY OF THIS EULA, THE\nCUSTOMER HEREBY
+        ACKNOWLEDGES THAT CUSTOMER HAS READ, UNDERSTOOD, AND AGREES TO\nBE BOUND BY
+        THE TERMS OF THIS EULA AND AGREEMENT, INCLUDING ALL TERMS\nINCORPORATED HEREIN
+        BY REFERENCE, AND THAT THIS EULA AND AGREEMENT IS\nEQUIVALENT TO ANY WRITTEN
+        NEGOTIATED AGREEMENT BETWEEN CUSTOMER AND ANSIBLE.\nTHIS EULA AND AGREEMENT
+        IS ENFORCEABLE AGAINST ANY PERSON OR ENTITY THAT USES\nOR AVAILS ITSELF OF
+        THE TOWER SOFTWARE OR ANY PERSON OR ENTITY THAT USES THE OR\nAVAILS ITSELF
+        OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
+        "license_info": {"deployment_id": "21c7c190b553a923410b8027f7890b8483ba892a",
+        "subscription_name": "Ansible Tower by Red Hat, Self-Support (500 Managed
+        Nodes)", "grace_period_remaining": 6940396, "features": {"surveys": false,
+        "multiple_organizations": false, "system_tracking": false, "enterprise_auth":
+        false, "rebranding": false, "activity_streams": false, "ldap": false, "ha":
+        false}, "date_expired": false, "available_instances": 500, "time_remaining":
+        4348396, "current_instances": 168, "free_instances": 332, "instance_count":
+        500, "trial": false, "compliant": true, "valid_key": true, "contact_email":
+        "matburt@redhat.com", "company_name": "Basic Company", "date_warning": false,
+        "license_type": "basic", "contact_name": "Lumber McLumberjack", "license_date":
+        1491019200, "license_key": "8bf9fdcfe49850186bf5d47103d25a3d67cd59c06977ec1529670b1df6a9ea5b"},
+        "analytics_status": "detailed", "version": "2.4.2", "project_base_dir": "/var/lib/awx/projects",
+        "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
+        []}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:43 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/job_templates/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:43 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.197s
+      Content-Length:
+      - '35312'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 14, "next": null, "previous": null, "results": [{"id": 149,
+        "type": "job_template", "url": "/api/v1/job_templates/149/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/75/", "last_job": "/api/v1/jobs/119/", "launch":
+        "/api/v1/job_templates/149/launch/", "jobs": "/api/v1/job_templates/149/jobs/",
+        "activity_stream": "/api/v1/job_templates/149/activity_stream/", "schedules":
+        "/api/v1/job_templates/149/schedules/"}, "summary_fields": {"project": {"name":
+        "bd-project", "description": "", "status": "successful"}, "last_job": {"name":
+        "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description", "finished":
+        "2016-02-18T21:52:36.072Z", "status": "failed", "failed": true}, "last_update":
+        {"name": "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description",
+        "status": "failed", "failed": true}, "inventory": {"name": "AWS", "description":
+        "CFME AWS Lab", "has_active_failures": false, "total_hosts": 21, "hosts_with_active_failures":
+        0, "total_groups": 63, "groups_with_active_failures": 0, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
+        "finished": "2016-02-18T21:52:36.072Z", "id": 119}]}, "created": "2016-02-05T23:09:47.943Z",
+        "modified": "2016-11-15T19:07:10.239Z", "name": "Ansible-JobTemplate", "description":
+        "Ansible-JobTemplate-Description", "job_type": "run", "inventory": 2, "project":
+        75, "playbook": "language_features/group_commands.yml", "credential": null,
+        "cloud_credential": null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
+        "abc: 123\n", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
+        "", "last_job_run": "2016-02-18T21:52:36.072Z", "last_job_failed": true, "has_schedules":
+        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 155, "type":
+        "job_template", "url": "/api/v1/job_templates/155/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/75/", "launch": "/api/v1/job_templates/155/launch/",
+        "jobs": "/api/v1/job_templates/155/jobs/", "activity_stream": "/api/v1/job_templates/155/activity_stream/",
+        "schedules": "/api/v1/job_templates/155/schedules/", "survey_spec": "/api/v1/job_templates/155/survey_spec/"},
+        "summary_fields": {"project": {"name": "bd-project", "description": "", "status":
+        "successful"}, "inventory": {"name": "AWS", "description": "CFME AWS Lab",
+        "has_active_failures": false, "total_hosts": 21, "hosts_with_active_failures":
+        0, "total_groups": 63, "groups_with_active_failures": 0, "has_inventory_sources":
+        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": []}, "created": "2016-03-02T22:13:09.055Z", "modified":
+        "2016-03-02T22:13:49.206Z", "name": "Ansible-JobTemplate-Survey", "description":
+        "Ansible-JobTemplate-Description", "job_type": "run", "inventory": 2, "project":
+        75, "playbook": "language_features/group_commands.yml", "credential": null,
+        "cloud_credential": null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
+        "{\n \"abc\": 123\n}", "job_tags": "", "force_handlers": false, "skip_tags":
+        "", "start_at_task": "", "last_job_run": null, "last_job_failed": false, "has_schedules":
+        false, "next_job_run": null, "status": "never updated", "host_config_key":
+        "", "ask_variables_on_launch": false, "survey_enabled": true, "become_enabled":
+        false}, {"id": 94, "type": "job_template", "url": "/api/v1/job_templates/94/",
+        "related": {"created_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
+        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/382/",
+        "launch": "/api/v1/job_templates/94/launch/", "jobs": "/api/v1/job_templates/94/jobs/",
+        "activity_stream": "/api/v1/job_templates/94/activity_stream/", "schedules":
+        "/api/v1/job_templates/94/schedules/"}, "summary_fields": {"credential": {"name":
+        "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false}, "project":
+        {"name": "db-projects", "description": "projects", "status": "successful"},
+        "last_job": {"name": "AWS Provision", "description": "db", "finished": "2016-04-12T21:32:27.620Z",
+        "status": "successful", "failed": false}, "last_update": {"name": "AWS Provision",
+        "description": "db", "status": "successful", "failed": false}, "cloud_credential":
+        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
+        "inventory": {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures":
+        false, "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups":
+        63, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-12T21:32:27.620Z",
+        "id": 382}, {"status": "successful", "finished": "2016-04-05T19:45:02.861Z",
+        "id": 350}, {"status": "successful", "finished": "2016-04-05T19:39:37.767Z",
+        "id": 348}, {"status": "successful", "finished": "2016-03-09T21:20:24.109Z",
+        "id": 149}, {"status": "successful", "finished": "2016-03-02T20:00:12.803Z",
+        "id": 138}, {"status": "successful", "finished": "2016-02-23T22:02:40.397Z",
+        "id": 133}, {"status": "successful", "finished": "2016-02-23T19:28:53.584Z",
+        "id": 121}, {"status": "successful", "finished": "2016-02-11T18:22:49.867Z",
+        "id": 117}, {"status": "successful", "finished": "2016-02-09T22:29:51.728Z",
+        "id": 113}, {"status": "successful", "finished": "2016-02-08T20:26:31.114Z",
+        "id": 111}]}, "created": "2016-01-28T14:31:52.576Z", "modified": "2016-04-12T21:31:26.339Z",
+        "name": "AWS Provision", "description": "db", "job_type": "run", "inventory":
+        2, "project": 93, "playbook": "create_ec2.yml", "credential": 11, "cloud_credential":
+        2, "forks": 0, "limit": "", "verbosity": 0, "extra_vars": "", "job_tags":
+        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
+        "2016-04-12T21:32:27.620Z", "last_job_failed": false, "has_schedules": false,
+        "next_job_run": null, "status": "successful", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 143, "type":
+        "job_template", "url": "/api/v1/job_templates/143/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
+        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/357/",
+        "launch": "/api/v1/job_templates/143/launch/", "jobs": "/api/v1/job_templates/143/jobs/",
+        "activity_stream": "/api/v1/job_templates/143/activity_stream/", "schedules":
+        "/api/v1/job_templates/143/schedules/", "survey_spec": "/api/v1/job_templates/143/survey_spec/"},
+        "summary_fields": {"credential": {"name": "db", "description": "Drew Bomhof
+        Key", "kind": "ssh", "cloud": false}, "project": {"name": "db-projects", "description":
+        "projects", "status": "successful"}, "last_job": {"name": "AWS State Change",
+        "description": "db (state: present, absent, running, stopped)", "finished":
+        "2016-04-07T16:54:29.339Z", "status": "successful", "failed": false}, "last_update":
+        {"name": "AWS State Change", "description": "db (state: present, absent, running,
+        stopped)", "status": "successful", "failed": false}, "cloud_credential": {"name":
+        "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true}, "inventory":
+        {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": false,
+        "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-07T16:54:29.339Z",
+        "id": 357}, {"status": "failed", "finished": "2016-04-07T16:53:02.493Z", "id":
+        354}, {"status": "failed", "finished": "2016-04-01T21:25:46.816Z", "id": 291},
+        {"status": "failed", "finished": "2016-04-01T21:23:33.943Z", "id": 289}, {"status":
+        "failed", "finished": "2016-03-24T16:15:25.025Z", "id": 179}, {"status": "failed",
+        "finished": "2016-03-15T19:33:02.197Z", "id": 165}, {"status": "failed", "finished":
+        "2016-03-15T19:13:20.395Z", "id": 163}, {"status": "failed", "finished": "2016-03-15T18:49:24.819Z",
+        "id": 161}, {"status": "failed", "finished": "2016-03-11T22:51:33.799Z", "id":
+        159}, {"status": "failed", "finished": "2016-03-11T21:43:39.372Z", "id": 157}]},
+        "created": "2016-01-28T17:12:46.235Z", "modified": "2016-05-24T18:48:43.608Z",
+        "name": "AWS State Change", "description": "db (state: present, absent, running,
+        stopped)", "job_type": "run", "inventory": 2, "project": 93, "playbook": "general_state_ec2.yml",
+        "credential": 11, "cloud_credential": 2, "forks": 90, "limit": "", "verbosity":
+        3, "extra_vars": "instance_ids: []\nregion: us-east-1\nstate: absent\nsubnet_id:
+        subnet-16c70477\n", "job_tags": "", "force_handlers": false, "skip_tags":
+        "", "start_at_task": "", "last_job_run": "2016-04-07T16:54:29.339Z", "last_job_failed":
+        false, "has_schedules": false, "next_job_run": null, "status": "successful",
+        "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
+        true, "become_enabled": false}, {"id": 76, "type": "job_template", "url":
+        "/api/v1/job_templates/76/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "project": "/api/v1/projects/75/", "last_job":
+        "/api/v1/jobs/140/", "launch": "/api/v1/job_templates/76/launch/", "jobs":
+        "/api/v1/job_templates/76/jobs/", "activity_stream": "/api/v1/job_templates/76/activity_stream/",
+        "schedules": "/api/v1/job_templates/76/schedules/"}, "summary_fields": {"project":
+        {"name": "bd-project", "description": "", "status": "successful"}, "last_job":
+        {"name": "bd-test", "description": "", "finished": "2016-03-08T15:07:47.479Z",
+        "status": "failed", "failed": true}, "last_update": {"name": "bd-test", "description":
+        "", "status": "failed", "failed": true}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "modified_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "failed", "finished": "2016-03-08T15:07:47.479Z",
+        "id": 140}, {"status": "failed", "finished": "2016-02-01T18:56:03.412Z", "id":
+        86}, {"status": "failed", "finished": "2016-01-05T21:04:19.877Z", "id": 16},
+        {"status": "failed", "finished": "2016-01-05T21:02:38.834Z", "id": 15}]},
+        "created": "2016-01-05T21:01:01.678Z", "modified": "2016-03-23T23:25:00.786Z",
+        "name": "bd-test", "description": "", "job_type": "run", "inventory": null,
+        "project": 75, "playbook": "windows/test.yml", "credential": null, "cloud_credential":
+        null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars": "", "job_tags":
+        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
+        "2016-03-08T15:07:47.479Z", "last_job_failed": true, "has_schedules": false,
+        "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 376, "type":
+        "job_template", "url": "/api/v1/job_templates/376/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/6/",
+        "project": "/api/v1/projects/75/", "credential": "/api/v1/credentials/10/",
+        "launch": "/api/v1/job_templates/376/launch/", "jobs": "/api/v1/job_templates/376/jobs/",
+        "activity_stream": "/api/v1/job_templates/376/activity_stream/", "schedules":
+        "/api/v1/job_templates/376/schedules/"}, "summary_fields": {"credential":
+        {"name": "bd-ssh-test", "description": "", "kind": "ssh", "cloud": false},
+        "project": {"name": "bd-project", "description": "", "status": "successful"},
+        "inventory": {"name": "bd", "description": "", "has_active_failures": false,
+        "total_hosts": 0, "hosts_with_active_failures": 0, "total_groups": 0, "groups_with_active_failures":
+        0, "has_inventory_sources": false, "total_inventory_sources": 0, "inventory_sources_with_failures":
+        0}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": []}, "created": "2016-11-28T19:36:51.518Z",
+        "modified": "2016-11-28T19:36:51.518Z", "name": "bd-test_no_survey", "description":
+        "", "job_type": "run", "inventory": 6, "project": 75, "playbook": "lamp_haproxy/rolling_update.yml",
+        "credential": 10, "cloud_credential": null, "forks": 0, "limit": "", "verbosity":
+        0, "extra_vars": "", "job_tags": "", "force_handlers": false, "skip_tags":
+        "", "start_at_task": "", "last_job_run": null, "last_job_failed": false, "has_schedules":
+        false, "next_job_run": null, "status": "never updated", "host_config_key":
+        "", "ask_variables_on_launch": false, "survey_enabled": false, "become_enabled":
+        false}, {"id": 153, "type": "job_template", "url": "/api/v1/job_templates/153/",
+        "related": {"created_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/75/", "credential": "/api/v1/credentials/8/",
+        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/762/",
+        "launch": "/api/v1/job_templates/153/launch/", "jobs": "/api/v1/job_templates/153/jobs/",
+        "activity_stream": "/api/v1/job_templates/153/activity_stream/", "schedules":
+        "/api/v1/job_templates/153/schedules/"}, "summary_fields": {"credential":
+        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
+        "project": {"name": "bd-project", "description": "", "status": "successful"},
+        "last_job": {"name": "bill-test", "description": "", "finished": "2016-09-12T21:12:56.077Z",
+        "status": "failed", "failed": true}, "last_update": {"name": "bill-test",
+        "description": "", "status": "failed", "failed": true}, "cloud_credential":
+        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
+        "inventory": {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures":
+        false, "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups":
+        63, "groups_with_active_failures": 0, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "failed", "finished": "2016-09-12T21:12:56.077Z",
+        "id": 762}, {"status": "failed", "finished": "2016-09-12T20:58:06.232Z", "id":
+        760}, {"status": "failed", "finished": "2016-09-12T20:56:53.361Z", "id": 758},
+        {"status": "failed", "finished": "2016-09-12T20:55:41.015Z", "id": 756}, {"status":
+        "failed", "finished": "2016-08-15T20:26:37.951Z", "id": 753}, {"status": "successful",
+        "finished": "2016-07-25T18:44:24.479Z", "id": 751}, {"status": "successful",
+        "finished": "2016-07-25T18:41:47.992Z", "id": 749}, {"status": "successful",
+        "finished": "2016-07-13T16:09:12.378Z", "id": 734}, {"status": "successful",
+        "finished": "2016-07-13T15:50:45.296Z", "id": 732}, {"status": "failed", "finished":
+        "2016-05-26T07:37:31.163Z", "id": 626}]}, "created": "2016-02-19T22:53:36.623Z",
+        "modified": "2016-09-12T20:58:06.263Z", "name": "bill-test", "description":
+        "", "job_type": "check", "inventory": 2, "project": 75, "playbook": "jboss-standalone/site.yml",
+        "credential": 8, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity":
+        0, "extra_vars": "extra1: val1\nextra2: val2\n", "job_tags": "", "force_handlers":
+        false, "skip_tags": "", "start_at_task": "", "last_job_run": "2016-09-12T21:12:56.077Z",
+        "last_job_failed": true, "has_schedules": false, "next_job_run": null, "status":
+        "failed", "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
+        false, "become_enabled": false}, {"id": 290, "type": "job_template", "url":
+        "/api/v1/job_templates/290/", "related": {"created_by": "/api/v1/users/1/",
+        "inventory": "/api/v1/inventories/2/", "project": "/api/v1/projects/289/",
+        "credential": "/api/v1/credentials/11/", "cloud_credential": "/api/v1/credentials/2/",
+        "last_job": "/api/v1/jobs/721/", "launch": "/api/v1/job_templates/290/launch/",
+        "jobs": "/api/v1/job_templates/290/jobs/", "activity_stream": "/api/v1/job_templates/290/activity_stream/",
+        "schedules": "/api/v1/job_templates/290/schedules/"}, "summary_fields": {"credential":
+        {"name": "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false},
+        "project": {"name": "db-minecraftpe-playbooks", "description": "EC2 PE MP
+        Server", "status": "successful"}, "last_job": {"name": "db-minecraftpe-ec2",
+        "description": "Minecraft Pocket Edition deployment via EC2", "finished":
+        "2016-06-15T19:02:29.460Z", "status": "successful", "failed": false}, "last_update":
+        {"name": "db-minecraftpe-ec2", "description": "Minecraft Pocket Edition deployment
+        via EC2", "status": "successful", "failed": false}, "cloud_credential": {"name":
+        "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true}, "inventory":
+        {"name": "AWS", "description": "CFME AWS Lab", "has_active_failures": false,
+        "total_hosts": 21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "successful",
+        "finished": "2016-06-15T19:02:29.460Z", "id": 721}, {"status": "successful",
+        "finished": "2016-06-15T18:06:41.660Z", "id": 718}, {"status": "successful",
+        "finished": "2016-06-01T22:37:34.183Z", "id": 715}, {"status": "successful",
+        "finished": "2016-06-01T19:30:49.772Z", "id": 712}, {"status": "canceled",
+        "finished": "2016-06-01T19:15:47.575Z", "id": 709}, {"status": "successful",
+        "finished": "2016-06-01T18:45:39.217Z", "id": 706}, {"status": "successful",
+        "finished": "2016-06-01T18:25:17.004Z", "id": 703}, {"status": "successful",
+        "finished": "2016-06-01T16:59:52.150Z", "id": 700}, {"status": "successful",
+        "finished": "2016-06-01T16:33:42.990Z", "id": 697}, {"status": "successful",
+        "finished": "2016-05-31T14:06:28.523Z", "id": 694}]}, "created": "2016-05-23T21:23:10.170Z",
+        "modified": "2016-06-15T18:54:04.941Z", "name": "db-minecraftpe-ec2", "description":
+        "Minecraft Pocket Edition deployment via EC2", "job_type": "run", "inventory":
+        2, "project": 289, "playbook": "minecraftpe-mp-ec2-ansible.yml", "credential":
+        11, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
+        "", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
+        "", "last_job_run": "2016-06-15T19:02:29.460Z", "last_job_failed": false,
+        "has_schedules": false, "next_job_run": null, "status": "successful", "host_config_key":
+        "", "ask_variables_on_launch": false, "survey_enabled": false, "become_enabled":
+        false}, {"id": 309, "type": "job_template", "url": "/api/v1/job_templates/309/",
+        "related": {"created_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/",
+        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/8/",
+        "last_job": "/api/v1/jobs/746/", "launch": "/api/v1/job_templates/309/launch/",
+        "jobs": "/api/v1/job_templates/309/jobs/", "activity_stream": "/api/v1/job_templates/309/activity_stream/",
+        "schedules": "/api/v1/job_templates/309/schedules/"}, "summary_fields": {"credential":
+        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
+        "project": {"name": "db-projects", "description": "projects", "status": "successful"},
+        "last_job": {"name": "db-package-info", "description": "", "finished": "2016-07-22T20:52:47.833Z",
+        "status": "failed", "failed": true}, "last_update": {"name": "db-package-info",
+        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
+        "finished": "2016-07-22T20:52:47.833Z", "id": 746}, {"status": "failed", "finished":
+        "2016-07-22T20:24:05.316Z", "id": 743}, {"status": "failed", "finished": "2016-07-22T20:18:06.722Z",
+        "id": 740}, {"status": "failed", "finished": "2016-07-22T20:00:50.067Z", "id":
+        736}]}, "created": "2016-07-22T19:36:22.509Z", "modified": "2016-07-22T20:52:19.007Z",
+        "name": "db-package-info", "description": "", "job_type": "run", "inventory":
+        17, "project": 93, "playbook": "pkginfo.yml", "credential": 8, "cloud_credential":
+        null, "forks": 0, "limit": "db-centos-7", "verbosity": 3, "extra_vars": "pkg:
+        abrt\nsleep: 15\nuser: root\npassword: \npostgresql_users:\n  - name: test\n    password:
+        test\n", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
+        "", "last_job_run": "2016-07-22T20:52:47.833Z", "last_job_failed": true, "has_schedules":
+        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 158, "type":
+        "job_template", "url": "/api/v1/job_templates/158/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
+        "project": "/api/v1/projects/93/", "credential": "/api/v1/credentials/11/",
+        "cloud_credential": "/api/v1/credentials/2/", "launch": "/api/v1/job_templates/158/launch/",
+        "jobs": "/api/v1/job_templates/158/jobs/", "activity_stream": "/api/v1/job_templates/158/activity_stream/",
+        "schedules": "/api/v1/job_templates/158/schedules/", "survey_spec": "/api/v1/job_templates/158/survey_spec/"},
+        "summary_fields": {"credential": {"name": "db", "description": "Drew Bomhof
+        Key", "kind": "ssh", "cloud": false}, "project": {"name": "db-projects", "description":
+        "projects", "status": "successful"}, "cloud_credential": {"name": "AWS", "description":
+        "AWS Instance", "kind": "aws", "cloud": true}, "inventory": {"name": "AWS",
+        "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "survey": {"description": "", "title": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": []}, "created": "2016-03-18T19:58:10.315Z", "modified":
+        "2016-03-18T19:59:27.667Z", "name": "db-survey-spec", "description": "db (state:
+        present, absent, running, stopped)", "job_type": "run", "inventory": 2, "project":
+        93, "playbook": "general_state_ec2.yml", "credential": 11, "cloud_credential":
+        2, "forks": 90, "limit": "test-from-keep", "verbosity": 3, "extra_vars": "instance_ids:
+        []\nregion: us-east-1\nstate: absent\nsubnet_id: subnet-16c70477\n", "job_tags":
+        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
+        null, "last_job_failed": false, "has_schedules": false, "next_job_run": null,
+        "status": "never updated", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": true, "become_enabled": false}, {"id": 147, "type":
+        "job_template", "url": "/api/v1/job_templates/147/", "related": {"created_by":
+        "/api/v1/users/1/", "inventory": "/api/v1/inventories/8/", "project": "/api/v1/projects/93/",
+        "credential": "/api/v1/credentials/11/", "cloud_credential": "/api/v1/credentials/2/",
+        "last_job": "/api/v1/jobs/172/", "launch": "/api/v1/job_templates/147/launch/",
+        "jobs": "/api/v1/job_templates/147/jobs/", "activity_stream": "/api/v1/job_templates/147/activity_stream/",
+        "schedules": "/api/v1/job_templates/147/schedules/"}, "summary_fields": {"credential":
+        {"name": "db", "description": "Drew Bomhof Key", "kind": "ssh", "cloud": false},
+        "project": {"name": "db-projects", "description": "projects", "status": "successful"},
+        "last_job": {"name": "Install Httpd / Ruby Modules / Start httpd", "description":
+        "db", "finished": "2016-03-24T14:59:03.013Z", "status": "failed", "failed":
+        true}, "last_update": {"name": "Install Httpd / Ruby Modules / Start httpd",
+        "description": "db", "status": "failed", "failed": true}, "cloud_credential":
+        {"name": "AWS", "description": "AWS Instance", "kind": "aws", "cloud": true},
+        "inventory": {"name": "Single AWS Host", "description": "54.86.210.90", "has_active_failures":
+        true, "total_hosts": 1, "hosts_with_active_failures": 1, "total_groups": 0,
+        "groups_with_active_failures": 0, "has_inventory_sources": false, "total_inventory_sources":
+        0, "inventory_sources_with_failures": 0}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "failed", "finished": "2016-03-24T14:59:03.013Z",
+        "id": 172}, {"status": "successful", "finished": "2016-01-29T21:28:19.553Z",
+        "id": 82}, {"status": "successful", "finished": "2016-01-29T21:21:34.597Z",
+        "id": 80}, {"status": "failed", "finished": "2016-01-29T21:19:04.267Z", "id":
+        78}]}, "created": "2016-01-29T21:17:18.420Z", "modified": "2016-03-23T23:30:03.345Z",
+        "name": "Install Httpd / Ruby Modules / Start httpd", "description": "db",
+        "job_type": "run", "inventory": 8, "project": 93, "playbook": "yum.yml", "credential":
+        11, "cloud_credential": 2, "forks": 0, "limit": "", "verbosity": 2, "extra_vars":
+        "", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
+        "", "last_job_run": "2016-03-24T14:59:03.013Z", "last_job_failed": true, "has_schedules":
+        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 242, "type":
+        "job_template", "url": "/api/v1/job_templates/242/", "related": {"created_by":
+        "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/", "project": "/api/v1/projects/240/",
+        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/730/", "launch":
+        "/api/v1/job_templates/242/launch/", "jobs": "/api/v1/job_templates/242/jobs/",
+        "activity_stream": "/api/v1/job_templates/242/activity_stream/", "schedules":
+        "/api/v1/job_templates/242/schedules/"}, "summary_fields": {"credential":
+        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
+        "project": {"name": "mkanoor", "description": "", "status": "successful"},
+        "last_job": {"name": "mk_sample", "description": "", "finished": "2016-06-23T18:47:46.680Z",
+        "status": "failed", "failed": true}, "last_update": {"name": "mk_sample",
+        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
+        "finished": "2016-06-23T18:47:46.680Z", "id": 730}, {"status": "successful",
+        "finished": "2016-04-19T14:20:01.028Z", "id": 411}, {"status": "successful",
+        "finished": "2016-04-19T14:00:22.817Z", "id": 407}, {"status": "successful",
+        "finished": "2016-04-19T13:23:45.379Z", "id": 401}, {"status": "successful",
+        "finished": "2016-04-04T19:40:57.514Z", "id": 342}, {"status": "successful",
+        "finished": "2016-04-04T16:10:35.124Z", "id": 329}, {"status": "successful",
+        "finished": "2016-04-04T15:17:42.086Z", "id": 325}, {"status": "successful",
+        "finished": "2016-04-04T14:54:36.057Z", "id": 315}, {"status": "successful",
+        "finished": "2016-04-04T01:21:08.024Z", "id": 311}, {"status": "successful",
+        "finished": "2016-04-02T00:10:57.944Z", "id": 305}]}, "created": "2016-04-01T21:13:52.006Z",
+        "modified": "2016-04-19T14:19:32.027Z", "name": "mk_sample", "description":
+        "", "job_type": "run", "inventory": 17, "project": 240, "playbook": "mk_sample_playbook.yaml",
+        "credential": 8, "cloud_credential": null, "forks": 0, "limit": "test_mkanoor_4_1420",
+        "verbosity": 0, "extra_vars": "{\n \"pkg\": \"abrt\",\n \"user\": \"root\"\n}",
+        "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
+        "", "last_job_run": "2016-06-23T18:47:46.680Z", "last_job_failed": true, "has_schedules":
+        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 241, "type":
+        "job_template", "url": "/api/v1/job_templates/241/", "related": {"created_by":
+        "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/", "project": "/api/v1/projects/240/",
+        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/864/", "launch":
+        "/api/v1/job_templates/241/launch/", "jobs": "/api/v1/job_templates/241/jobs/",
+        "activity_stream": "/api/v1/job_templates/241/activity_stream/", "schedules":
+        "/api/v1/job_templates/241/schedules/"}, "summary_fields": {"credential":
+        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
+        "project": {"name": "mkanoor", "description": "", "status": "successful"},
+        "last_job": {"name": "PackageInfo", "description": "", "finished": "2016-12-22T19:05:45.600Z",
+        "status": "failed", "failed": true}, "last_update": {"name": "PackageInfo",
+        "description": "", "status": "failed", "failed": true}, "inventory": {"name":
+        "Dev VC60", "description": "", "has_active_failures": true, "total_hosts":
+        139, "hosts_with_active_failures": 47, "total_groups": 28, "groups_with_active_failures":
+        24, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
+        "finished": "2016-12-22T19:05:45.600Z", "id": 864}, {"status": "failed", "finished":
+        "2016-12-19T20:24:44.587Z", "id": 862}, {"status": "failed", "finished": "2016-12-13T21:49:23.510Z",
+        "id": 860}, {"status": "failed", "finished": "2016-12-13T21:49:01.293Z", "id":
+        858}, {"status": "failed", "finished": "2016-12-07T16:24:27.841Z", "id": 856},
+        {"status": "successful", "finished": "2016-11-17T17:56:50.088Z", "id": 854},
+        {"status": "failed", "finished": "2016-11-17T17:25:55.010Z", "id": 852}, {"status":
+        "failed", "finished": "2016-11-15T19:08:33.238Z", "id": 850}, {"status": "failed",
+        "finished": "2016-11-15T18:39:41.601Z", "id": 848}, {"status": "failed", "finished":
+        "2016-11-15T15:33:35.359Z", "id": 846}]}, "created": "2016-04-01T20:27:22.819Z",
+        "modified": "2016-12-22T19:05:28.172Z", "name": "PackageInfo", "description":
+        "", "job_type": "run", "inventory": 17, "project": 240, "playbook": "pkg_info.yaml",
+        "credential": 8, "cloud_credential": null, "forks": 0, "limit": "test_mkanoor_05_24_16",
+        "verbosity": 0, "extra_vars": "pkg: abrt\nsleep: 15\nuser: root\n", "job_tags":
+        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
+        "2016-12-22T19:05:45.600Z", "last_job_failed": true, "has_schedules": false,
+        "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        false, "survey_enabled": false, "become_enabled": false}, {"id": 157, "type":
+        "job_template", "url": "/api/v1/job_templates/157/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/17/",
+        "credential": "/api/v1/credentials/8/", "last_job": "/api/v1/jobs/266/", "launch":
+        "/api/v1/job_templates/157/launch/", "jobs": "/api/v1/job_templates/157/jobs/",
+        "activity_stream": "/api/v1/job_templates/157/activity_stream/", "schedules":
+        "/api/v1/job_templates/157/schedules/"}, "summary_fields": {"credential":
+        {"name": "root", "description": "appliance2", "kind": "ssh", "cloud": false},
+        "last_job": {"name": "Sleep and Package Info", "description": "", "finished":
+        "2016-04-01T19:12:20.736Z", "status": "successful", "failed": false}, "last_update":
+        {"name": "Sleep and Package Info", "description": "", "status": "successful",
+        "failed": false}, "inventory": {"name": "Dev VC60", "description": "", "has_active_failures":
+        true, "total_hosts": 139, "hosts_with_active_failures": 47, "total_groups":
+        28, "groups_with_active_failures": 24, "has_inventory_sources": true, "total_inventory_sources":
+        1, "inventory_sources_with_failures": 1}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "modified_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "can_copy": true, "can_edit":
+        true, "recent_jobs": [{"status": "successful", "finished": "2016-04-01T19:12:20.736Z",
+        "id": 266}, {"status": "successful", "finished": "2016-04-01T18:58:46.152Z",
+        "id": 264}, {"status": "successful", "finished": "2016-04-01T18:40:52.071Z",
+        "id": 262}, {"status": "successful", "finished": "2016-04-01T16:00:16.592Z",
+        "id": 260}, {"status": "successful", "finished": "2016-04-01T14:48:22.257Z",
+        "id": 258}, {"status": "successful", "finished": "2016-04-01T13:38:44.674Z",
+        "id": 256}, {"status": "failed", "finished": "2016-04-01T13:34:02.275Z", "id":
+        255}, {"status": "failed", "finished": "2016-04-01T13:28:01.110Z", "id": 254},
+        {"status": "failed", "finished": "2016-03-31T19:52:14.905Z", "id": 252}, {"status":
+        "failed", "finished": "2016-03-31T19:50:14.419Z", "id": 250}]}, "created":
+        "2016-03-08T19:07:48.379Z", "modified": "2016-05-25T14:11:27.070Z", "name":
+        "Sleep and Package Info", "description": "", "job_type": "run", "inventory":
+        17, "project": null, "playbook": "", "credential": 8, "cloud_credential":
+        null, "forks": 0, "limit": "test_mk3_centos_7_1", "verbosity": 0, "extra_vars":
+        "{\n \"host\": \"test_mk3_centos_7_1\",\n \"pkg\": \"abrt\",\n \"sleep\":
+        30,\n \"user\": \"root\"\n}", "job_tags": "", "force_handlers": false, "skip_tags":
+        "", "start_at_task": "", "last_job_run": "2016-04-01T19:12:20.736Z", "last_job_failed":
+        false, "has_schedules": false, "next_job_run": null, "status": "successful",
+        "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
+        false, "become_enabled": false}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:44 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.052s
+      Content-Length:
+      - '223'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_description":
+        "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
+        "required": false, "variable": "test", "choices": "", "type": "text"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:45 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.054s
+      Content-Length:
+      - '223'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_description":
+        "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
+        "required": false, "variable": "test", "choices": "", "type": "text"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:45 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.052s
+      Content-Length:
+      - '456'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_name":
+        "Instance Id&apos;s", "min": "", "default": "", "max": "", "question_description":
+        "List of Instance Id&apos;s separated by a comma", "required": true, "variable":
+        "instance_ids", "choices": "", "type": "text"}, {"index": 1, "required": true,
+        "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
+        "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:46 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.053s
+      Content-Length:
+      - '456'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "question_name":
+        "Instance Id&apos;s", "min": "", "default": "", "max": "", "question_description":
+        "List of Instance Id&apos;s separated by a comma", "required": true, "variable":
+        "instance_ids", "choices": "", "type": "text"}, {"index": 1, "required": true,
+        "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
+        "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:47 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.052s
+      Content-Length:
+      - '189'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "required": true,
+        "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
+        "variable": "test_id", "type": "integer"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:47 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, DELETE, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.053s
+      Content-Length:
+      - '189'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"description": "", "name": "", "spec": [{"index": 0, "required": true,
+        "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
+        "variable": "test_id", "type": "integer"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:48 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/projects/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:48 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.112s
+      Content-Length:
+      - '9681'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 6, "next": null, "previous": null, "results": [{"id": 75,
+        "type": "project", "url": "/api/v1/projects/75/", "related": {"created_by":
+        "/api/v1/users/1/", "last_job": "/api/v1/project_updates/870/", "organizations":
+        "/api/v1/projects/75/organizations/", "playbooks": "/api/v1/projects/75/playbooks/",
+        "schedules": "/api/v1/projects/75/schedules/", "activity_stream": "/api/v1/projects/75/activity_stream/",
+        "project_updates": "/api/v1/projects/75/project_updates/", "update": "/api/v1/projects/75/update/",
+        "teams": "/api/v1/projects/75/teams/", "last_update": "/api/v1/project_updates/870/"},
+        "summary_fields": {"last_job": {"name": "bd-project", "description": "", "finished":
+        "2017-01-05T21:36:43.854Z", "status": "successful", "failed": false}, "last_update":
+        {"name": "bd-project", "description": "", "status": "successful", "failed":
+        false}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-05T20:49:49.548Z", "modified": "2016-01-05T20:51:34.467Z",
+        "name": "bd-project", "description": "", "local_path": "_75__bd_project",
+        "scm_type": "git", "scm_url": "https://github.com/ansible/ansible-examples.git",
+        "scm_branch": "", "scm_clean": false, "scm_delete_on_update": false, "credential":
+        null, "last_job_run": "2017-01-05T21:36:43.854Z", "last_job_failed": false,
+        "has_schedules": false, "next_job_run": null, "status": "successful", "scm_delete_on_next_update":
+        false, "scm_update_on_launch": false, "scm_update_cache_timeout": 0, "last_update_failed":
+        false, "last_updated": "2017-01-05T21:36:43.854Z"}, {"id": 93, "type": "project",
+        "url": "/api/v1/projects/93/", "related": {"created_by": "/api/v1/users/1/",
+        "credential": "/api/v1/credentials/9/", "last_job": "/api/v1/project_updates/747/",
+        "organizations": "/api/v1/projects/93/organizations/", "playbooks": "/api/v1/projects/93/playbooks/",
+        "schedules": "/api/v1/projects/93/schedules/", "activity_stream": "/api/v1/projects/93/activity_stream/",
+        "project_updates": "/api/v1/projects/93/project_updates/", "update": "/api/v1/projects/93/update/",
+        "teams": "/api/v1/projects/93/teams/", "last_update": "/api/v1/project_updates/747/"},
+        "summary_fields": {"credential": {"name": "db-github", "description": "db",
+        "kind": "scm", "cloud": false}, "last_job": {"name": "db-projects", "description":
+        "projects", "finished": "2016-07-22T20:52:29.666Z", "status": "successful",
+        "failed": false}, "last_update": {"name": "db-projects", "description": "projects",
+        "status": "successful", "failed": false}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}}, "created": "2016-01-21T16:58:55.698Z",
+        "modified": "2016-07-22T20:10:36.014Z", "name": "db-projects", "description":
+        "projects", "local_path": "_93__db_projects", "scm_type": "git", "scm_url":
+        "https://github.com/syncrou/playbooks.git", "scm_branch": "master", "scm_clean":
+        false, "scm_delete_on_update": false, "credential": 9, "last_job_run": "2016-07-22T20:52:29.666Z",
+        "last_job_failed": false, "has_schedules": false, "next_job_run": null, "status":
+        "successful", "scm_delete_on_next_update": false, "scm_update_on_launch":
+        true, "scm_update_cache_timeout": 0, "last_update_failed": false, "last_updated":
+        "2016-07-22T20:52:29.666Z"}, {"id": 240, "type": "project", "url": "/api/v1/projects/240/",
+        "related": {"created_by": "/api/v1/users/1/", "last_job": "/api/v1/project_updates/286/",
+        "organizations": "/api/v1/projects/240/organizations/", "playbooks": "/api/v1/projects/240/playbooks/",
+        "schedules": "/api/v1/projects/240/schedules/", "activity_stream": "/api/v1/projects/240/activity_stream/",
+        "project_updates": "/api/v1/projects/240/project_updates/", "update": "/api/v1/projects/240/update/",
+        "teams": "/api/v1/projects/240/teams/", "last_update": "/api/v1/project_updates/286/"},
+        "summary_fields": {"last_job": {"name": "mkanoor", "description": "", "finished":
+        "2016-04-01T21:12:31.634Z", "status": "successful", "failed": false}, "last_update":
+        {"name": "mkanoor", "description": "", "status": "successful", "failed": false},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-04-01T19:25:20.300Z", "modified": "2016-04-01T21:12:22.736Z",
+        "name": "mkanoor", "description": "", "local_path": "_240__mkanoor", "scm_type":
+        "git", "scm_url": "https://github.com/mkanoor/playbook", "scm_branch": "master",
+        "scm_clean": false, "scm_delete_on_update": false, "credential": null, "last_job_run":
+        "2016-04-01T21:12:31.634Z", "last_job_failed": false, "has_schedules": false,
+        "next_job_run": null, "status": "successful", "scm_delete_on_next_update":
+        false, "scm_update_on_launch": false, "scm_update_cache_timeout": 0, "last_update_failed":
+        false, "last_updated": "2016-04-01T21:12:31.634Z"}, {"id": 289, "type": "project",
+        "url": "/api/v1/projects/289/", "related": {"created_by": "/api/v1/users/1/",
+        "credential": "/api/v1/credentials/9/", "last_job": "/api/v1/project_updates/722/",
+        "organizations": "/api/v1/projects/289/organizations/", "playbooks": "/api/v1/projects/289/playbooks/",
+        "schedules": "/api/v1/projects/289/schedules/", "activity_stream": "/api/v1/projects/289/activity_stream/",
+        "project_updates": "/api/v1/projects/289/project_updates/", "update": "/api/v1/projects/289/update/",
+        "teams": "/api/v1/projects/289/teams/", "last_update": "/api/v1/project_updates/722/"},
+        "summary_fields": {"credential": {"name": "db-github", "description": "db",
+        "kind": "scm", "cloud": false}, "last_job": {"name": "db-minecraftpe-playbooks",
+        "description": "EC2 PE MP Server", "finished": "2016-06-15T18:54:16.637Z",
+        "status": "successful", "failed": false}, "last_update": {"name": "db-minecraftpe-playbooks",
+        "description": "EC2 PE MP Server", "status": "successful", "failed": false},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-05-23T21:21:05.336Z", "modified": "2016-05-26T18:04:58.675Z",
+        "name": "db-minecraftpe-playbooks", "description": "EC2 PE MP Server", "local_path":
+        "_289__db_minecraftpe_mp", "scm_type": "git", "scm_url": "https://github.com/syncrou/minecraft-pe-ec2-ansible",
+        "scm_branch": "master", "scm_clean": false, "scm_delete_on_update": false,
+        "credential": 9, "last_job_run": "2016-06-15T18:54:16.637Z", "last_job_failed":
+        false, "has_schedules": false, "next_job_run": null, "status": "successful",
+        "scm_delete_on_next_update": false, "scm_update_on_launch": true, "scm_update_cache_timeout":
+        10, "last_update_failed": false, "last_updated": "2016-06-15T18:54:16.637Z"},
+        {"id": 377, "type": "project", "url": "/api/v1/projects/377/", "related":
+        {"created_by": "/api/v1/users/1/", "last_job": "/api/v1/project_updates/866/",
+        "organizations": "/api/v1/projects/377/organizations/", "playbooks": "/api/v1/projects/377/playbooks/",
+        "schedules": "/api/v1/projects/377/schedules/", "activity_stream": "/api/v1/projects/377/activity_stream/",
+        "project_updates": "/api/v1/projects/377/project_updates/", "update": "/api/v1/projects/377/update/",
+        "teams": "/api/v1/projects/377/teams/", "last_update": "/api/v1/project_updates/866/"},
+        "summary_fields": {"last_job": {"name": "jwong-project", "description": "universe-creation",
+        "finished": "2017-01-04T15:33:20.766Z", "status": "failed", "failed": true},
+        "last_update": {"name": "jwong-project", "description": "universe-creation",
+        "status": "failed", "failed": true}, "created_by": {"id": 1, "username": "admin",
+        "first_name": "", "last_name": ""}}, "created": "2017-01-04T15:33:06.086Z",
+        "modified": "2017-01-04T15:33:07.222Z", "name": "jwong-project", "description":
+        "universe-creation", "local_path": "_377__jwong_project", "scm_type": "git",
+        "scm_url": "https://github.com/jameswnl/playbooks", "scm_branch": "", "scm_clean":
+        false, "scm_delete_on_update": false, "credential": null, "last_job_run":
+        "2017-01-04T15:33:20.766Z", "last_job_failed": true, "has_schedules": false,
+        "next_job_run": null, "status": "failed", "scm_delete_on_next_update": false,
+        "scm_update_on_launch": false, "scm_update_cache_timeout": 0, "last_update_failed":
+        true, "last_updated": "2017-01-04T15:33:20.766Z"}, {"id": 378, "type": "project",
+        "url": "/api/v1/projects/378/", "related": {"created_by": "/api/v1/users/1/",
+        "last_job": "/api/v1/project_updates/869/", "organizations": "/api/v1/projects/378/organizations/",
+        "playbooks": "/api/v1/projects/378/playbooks/", "schedules": "/api/v1/projects/378/schedules/",
+        "activity_stream": "/api/v1/projects/378/activity_stream/", "project_updates":
+        "/api/v1/projects/378/project_updates/", "update": "/api/v1/projects/378/update/",
+        "teams": "/api/v1/projects/378/teams/", "last_update": "/api/v1/project_updates/869/"},
+        "summary_fields": {"last_job": {"name": "test_madhu", "description": "testing
+        creating from REST API", "finished": "2017-01-04T22:12:12.741Z", "status":
+        "successful", "failed": false}, "last_update": {"name": "test_madhu", "description":
+        "testing creating from REST API", "status": "successful", "failed": false},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2017-01-04T21:29:32.479Z", "modified": "2017-01-04T21:40:46.051Z",
+        "name": "test_madhu", "description": "testing creating from REST API", "local_path":
+        "_378__test_madhu", "scm_type": "git", "scm_url": "https://github.com/mkanoor/playbook",
+        "scm_branch": "", "scm_clean": false, "scm_delete_on_update": false, "credential":
+        null, "last_job_run": "2017-01-04T22:12:12.741Z", "last_job_failed": false,
+        "has_schedules": false, "next_job_run": null, "status": "successful", "scm_delete_on_next_update":
+        false, "scm_update_on_launch": false, "scm_update_cache_timeout": 0, "last_update_failed":
+        false, "last_updated": "2017-01-04T22:12:12.741Z"}]}'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:49 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/75/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.069s
+      Content-Length:
+      - '2109'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '["jboss-standalone/demo-aws-launch.yml", "jboss-standalone/deploy-application.yml",
+        "jboss-standalone/site.yml", "lamp_haproxy/aws/demo-aws-launch.yml", "lamp_haproxy/aws/rolling_update.yml",
+        "lamp_haproxy/aws/site.yml", "lamp_haproxy/provision.yml", "lamp_haproxy/rolling_update.yml",
+        "lamp_haproxy/site.yml", "lamp_simple/site.yml", "lamp_simple_rhel7/site.yml",
+        "language_features/ansible_pull.yml", "language_features/batch_size_control.yml",
+        "language_features/cloudformation.yaml", "language_features/complex_args.yml",
+        "language_features/conditionals_part1.yml", "language_features/conditionals_part2.yml",
+        "language_features/custom_filters.yml", "language_features/delegation.yml",
+        "language_features/environment.yml", "language_features/eucalyptus-ec2.yml",
+        "language_features/file_secontext.yml", "language_features/get_url.yml", "language_features/group_by.yml",
+        "language_features/group_commands.yml", "language_features/intermediate_example.yml",
+        "language_features/intro_example.yml", "language_features/loop_nested.yml",
+        "language_features/loop_plugins.yml", "language_features/loop_with_items.yml",
+        "language_features/mysql.yml", "language_features/nested_playbooks.yml", "language_features/netscaler.yml",
+        "language_features/postgresql.yml", "language_features/prompts.yml", "language_features/rabbitmq.yml",
+        "language_features/register_logic.yml", "language_features/roletest.yml",
+        "language_features/roletest2.yml", "language_features/selective_file_sources.yml",
+        "language_features/tags.yml", "language_features/upgraded_vars.yml", "language_features/user_commands.yml",
+        "language_features/zfs.yml", "mongodb/playbooks/testsharding.yml", "mongodb/site.yml",
+        "tomcat-memcached-failover/site.yml", "tomcat-standalone/site.yml", "windows/create-user.yml",
+        "windows/deploy-site.yml", "windows/enable-iis.yml", "windows/install-msi.yml",
+        "windows/ping.yml", "windows/run-powershell.yml", "windows/test.yml", "windows/wamp_haproxy/demo-aws-wamp-launch.yml",
+        "windows/wamp_haproxy/rolling_update.yml", "windows/wamp_haproxy/site.yml",
+        "wordpress-nginx/site.yml", "wordpress-nginx_rhel7/site.yml"]'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:50 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/93/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.058s
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '["create_ec2.yml", "general_state_ec2.yml", "pkginfo.yml", "start_ec2.yml",
+        "stop_ec2.yml", "tag_old_nodes.yml", "yum.yml"]'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:50 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/240/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.058s
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '["mk_sample_playbook.yaml", "pkg_info.yaml", "pkg_info_no_sleep.yaml",
+        "test1.yaml"]'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:51 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/289/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.061s
+      Content-Length:
+      - '55'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '["minecraftpe-mp-ec2-ansible.yml", "server_config.yml"]'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:51 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/377/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.054s
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:52 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/378/playbooks/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Feb 2017 20:06:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.056s
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '["mk_sample_playbook.yaml", "pkg_info.yaml", "pkg_info_no_sleep.yaml",
+        "test1.yaml"]'
+    http_version: 
+  recorded_at: Thu, 09 Feb 2017 20:06:53 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
# The 📼 🕺 

Here it is, 2++ hours of my life

### Why?

Because, in Tower v3 Job Templates can have `network_credentials` - in Tower v3 not.

### Changes

Updated specs and re-recorded cassette to work with ansible tower v3

@miq-bot add_labels providers/ansible_tower
@miq-bot assign bdunne

@bdunne please review

<sub>
Did I mention we are in post vcr age? It's your random tube streaming on your mobile, man.
</sub>