### PR TITLE
Api enhancement to support optional collection_class parameter

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -341,18 +341,11 @@ module Api
         param = params['collection_class']
         return unless param.present?
 
-        begin
-          param_klass = param.constantize
-        rescue
-          raise BadRequestError, "Invalid collection_class #{param} specified"
-        end
+        klass = collection_class(@req.collection)
+        return if param == klass.name
 
-        collection_klass = collection_config[@req.collection].klass.constantize
-
-        # If it is the collection's class, then we're good to go as is.
-        return if param_klass == collection_klass
-
-        if param_klass < collection_klass
+        param_klass = klass.descendants.detect { |sub_klass| param == sub_klass.name }
+        if param_klass.present?
           @collection_klasses[@req.collection.to_sym] = param_klass
           return
         end

--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -47,7 +47,7 @@ class RestApi
     API_PARAMETERS       = %w(expand hide attributes decorators limit offset
                               depth search_options
                               sort_by sort_order sort_options
-                              filter by_tag provider_class requester_type).freeze
+                              filter by_tag provider_class collection_class requester_type).freeze
 
     MULTI_PARAMS         = %w(filter).freeze
 


### PR DESCRIPTION
- Allows subclassing any collection
- specified via ?collection_class=<class>
      i.e. GET /api/vms?collection_class=ManageIQ::Providers::CloudManager::Vm
- Updated CLI to support --collection-class=<class>

https://www.pivotaltracker.com/story/show/139478269