### PR TITLE
Include all sub{resource,collection} identifiers in API config test

### DIFF
--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -15,8 +15,9 @@ describe 'API configuration (config/api.yml)' do
       let(:api_feature_identifiers) do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
           set.add(cfg[:identifier]) if cfg[:identifier]
+          keys = [:collection_actions, :resource_actions]
           subcollections = Array(cfg[:subcollections]).collect { |s| "#{s}_subcollection_actions" }
-          (subcollections + [:collection_actions, :resource_actions]).each do |action_type|
+          (subcollections + keys).each do |action_type|
             next unless cfg[action_type]
             cfg[action_type].each do |_, method_cfg|
               method_cfg.each do |action_cfg|

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -15,7 +15,7 @@ describe 'API configuration (config/api.yml)' do
       let(:api_feature_identifiers) do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
           set.add(cfg[:identifier]) if cfg[:identifier]
-          keys = [:collection_actions, :resource_actions]
+          keys = [:collection_actions, :resource_actions, :subcollection_actions, :subresource_actions]
           Array(cfg[:subcollections]).each do |s|
             keys << "#{s}_subcollection_actions" << "#{s}_subresource_actions"
           end

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -16,8 +16,8 @@ describe 'API configuration (config/api.yml)' do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
           set.add(cfg[:identifier]) if cfg[:identifier]
           keys = [:collection_actions, :resource_actions]
-          subcollections = Array(cfg[:subcollections]).collect { |s| "#{s}_subcollection_actions" }
-          (subcollections + keys).each do |action_type|
+          Array(cfg[:subcollections]).each { |s| keys << "#{s}_subcollection_actions" }
+          keys.each do |action_type|
             next unless cfg[action_type]
             cfg[action_type].each do |_, method_cfg|
               method_cfg.each do |action_cfg|

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -16,7 +16,9 @@ describe 'API configuration (config/api.yml)' do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
           set.add(cfg[:identifier]) if cfg[:identifier]
           keys = [:collection_actions, :resource_actions]
-          Array(cfg[:subcollections]).each { |s| keys << "#{s}_subcollection_actions" }
+          Array(cfg[:subcollections]).each do |s|
+            keys << "#{s}_subcollection_actions" << "#{s}_subresource_actions"
+          end
           keys.each do |action_type|
             next unless cfg[action_type]
             cfg[action_type].each do |_, method_cfg|


### PR DESCRIPTION
Updates this test to include typed subresource actions, and generic subresource/subcollection actions

@miq-bot add-label api, test
@miq-bot assign @abellotti 