### PR TITLE
Fix broken C&U collection

### DIFF
--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -151,6 +151,7 @@ class VimPerformanceState < ApplicationRecord
   def capture_disk_types
     if hardware
       self.allocated_disk_types = hardware.disks.each_with_object({}) do |disk, res|
+        next if disk.size.nil?
         type = disk.backing.try(:volume_type) || 'unclassified'
         res[type] = (res[type] || 0) + disk.size
       end


### PR DESCRIPTION
in cases when we don't collect disk size.

Addressing failure like:
```
TypeError: nil can't be coerced into Fixnum
	from app/models/vim_performance_state.rb:156:in `+'
	from app/models/vim_performance_state.rb:156:in `block in capture_disk_types'
	from app/models/vim_performance_state.rb:153:in `each_with_object'
	from app/models/vim_performance_state.rb:153:in `capture_disk_types'
	from app/models/vim_performance_state.rb:71:in `capture'
	from app/models/vim_performance_state.rb:53:in `capture'
	from app/models/metric/ci_mixin/capture.rb:216:in `perf_capture_state'
```

This is broken since day 0, as I didn't anticipated `nil` in `Disk.pluck(:size)`

This code is in master only. So euwe/no.

@miq-bot add_label metrics, bug, euwe/no
@miq-bot assign @gtanzillo 
