### PR TITLE
Fix load balancers access in API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -834,6 +834,10 @@
       :get:
       - :name: read
         :identifier: load_balancer_show
+    :load_balancers_subresource_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show
     :snapshots_subcollection_actions:
       :get:
       - :name: read
@@ -1125,6 +1129,10 @@
       - :name: show
       - :identifier: miq_cloud_networks_view
     :load_balancers_subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show
+    :load_balancers_subresource_actions:
       :get:
       - :name: read
         :identifier: load_balancer_show

--- a/config/api.yml
+++ b/config/api.yml
@@ -830,14 +830,6 @@
         :identifier: instance_guest_restart
       - :name: reset
         :identifier: instance_reset
-    :load_balancers_subcollection_actions:
-      :get:
-      - :name: read
-        :identifier: load_balancer_show
-    :load_balancers_subresource_actions:
-      :get:
-      - :name: read
-        :identifier: load_balancer_show
     :snapshots_subcollection_actions:
       :get:
       - :name: read
@@ -872,6 +864,14 @@
       - :name: query
         :identifier: load_balancer_show_list
     :resource_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: load_balancer_show
+    :subresource_actions:
       :get:
       - :name: read
         :identifier: load_balancer_show
@@ -1128,14 +1128,6 @@
       :get:
       - :name: show
       - :identifier: miq_cloud_networks_view
-    :load_balancers_subcollection_actions:
-      :get:
-      - :name: read
-        :identifier: load_balancer_show
-    :load_balancers_subresource_actions:
-      :get:
-      - :name: read
-        :identifier: load_balancer_show
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/config/api.yml
+++ b/config/api.yml
@@ -832,7 +832,7 @@
         :identifier: instance_reset
     :load_balancers_subcollection_actions:
       :get:
-      - :name: show
+      - :name: read
         :identifier: load_balancer_show
     :snapshots_subcollection_actions:
       :get:
@@ -1126,7 +1126,7 @@
       - :identifier: miq_cloud_networks_view
     :load_balancers_subcollection_actions:
       :get:
-      - :name: show
+      - :name: read
         :identifier: load_balancer_show
   :provision_dialogs:
     :description: Provisioning Dialogs

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe "Instances API" do
     end
 
     it 'queries all load balancers on an instance' do
-      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :read, :get)
       expected = {
         'name'      => 'load_balancers',
         'resources' => [
@@ -478,7 +478,7 @@ RSpec.describe "Instances API" do
     end
 
     it 'queries a single load balancer on an instance' do
-      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :read, :get)
       run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -469,12 +469,28 @@ RSpec.describe "Instances API" do
       expect(response.parsed_body).to include(expected)
     end
 
+    it "will not show an instance's load balancers without the appropriate role" do
+      api_basic_authorize
+
+      run_get("#{instances_url(@vm.id)}/load_balancers")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'queries a single load balancer on an instance' do
       api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
       run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => @load_balancer.id)
+    end
+
+    it "will not show an instance's load balancer without the appropriate role" do
+      api_basic_authorize
+
+      run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -832,7 +832,7 @@ describe "Providers API" do
     end
 
     it 'queries all load balancers' do
-      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :read, :get)
       expected = {
         'resources' => [
           { 'href' => a_string_matching("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}") }
@@ -854,7 +854,7 @@ describe "Providers API" do
     end
 
     it 'queries a single load balancer' do
-      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :read, :get)
 
       run_get("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}")
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -845,6 +845,14 @@ describe "Providers API" do
       expect(response.parsed_body).to include(expected)
     end
 
+    it "will not show a provider's load balancers without the appropriate role" do
+      api_basic_authorize
+
+      run_get("#{providers_url(@provider.id)}/load_balancers")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'queries a single load balancer' do
       api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
 
@@ -852,6 +860,14 @@ describe "Providers API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include('id' => @load_balancer.id)
+    end
+
+    it "will not show a provider's load balancer without the appropriate role" do
+      api_basic_authorize
+
+      run_get("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}")
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
Fixes load balancer subcollection member read access.

@miq-bot add-label api, bug
@miq-bot assign @abellotti 