### PR TITLE
[EUWE] Fix Host getting disconnected from Cluster when migrating a VM in RHEV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -403,7 +403,8 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
       # If the vm has a host but the refresh does not include it in the "hosts" hash
       if host.blank? && vm_inv[:host].present?
-        host = partial_host_hash(vm_inv[:host])
+        host_inv = vm_inv[:host].merge(:cluster => ems_cluster)
+        host = partial_host_hash(host_inv)
         added_hosts << host if host
       end
 
@@ -444,7 +445,11 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
   def self.partial_host_hash(partial_host_inv)
     ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(partial_host_inv[:href])
-    { :ems_ref => ems_ref, :uid_ems => partial_host_inv[:id] }
+    {
+      :ems_ref     => ems_ref,
+      :uid_ems     => partial_host_inv[:id],
+      :ems_cluster => partial_host_inv[:cluster]
+    }
   end
 
   def self.create_vm_hash(template, ems_ref, vm_id, name)


### PR DESCRIPTION
Euwe backport of https://github.com/ManageIQ/manageiq/pull/13815

When building a minimal host hash for migrated vm targeted refresh include the ems_cluster with the host so that it doesn't clear the ems_cluster_id when saving.

#13511 fixed saving a VM when it gets migrated to a new host but as a result the cluster link to that host got cleared when it was saved. This adds the cluster link to the minimal host hash so that it is saved properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1420003