### PR TITLE
Fix cloud networks access in API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1128,6 +1128,10 @@
       :get:
       - :name: read
         :identifier: miq_cloud_networks_view
+    :cloud_networks_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_cloud_networks_view
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/config/api.yml
+++ b/config/api.yml
@@ -1126,8 +1126,8 @@
         :identifier: ems_infra_protect
     :cloud_networks_subcollection_actions:
       :get:
-      - :name: show
-      - :identifier: miq_cloud_networks_view
+      - :name: read
+        :identifier: miq_cloud_networks_view
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/config/api.yml
+++ b/config/api.yml
@@ -409,6 +409,14 @@
       :post:
       - :name: query
         :identifier: miq_cloud_networks_view
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_cloud_networks_view
+    :subresource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_cloud_networks_view
   :clusters:
     :description: Clusters
     :identifier: ems_cluster
@@ -1124,14 +1132,6 @@
         :identifier: ems_infra_protect
       - :name: unassign
         :identifier: ems_infra_protect
-    :cloud_networks_subcollection_actions:
-      :get:
-      - :name: read
-        :identifier: miq_cloud_networks_view
-    :cloud_networks_subresource_actions:
-      :get:
-      - :name: read
-        :identifier: miq_cloud_networks_view
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Cloud Networks API' do
     end
 
     it 'queries individual provider cloud_network' do
-      api_basic_authorize(action_identifier(:providers, :read, :cloud_networks_subresource_actions, :get))
+      api_basic_authorize(action_identifier(:cloud_networks, :read, :subresource_actions, :get))
       network = provider.cloud_networks.first
       cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
 

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Cloud Networks API' do
     end
 
     it 'queries individual provider cloud_network' do
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize(action_identifier(:providers, :read, :cloud_networks_subresource_actions, :get))
       network = provider.cloud_networks.first
       cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
 

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe 'Cloud Networks API' do
       expect_result_resources_to_include_data('resources', 'id' => cloud_network_ids)
     end
 
+    it "will not list cloud networks of a provider without the appropriate role" do
+      api_basic_authorize
+
+      run_get providers_cloud_networks_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'queries individual provider cloud_network' do
       api_basic_authorize collection_action_identifier(:providers, :read, :get)
       network = provider.cloud_networks.first
@@ -42,6 +50,16 @@ RSpec.describe 'Cloud Networks API' do
       run_get cloud_network_url
 
       expect_single_resource_query('name' => network.name, 'id' => network.id, 'ems_ref' => network.ems_ref)
+    end
+
+    it "will not show the cloud network of a provider without the appropriate role" do
+      api_basic_authorize
+      network = provider.cloud_networks.first
+      cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
+
+      run_get cloud_network_url
+
+      expect(response).to have_http_status(:forbidden)
     end
 
     it 'successfully returns providers on query when providers do not have cloud_networks attribute' do

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Cloud Networks API' do
 
     it 'queries Providers cloud_networks' do
       cloud_network_ids = provider.cloud_networks.pluck(:id)
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
       run_get providers_cloud_networks_url, :expand => 'resources'
 
@@ -88,7 +88,7 @@ RSpec.describe 'Cloud Networks API' do
       openshift = FactoryGirl.create(:ems_openshift)
       openshift_cloud_networks_url = "#{providers_url(openshift.id)}/cloud_networks"
 
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
       run_get openshift_cloud_networks_url, :expand => 'resources'
 


### PR DESCRIPTION
I noticed that the cloud networks subcollection actions were not configured correctly, so I added some failing tests and corrected/refactored

@miq-bot add-label api, bug
@miq-bot assign @abellotti 
