### PR TITLE
Migrate Ansible Tower InventoryRootGroup to be of AutomationManager

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/inventory.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/inventory.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory < ManageIQ::Providers::AutomationManager::InventoryGroup
+end

--- a/db/migrate/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type.rb
+++ b/db/migrate/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type.rb
@@ -1,0 +1,21 @@
+class MigrateAnsibleTowerConfigurationManagerInventoryRootGroupStiType < ActiveRecord::Migration[5.0]
+  class EmsFolder < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Migrating STI type of ansible_tower inventory_root_groups to be of automation_manager') do
+      EmsFolder.where(:type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup').update_all(
+        :type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup'
+      )
+    end
+  end
+
+  def down
+    say_with_time('Migrating STI type of ansible_tower inventory_root_groups to be of configuration_manager') do
+      EmsFolder.where(:type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup').update_all(
+        :type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup'
+      )
+    end
+  end
+end

--- a/db/migrate/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type.rb
+++ b/db/migrate/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type.rb
@@ -4,16 +4,16 @@ class MigrateAnsibleTowerConfigurationManagerInventoryRootGroupStiType < ActiveR
   end
 
   def up
-    say_with_time('Migrating STI type of ansible_tower inventory_root_groups to be of automation_manager') do
+    say_with_time('Migrating STI type of ansible_tower inventory_root_groups to automation_manager inventorys') do
       EmsFolder.where(:type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup').update_all(
-        :type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup'
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory'
       )
     end
   end
 
   def down
-    say_with_time('Migrating STI type of ansible_tower inventory_root_groups to be of configuration_manager') do
-      EmsFolder.where(:type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup').update_all(
+    say_with_time('Migrating STI type of ansible_tower inventorys to configuration_manager inventory_root_groups') do
+      EmsFolder.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory').update_all(
         :type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup'
       )
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-inventory.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-inventory.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_Inventory < MiqAeServiceManageIQ_Providers_AutomationManager_InventoryGroup
+  end
+end

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-inventory_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-inventory_spec.rb
@@ -1,0 +1,5 @@
+describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_Inventory do
+  it "get the service model class" do
+    expect { described_class }.not_to raise_error
+  end
+end

--- a/spec/migrations/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type_spec.rb
+++ b/spec/migrations/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type_spec.rb
@@ -1,0 +1,35 @@
+require_migration
+
+describe MigrateAnsibleTowerConfigurationManagerInventoryRootGroupStiType do
+  let(:inventory_root_group_stub) { migration_stub(:EmsFolder) }
+
+  migration_context :up do
+    it 'migrates Ansible Tower InventoryRootGroup to be of AutomationManager type' do
+      irg = inventory_root_group_stub.create!(
+        :type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup'
+      )
+
+      migrate
+
+      expect(irg.reload.type).to eq('ManageIQ::Providers::AutomationManager::InventoryRootGroup')
+    end
+
+    it 'will not migrate InventoryRootGroup other than those of Ansible Tower ConfigurationManager' do
+      irg = inventory_root_group_stub.create!(:type => 'ManageIQ::Providers::SomeManager::InventoryRootGroup')
+
+      migrate
+
+      expect(irg.reload.type).to eq('ManageIQ::Providers::SomeManager::InventoryRootGroup')
+    end
+  end
+
+  migration_context :down do
+    it 'migrates Ansible Tower InventoryRootGroup to be of ConfigurationManager type' do
+      irg = inventory_root_group_stub.create!(:type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup')
+
+      migrate
+
+      expect(irg.reload.type).to eq('ManageIQ::Providers::ConfigurationManager::InventoryRootGroup')
+    end
+  end
+end

--- a/spec/migrations/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type_spec.rb
+++ b/spec/migrations/20170209192130_migrate_ansible_tower_configuration_manager_inventory_root_group_sti_type_spec.rb
@@ -4,14 +4,14 @@ describe MigrateAnsibleTowerConfigurationManagerInventoryRootGroupStiType do
   let(:inventory_root_group_stub) { migration_stub(:EmsFolder) }
 
   migration_context :up do
-    it 'migrates Ansible Tower InventoryRootGroup to be of AutomationManager type' do
+    it 'migrates Ansible Tower InventoryRootGroup to ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory' do
       irg = inventory_root_group_stub.create!(
         :type => 'ManageIQ::Providers::ConfigurationManager::InventoryRootGroup'
       )
 
       migrate
 
-      expect(irg.reload.type).to eq('ManageIQ::Providers::AutomationManager::InventoryRootGroup')
+      expect(irg.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory')
     end
 
     it 'will not migrate InventoryRootGroup other than those of Ansible Tower ConfigurationManager' do
@@ -24,8 +24,8 @@ describe MigrateAnsibleTowerConfigurationManagerInventoryRootGroupStiType do
   end
 
   migration_context :down do
-    it 'migrates Ansible Tower InventoryRootGroup to be of ConfigurationManager type' do
-      irg = inventory_root_group_stub.create!(:type => 'ManageIQ::Providers::AutomationManager::InventoryRootGroup')
+    it 'migrates Ansible Tower InventoryRootGroup to ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory' do
+      irg = inventory_root_group_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Inventory')
 
       migrate
 


### PR DESCRIPTION
A sequel to #13720 
From `ConfigurationManager` to `AutomationManager`