### PR TITLE
Use eager loading and include :miq_task and :miq_group in Reports

### DIFF
--- a/product/views/MiqReportResult-all.yaml
+++ b/product/views/MiqReportResult-all.yaml
@@ -43,6 +43,11 @@ col_order:
 - miq_group_description
 - status
 
+include_for_find:
+  :miq_task: {}
+  :miq_group: {}
+
+
 # Column titles, in order
 headers:
 - Queued At


### PR DESCRIPTION
Cloud Intel -> Reports -> Saved Reports
![screen shot 2017-02-10 at 14 02 06](https://cloud.githubusercontent.com/assets/14937244/22827717/9068e3de-ef99-11e6-9f21-eb9e16e67517.png)

There is used `status` and `group` in results but it is not included in query => this is removing unnecessary queries







