### PR TITLE
Allow adding datawarehouse provider with a port other than 80

### DIFF
--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -9,7 +9,9 @@ module ManageIQ::Providers
     include AuthenticationMixin
 
     DEFAULT_PORT = 80
-    default_value_for :port, DEFAULT_PORT
+    default_value_for :port do |provider|
+      provider.port || DEFAULT_PORT
+    end
 
     def verify_credentials(_auth_type = nil, options = {})
       connect(options).fetch_version_and_status


### PR DESCRIPTION
When adding a datawarehouse provider, port 80 is being used for the "default" role endpoint, even if a different port was specified.
