### PR TITLE
MiqReport: Avoid calculation of array's length if you just check emptyness

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -175,7 +175,7 @@ class MiqReport < ApplicationRecord
 
   def contains_records?
     (extras.key?(:total_html_rows) && extras[:total_html_rows] > 0) ||
-      (table && table.data.length > 0)
+      (table && !table.data.empty?)
   end
 
   def to_hash

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -400,7 +400,7 @@ module MiqReport::Generator
     result = build_apply_display_filter(result) unless display_filter.nil?
 
     @table = Ruport::Data::Table.new(:data => result, :column_names => column_names)
-    @table.reorder(column_names) unless @table.data.length == 0
+    @table.reorder(column_names) unless @table.data.empty?
 
     # Remove any resource columns that were added earlier to col_order so they won't appear in the report
     col_order.delete_if { |c| res_cols.include?(c) && !orig_col_order.include?(c) } if res_cols
@@ -430,7 +430,7 @@ module MiqReport::Generator
     only_cols = options[:only] || (self.cols + generate_cols + build_cols_from_include(include)).uniq
     column_names = result.empty? ? self.cols : result.first.keys
     @table = Ruport::Data::Table.new(:data => result, :column_names => column_names)
-    @table.reorder(only_cols) unless @table.data.length == 0
+    @table.reorder(only_cols) unless @table.data.empty?
 
     build_sort_table
   end
@@ -815,7 +815,7 @@ module MiqReport::Generator
   end
 
   def table_has_records?
-    table.length > 0
+    !table.empty?
   end
 
   def queue_timeout

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -11,7 +11,7 @@ module MiqReport::Generator::Html
     group_limit = self.rpt_options[:group_limit]
     in_a_widget = self.rpt_options[:in_a_widget] || false
 
-    unless table.nil? || table.data.length == 0
+    unless table.nil? || table.data.empty?
       # Following line commented for now - for not showing repeating column values
       #       prev_data = String.new                # Initialize the prev_data variable
 


### PR DESCRIPTION
This is a nitpick.

However, I started looking into MiqReport codebase. This bothered me to look at as it
 * was longer & harder to read
 * brings unnecessary performance hit

@miq-bot add_label reporting, technical debt, euwe/no
@miq-bot assign @gtanzillo 