### PR TITLE
Regression: bring currency symbols back to chargeback reports

### DIFF
--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -27,7 +27,7 @@ class MiqReport::Formats
   end
 
   def self.default_format_details_for(column, suffix, datatype)
-    format = FORMATS[default_format_for(column, suffix, datatype)]
+    format = FORMATS[default_format_for(column.to_sym, suffix, datatype)]
     if format
       format = format.deep_clone # Make sure we don't taint the original
       if DEFAULTS_AND_OVERRIDES[:precision_by_column].key?(column.to_sym)


### PR DESCRIPTION
Addressing regression introduced in e6b02b5940cab3c27a7bd0c047a13dc55d2fd16f

The yaml file contains symbolized keys, when accessing format values, we
need to use symbols as well.

Not in euwe. Just in master.

@miq-bot add_label bug, reporting, chargeback, euwe/no
@miq-bot assign @gtanzillo 