### PR TITLE
Do not run 18 useless selects for every field -- use cache instead

### DIFF
--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -7,6 +7,16 @@ class Chargeback
       @rates[consumption.hash_features_affecting_rate] ||= rates(consumption)
     end
 
+    def currency_for_report
+      @currency_for_report ||=
+        begin
+          # A very problematic way to get currency info when formatting a chargeback report.
+          # The only right way is to carry currency info. TBD.
+          rate = ChargebackRate.get_assignments(:compute)[0] || ChargebackRate.get_assignments(:storage)[0]
+          rate[:cb_rate].chargeback_rate_details[0].detail_currency.symbol unless rate.nil?
+        end
+    end
+
     private
 
     def rates(consumption)

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -74,10 +74,8 @@ module MiqReport::Formatting
 
     # Chargeback Reports: Add the selected currency in the assigned rate to options
     if Chargeback.db_is_chargeback?(db)
-      compute_selected_rate = ChargebackRate.get_assignments(:compute)[0]
-      storage_selected_rate = ChargebackRate.get_assignments(:storage)[0]
-      selected_rate = compute_selected_rate.nil? ? storage_selected_rate : compute_selected_rate
-      options[:unit] = selected_rate[:cb_rate].chargeback_rate_details[0].detail_currency.symbol unless selected_rate.nil?
+      @rates_cache ||= Chargeback::RatesCache.new
+      options[:unit] = @rates_cache.currency_for_report
     end
 
     format.merge!(options) if format # Merge additional options that were passed in as overrides


### PR DESCRIPTION
## Problem
We run 18 selects for every field in chargeback report (that is ~ `18 * columns * rows`). These select find out what was the currency of first (not necessary related) chargeback rate.

I don't have the numbers, but this is huge improvement for devel setup, when you have 200 rows and 15 cols you will avoid 54000 useless selects.

```
  ChargebackRate Load (0.2ms)  SELECT "chargeback_rates".* FROM "chargeback_rates" WHERE "chargeback_rates"."rate_type" = $1  [["rate_type", "Compute"]]
  ChargebackRate Inst Including Associations (0.2ms - 8rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000003], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000006], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000004], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000019], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.1ms - 1rows)
  Tenant Load (0.1ms)  SELECT  "tenants".* FROM "tenants" WHERE "tenants"."id" = $1 LIMIT $2  [["id", 1000000000001], ["LIMIT", 1]]
  Tenant Inst Including Associations (0.1ms - 1rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000001], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000014], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000016], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000018], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  ChargebackRate Load (0.1ms)  SELECT "chargeback_rates".* FROM "chargeback_rates" WHERE "chargeback_rates"."rate_type" = $1  [["rate_type", "Storage"]]
  ChargebackRate Inst Including Associations (0.2ms - 6rows)
  Tag Load (0.3ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000011], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000013], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000020], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.1ms - 1rows)
  Tenant Load (0.1ms)  SELECT  "tenants".* FROM "tenants" WHERE "tenants"."id" = $1 LIMIT $2  [["id", 1000000000001], ["LIMIT", 1]]
  Tenant Inst Including Associations (0.1ms - 1rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000002], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000015], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2  [["taggable_id", 1000000000017], ["taggable_type", "ChargebackRate"]]
  Tag Inst Including Associations (0.0ms - 0rows)
  ChargebackRateDetail Load (0.2ms)  SELECT "chargeback_rate_details".* FROM "chargeback_rate_details" WHERE "chargeback_rate_details"."chargeback_rate_id" = $1 ORDER BY "chargeback_rate_details"."group" ASC, "chargeback_rate_details"."description" ASC  [["chargeback_rate_id", 1000000000019]]
  ChargebackRateDetail Inst Including Associations (0.3ms - 9rows)
  ChargebackRateDetailCurrency Load (0.1ms)  SELECT  "chargeback_rate_detail_currencies".* FROM "chargeback_rate_detail_currencies" WHERE "chargeback_rate_detail_currencies"."id" = $1 LIMIT $2  [["id", 1000000000001], ["LIMIT", 1]]
  ChargebackRateDetailCurrency Inst Including Associations (0.1ms - 1rows)
```

## Fix
Use the cache instead.

Putting this to `ChargebackRates` cache class. As these two methods are related needs to be kept in sync.


@miq-bot add_label chargeback, reporting, performance, technical debt
@miq-bot assign @kbrock 