### PR TITLE
Add config_info as additional attribute to Service Templates API

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -5,7 +5,7 @@ module Api
     include Subcollections::ResourceActions
     include Subcollections::ServiceRequests
 
-    before_action :set_additional_attributes, :only => [:index, :show]
+    before_action :set_additional_attributes, :only => [:show]
 
     private
 

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -4,5 +4,13 @@ module Api
     include Subcollections::Tags
     include Subcollections::ResourceActions
     include Subcollections::ServiceRequests
+
+    before_action :set_additional_attributes, :only => [:index, :show]
+
+    private
+
+    def set_additional_attributes
+      @additional_attributes = %w(config_info)
+    end
   end
 end

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -65,20 +65,6 @@ describe "Service Templates API" do
                                   "image_href"  => /^http:.*#{picture.image_href}$/)
     end
 
-    it 'returns config_info on all service template resources' do
-      api_basic_authorize collection_action_identifier(:service_templates, :read, :get)
-
-      run_get(service_templates_url, :expand => 'resources')
-
-      expected = {
-        'resources' => [
-          a_hash_including('config_info' => template.config_info.deep_stringify_keys)
-        ]
-      }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(expected)
-    end
-
     it 'returns config_info for a specific service_template resource' do
       api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
 

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -64,6 +64,32 @@ describe "Service Templates API" do
                                   "resource_id" => template.id,
                                   "image_href"  => /^http:.*#{picture.image_href}$/)
     end
+
+    it 'returns config_info on all service template resources' do
+      api_basic_authorize collection_action_identifier(:service_templates, :read, :get)
+
+      run_get(service_templates_url, :expand => 'resources')
+
+      expected = {
+        'resources' => [
+          a_hash_including('config_info' => template.config_info.deep_stringify_keys)
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns config_info for a specific service_template resource' do
+      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+
+      run_get(service_templates_url(template.id))
+
+      expected = {
+        'config_info' => template.config_info.deep_stringify_keys
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe "Service Templates edit" do


### PR DESCRIPTION
This returns the `config_info` of a `ServiceTemplate` so the format returned matches the format that is expected for both `create` and `update` actions. IE, the expected input is:

```
      {
        :name         => 'Ansible Tower',
        :service_type => 'generic_ansible_tower',
        :prov_type    => 'amazon',
        :display      => 'false',
        :description  => 'a description',
        :config_info  => {
          :configuration_script_id => configuration_script.id,
          :provision               => {
            :fqname    => ra1.fqname,
            :dialog_id => service_dialog.id
          },
          :retirement              => {
            :fqname    => ra2.fqname,
            :dialog_id => service_dialog.id
          }
        }
      }
```

This format will now be returned when retrieving the service template.

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 

cc: @bzwei 