### PR TITLE
Ansible refresh inventory credentials

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/inventory/collector/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/collector/automation_manager.rb
@@ -16,10 +16,10 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Collector::AutomationManager
   end
 
   def projects
-    @connection.api.projects.all
+    connection.api.projects.all
   end
 
   def credentials
-    @connection.api.credentials.all
+    connection.api.credentials.all
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/collector/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/collector/automation_manager.rb
@@ -18,4 +18,8 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Collector::AutomationManager
   def projects
     @connection.api.projects.all
   end
+
+  def credentials
+    @connection.api.credentials.all
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
       %w(credential_id cloud_credential network_credential).each do |credential_attr|
         credential_id = i.send(credential_attr).to_s
         next if credential_id.blank?
-        o[:authentications] << target.configuration_script_authentications.lazy_find(credential_id)
+        o[:authentications] << target.credentials.lazy_find(credential_id)
       end
     end
   end
@@ -59,7 +59,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
 
   def credentials
     collector.credentials.each do |i|
-      o = target.configuration_script_authentications.find_or_build(i.id.to_s)
+      o = target.credentials.find_or_build(i.id.to_s)
       o[:name] = i.name
       # i.description
       # i.host
@@ -95,6 +95,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
                  when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
                    # when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
                  when 'openstack' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential'
+                 else 'ManageIQ::Providers::AutomationManager::Authentication'
                  end
     end
   end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -34,8 +34,9 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
       o[:inventory_root_group] = target.inventory_groups.lazy_find(i.inventory_id.to_s)
 
       o[:authentications] = []
-      %w(credential_id cloud_credential network_credential).each do |credential_attr|
-        credential_id = i.send(credential_attr).to_s
+      %w(credential_id cloud_credential_id network_credential_id).each do |credential_attr|
+        next unless i.respond_to?(credential_attr)
+        credential_id = i.public_send(credential_attr).to_s
         next if credential_id.blank?
         o[:authentications] << target.credentials.lazy_find(credential_id)
       end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -8,96 +8,95 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
   end
 
   def inventory_groups
-    collector.inventories.each do |i|
-      o = target.inventory_groups.find_or_build(i.id.to_s)
-      o[:name] = i.name
+    collector.inventories.each do |inventory|
+      inventory_object = target.inventory_groups.find_or_build(inventory.id.to_s)
+      inventory_object[:name] = inventory.name
     end
   end
 
   def configured_systems
-    collector.hosts.each do |i|
-      o = target.configured_systems.find_or_build(i.id)
-      o[:hostname] = i.name
-      o[:virtual_instance_ref] = i.instance_id
-      o[:inventory_root_group] = target.inventory_groups.lazy_find(i.inventory_id.to_s)
-      o[:counterpart] = Vm.find_by(:uid_ems => i.instance_id)
+    collector.hosts.each do |host|
+      inventory_object = target.configured_systems.find_or_build(host.id)
+      inventory_object[:hostname] = host.name
+      inventory_object[:virtual_instance_ref] = host.instance_id
+      inventory_object[:inventory_root_group] = target.inventory_groups.lazy_find(host.inventory_id.to_s)
+      inventory_object[:counterpart] = Vm.find_by(:uid_ems => host.instance_id)
     end
   end
 
   def configuration_scripts
-    collector.job_templates.each do |i|
-      o = target.configuration_scripts.find_or_build(i.id.to_s)
-      o[:description] = i.description
-      o[:name] = i.name
-      o[:survey_spec] = i.survey_spec_hash
-      o[:variables] = i.extra_vars_hash
-      o[:inventory_root_group] = target.inventory_groups.lazy_find(i.inventory_id.to_s)
+    collector.job_templates.each do |job_template|
+      inventory_object = target.configuration_scripts.find_or_build(job_template.id.to_s)
+      inventory_object[:description] = job_template.description
+      inventory_object[:name] = job_template.name
+      inventory_object[:survey_spec] = job_template.survey_spec_hash
+      inventory_object[:variables] = job_template.extra_vars_hash
+      inventory_object[:inventory_root_group] = target.inventory_groups.lazy_find(job_template.inventory_id.to_s)
 
-      o[:authentications] = []
+      inventory_object[:authentications] = []
       %w(credential_id cloud_credential_id network_credential_id).each do |credential_attr|
-        next unless i.respond_to?(credential_attr)
-        credential_id = i.public_send(credential_attr).to_s
+        next unless job_template.respond_to?(credential_attr)
+        credential_id = job_template.public_send(credential_attr).to_s
         next if credential_id.blank?
-        o[:authentications] << target.credentials.lazy_find(credential_id)
+        inventory_object[:authentications] << target.credentials.lazy_find(credential_id)
       end
     end
   end
 
   def configuration_script_sources
-    collector.projects.each do |i|
-      o = target.configuration_script_sources.find_or_build(i.id.to_s)
-      o[:description] = i.description
-      o[:name] = i.name
+    collector.projects.each do |project|
+      inventory_object = target.configuration_script_sources.find_or_build(project.id.to_s)
+      inventory_object[:description] = project.description
+      inventory_object[:name] = project.name
 
-      i.playbooks.each do |playbook_name|
+      project.playbooks.each do |playbook_name|
         # FIXME: its not really nice how I have to build a manager_ref / uuid here
-        p = target.playbooks.find_or_build("#{i.id}__#{playbook_name}")
-        p[:configuration_script_source] = o
-        p[:name] = playbook_name
+        inventory_object_playbook = target.playbooks.find_or_build("#{project.id}__#{playbook_name}")
+        inventory_object_playbook[:configuration_script_source] = inventory_object
+        inventory_object_playbook[:name] = playbook_name
       end
     end
   end
 
   def credentials
-    collector.credentials.each do |i|
-      o = target.credentials.find_or_build(i.id.to_s)
-      o[:name] = i.name
-      # i.description
-      # i.host
-      o[:userid] = i.username
-      # i.password
-      # i.security_token
-      # i.project
-      # i.domain
-      # i.ssh_key_data
-      # i.ssh_key_unlock
-      # i.organization
-      # i.become_method # '', 'sudo', 'su', 'pbrun', 'pfexec'
-      # i.become_username
-      # i.become_password
-      # i.vault_password
-      # i.subscription
-      # i.tenant
-      # i.secret
-      # i.client
-      # i.authorize
-      # i.authorize_password
-      o[:type] = case i.kind
-                   # FIXME: not a big fan of modelling all credentials via inheritance
-                 when 'net' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential'
-                 when 'ssh' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential'
-                 when 'vmware' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential'
-                   # when 'scm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
-                 when 'aws' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential'
-                 when 'rax' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::RackspaceCredential'
-                 when 'satellite6' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential'
-                   # when 'cloudforms' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::$$$Credential'
-                 when 'gce' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential'
-                 when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
-                   # when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
-                 when 'openstack' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential'
-                 else 'ManageIQ::Providers::AutomationManager::Authentication'
-                 end
+    collector.credentials.each do |credential|
+      inventory_object = target.credentials.find_or_build(credential.id.to_s)
+      inventory_object[:name] = credential.name
+      inventory_object[:userid] = credential.username
+      # credential.description
+      # credential.host
+      # credential.password
+      # credential.security_token
+      # credential.project
+      # credential.domain
+      # credential.ssh_key_data
+      # credential.ssh_key_unlock
+      # credential.organization
+      # credential.become_method # '', 'sudo', 'su', 'pbrun', 'pfexec'
+      # credential.become_username
+      # credential.become_password
+      # credential.vault_password
+      # credential.subscription
+      # credential.tenant
+      # credential.secret
+      # credential.client
+      # credential.authorize
+      # credential.authorize_password
+      inventory_object[:type] = case credential.kind
+                                when 'net' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential'
+                                when 'ssh' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential'
+                                when 'vmware' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential'
+                                # when 'scm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
+                                when 'aws' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential'
+                                when 'rax' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::RackspaceCredential'
+                                when 'satellite6' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential'
+                                # when 'cloudforms' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::$$$Credential'
+                                when 'gce' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential'
+                                when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
+                                # when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
+                                when 'openstack' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential'
+                                else 'ManageIQ::Providers::AutomationManager::Authentication'
+                                end
     end
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -92,8 +92,8 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
                                 when 'satellite6' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential'
                                 # when 'cloudforms' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::$$$Credential'
                                 when 'gce' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential'
-                                when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
-                                # when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
+                                # when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
+                                when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
                                 when 'openstack' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential'
                                 else 'ManageIQ::Providers::AutomationManager::Authentication'
                                 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -33,13 +33,11 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
       o[:variables] = i.extra_vars_hash
       o[:inventory_root_group] = target.inventory_groups.lazy_find(i.inventory_id.to_s)
 
+      o[:authentications] = []
       %w(credential_id cloud_credential network_credential).each do |credential_attr|
         credential_id = i.send(credential_attr).to_s
         next if credential_id.blank?
-        target.authentication_configuration_script_bases.build(
-          :authentication            => target.configuration_script_authentications.lazy_find(credential_id),
-          :configuration_script_base => o
-        )
+        o[:authentications] << target.configuration_script_authentications.lazy_find(credential_id)
       end
     end
   end

--- a/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
@@ -48,12 +48,13 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < 
     )
   end
 
-  def configuration_script_authentications
-    collections[:configuration_script_authentications] ||= ManagerRefresh::InventoryCollection.new(
-      :model_class => ManageIQ::Providers::AutomationManager::Authentication,
-      :association => :configuration_script_authentications,
-      :manager_ref => [:manager_ref],
-      :parent      => @root,
+  def credentials
+    collections[:credentials] ||= ManagerRefresh::InventoryCollection.new(
+      :model_class    => ManageIQ::Providers::AutomationManager::Authentication,
+      :association    => :credentials,
+      :manager_ref    => [:manager_ref],
+      :parent         => @root,
+      :builder_params => {:resource => @root}
     )
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
@@ -47,4 +47,22 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < 
       :builder_params => {:manager => @root}
     )
   end
+
+  def authentication_configuration_script_bases
+    collections[:authentication_configuration_script_bases] ||= ManagerRefresh::InventoryCollection.new(
+      :model_class => AuthenticationConfigurationScriptBase,
+      :association => :authentication_configuration_script_bases,
+      :manager_ref => [:authentication, :configuration_script_base],
+      :parent      => @root,
+    )
+  end
+
+  def configuration_script_authentications
+    collections[:configuration_script_authentications] ||= ManagerRefresh::InventoryCollection.new(
+      :model_class => ManageIQ::Providers::AutomationManager::Authentication,
+      :association => :configuration_script_authentications,
+      :manager_ref => [:manager_ref],
+      :parent      => @root,
+    )
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/target/automation_manager.rb
@@ -48,15 +48,6 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Target::AutomationManager < 
     )
   end
 
-  def authentication_configuration_script_bases
-    collections[:authentication_configuration_script_bases] ||= ManagerRefresh::InventoryCollection.new(
-      :model_class => AuthenticationConfigurationScriptBase,
-      :association => :authentication_configuration_script_bases,
-      :manager_ref => [:authentication, :configuration_script_base],
-      :parent      => @root,
-    )
-  end
-
   def configuration_script_authentications
     collections[:configuration_script_authentications] ||= ManagerRefresh::InventoryCollection.new(
       :model_class => ManageIQ::Providers::AutomationManager::Authentication,

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -5,9 +5,7 @@ class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :authentication_configuration_script_bases, :through => :configuration_scripts
-  # FIXME: cant use :authentications here, because thats delegated to :provider in ansible
-  has_many :configuration_script_authentications, :through => :authentication_configuration_script_bases, :source => :authentication
+  has_many :configuration_script_authentications, :through => :configuration_scripts, :source => :authentications
   has_many :inventory_groups,             :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :inventory_root_groups,        :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -5,6 +5,9 @@ class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :authentication_configuration_script_bases, :through => :configuration_scripts
+  # FIXME: cant use :authentications here, because thats delegated to :provider in ansible
+  has_many :configuration_script_authentications, :through => :authentication_configuration_script_bases, :source => :authentication
   has_many :inventory_groups,             :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :inventory_root_groups,        :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -5,7 +5,8 @@ class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_script_authentications, :through => :configuration_scripts, :source => :authentications
+  has_many :credentials,                  :class_name => "ManageIQ::Providers::AutomationManager::Authentication",
+           :as => :resource, :dependent => :destroy
   has_many :inventory_groups,             :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :inventory_root_groups,        :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager
   has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager.rb
@@ -2,5 +2,6 @@ module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager <
       MiqAeServiceManageIQ_Providers_ExternalAutomationManager
     expose :configuration_scripts, :association => true
+    expose :credentials, :association => true
   end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
@@ -73,7 +73,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
     expect(automation_manager.inventory_groups.count).to      eq(6)
     expect(automation_manager.configuration_script_sources.count).to eq(6)
     expect(automation_manager.configuration_script_payloads.count).to eq(438)
-    expect(automation_manager.configuration_script_authentications.count).to eq(13)
+    expect(automation_manager.credentials.count).to eq(8)
   end
 
   def assert_credentials

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
@@ -39,6 +39,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
       assert_inventory_root_group
       assert_configuration_script_sources
       assert_playbooks
+      assert_credentials
     end
   end
 
@@ -50,6 +51,25 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
     expect(automation_manager.inventory_groups.count).to      eq(8)
     expect(automation_manager.configuration_script_sources.count).to eq(6)
     expect(automation_manager.configuration_script_payloads.count).to eq(77)
+    expect(automation_manager.credentials.count).to eq(11)
+  end
+
+  def assert_credentials
+    expect(expected_configuration_script.authentications.count).to eq(2)
+    machine_credential = expected_configuration_script.authentications.find_by(
+      :type => ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential
+    )
+    expect(machine_credential).to have_attributes(
+      :name   => "appliance",
+      :userid => "root",
+    )
+    cloud_credential = expected_configuration_script.authentications.find_by(
+      :type => ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential
+    )
+    expect(cloud_credential).to have_attributes(
+      :name   => "AWS",
+      :userid => "065ZMGNV5WNKPMX4FF82",
+    )
   end
 
   def assert_playbooks

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_credentials.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_credentials.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Wed, 08 Feb 2017 12:24:06 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/credentials/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 08 Feb 2017 11:24:08 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 08 Feb 2017 12:24:07 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.138s
+      Content-Length:
+      - '11849'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count":8,"next":null,"previous":null,"results":[{"id":5,"type":"credential","url":"/api/v1/credentials/5/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/5/owner_teams/","owner_users":"/api/v1/credentials/5/owner_users/","activity_stream":"/api/v1/credentials/5/activity_stream/","access_list":"/api/v1/credentials/5/access_list/","object_roles":"/api/v1/credentials/5/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":92,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":94,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":93,"name":"Read"}},"owners":[]},"created":"2017-01-17T22:13:22.752Z","modified":"2017-01-17T22:13:22.805Z","name":"Demo
+        Creds 2","description":"test","kind":"net","cloud":false,"host":"","username":"awdd","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":3,"type":"credential","url":"/api/v1/credentials/3/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/3/owner_teams/","owner_users":"/api/v1/credentials/3/owner_users/","activity_stream":"/api/v1/credentials/3/activity_stream/","access_list":"/api/v1/credentials/3/access_list/","object_roles":"/api/v1/credentials/3/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":71,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":73,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":72,"name":"Read"}},"owners":[]},"created":"2017-01-09T16:12:22.945Z","modified":"2017-01-09T16:12:22.994Z","name":"db-github","description":"db-github","kind":"scm","cloud":false,"host":"","username":"syncrou","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":8,"type":"credential","url":"/api/v1/credentials/8/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/8/owner_teams/","owner_users":"/api/v1/credentials/8/owner_users/","activity_stream":"/api/v1/credentials/8/activity_stream/","access_list":"/api/v1/credentials/8/access_list/","object_roles":"/api/v1/credentials/8/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":152,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":154,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":153,"name":"Read"}},"owners":[{"url":"/api/v1/users/1/","description":"
+        ","type":"user","id":1,"name":"admin"}]},"created":"2017-02-01T19:34:37.462Z","modified":"2017-02-01T19:34:45.377Z","name":"bd-test-change","description":"","kind":"ssh","cloud":false,"host":"","username":"admin","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":6,"type":"credential","url":"/api/v1/credentials/6/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/6/owner_teams/","owner_users":"/api/v1/credentials/6/owner_users/","activity_stream":"/api/v1/credentials/6/activity_stream/","access_list":"/api/v1/credentials/6/access_list/","object_roles":"/api/v1/credentials/6/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":95,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":97,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":96,"name":"Read"}},"owners":[]},"created":"2017-01-24T21:24:48.633Z","modified":"2017-01-24T21:24:48.683Z","name":"db_test","description":"","kind":"ssh","cloud":false,"host":"","username":"","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":1,"type":"credential","url":"/api/v1/credentials/1/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/1/owner_teams/","owner_users":"/api/v1/credentials/1/owner_users/","activity_stream":"/api/v1/credentials/1/activity_stream/","access_list":"/api/v1/credentials/1/access_list/","object_roles":"/api/v1/credentials/1/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":12,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":14,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":13,"name":"Read"}},"owners":[{"url":"/api/v1/users/1/","description":"
+        ","type":"user","id":1,"name":"admin"}]},"created":"2016-08-02T17:57:03.019Z","modified":"2016-08-02T17:57:03.109Z","name":"Demo
+        Credential","description":"","kind":"ssh","cloud":false,"host":"","username":"admin","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":4,"type":"credential","url":"/api/v1/credentials/4/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/1/","owner_teams":"/api/v1/credentials/4/owner_teams/","owner_users":"/api/v1/credentials/4/owner_users/","activity_stream":"/api/v1/credentials/4/activity_stream/","access_list":"/api/v1/credentials/4/access_list/","object_roles":"/api/v1/credentials/4/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":1,"name":"Default","description":""},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":86,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":88,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":87,"name":"Read"}},"owners":[]},"created":"2017-01-16T15:50:23.815Z","modified":"2017-01-16T15:50:23.865Z","name":"Demo
+        Creds 2","description":"test","kind":"ssh","cloud":false,"host":"","username":"demo-cred","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"sudo","become_username":"root","become_password":"$encrypted$","vault_password":"$encrypted$","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":2,"type":"credential","url":"/api/v1/credentials/2/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/2/owner_teams/","owner_users":"/api/v1/credentials/2/owner_users/","activity_stream":"/api/v1/credentials/2/activity_stream/","access_list":"/api/v1/credentials/2/access_list/","object_roles":"/api/v1/credentials/2/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":28,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":30,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":29,"name":"Read"}},"owners":[{"url":"/api/v1/users/1/","description":"
+        ","type":"user","id":1,"name":"admin"}]},"created":"2016-08-30T22:41:59.056Z","modified":"2016-08-31T16:59:02.652Z","name":"dev-vc60","description":"","kind":"vmware","cloud":true,"host":"dev-vc60.cloudforms.lab.eng.rdu2.redhat.com","username":"MiqAnsibleUser@vsphere.local","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""},{"id":7,"type":"credential","url":"/api/v1/credentials/7/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","organization":"/api/v1/organizations/3/","owner_teams":"/api/v1/credentials/7/owner_teams/","owner_users":"/api/v1/credentials/7/owner_users/","activity_stream":"/api/v1/credentials/7/activity_stream/","access_list":"/api/v1/credentials/7/access_list/","object_roles":"/api/v1/credentials/7/object_roles/"},"summary_fields":{"host":{},"project":{},"organization":{"id":3,"name":"ACME
+        Corp","description":"Which belongs to goern"},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":112,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":114,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":113,"name":"Read"}},"owners":[]},"created":"2017-01-30T11:07:37.190Z","modified":"2017-01-30T11:07:37.269Z","name":"syseng-e2e-vcenter6","description":"This
+        is a vCenter","kind":"vmware","cloud":true,"host":"vcsa6.vcenter.e2e.bos.redhat.com","username":"administrator@vsphere.local","password":"$encrypted$","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""}]}'
+    http_version: 
+  recorded_at: Wed, 08 Feb 2017 11:24:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_credentials.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_credentials.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower2.example.com/api/v1/credentials/
+      - https://dev-ansible-tower3.example.com/api/v1/credentials/
       Content-Length:
       - '0'
       Content-Type:
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Wed, 08 Feb 2017 11:24:08 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials/
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/credentials/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:31 GMT
+      - Fri, 10 Feb 2017 16:16:05 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -32,7 +32,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:30 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:04 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
@@ -52,7 +52,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:32 GMT
+      - Fri, 10 Feb 2017 16:16:05 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -60,7 +60,7 @@ http_interactions:
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.212s
+      - 0.204s
       Content-Length:
       - '2548'
       Content-Type:
@@ -88,11 +88,11 @@ http_interactions:
         OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
         "license_info": {"deployment_id": "21c7c190b553a923410b8027f7890b8483ba892a",
         "subscription_name": "Ansible Tower by Red Hat, Self-Support (500 Managed
-        Nodes)", "grace_period_remaining": 6940408, "features": {"surveys": false,
+        Nodes)", "grace_period_remaining": 6867834, "features": {"surveys": false,
         "multiple_organizations": false, "system_tracking": false, "enterprise_auth":
         false, "rebranding": false, "activity_streams": false, "ldap": false, "ha":
         false}, "date_expired": false, "available_instances": 500, "time_remaining":
-        4348408, "current_instances": 168, "free_instances": 332, "instance_count":
+        4275834, "current_instances": 168, "free_instances": 332, "instance_count":
         500, "trial": false, "compliant": true, "valid_key": true, "contact_email":
         "matburt@redhat.com", "company_name": "Basic Company", "date_warning": false,
         "license_type": "basic", "contact_name": "Lumber McLumberjack", "license_date":
@@ -101,7 +101,7 @@ http_interactions:
         "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
         []}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:31 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:05 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories
@@ -121,7 +121,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:33 GMT
+      - Fri, 10 Feb 2017 16:16:06 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -134,7 +134,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:32 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:05 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/inventories/
@@ -154,7 +154,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:33 GMT
+      - Fri, 10 Feb 2017 16:16:07 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -162,7 +162,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.080s
+      - 0.077s
       Content-Length:
       - '10375'
       Content-Type:
@@ -289,7 +289,7 @@ http_interactions:
         1, "total_groups": 0, "groups_with_active_failures": 0, "has_inventory_sources":
         false, "total_inventory_sources": 0, "inventory_sources_with_failures": 0}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:32 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:06 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts
@@ -309,7 +309,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:34 GMT
+      - Fri, 10 Feb 2017 16:16:07 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -322,7 +322,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:33 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:07 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/
@@ -342,7 +342,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:34 GMT
+      - Fri, 10 Feb 2017 16:16:08 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -350,7 +350,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.273s
+      - 0.274s
       Content-Length:
       - '75817'
       Content-Type:
@@ -1230,7 +1230,7 @@ http_interactions:
         \"gray\"}", "has_active_failures": false, "has_inventory_sources": true, "last_job":
         852, "last_job_host_summary": 1451}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:34 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:08 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=2
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:36 GMT
+      - Fri, 10 Feb 2017 16:16:09 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -1258,7 +1258,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.283s
+      - 0.286s
       Content-Length:
       - '96525'
       Content-Type:
@@ -2375,7 +2375,7 @@ http_interactions:
         \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
         true, "last_job": null, "last_job_host_summary": null}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:35 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:09 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=3
@@ -2395,7 +2395,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:37 GMT
+      - Fri, 10 Feb 2017 16:16:11 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -2403,7 +2403,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.309s
+      - 0.286s
       Content-Length:
       - '96385'
       Content-Type:
@@ -3521,7 +3521,7 @@ http_interactions:
         "has_active_failures": false, "has_inventory_sources": true, "last_job": 852,
         "last_job_host_summary": 1436}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:36 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:11 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=4
@@ -3541,7 +3541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:38 GMT
+      - Fri, 10 Feb 2017 16:16:12 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -3549,7 +3549,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.310s
+      - 0.302s
       Content-Length:
       - '112298'
       Content-Type:
@@ -4855,7 +4855,7 @@ http_interactions:
         \"rhel6_64Guest\"}", "has_active_failures": false, "has_inventory_sources":
         true, "last_job": 852, "last_job_host_summary": 1433}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:38 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:12 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=5
@@ -4875,7 +4875,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:39 GMT
+      - Fri, 10 Feb 2017 16:16:14 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -4883,7 +4883,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.330s
+      - 0.291s
       Content-Length:
       - '101439'
       Content-Type:
@@ -6060,7 +6060,7 @@ http_interactions:
         "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
         "last_job_host_summary": 1462}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:39 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:13 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=6
@@ -6080,7 +6080,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:41 GMT
+      - Fri, 10 Feb 2017 16:16:15 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -6088,7 +6088,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.303s
+      - 0.300s
       Content-Length:
       - '106639'
       Content-Type:
@@ -7327,7 +7327,7 @@ http_interactions:
         "has_active_failures": true, "has_inventory_sources": true, "last_job": 852,
         "last_job_host_summary": 1463}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:40 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:15 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/hosts/?page=7
@@ -7347,7 +7347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:42 GMT
+      - Fri, 10 Feb 2017 16:16:16 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -7355,7 +7355,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.239s
+      - 0.243s
       Content-Length:
       - '70229'
       Content-Type:
@@ -8155,7 +8155,7 @@ http_interactions:
         "instance_id": "", "variables": "---", "has_active_failures": true, "has_inventory_sources":
         false, "last_job": 172, "last_job_host_summary": 215}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:42 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:16 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config
@@ -8175,7 +8175,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:43 GMT
+      - Fri, 10 Feb 2017 16:16:17 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -8188,7 +8188,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:42 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:16 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/config/
@@ -8208,7 +8208,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:44 GMT
+      - Fri, 10 Feb 2017 16:16:18 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8216,7 +8216,7 @@ http_interactions:
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.204s
+      - 0.206s
       Content-Length:
       - '2548'
       Content-Type:
@@ -8244,11 +8244,11 @@ http_interactions:
         OF THE TOWER SOFTWARE ON ANOTHER PERSON\u2019S OR ENTITY\u2019S BEHALF.\n",
         "license_info": {"deployment_id": "21c7c190b553a923410b8027f7890b8483ba892a",
         "subscription_name": "Ansible Tower by Red Hat, Self-Support (500 Managed
-        Nodes)", "grace_period_remaining": 6940396, "features": {"surveys": false,
+        Nodes)", "grace_period_remaining": 6867822, "features": {"surveys": false,
         "multiple_organizations": false, "system_tracking": false, "enterprise_auth":
         false, "rebranding": false, "activity_streams": false, "ldap": false, "ha":
         false}, "date_expired": false, "available_instances": 500, "time_remaining":
-        4348396, "current_instances": 168, "free_instances": 332, "instance_count":
+        4275822, "current_instances": 168, "free_instances": 332, "instance_count":
         500, "trial": false, "compliant": true, "valid_key": true, "contact_email":
         "matburt@redhat.com", "company_name": "Basic Company", "date_warning": false,
         "license_type": "basic", "contact_name": "Lumber McLumberjack", "license_date":
@@ -8257,7 +8257,7 @@ http_interactions:
         "time_zone": "America/New_York", "ansible_version": "1.9.4", "project_local_paths":
         []}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:43 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:17 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates
@@ -8277,7 +8277,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:44 GMT
+      - Fri, 10 Feb 2017 16:16:19 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -8290,7 +8290,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:43 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:18 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/
@@ -8310,7 +8310,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:45 GMT
+      - Fri, 10 Feb 2017 16:16:19 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8318,9 +8318,9 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.197s
+      - 0.202s
       Content-Length:
-      - '35312'
+      - '35577'
       Content-Type:
       - application/json
     body:
@@ -8328,29 +8328,32 @@ http_interactions:
       string: '{"count": 14, "next": null, "previous": null, "results": [{"id": 149,
         "type": "job_template", "url": "/api/v1/job_templates/149/", "related": {"created_by":
         "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
-        "project": "/api/v1/projects/75/", "last_job": "/api/v1/jobs/119/", "launch":
-        "/api/v1/job_templates/149/launch/", "jobs": "/api/v1/job_templates/149/jobs/",
+        "project": "/api/v1/projects/75/", "credential": "/api/v1/credentials/6/",
+        "cloud_credential": "/api/v1/credentials/2/", "last_job": "/api/v1/jobs/119/",
+        "launch": "/api/v1/job_templates/149/launch/", "jobs": "/api/v1/job_templates/149/jobs/",
         "activity_stream": "/api/v1/job_templates/149/activity_stream/", "schedules":
-        "/api/v1/job_templates/149/schedules/"}, "summary_fields": {"project": {"name":
-        "bd-project", "description": "", "status": "successful"}, "last_job": {"name":
-        "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description", "finished":
-        "2016-02-18T21:52:36.072Z", "status": "failed", "failed": true}, "last_update":
+        "/api/v1/job_templates/149/schedules/"}, "summary_fields": {"credential":
+        {"name": "appliance", "description": "", "kind": "ssh", "cloud": false}, "project":
+        {"name": "bd-project", "description": "", "status": "successful"}, "last_job":
         {"name": "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description",
-        "status": "failed", "failed": true}, "inventory": {"name": "AWS", "description":
-        "CFME AWS Lab", "has_active_failures": false, "total_hosts": 21, "hosts_with_active_failures":
-        0, "total_groups": 63, "groups_with_active_failures": 0, "has_inventory_sources":
-        true, "total_inventory_sources": 1, "inventory_sources_with_failures": 1},
-        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        "finished": "2016-02-18T21:52:36.072Z", "status": "failed", "failed": true},
+        "last_update": {"name": "Ansible-JobTemplate", "description": "Ansible-JobTemplate-Description",
+        "status": "failed", "failed": true}, "cloud_credential": {"name": "AWS", "description":
+        "AWS Instance", "kind": "aws", "cloud": true}, "inventory": {"name": "AWS",
+        "description": "CFME AWS Lab", "has_active_failures": false, "total_hosts":
+        21, "hosts_with_active_failures": 0, "total_groups": 63, "groups_with_active_failures":
+        0, "has_inventory_sources": true, "total_inventory_sources": 1, "inventory_sources_with_failures":
+        1}, "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
         ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
         ""}, "can_copy": true, "can_edit": true, "recent_jobs": [{"status": "failed",
         "finished": "2016-02-18T21:52:36.072Z", "id": 119}]}, "created": "2016-02-05T23:09:47.943Z",
-        "modified": "2016-11-15T19:07:10.239Z", "name": "Ansible-JobTemplate", "description":
+        "modified": "2017-02-10T16:15:29.704Z", "name": "Ansible-JobTemplate", "description":
         "Ansible-JobTemplate-Description", "job_type": "run", "inventory": 2, "project":
-        75, "playbook": "language_features/group_commands.yml", "credential": null,
-        "cloud_credential": null, "forks": 0, "limit": "", "verbosity": 0, "extra_vars":
-        "abc: 123\n", "job_tags": "", "force_handlers": false, "skip_tags": "", "start_at_task":
-        "", "last_job_run": "2016-02-18T21:52:36.072Z", "last_job_failed": true, "has_schedules":
-        false, "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
+        75, "playbook": "language_features/group_commands.yml", "credential": 6, "cloud_credential":
+        2, "forks": 0, "limit": "", "verbosity": 0, "extra_vars": "abc: 123\n", "job_tags":
+        "", "force_handlers": false, "skip_tags": "", "start_at_task": "", "last_job_run":
+        "2016-02-18T21:52:36.072Z", "last_job_failed": true, "has_schedules": false,
+        "next_job_run": null, "status": "failed", "host_config_key": "", "ask_variables_on_launch":
         false, "survey_enabled": false, "become_enabled": false}, {"id": 155, "type":
         "job_template", "url": "/api/v1/job_templates/155/", "related": {"created_by":
         "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "inventory": "/api/v1/inventories/2/",
@@ -8755,7 +8758,7 @@ http_interactions:
         "host_config_key": "", "ask_variables_on_launch": false, "survey_enabled":
         false, "become_enabled": false}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:44 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:19 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
@@ -8775,7 +8778,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:46 GMT
+      - Fri, 10 Feb 2017 16:16:20 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8794,7 +8797,7 @@ http_interactions:
         "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
         "required": false, "variable": "test", "choices": "", "type": "text"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:45 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:19 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/155/survey_spec/
@@ -8814,7 +8817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:46 GMT
+      - Fri, 10 Feb 2017 16:16:21 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8822,7 +8825,7 @@ http_interactions:
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.054s
+      - 0.052s
       Content-Length:
       - '223'
       Content-Type:
@@ -8833,7 +8836,7 @@ http_interactions:
         "Survey", "min": "", "default": "", "max": "", "question_name": "Survey",
         "required": false, "variable": "test", "choices": "", "type": "text"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:45 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:20 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
@@ -8853,7 +8856,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:47 GMT
+      - Fri, 10 Feb 2017 16:16:21 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8875,7 +8878,7 @@ http_interactions:
         "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
         "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:46 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:20 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/143/survey_spec/
@@ -8895,7 +8898,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:48 GMT
+      - Fri, 10 Feb 2017 16:16:22 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8917,7 +8920,7 @@ http_interactions:
         "min": "", "default": "", "max": "", "question_name": "Big list", "choices":
         "Blah\nNah\nTah", "variable": "crap_id", "type": "multiselect"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:47 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:21 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
@@ -8937,7 +8940,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:48 GMT
+      - Fri, 10 Feb 2017 16:16:22 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8956,7 +8959,7 @@ http_interactions:
         "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
         "variable": "test_id", "type": "integer"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:47 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:22 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/job_templates/158/survey_spec/
@@ -8976,7 +8979,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:49 GMT
+      - Fri, 10 Feb 2017 16:16:23 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -8984,7 +8987,7 @@ http_interactions:
       Allow:
       - GET, POST, DELETE, HEAD, OPTIONS
       X-Api-Time:
-      - 0.053s
+      - 0.052s
       Content-Length:
       - '189'
       Content-Type:
@@ -8995,7 +8998,7 @@ http_interactions:
         "min": 0, "default": 0, "max": 2, "question_name": "Test", "choices": "",
         "variable": "test_id", "type": "integer"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:48 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:22 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects
@@ -9015,7 +9018,7 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:49 GMT
+      - Fri, 10 Feb 2017 16:16:24 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
@@ -9028,7 +9031,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:48 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:23 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/
@@ -9048,7 +9051,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:50 GMT
+      - Fri, 10 Feb 2017 16:16:24 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9056,7 +9059,7 @@ http_interactions:
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Api-Time:
-      - 0.112s
+      - 0.116s
       Content-Length:
       - '9681'
       Content-Type:
@@ -9178,7 +9181,7 @@ http_interactions:
         false, "scm_update_on_launch": false, "scm_update_cache_timeout": 0, "last_update_failed":
         false, "last_updated": "2017-01-04T22:12:12.741Z"}]}'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:49 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:23 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/75/playbooks/
@@ -9198,7 +9201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:51 GMT
+      - Fri, 10 Feb 2017 16:16:25 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9206,7 +9209,7 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.069s
+      - 0.066s
       Content-Length:
       - '2109'
       Content-Type:
@@ -9238,7 +9241,7 @@ http_interactions:
         "windows/wamp_haproxy/rolling_update.yml", "windows/wamp_haproxy/site.yml",
         "wordpress-nginx/site.yml", "wordpress-nginx_rhel7/site.yml"]'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:50 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:24 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/93/playbooks/
@@ -9258,7 +9261,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:51 GMT
+      - Fri, 10 Feb 2017 16:16:25 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9266,7 +9269,7 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.058s
+      - 0.057s
       Content-Length:
       - '123'
       Content-Type:
@@ -9276,7 +9279,7 @@ http_interactions:
       string: '["create_ec2.yml", "general_state_ec2.yml", "pkginfo.yml", "start_ec2.yml",
         "stop_ec2.yml", "tag_old_nodes.yml", "yum.yml"]'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:50 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:25 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/240/playbooks/
@@ -9296,7 +9299,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:52 GMT
+      - Fri, 10 Feb 2017 16:16:26 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9304,7 +9307,7 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.058s
+      - 0.055s
       Content-Length:
       - '84'
       Content-Type:
@@ -9314,7 +9317,7 @@ http_interactions:
       string: '["mk_sample_playbook.yaml", "pkg_info.yaml", "pkg_info_no_sleep.yaml",
         "test1.yaml"]'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:51 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:25 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/289/playbooks/
@@ -9334,7 +9337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:52 GMT
+      - Fri, 10 Feb 2017 16:16:27 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9342,7 +9345,7 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.061s
+      - 0.059s
       Content-Length:
       - '55'
       Content-Type:
@@ -9351,7 +9354,7 @@ http_interactions:
       encoding: UTF-8
       string: '["minecraftpe-mp-ec2-ansible.yml", "server_config.yml"]'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:51 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:26 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/377/playbooks/
@@ -9371,7 +9374,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:53 GMT
+      - Fri, 10 Feb 2017 16:16:27 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9388,7 +9391,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:52 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:27 GMT
 - request:
     method: get
     uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/projects/378/playbooks/
@@ -9408,7 +9411,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 09 Feb 2017 20:06:54 GMT
+      - Fri, 10 Feb 2017 16:16:28 GMT
       Server:
       - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -9416,7 +9419,7 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.056s
+      - 0.058s
       Content-Length:
       - '84'
       Content-Type:
@@ -9426,5 +9429,203 @@ http_interactions:
       string: '["mk_sample_playbook.yaml", "pkg_info.yaml", "pkg_info_no_sleep.yaml",
         "test1.yaml"]'
     http_version: 
-  recorded_at: Thu, 09 Feb 2017 20:06:53 GMT
+  recorded_at: Fri, 10 Feb 2017 16:16:27 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Fri, 10 Feb 2017 16:16:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower2.example.com/api/v1/credentials/
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 10 Feb 2017 16:16:28 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower2.example.com/api/v1/credentials/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Feb 2017 16:16:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.074s
+      Content-Length:
+      - '10459'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count": 11, "next": null, "previous": null, "results": [{"id": 2,
+        "type": "credential", "url": "/api/v1/credentials/2/", "related": {"created_by":
+        "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "activity_stream":
+        "/api/v1/credentials/2/activity_stream/", "user": "/api/v1/users/1/"}, "summary_fields":
+        {"project": {}, "host": {}, "user": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:04:04.021Z", "modified":
+        "2016-01-28T16:24:36.551Z", "name": "AWS", "description": "AWS Instance",
+        "user": 1, "team": null, "kind": "aws", "cloud": true, "host": "", "username":
+        "065ZMGNV5WNKPMX4FF82", "password": "$encrypted$", "security_token": "", "project":
+        "", "ssh_key_data": "", "ssh_key_unlock": "", "become_method": "", "become_username":
+        "", "become_password": "", "vault_password": ""}, {"id": 1, "type": "credential",
+        "url": "/api/v1/credentials/1/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "activity_stream": "/api/v1/credentials/1/activity_stream/",
+        "user": "/api/v1/users/2/"}, "summary_fields": {"project": {}, "host": {},
+        "user": {"id": 2, "username": "dbomhof", "first_name": "Drew", "last_name":
+        "Bomhof"}, "created_by": {"id": 1, "username": "admin", "first_name": "",
+        "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T16:55:29.495Z", "modified":
+        "2015-12-17T21:27:48.511Z", "name": "Openstack", "description": "RHOS in NC",
+        "user": 2, "team": null, "kind": "openstack", "cloud": true, "host": "http://10.8.96.4:5000/v2.0",
+        "username": "admin", "password": "$encrypted$", "security_token": "", "project":
+        "admin", "ssh_key_data": "", "ssh_key_unlock": "", "become_method": "", "become_username":
+        "", "become_password": "", "vault_password": ""}, {"id": 3, "type": "credential",
+        "url": "/api/v1/credentials/3/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "activity_stream": "/api/v1/credentials/3/activity_stream/",
+        "user": "/api/v1/users/2/"}, "summary_fields": {"project": {}, "host": {},
+        "user": {"id": 2, "username": "dbomhof", "first_name": "Drew", "last_name":
+        "Bomhof"}, "created_by": {"id": 1, "username": "admin", "first_name": "",
+        "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2015-12-17T18:10:39.866Z", "modified":
+        "2015-12-17T21:27:58.989Z", "name": "Skynet", "description": "Openstack Support
+        Area", "user": 2, "team": null, "kind": "openstack", "cloud": true, "host":
+        "http://skynet-cloud.usersys.redhat.com:5000/v2.0", "username": "admin", "password":
+        "$encrypted$", "security_token": "", "project": "admin", "ssh_key_data": "",
+        "ssh_key_unlock": "", "become_method": "", "become_username": "", "become_password":
+        "", "vault_password": ""}, {"id": 9, "type": "credential", "url": "/api/v1/credentials/9/",
+        "related": {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/",
+        "activity_stream": "/api/v1/credentials/9/activity_stream/", "user": "/api/v1/users/2/"},
+        "summary_fields": {"project": {}, "host": {}, "user": {"id": 2, "username":
+        "dbomhof", "first_name": "Drew", "last_name": "Bomhof"}, "created_by": {"id":
+        1, "username": "admin", "first_name": "", "last_name": ""}, "modified_by":
+        {"id": 1, "username": "admin", "first_name": "", "last_name": ""}}, "created":
+        "2016-01-21T16:57:51.833Z", "modified": "2016-01-21T16:57:51.846Z", "name":
+        "db-github", "description": "db", "user": 2, "team": null, "kind": "scm",
+        "cloud": false, "host": "", "username": "syncrou", "password": "$encrypted$",
+        "security_token": "", "project": "", "ssh_key_data": "", "ssh_key_unlock":
+        "", "become_method": "", "become_username": "", "become_password": "", "vault_password":
+        ""}, {"id": 6, "type": "credential", "url": "/api/v1/credentials/6/", "related":
+        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "activity_stream":
+        "/api/v1/credentials/6/activity_stream/", "user": "/api/v1/users/1/"}, "summary_fields":
+        {"project": {}, "host": {}, "user": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2016-01-05T21:01:58.823Z", "modified":
+        "2016-01-05T21:01:58.836Z", "name": "appliance", "description": "", "user":
+        1, "team": null, "kind": "ssh", "cloud": false, "host": "", "username": "root",
+        "password": "$encrypted$", "security_token": "", "project": "", "ssh_key_data":
+        "", "ssh_key_unlock": "", "become_method": "", "become_username": "", "become_password":
+        "", "vault_password": ""}, {"id": 10, "type": "credential", "url": "/api/v1/credentials/10/",
+        "related": {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/",
+        "activity_stream": "/api/v1/credentials/10/activity_stream/", "user": "/api/v1/users/1/"},
+        "summary_fields": {"project": {}, "host": {}, "user": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "created_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}, "modified_by": {"id": 1, "username":
+        "admin", "first_name": "", "last_name": ""}}, "created": "2016-01-25T21:30:00.798Z",
+        "modified": "2016-01-25T21:30:00.810Z", "name": "bd-ssh-test", "description":
+        "", "user": 1, "team": null, "kind": "ssh", "cloud": false, "host": "", "username":
+        "bdunne", "password": "", "security_token": "", "project": "", "ssh_key_data":
+        "$encrypted$", "ssh_key_unlock": "", "become_method": "", "become_username":
+        "", "become_password": "", "vault_password": ""}, {"id": 11, "type": "credential",
+        "url": "/api/v1/credentials/11/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "activity_stream": "/api/v1/credentials/11/activity_stream/",
+        "user": "/api/v1/users/1/"}, "summary_fields": {"project": {}, "host": {},
+        "user": {"id": 1, "username": "admin", "first_name": "", "last_name": ""},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-01-28T14:28:57.891Z", "modified": "2016-01-28T16:20:54.535Z",
+        "name": "db", "description": "Drew Bomhof Key", "user": 1, "team": null, "kind":
+        "ssh", "cloud": false, "host": "", "username": "ec2-user", "password": "",
+        "security_token": "", "project": "", "ssh_key_data": "$encrypted$", "ssh_key_unlock":
+        "$encrypted$", "become_method": "", "become_username": "", "become_password":
+        "", "vault_password": ""}, {"id": 18, "type": "credential", "url": "/api/v1/credentials/18/",
+        "related": {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/",
+        "activity_stream": "/api/v1/credentials/18/activity_stream/", "user": "/api/v1/users/5/"},
+        "summary_fields": {"project": {}, "host": {}, "user": {"id": 5, "username":
+        "mkanoor", "first_name": "Madhu", "last_name": "Kanoor"}, "created_by": {"id":
+        1, "username": "admin", "first_name": "", "last_name": ""}, "modified_by":
+        {"id": 1, "username": "admin", "first_name": "", "last_name": ""}}, "created":
+        "2017-01-04T22:29:44.025Z", "modified": "2017-01-04T22:29:44.035Z", "name":
+        "GIT", "description": "built using rest api", "user": 5, "team": null, "kind":
+        "ssh", "cloud": false, "host": "", "username": "freddy", "password": "$encrypted$",
+        "security_token": "", "project": "", "ssh_key_data": "", "ssh_key_unlock":
+        "", "become_method": "", "become_username": "", "become_password": "", "vault_password":
+        ""}, {"id": 8, "type": "credential", "url": "/api/v1/credentials/8/", "related":
+        {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/", "activity_stream":
+        "/api/v1/credentials/8/activity_stream/", "user": "/api/v1/users/1/"}, "summary_fields":
+        {"project": {}, "host": {}, "user": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2016-01-21T16:51:19.073Z", "modified":
+        "2016-01-21T16:51:19.085Z", "name": "root", "description": "appliance2", "user":
+        1, "team": null, "kind": "ssh", "cloud": false, "host": "", "username": "root",
+        "password": "$encrypted$", "security_token": "", "project": "", "ssh_key_data":
+        "", "ssh_key_unlock": "", "become_method": "", "become_username": "", "become_password":
+        "", "vault_password": ""}, {"id": 17, "type": "credential", "url": "/api/v1/credentials/17/",
+        "related": {"created_by": "/api/v1/users/1/", "modified_by": "/api/v1/users/1/",
+        "activity_stream": "/api/v1/credentials/17/activity_stream/"}, "summary_fields":
+        {"project": {}, "host": {}, "created_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}, "modified_by": {"id": 1, "username": "admin", "first_name":
+        "", "last_name": ""}}, "created": "2017-01-04T22:22:46.022Z", "modified":
+        "2017-01-04T22:22:46.072Z", "name": "testing madhu", "description": "", "user":
+        null, "team": null, "kind": "ssh", "cloud": false, "host": "", "username":
+        "freddy", "password": "$encrypted$", "security_token": "", "project": "",
+        "ssh_key_data": "", "ssh_key_unlock": "", "become_method": "", "become_username":
+        "", "become_password": "", "vault_password": ""}, {"id": 16, "type": "credential",
+        "url": "/api/v1/credentials/16/", "related": {"created_by": "/api/v1/users/1/",
+        "modified_by": "/api/v1/users/1/", "activity_stream": "/api/v1/credentials/16/activity_stream/",
+        "user": "/api/v1/users/1/"}, "summary_fields": {"project": {}, "host": {},
+        "user": {"id": 1, "username": "admin", "first_name": "", "last_name": ""},
+        "created_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}, "modified_by": {"id": 1, "username": "admin", "first_name": "", "last_name":
+        ""}}, "created": "2016-03-31T18:42:11.244Z", "modified": "2016-08-31T15:58:17.005Z",
+        "name": "Dev VC60", "description": "", "user": 1, "team": null, "kind": "vmware",
+        "cloud": true, "host": "dev-vc60.example.com", "username":
+        "MiqAnsibleUser@vsphere.local", "password": "$encrypted$", "security_token":
+        "", "project": "", "ssh_key_data": "", "ssh_key_unlock": "", "become_method":
+        "", "become_username": "", "become_password": "", "vault_password": ""}]}'
+    http_version: 
+  recorded_at: Fri, 10 Feb 2017 16:16:28 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
# Refreshes credentials for Ansible Tower

* I only include `:name` and `:userid` for now, because I dont know how the other fields should map to our model

* I dont like the massive sub classing of credentials - isnt there a field in `authentications` which we can just re-use and fill from ansible? Now we have to touch this code whenever ansible introduces an new credentials type

* The naming of `authentication_configuration_script_bases` caused some severe pain in my head. Can we try to give it a bit more descriptive name? Like `ConfigurationScriptRelationToAuthentication`? Not really much better, but still.

@miq-bot assign @blomquisg 
@Ladas please review the inventory refresh part
@jameswnl please review the credentials part
