### PR TITLE
Replace action_identifier helpers with literals

### DIFF
--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -22,7 +22,7 @@ describe "Actions API" do
     end
 
     it "creates new action" do
-      api_basic_authorize collection_action_identifier(:actions, :create)
+      api_basic_authorize "action_new"
       run_post(actions_url, sample_action)
 
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ describe "Actions API" do
     end
 
     it "creates new actions" do
-      api_basic_authorize collection_action_identifier(:actions, :create)
+      api_basic_authorize "action_new"
       run_post(actions_url, gen_request(:create, [sample_action,
                                                   sample_action.merge(:name => "foo", :description => "bar")]))
       expect(response).to have_http_status(:ok)
@@ -42,7 +42,7 @@ describe "Actions API" do
     end
 
     it "reads all actions" do
-      api_basic_authorize collection_action_identifier(:actions, :read, :get)
+      api_basic_authorize "action_show_list"
       FactoryGirl.create(:miq_action)
       run_get(actions_url)
       expect(response).to have_http_status(:ok)
@@ -53,7 +53,7 @@ describe "Actions API" do
     end
 
     it "deletes action" do
-      api_basic_authorize collection_action_identifier(:actions, :delete)
+      api_basic_authorize "action_delete"
       run_post(actions_url, gen_request(:delete, "name" => action.name, "href" => action_url))
 
       expect(response).to have_http_status(:ok)
@@ -62,7 +62,7 @@ describe "Actions API" do
     end
 
     it "deletes actions" do
-      api_basic_authorize collection_action_identifier(:actions, :delete)
+      api_basic_authorize "action_delete"
       run_post(actions_url, gen_request(:delete, [{"name" => actions.first.name,
                                                    "href" => actions_url(actions.first.id)},
                                                   {"name" => actions.second.name,
@@ -74,7 +74,7 @@ describe "Actions API" do
     end
 
     it "deletes action via DELETE" do
-      api_basic_authorize collection_action_identifier(:actions, :delete)
+      api_basic_authorize "action_delete"
 
       run_delete(actions_url(action.id))
 
@@ -83,7 +83,7 @@ describe "Actions API" do
     end
 
     it "edits new action" do
-      api_basic_authorize collection_action_identifier(:actions, :edit)
+      api_basic_authorize "action_edit"
       run_post(action_url, gen_request(:edit, "description" => "change"))
 
       expect(response).to have_http_status(:ok)
@@ -92,7 +92,7 @@ describe "Actions API" do
     end
 
     it "edits new actions" do
-      api_basic_authorize collection_action_identifier(:actions, :edit)
+      api_basic_authorize "action_edit"
       run_post(actions_url, gen_request(:edit, [{"id" => actions.first.id, "description" => "change"},
                                                 {"id" => actions.second.id, "description" => "change2"}]))
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/alerts_spec.rb
+++ b/spec/requests/api/alerts_spec.rb
@@ -8,7 +8,7 @@ describe "Alerts API" do
   end
 
   it "reads 2 alerts as a collection" do
-    api_basic_authorize collection_action_identifier(:alerts, :read, :get)
+    api_basic_authorize "alert_status_show_list"
     alert_statuses = FactoryGirl.create_list(:miq_alert_status, 2)
     run_get(alerts_url)
     expect(response).to have_http_status(:ok)
@@ -35,7 +35,7 @@ describe "Alerts API" do
   end
 
   it "reads an alert as a resource" do
-    api_basic_authorize action_identifier(:alerts, :read, :resource_actions, :get)
+    api_basic_authorize "alert_status_show"
     alert_status = FactoryGirl.create(:miq_alert_status)
     run_get(alerts_url(alert_status.id))
     expect(response).to have_http_status(:ok)
@@ -69,7 +69,7 @@ describe "Alerts API" do
     end
 
     it "reads an alert action as a sub collection under an alert" do
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :read, :get)
+      api_basic_authorize "alert_status_action_show_list"
       alert_action = FactoryGirl.create(
         :miq_alert_status_action,
         :miq_alert_status => alert,
@@ -104,7 +104,7 @@ describe "Alerts API" do
         "action_type" => "comment",
         "comment"     => "comment text",
       }
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
+      api_basic_authorize "alert_status_action_new"
       run_post(actions_subcollection_url, attributes)
       expect(response).to have_http_status(:ok)
       expected = {
@@ -122,7 +122,7 @@ describe "Alerts API" do
         "comment"     => "comment text",
         "user_id"     => user.id # should be ignored
       }
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
+      api_basic_authorize "alert_status_action_new"
       run_post(actions_subcollection_url, attributes)
       expect(response).to have_http_status(:ok)
       expected = {
@@ -139,7 +139,7 @@ describe "Alerts API" do
         "action_type" => "assign",
         "assignee"    => { "id" => assignee.id }
       }
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
+      api_basic_authorize "alert_status_action_new"
       run_post(actions_subcollection_url, attributes)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected_assignee)
@@ -150,14 +150,14 @@ describe "Alerts API" do
         "action_type" => "assign",
         "assignee"    => { "href" => users_url(assignee.id) }
       }
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
+      api_basic_authorize "alert_status_action_new"
       run_post(actions_subcollection_url, attributes)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected_assignee)
     end
 
     it "returns errors when creating an invalid alert" do
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
+      api_basic_authorize "alert_status_action_new"
       run_post(
         actions_subcollection_url,
         "action_type" => "assign",
@@ -169,7 +169,7 @@ describe "Alerts API" do
     end
 
     it "reads an alert action as a resource under an alert" do
-      api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :read, :get)
+      api_basic_authorize "alert_status_action_show_list"
       user = FactoryGirl.create(:user)
       alert_action = FactoryGirl.create(
         :miq_alert_status_action,

--- a/spec/requests/api/arbitration_profile_spec.rb
+++ b/spec/requests/api/arbitration_profile_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Arbitration Profile API' do
     it 'can list the arbitration defaults' do
       FactoryGirl.create(:arbitration_profile, :ext_management_system => ems)
 
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :read, :get)
+      api_basic_authorize "arbitration_profile_show_list"
       run_get(arbitration_profiles_url)
       expect_query_result(:arbitration_profiles, 1, 1)
     end
@@ -23,7 +23,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'accepts resource get requests with appropriate role' do
-      api_basic_authorize action_identifier(:arbitration_profiles, :read, :resource_actions, :get)
+      api_basic_authorize "arbitration_profile_show"
 
       ap = FactoryGirl.create(:arbitration_profile, :ext_management_system => ems)
 
@@ -49,7 +49,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports single arbitration_default creation' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       expect do
         run_post(arbitration_profiles_url, request_body)
@@ -58,7 +58,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation via action' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       expect do
         run_post(arbitration_profiles_url, gen_request(:create, request_body))
@@ -68,7 +68,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with provider id' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       provider = FactoryGirl.create(:ext_management_system)
 
       expect do
@@ -78,7 +78,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with provider href ' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       provider = FactoryGirl.create(:ext_management_system)
       provider_href = providers_url(provider.id)
       request_json = {:name => 'arbitration profile'}
@@ -90,7 +90,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with ext_management_system id' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       provider = FactoryGirl.create(:ext_management_system)
       request_json = {:name => 'arbitration profile'}
 
@@ -101,7 +101,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with ext_management_system href' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       provider = FactoryGirl.create(:ext_management_system)
       provider_href = providers_url(provider.id)
       request_json = {:name => 'arbitration profile'}
@@ -113,7 +113,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with availability_zone id' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       availability_zone = FactoryGirl.create(:availability_zone)
 
       expect do
@@ -123,7 +123,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports arbitration_default creation with availability_zone href' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       availability_zone = FactoryGirl.create(:availability_zone)
       availability_zone_href = availability_zones_url(availability_zone.id)
 
@@ -134,7 +134,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an invalid availability zone' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       run_post(arbitration_profiles_url, request_body.merge(:availability_zone => {:id => 999_999}))
 
@@ -142,7 +142,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an invalid provider' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       run_post(arbitration_profiles_url, request_body.merge(:provider => {:id => 999_999}))
 
@@ -150,7 +150,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an invalid ext_management_system' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       request_json = {:name => 'arbitration profile'}
 
       run_post(arbitration_profiles_url, request_json.merge(:provider => {:id => 999_999}))
@@ -159,7 +159,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with both a provider and ext_management_system specified' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
       request_json = {:name => 'arbitration profile'}
 
       run_post(arbitration_profiles_url, request_json.merge(:provider              => {:id => 999_999},
@@ -168,7 +168,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an href' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       run_post(arbitration_profiles_url, request_body.merge(:href => arbitration_profiles_url))
 
@@ -176,7 +176,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an id' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :create)
+      api_basic_authorize "arbitration_profile_new"
 
       run_post(arbitration_profiles_url, request_body.merge(:id => 1))
 
@@ -194,7 +194,7 @@ RSpec.describe 'Arbitration Profile API' do
 
     it 'supports single arbitration_default edit' do
       subnet = FactoryGirl.create(:cloud_subnet)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :edit)
+      api_basic_authorize "arbitration_profile_edit"
 
       run_post(arbitration_profiles_url(default.id), gen_request(:edit, :cloud_subnet_id => subnet.id))
 
@@ -203,7 +203,7 @@ RSpec.describe 'Arbitration Profile API' do
 
     it 'supports edit with a provider id' do
       provider = FactoryGirl.create(:ext_management_system)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :edit)
+      api_basic_authorize "arbitration_profile_edit"
 
       run_post(arbitration_profiles_url(default.id), gen_request(:edit, :provider => {:id => provider.id}))
 
@@ -212,7 +212,7 @@ RSpec.describe 'Arbitration Profile API' do
 
     it 'supports edit with an ext_management_system id' do
       provider = FactoryGirl.create(:ext_management_system)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :edit)
+      api_basic_authorize "arbitration_profile_edit"
 
       run_post(arbitration_profiles_url(default.id), gen_request(:edit, :ext_management_system => {:id => provider.id}))
 
@@ -221,7 +221,7 @@ RSpec.describe 'Arbitration Profile API' do
 
     it 'supports edit with an availability_zone id specified' do
       az = FactoryGirl.create(:availability_zone)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :edit)
+      api_basic_authorize "arbitration_profile_edit"
 
       run_post(arbitration_profiles_url(default.id), gen_request(:edit, :availability_zone => {:id => az.id}))
 
@@ -232,7 +232,7 @@ RSpec.describe 'Arbitration Profile API' do
       subnet = FactoryGirl.create(:cloud_subnet)
       ext = FactoryGirl.create(:ext_management_system)
       default_two = FactoryGirl.create(:arbitration_profile, :ext_management_system => ext)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :edit)
+      api_basic_authorize "arbitration_profile_edit"
 
       default_id_1, default_id_2 = default.id, default_two.id
 
@@ -255,7 +255,7 @@ RSpec.describe 'Arbitration Profile API' do
   context 'arbitration_defaults delete' do
     it 'supports single arbitration_default delete' do
       arb_default = FactoryGirl.create(:arbitration_profile, :ext_management_system => ems)
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :delete)
+      api_basic_authorize "arbitration_profile_delete"
 
       run_delete(arbitration_profiles_url(arb_default.id))
 
@@ -264,7 +264,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports multiple arbitration_default delete' do
-      api_basic_authorize collection_action_identifier(:arbitration_profiles, :delete)
+      api_basic_authorize "arbitration_profile_delete"
 
       ems_2 = FactoryGirl.create(:ext_management_system)
       arb_default_1 = FactoryGirl.create(:arbitration_profile, :ext_management_system => ems)

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Arbitration Rule API' do
 
     it 'can list arbitration rules' do
       rules = FactoryGirl.create_list(:arbitration_rule, 2)
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :read, :get)
+      api_basic_authorize "arbitration_rule_show_list"
 
       run_get arbitration_rules_url
 
@@ -25,7 +25,7 @@ RSpec.describe 'Arbitration Rule API' do
   context 'GET /api/arbitration_rules/:id' do
     it 'shows an arbitration rule' do
       rule = FactoryGirl.create(:arbitration_rule)
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :read, :get)
+      api_basic_authorize "arbitration_rule_show_list"
 
       run_get arbitration_rules_url(rule.id)
 
@@ -60,7 +60,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'supports single arbitration_rule creation' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      api_basic_authorize "arbitration_rule_new"
 
       expect do
         run_post(arbitration_rules_url, gen_request(:create, request_body))
@@ -69,7 +69,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'supports multiple arbitration_rule creation' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      api_basic_authorize "arbitration_rule_new"
 
       expected = {
         'results' => a_collection_containing_exactly(
@@ -90,7 +90,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'supports single arbitration_rule creation using arbitration_profile reference by id' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      api_basic_authorize "arbitration_rule_new"
 
       request = request_body.dup
       arbitration_profile_id = request.delete('arbitration_profile_id')
@@ -104,7 +104,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'supports single arbitration_rule creation using arbitration_profile reference by href' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      api_basic_authorize "arbitration_rule_new"
 
       request = request_body.dup
       arbitration_profile_id = request.delete('arbitration_profile_id')
@@ -118,7 +118,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'rejects a request with an id' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      api_basic_authorize "arbitration_rule_new"
 
       run_post(arbitration_rules_url(999_999), request_body.merge(:id => 999_999))
 
@@ -139,7 +139,7 @@ RSpec.describe 'Arbitration Rule API' do
     end
 
     it 'can edit a setting' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :edit)
+      api_basic_authorize "arbitration_rule_edit"
 
       expected = {
         'href'        => a_string_including(arbitration_rules_url(rule.id)),
@@ -159,7 +159,7 @@ RSpec.describe 'Arbitration Rule API' do
   context 'arbitration rules delete' do
     it 'supports single arbitration rule delete' do
       rule = FactoryGirl.create(:arbitration_rule)
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :delete)
+      api_basic_authorize "arbitration_rule_delete"
 
       expect do
         run_delete(arbitration_rules_url(rule.id))
@@ -170,7 +170,7 @@ RSpec.describe 'Arbitration Rule API' do
     it 'supports multiple arbitration rule delete' do
       rules = FactoryGirl.create_list(:arbitration_rule, 2)
       hrefs = rules.map { |rule| { 'href' => arbitration_rules_url(rule.id) } }
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :delete)
+      api_basic_authorize "arbitration_rule_delete"
 
       expect do
         run_post(arbitration_rules_url, gen_request(:delete, hrefs))

--- a/spec/requests/api/arbitration_settings_spec.rb
+++ b/spec/requests/api/arbitration_settings_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Arbitration Profile API' do
 
     it 'can list the arbitration settings' do
       settings = FactoryGirl.create_list(:arbitration_setting, 2)
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :read, :get)
+      api_basic_authorize "show_arbitration_setting"
 
       run_get arbitration_settings_url
 
@@ -36,7 +36,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports single arbitration_setting creation' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :create)
+      api_basic_authorize "create_arbitration_setting"
 
       expect do
         run_post(arbitration_settings_url, request_body)
@@ -46,7 +46,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports multiple arbitration_setting creation' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :create)
+      api_basic_authorize "create_arbitration_setting"
       request_body_2 = { :name => 'test_setting_2', :display_name => 'Test Setting 2' }
 
       expect do
@@ -57,7 +57,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an href' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :create)
+      api_basic_authorize "create_arbitration_setting"
 
       run_post(arbitration_settings_url, request_body.merge(:href => arbitration_settings_url(999_999)))
 
@@ -65,7 +65,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'rejects a request with an id' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :create)
+      api_basic_authorize "create_arbitration_setting"
 
       run_post(arbitration_settings_url, request_body.merge(:id => 999_999))
 
@@ -85,7 +85,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'can edit a setting' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :edit)
+      api_basic_authorize "edit_arbitration_setting"
 
       expect do
         run_post(arbitration_settings_url(setting.id), gen_request(:edit, :value => 'new value'))
@@ -113,7 +113,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports single arbitration_setting delete' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :delete)
+      api_basic_authorize "delete_arbitration_setting"
       setting = FactoryGirl.create(:arbitration_setting)
 
       expect do
@@ -125,7 +125,7 @@ RSpec.describe 'Arbitration Profile API' do
     end
 
     it 'supports multiple arbitration_setting delete' do
-      api_basic_authorize collection_action_identifier(:arbitration_settings, :delete)
+      api_basic_authorize "delete_arbitration_setting"
       settings = FactoryGirl.create_list(:arbitration_setting, 2)
       setting_urls = settings.map { |setting| { 'href' => arbitration_settings_url(setting.id) } }
 

--- a/spec/requests/api/automate_domains_spec.rb
+++ b/spec/requests/api/automate_domains_spec.rb
@@ -13,7 +13,7 @@ describe "Automate Domains API" do
     end
 
     it 'fails to refresh git when the region misses git_owner role' do
-      api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
+      api_basic_authorize "miq_ae_git_refresh"
       expect(GitBasedDomainImportService).to receive(:available?).and_return(false)
 
       run_post(automate_domains_url(git_domain.id), gen_request(:refresh_from_source))
@@ -28,7 +28,7 @@ describe "Automate Domains API" do
       end
 
       it 'fails to refresh when domain did not originate from git' do
-        api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
+        api_basic_authorize "miq_ae_git_refresh"
 
         run_post(automate_domains_url(non_git_domain.id), gen_request(:refresh_from_source))
         expect_single_action_result(
@@ -38,7 +38,7 @@ describe "Automate Domains API" do
       end
 
       it 'refreshes domain from git_repository' do
-        api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
+        api_basic_authorize "miq_ae_git_refresh"
 
         expect_any_instance_of(GitBasedDomainImportService).to receive(:queue_refresh_and_import)
         run_post(automate_domains_url(git_domain.id), gen_request(:refresh_from_source))
@@ -50,7 +50,7 @@ describe "Automate Domains API" do
       end
 
       it 'refreshes domain from git_repository by domain name' do
-        api_basic_authorize action_identifier(:automate_domains, :refresh_from_source)
+        api_basic_authorize "miq_ae_git_refresh"
 
         expect_any_instance_of(GitBasedDomainImportService).to receive(:queue_refresh_and_import)
         run_post(automate_domains_url(git_domain.name), gen_request(:refresh_from_source))

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -13,7 +13,7 @@ describe "Automate API" do
     end
 
     it "returns domains by default" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get automate_url
 
@@ -29,7 +29,7 @@ describe "Automate API" do
     end
 
     it "default to depth 0 for non-root queries" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get automate_url("custom")
 
@@ -40,7 +40,7 @@ describe "Automate API" do
     end
 
     it "supports depth 1" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get(automate_url("custom"), :depth => 1)
 
@@ -52,7 +52,7 @@ describe "Automate API" do
     end
 
     it "supports depth -1" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get(automate_url, :depth => -1)
 
@@ -65,7 +65,7 @@ describe "Automate API" do
     end
 
     it "supports state_machines search option" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get(automate_url, :depth => -1, :search_options => "state_machines")
 
@@ -77,7 +77,7 @@ describe "Automate API" do
     end
 
     it "always return the fqname" do
-      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+      api_basic_authorize "miq_ae_domain_view"
 
       run_get(automate_url("custom/system"), :attributes => "name")
 

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -76,7 +76,7 @@ describe "Automation Requests API" do
     let(:request2_url)  { automation_requests_url(request2.id) }
 
     it "supports approving a request" do
-      api_basic_authorize collection_action_identifier(:automation_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request1_url, gen_request(:approve, :reason => "approve reason"))
 
@@ -85,7 +85,7 @@ describe "Automation Requests API" do
     end
 
     it "supports denying a request" do
-      api_basic_authorize collection_action_identifier(:automation_requests, :deny)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request2_url, gen_request(:deny, :reason => "deny reason"))
 
@@ -94,7 +94,7 @@ describe "Automation Requests API" do
     end
 
     it "supports approving multiple requests" do
-      api_basic_authorize collection_action_identifier(:automation_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(automation_requests_url, gen_request(:approve, [{"href" => request1_url, "reason" => "approve reason"},
                                                                {"href" => request2_url, "reason" => "approve reason"}]))
@@ -118,7 +118,7 @@ describe "Automation Requests API" do
     end
 
     it "supports denying multiple requests" do
-      api_basic_authorize collection_action_identifier(:automation_requests, :deny)
+      api_basic_authorize "miq_request_approval"
 
       run_post(automation_requests_url, gen_request(:deny, [{"href" => request1_url, "reason" => "deny reason"},
                                                             {"href" => request2_url, "reason" => "deny reason"}]))

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Blueprints API" do
   describe "GET /api/blueprints" do
     it "lists all the blueprints with an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint)
-      api_basic_authorize collection_action_identifier(:blueprints, :read, :get)
+      api_basic_authorize "blueprint_show_list"
 
       run_get(blueprints_url)
 
@@ -31,7 +31,7 @@ RSpec.describe "Blueprints API" do
   describe "GET /api/blueprints/:id" do
     it "will show a blueprint with an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint)
-      api_basic_authorize action_identifier(:blueprints, :read, :resource_actions, :get)
+      api_basic_authorize "blueprint_show"
 
       run_get(blueprints_url(blueprint.id))
 
@@ -51,7 +51,7 @@ RSpec.describe "Blueprints API" do
 
   describe "POST /api/blueprints" do
     it "can create a blueprint" do
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
+      api_basic_authorize "blueprint_new"
       ui_properties = {
         :service_catalog      => {},
         :service_dialog       => {},
@@ -80,7 +80,7 @@ RSpec.describe "Blueprints API" do
     end
 
     it "rejects blueprint creation with id specified" do
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
+      api_basic_authorize "blueprint_new"
 
       run_post(blueprints_url, :name => "foo", :description => "bar", :id => 123)
 
@@ -95,7 +95,7 @@ RSpec.describe "Blueprints API" do
     end
 
     it "rejects blueprint creation with an href specified" do
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
+      api_basic_authorize "blueprint_new"
 
       run_post(blueprints_url, :name => "foo", :description => "bar", :href => blueprints_url(123))
 
@@ -110,7 +110,7 @@ RSpec.describe "Blueprints API" do
     end
 
     it "can create blueprints in bulk" do
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
+      api_basic_authorize "blueprint_new"
       ui_properties = {
         :service_catalog      => {},
         :service_dialog       => {},
@@ -149,7 +149,7 @@ RSpec.describe "Blueprints API" do
     it "can update attributes of multiple blueprints with an appropirate role" do
       blueprint1 = FactoryGirl.create(:blueprint, :name => "foo")
       blueprint2 = FactoryGirl.create(:blueprint, :name => "bar")
-      api_basic_authorize collection_action_identifier(:blueprints, :edit)
+      api_basic_authorize "blueprint_edit"
 
       run_post(blueprints_url, :action => "edit", :resources => [{:id => blueprint1.id, :name => "baz"},
                                                                  {:id => blueprint2.id, :name => "qux"}])
@@ -183,7 +183,7 @@ RSpec.describe "Blueprints API" do
 
     it "can delete multiple blueprints" do
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
-      api_basic_authorize collection_action_identifier(:blueprints, :delete)
+      api_basic_authorize "blueprint_delete"
 
       run_post(blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
 
@@ -216,7 +216,7 @@ RSpec.describe "Blueprints API" do
       }
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2, :ui_properties => ui_properties)
 
-      api_basic_authorize collection_action_identifier(:blueprints, :publish)
+      api_basic_authorize "blueprint_publish"
 
       run_post(blueprints_url, :action => "publish", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
 
@@ -244,7 +244,7 @@ RSpec.describe "Blueprints API" do
 
     it "can delete a blueprint with an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint)
-      api_basic_authorize action_identifier(:blueprints, :delete)
+      api_basic_authorize "blueprint_delete"
 
       run_post(blueprints_url(blueprint.id), :action => "delete")
 
@@ -276,7 +276,7 @@ RSpec.describe "Blueprints API" do
         }
       }
       blueprint = FactoryGirl.create(:blueprint, :ui_properties => ui_properties)
-      api_basic_authorize action_identifier(:blueprints, :publish)
+      api_basic_authorize "blueprint_publish"
 
       run_post(blueprints_url(blueprint.id), :action => "publish")
 
@@ -290,7 +290,7 @@ RSpec.describe "Blueprints API" do
 
     it "fails appropriately if a blueprint publish raises" do
       blueprint = FactoryGirl.create(:blueprint)
-      api_basic_authorize action_identifier(:blueprints, :publish)
+      api_basic_authorize "blueprint_publish"
 
       run_post(blueprints_url(blueprint.id), :action => "publish")
 
@@ -309,7 +309,7 @@ RSpec.describe "Blueprints API" do
   describe "DELETE /api/blueprints/:id" do
     it "can delete a blueprint with an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint)
-      api_basic_authorize action_identifier(:blueprints, :delete, :resource_actions, :delete)
+      api_basic_authorize "blueprint_delete"
 
       run_delete(blueprints_url(blueprint.id))
 

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "categories API" do
   it "can list all the categories" do
     categories = FactoryGirl.create_list(:category, 2)
-    api_basic_authorize collection_action_identifier(:categories, :read, :get)
+    api_basic_authorize "ops_settings"
 
     run_get categories_url
 
@@ -15,7 +15,7 @@ RSpec.describe "categories API" do
   it "can filter the list of categories by name" do
     category_1 = FactoryGirl.create(:category, :name => "foo")
     _category_2 = FactoryGirl.create(:category, :name => "bar")
-    api_basic_authorize collection_action_identifier(:categories, :read, :get)
+    api_basic_authorize "ops_settings"
 
     run_get categories_url, :filter => ["name=foo"]
 
@@ -25,7 +25,7 @@ RSpec.describe "categories API" do
 
   it "will return a bad request error if the filter name is invalid" do
     FactoryGirl.create(:category)
-    api_basic_authorize collection_action_identifier(:categories, :read, :get)
+    api_basic_authorize "ops_settings"
 
     run_get categories_url, :filter => ["not_an_attribute=foo"]
 
@@ -34,7 +34,7 @@ RSpec.describe "categories API" do
 
   it "can read a category" do
     category = FactoryGirl.create(:category)
-    api_basic_authorize action_identifier(:categories, :read, :resource_actions, :get)
+    api_basic_authorize "ops_settings"
 
     run_get categories_url(category.id)
     expect_result_to_match_hash(
@@ -64,7 +64,7 @@ RSpec.describe "categories API" do
 
   context "with an appropriate role" do
     it "can create a category" do
-      api_basic_authorize collection_action_identifier(:categories, :create)
+      api_basic_authorize "ops_settings"
 
       expect do
         run_post categories_url, :name => "test", :description => "Test"
@@ -74,7 +74,7 @@ RSpec.describe "categories API" do
     end
 
     it "can set read_only/show/single_value when creating a category" do
-      api_basic_authorize collection_action_identifier(:categories, :create)
+      api_basic_authorize "ops_settings"
 
       options = {
         :name         => "test",
@@ -94,7 +94,7 @@ RSpec.describe "categories API" do
     end
 
     it "can create an associated tag" do
-      api_basic_authorize collection_action_identifier(:categories, :create)
+      api_basic_authorize "ops_settings"
 
       run_post categories_url, :name => "test", :description => "Test"
       category = Category.find(response.parsed_body["results"].first["id"])
@@ -104,7 +104,7 @@ RSpec.describe "categories API" do
 
     it "can update a category" do
       category = FactoryGirl.create(:category)
-      api_basic_authorize action_identifier(:categories, :edit)
+      api_basic_authorize "ops_settings"
 
       expect do
         run_post categories_url(category.id), gen_request(:edit, :description => "New description")
@@ -116,7 +116,7 @@ RSpec.describe "categories API" do
 
     it "can delete a category through POST" do
       category = FactoryGirl.create(:category)
-      api_basic_authorize action_identifier(:categories, :delete)
+      api_basic_authorize "ops_settings"
 
       expect do
         run_post categories_url(category.id), gen_request(:delete)
@@ -127,7 +127,7 @@ RSpec.describe "categories API" do
 
     it "can delete a category through DELETE" do
       category = FactoryGirl.create(:category)
-      api_basic_authorize action_identifier(:categories, :delete)
+      api_basic_authorize "ops_settings"
 
       expect do
         run_delete categories_url(category.id)
@@ -139,7 +139,7 @@ RSpec.describe "categories API" do
     context "read-only categories" do
       it "can't delete a read-only category" do
         category = FactoryGirl.create(:category, :read_only => true)
-        api_basic_authorize action_identifier(:categories, :delete)
+        api_basic_authorize "ops_settings"
 
         expect do
           run_post categories_url(category.id), gen_request(:delete)
@@ -150,7 +150,7 @@ RSpec.describe "categories API" do
 
       it "can't update a read-only category" do
         category = FactoryGirl.create(:category, :description => "old description", :read_only => true)
-        api_basic_authorize action_identifier(:categories, :edit)
+        api_basic_authorize "ops_settings"
 
         expect do
           run_post categories_url(category.id), gen_request(:edit, :description => "new description")

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "chargebacks API" do
   it "can fetch the list of all chargeback rates" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
-    api_basic_authorize collection_action_identifier(:chargebacks, :read, :get)
+    api_basic_authorize "chargeback"
     run_get chargebacks_url
 
     expect_result_resources_to_include_hrefs(
@@ -15,7 +15,7 @@ RSpec.describe "chargebacks API" do
   it "can show an individual chargeback rate" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
-    api_basic_authorize action_identifier(:chargebacks, :read, :resource_actions, :get)
+    api_basic_authorize "chargeback"
     run_get chargebacks_url(chargeback_rate.id)
 
     expect_result_to_match_hash(
@@ -127,7 +127,7 @@ RSpec.describe "chargebacks API" do
 
   context "with an appropriate role" do
     it "can create a new chargeback rate" do
-      api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
+      api_basic_authorize "chargeback_rates_new"
 
       expect do
         run_post chargebacks_url,
@@ -141,7 +141,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "returns bad request for incomplete chargeback rate" do
-      api_basic_authorize action_identifier(:chargebacks, :create, :collection_actions)
+      api_basic_authorize "chargeback_rates_new"
 
       expect do
         run_post chargebacks_url,
@@ -153,7 +153,7 @@ RSpec.describe "chargebacks API" do
     it "can edit a chargeback rate through POST" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
-      api_basic_authorize action_identifier(:chargebacks, :edit)
+      api_basic_authorize "chargeback_rates_edit"
       run_post chargebacks_url(chargeback_rate.id), gen_request(:edit, :description => "chargeback_1")
 
       expect(response.parsed_body["description"]).to eq("chargeback_1")
@@ -164,7 +164,7 @@ RSpec.describe "chargebacks API" do
     it "can edit a chargeback rate through PATCH" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate, :description => "chargeback_0")
 
-      api_basic_authorize action_identifier(:chargebacks, :edit)
+      api_basic_authorize "chargeback_rates_edit"
       run_patch chargebacks_url(chargeback_rate.id), [{:action => "edit",
                                                        :path   => "description",
                                                        :value  => "chargeback_1"}]
@@ -177,7 +177,7 @@ RSpec.describe "chargebacks API" do
     it "can delete a chargeback rate" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
-      api_basic_authorize action_identifier(:chargebacks, :delete)
+      api_basic_authorize "chargeback_rates_delete"
 
       expect do
         run_delete chargebacks_url(chargeback_rate.id)
@@ -188,7 +188,7 @@ RSpec.describe "chargebacks API" do
     it "can delete a chargeback rate through POST" do
       chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
-      api_basic_authorize action_identifier(:chargebacks, :delete)
+      api_basic_authorize "chargeback_rates_delete"
 
       expect do
         run_post chargebacks_url(chargeback_rate.id), :action => "delete"
@@ -197,7 +197,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "can create a new chargeback rate detail" do
-      api_basic_authorize action_identifier(:rates, :create, :collection_actions)
+      api_basic_authorize "chargeback_rates_new"
       chargeback_rate = FactoryGirl.create(:chargeback_rate)
 
       expect do
@@ -213,7 +213,7 @@ RSpec.describe "chargebacks API" do
     end
 
     it "returns bad request for incomplete chargeback rate detail" do
-      api_basic_authorize action_identifier(:rates, :create, :collection_actions)
+      api_basic_authorize "chargeback_rates_new"
 
       expect do
         run_post rates_url,
@@ -232,7 +232,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
 
-      api_basic_authorize action_identifier(:rates, :edit)
+      api_basic_authorize "chargeback_rates_edit"
       run_post rates_url(chargeback_rate_detail.id), gen_request(:edit, :description => "rate_1")
 
       expect(response.parsed_body["description"]).to eq("rate_1")
@@ -248,7 +248,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
 
-      api_basic_authorize action_identifier(:rates, :edit)
+      api_basic_authorize "chargeback_rates_edit"
       run_patch rates_url(chargeback_rate_detail.id), [{:action => "edit", :path => "description", :value => "rate_1"}]
 
       expect(response.parsed_body["description"]).to eq("rate_1")
@@ -264,7 +264,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
 
-      api_basic_authorize action_identifier(:rates, :delete)
+      api_basic_authorize "chargeback_rates_delete"
 
       expect do
         run_delete rates_url(chargeback_rate_detail.id)
@@ -280,7 +280,7 @@ RSpec.describe "chargebacks API" do
       chargeback_rate_detail.chargeback_tiers = [chargeback_tier]
       chargeback_rate_detail.save
 
-      api_basic_authorize action_identifier(:rates, :delete)
+      api_basic_authorize "chargeback_rates_delete"
 
       expect do
         run_post rates_url(chargeback_rate_detail.id), :action => "delete"

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Cloud Networks API' do
 
     it 'can list cloud networks' do
       FactoryGirl.create_list(:cloud_network, 2)
-      api_basic_authorize collection_action_identifier(:cloud_networks, :read, :get)
+      api_basic_authorize "miq_cloud_networks_view"
 
       run_get cloud_networks_url
 
@@ -26,7 +26,7 @@ RSpec.describe 'Cloud Networks API' do
 
     it 'queries Providers cloud_networks' do
       cloud_network_ids = provider.cloud_networks.pluck(:id)
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize "ems_infra_show_list"
 
       run_get providers_cloud_networks_url, :expand => 'resources'
 
@@ -35,7 +35,7 @@ RSpec.describe 'Cloud Networks API' do
     end
 
     it 'queries individual provider cloud_network' do
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize "ems_infra_show_list"
       network = provider.cloud_networks.first
       cloud_network_url = "#{providers_cloud_networks_url}/#{network.id}"
 
@@ -47,7 +47,7 @@ RSpec.describe 'Cloud Networks API' do
     it 'successfully returns providers on query when providers do not have cloud_networks attribute' do
       FactoryGirl.create(:ems_openshift) # Openshift does not respond to #cloud_networks
       FactoryGirl.create(:ems_amazon_with_cloud_networks) # Provider with cloud networks
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize "ems_infra_show_list"
 
       run_get providers_url, :expand => 'resources,cloud_networks'
 
@@ -70,7 +70,7 @@ RSpec.describe 'Cloud Networks API' do
       openshift = FactoryGirl.create(:ems_openshift)
       openshift_cloud_networks_url = "#{providers_url(openshift.id)}/cloud_networks"
 
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize "ems_infra_show_list"
 
       run_get openshift_cloud_networks_url, :expand => 'resources'
 

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -10,12 +10,6 @@ describe "Rest API Collections" do
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)
-    if Api::ApiConfig.fetch_path(:collections, collection, :collection_actions, :get)
-      api_basic_authorize collection_action_identifier(collection, :read, :get)
-    else
-      api_basic_authorize
-    end
-
     run_get collection_url, :expand => "resources"
 
     expect_query_result(collection, klass.count, klass.count)
@@ -23,8 +17,6 @@ describe "Rest API Collections" do
   end
 
   def test_collection_bulk_query(collection, collection_url, klass, id = nil)
-    api_basic_authorize collection_action_identifier(collection, :query)
-
     obj = id.nil? ? klass.first : klass.find(id)
     url = send("#{collection}_url", obj.id)
     attr_list = String(Api::ApiConfig.collections[collection].identifying_attrs).split(",")
@@ -45,71 +37,85 @@ describe "Rest API Collections" do
 
   context "Collections" do
     it "query Automate Domains" do
+      api_basic_authorize("miq_ae_domain_view")
       FactoryGirl.create(:miq_ae_domain)
       test_collection_query(:automate_domains, automate_domains_url, MiqAeDomain)
     end
 
     it "query Automation Requests" do
+      api_basic_authorize
       FactoryGirl.create(:automation_request)
       test_collection_query(:automation_requests, automation_requests_url, AutomationRequest)
     end
 
     it "query Availability Zones" do
+      api_basic_authorize("availability_zone_show_list")
       FactoryGirl.create(:availability_zone)
       test_collection_query(:availability_zones, availability_zones_url, AvailabilityZone)
     end
 
     it "query Categories" do
+      api_basic_authorize("ops_settings")
       FactoryGirl.create(:category)
       test_collection_query(:categories, categories_url, Category)
     end
 
     it "query Chargebacks" do
+      api_basic_authorize("chargeback")
       FactoryGirl.create(:chargeback_rate)
       test_collection_query(:chargebacks, chargebacks_url, ChargebackRate)
     end
 
     it "query Currencies" do
+      api_basic_authorize
       FactoryGirl.create(:chargeback_rate_detail_currency)
       test_collection_query(:currencies, "/api/currencies", ChargebackRateDetailCurrency)
     end
 
     it "query Measures" do
+      api_basic_authorize
       FactoryGirl.create(:chargeback_rate_detail_measure)
       test_collection_query(:measures, "/api/measures", ChargebackRateDetailMeasure)
     end
 
     it "query Clusters" do
+      api_basic_authorize("ems_cluster_show_list")
       FactoryGirl.create(:ems_cluster)
       test_collection_query(:clusters, clusters_url, EmsCluster)
     end
 
     it "query Conditions" do
+      api_basic_authorize("condition")
       FactoryGirl.create(:condition)
       test_collection_query(:conditions, conditions_url, Condition)
     end
 
     it "query Actions" do
+      api_basic_authorize("action_show_list")
       FactoryGirl.create(:miq_action)
       test_collection_query(:actions, actions_url, MiqAction)
     end
 
     it "query Data Stores" do
+      api_basic_authorize("storage_show_list")
       FactoryGirl.create(:storage)
       test_collection_query(:data_stores, data_stores_url, Storage)
     end
 
     it "query Events" do
+      api_basic_authorize("event")
       FactoryGirl.create(:miq_event_definition)
       test_collection_query(:events, events_url, MiqEventDefinition)
     end
 
     it "query Features" do
+      api_basic_authorize
       FactoryGirl.create(:miq_product_feature, :identifier => "vm_auditing")
       test_collection_query(:features, features_url, MiqProductFeature)
     end
 
     it "query Flavors" do
+      api_basic_authorize("flavor_show_list")
       FactoryGirl.create(:flavor)
       test_collection_query(:flavors, flavors_url, Flavor)
     end
@@ -117,133 +123,158 @@ describe "Rest API Collections" do
     it "query Groups" do
       expect(Tenant.exists?).to be_truthy
       FactoryGirl.create(:miq_group)
-      api_basic_authorize collection_action_identifier(:groups, :read, :get)
+      api_basic_authorize "rbac_group_show_list"
       run_get groups_url, :expand => 'resources'
       expect_query_result(:groups, MiqGroup.non_tenant_groups.count, MiqGroup.count)
       expect_result_resources_to_include_data('resources', 'id' => MiqGroup.non_tenant_groups.pluck(:id))
     end
 
     it "query Hosts" do
+      api_basic_authorize("host_show_list")
       FactoryGirl.create(:host)
       test_collection_query(:hosts, hosts_url, Host, :guid)
     end
 
     it "query Pictures" do
+      api_basic_authorize
       FactoryGirl.create(:picture)
       test_collection_query(:pictures, pictures_url, Picture)
     end
 
     it "query Policies" do
+      api_basic_authorize("policy_view")
       FactoryGirl.create(:miq_policy)
       test_collection_query(:policies, policies_url, MiqPolicy)
     end
 
     it "query Policy Actions" do
+      api_basic_authorize("control_explorer_view")
       FactoryGirl.create(:miq_action)
       test_collection_query(:policy_actions, policy_actions_url, MiqAction)
     end
 
     it "query Policy Profiles" do
+      api_basic_authorize("policy_profile_view")
       FactoryGirl.create(:miq_policy_set)
       test_collection_query(:policy_profiles, policy_profiles_url, MiqPolicySet)
     end
 
     it "query Providers" do
+      api_basic_authorize("ems_infra_show_list")
       FactoryGirl.create(:ext_management_system)
       test_collection_query(:providers, providers_url, ExtManagementSystem, :guid)
     end
 
     it "query Provision Dialogs" do
+      api_basic_authorize("miq_ae_customization_explorer")
       FactoryGirl.create(:miq_dialog)
       test_collection_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
     end
 
     it "query Provision Requests" do
+      api_basic_authorize("miq_request_show_list")
       FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
       test_collection_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
     end
 
     it "query Rates" do
+      api_basic_authorize("chargeback_rates")
       FactoryGirl.build(:chargeback_rate_detail)
       test_collection_query(:rates, rates_url, ChargebackRateDetail)
     end
 
     it "query Reports" do
+      api_basic_authorize("miq_report_saved_reports_view")
       FactoryGirl.create(:miq_report)
       test_collection_query(:reports, reports_url, MiqReport)
     end
 
     it "query Report Results" do
+      api_basic_authorize("miq_report_view")
       FactoryGirl.create(:miq_report_result)
       test_collection_query(:results, results_url, MiqReportResult)
     end
 
     it "query Request Tasks" do
+      api_basic_authorize
       FactoryGirl.create(:miq_request_task)
       test_collection_query(:request_tasks, request_tasks_url, MiqRequestTask)
     end
 
     it "query Requests" do
+      api_basic_authorize("miq_request_show_list")
       FactoryGirl.create(:vm_migrate_request, :requester => @user)
       test_collection_query(:requests, requests_url, MiqRequest)
     end
 
     it "query Resource Pools" do
+      api_basic_authorize("resource_pool_show_list")
       FactoryGirl.create(:resource_pool)
       test_collection_query(:resource_pools, resource_pools_url, ResourcePool)
     end
 
     it "query Roles" do
+      api_basic_authorize("rbac_role_show_list")
       FactoryGirl.create(:miq_user_role)
       test_collection_query(:roles, roles_url, MiqUserRole)
     end
 
     it "query Security Groups" do
+      api_basic_authorize("security_group_show_list")
       FactoryGirl.create(:security_group)
       test_collection_query(:security_groups, security_groups_url, SecurityGroup)
     end
 
     it "query Servers" do
+      api_basic_authorize
       miq_server # create resource
       test_collection_query(:servers, servers_url, MiqServer, :guid)
     end
 
     it "query Service Catalogs" do
+      api_basic_authorize("svc_catalog_provision")
       FactoryGirl.create(:service_template_catalog)
       test_collection_query(:service_catalogs, service_catalogs_url, ServiceTemplateCatalog)
     end
 
     it "query Service Dialogs" do
+      api_basic_authorize("miq_ae_customization_explorer")
       FactoryGirl.create(:dialog, :label => "ServiceDialog1")
       test_collection_query(:service_dialogs, service_dialogs_url, Dialog)
     end
 
     it "query Service Requests" do
+      api_basic_authorize("miq_request_view")
       FactoryGirl.create(:service_template_provision_request, :requester => @user)
       test_collection_query(:service_requests, service_requests_url, ServiceTemplateProvisionRequest)
     end
 
     it "query Service Templates" do
+      api_basic_authorize("svc_catalog_provision")
       FactoryGirl.create(:service_template)
       test_collection_query(:service_templates, service_templates_url, ServiceTemplate, :guid)
     end
 
     it "query Services" do
+      api_basic_authorize("service_view")
       FactoryGirl.create(:service)
       test_collection_query(:services, services_url, Service)
     end
 
     it "query Tags" do
+      api_basic_authorize("ops_settings")
       FactoryGirl.create(:classification_cost_center_with_tags)
       test_collection_query(:tags, tags_url, Tag)
     end
 
     it "query Tasks" do
+      api_basic_authorize("tasks_view")
       FactoryGirl.create(:miq_task)
       test_collection_query(:tasks, tasks_url, MiqTask)
     end
 
     it "query Templates" do
+      api_basic_authorize("miq_template_show_list")
       template # create resource
       test_collection_query(:templates, templates_url, MiqTemplate, :guid)
     end
@@ -255,52 +286,62 @@ describe "Rest API Collections" do
     end
 
     it "query Users" do
+      api_basic_authorize("rbac_user_show_list")
       FactoryGirl.create(:user)
       test_collection_query(:users, users_url, User)
     end
 
     it "query Vms" do
+      api_basic_authorize("vm_show_list")
       FactoryGirl.create(:vm_vmware)
       test_collection_query(:vms, vms_url, Vm, :guid)
     end
 
     it "query Zones" do
+      api_basic_authorize("zone")
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_query(:zones, zones_url, Zone)
     end
 
     it "query ContainerDeployments" do
+      api_basic_authorize("container_deployment_show")
       FactoryGirl.create(:container_deployment)
       test_collection_query(:container_deployments, container_deployments_url, ContainerDeployment)
     end
 
     it 'queries ArbitrationProfiles' do
+      api_basic_authorize("arbitration_profile_show_list")
       ems = FactoryGirl.create(:ext_management_system)
       FactoryGirl.create(:arbitration_profile, :ems_id => ems.id)
       test_collection_query(:arbitration_profiles, arbitration_profiles_url, ArbitrationProfile)
     end
 
     it 'queries CloudNetworks' do
+      api_basic_authorize("miq_cloud_networks_view")
       FactoryGirl.create(:cloud_network)
       test_collection_query(:cloud_networks, cloud_networks_url, CloudNetwork)
     end
 
     it 'queries ArbitrationSettings' do
+      api_basic_authorize("show_arbitration_setting")
       FactoryGirl.create(:arbitration_setting)
       test_collection_query(:arbitration_settings, arbitration_settings_url, ArbitrationSetting)
     end
 
     it 'queries ArbitrationRules' do
+      api_basic_authorize("arbitration_rule_show_list")
       FactoryGirl.create(:arbitration_rule)
       test_collection_query(:arbitration_rules, arbitration_rules_url, ArbitrationRule)
     end
 
     it 'query LoadBalancers' do
+      api_basic_authorize("load_balancer_show_list")
       FactoryGirl.create(:load_balancer)
       test_collection_query(:load_balancers, load_balancers_url, LoadBalancer)
     end
 
     it 'query Alerts' do
+      api_basic_authorize("alert_status_show_list")
       FactoryGirl.create(:miq_alert_status)
       test_collection_query(:alerts, alerts_url, MiqAlertStatus)
     end
@@ -308,197 +349,236 @@ describe "Rest API Collections" do
 
   context "Collections Bulk Queries" do
     it 'bulk query MiqAeDomain' do
+      api_basic_authorize("miq_ae_domain_view")
       FactoryGirl.create(:miq_ae_domain)
       test_collection_bulk_query(:automate_domains, automate_domains_url, MiqAeDomain)
     end
 
     it 'bulk query ArbitrationProfiles' do
+      api_basic_authorize("arbitration_profile_show_list")
       ems = FactoryGirl.create(:ext_management_system)
       FactoryGirl.create(:arbitration_profile, :ems_id => ems.id)
       test_collection_bulk_query(:arbitration_profiles, arbitration_profiles_url, ArbitrationProfile)
     end
 
     it 'bulk query ArbitrationRules' do
+      api_basic_authorize("arbitration_rule_show_list")
       FactoryGirl.create(:arbitration_rule)
       test_collection_bulk_query(:arbitration_rules, arbitration_rules_url, ArbitrationRule)
     end
 
     it 'bulk query ArbitrationSettings' do
+      api_basic_authorize("show_arbitration_setting")
       FactoryGirl.create(:arbitration_setting)
       test_collection_bulk_query(:arbitration_settings, arbitration_settings_url, ArbitrationSetting)
     end
 
     it "bulk query Availability Zones" do
+      api_basic_authorize("availability_zone_show_list")
       FactoryGirl.create(:availability_zone)
       test_collection_bulk_query(:availability_zones, availability_zones_url, AvailabilityZone)
     end
 
     it "bulk query Blueprints" do
+      api_basic_authorize("blueprint_show_list")
       FactoryGirl.create(:blueprint)
       test_collection_bulk_query(:blueprints, blueprints_url, Blueprint)
     end
 
     it "bulk query Categories" do
+      api_basic_authorize("ops_settings")
       FactoryGirl.create(:category)
       test_collection_bulk_query(:categories, categories_url, Category)
     end
 
     it "bulk query Chargebacks" do
+      api_basic_authorize("chargeback")
       FactoryGirl.create(:chargeback_rate)
       test_collection_bulk_query(:chargebacks, chargebacks_url, ChargebackRate)
     end
 
     it 'bulk query CloudNetworks' do
+      api_basic_authorize("miq_cloud_networks_view")
       FactoryGirl.create(:cloud_network)
       test_collection_bulk_query(:cloud_networks, cloud_networks_url, CloudNetwork)
     end
 
     it "bulk query Clusters" do
+      api_basic_authorize("ems_cluster_show_list")
       FactoryGirl.create(:ems_cluster)
       test_collection_bulk_query(:clusters, clusters_url, EmsCluster)
     end
 
     it "bulk query Conditions" do
+      api_basic_authorize("condition")
       FactoryGirl.create(:condition)
       test_collection_bulk_query(:conditions, conditions_url, Condition)
     end
 
     it "bulk query Actions" do
+      api_basic_authorize("action_show_list")
       FactoryGirl.create(:miq_action)
       test_collection_bulk_query(:actions, actions_url, MiqAction)
     end
 
     it "bulk query ContainerDeployments" do
+      api_basic_authorize("container_deployment_show")
       FactoryGirl.create(:container_deployment)
       test_collection_bulk_query(:container_deployments, container_deployments_url, ContainerDeployment)
     end
 
     it "bulk query Data Stores" do
+      api_basic_authorize("storage_show_list")
       FactoryGirl.create(:storage)
       test_collection_bulk_query(:data_stores, data_stores_url, Storage)
     end
 
     it "bulk query Events" do
+      api_basic_authorize("event")
       FactoryGirl.create(:miq_event_definition)
       test_collection_bulk_query(:events, events_url, MiqEventDefinition)
     end
 
     it "bulk query Flavors" do
+      api_basic_authorize("flavor_show_list")
       FactoryGirl.create(:flavor)
       test_collection_bulk_query(:flavors, flavors_url, Flavor)
     end
 
     it "bulk query Groups" do
+      api_basic_authorize("rbac_group_show_list")
       group = FactoryGirl.create(:miq_group)
       test_collection_bulk_query(:groups, groups_url, MiqGroup, group.id)
     end
 
     it "bulk query Hosts" do
+      api_basic_authorize("host_show_list")
       FactoryGirl.create(:host)
       test_collection_bulk_query(:hosts, hosts_url, Host)
     end
 
     it "bulk query Policies" do
+      api_basic_authorize("policy_view")
       FactoryGirl.create(:miq_policy)
       test_collection_bulk_query(:policies, policies_url, MiqPolicy)
     end
 
     it "bulk query Policy Actions" do
+      api_basic_authorize("control_explorer_view")
       FactoryGirl.create(:miq_action)
       test_collection_bulk_query(:policy_actions, policy_actions_url, MiqAction)
     end
 
     it "bulk query Policy Profiles" do
+      api_basic_authorize("policy_profile_view")
       FactoryGirl.create(:miq_policy_set)
       test_collection_bulk_query(:policy_profiles, policy_profiles_url, MiqPolicySet)
     end
 
     it "bulk query Providers" do
+      api_basic_authorize("ems_infra_show_list")
       FactoryGirl.create(:ext_management_system)
       test_collection_bulk_query(:providers, providers_url, ExtManagementSystem)
     end
 
     it "bulk query Provision Dialogs" do
+      api_basic_authorize("miq_ae_customization_explorer")
       FactoryGirl.create(:miq_dialog)
       test_collection_bulk_query(:provision_dialogs, provision_dialogs_url, MiqDialog)
     end
 
     it "bulk query Provision Requests" do
+      api_basic_authorize("miq_request_show_list")
       FactoryGirl.create(:miq_provision_request, :source => template, :requester => @user)
       test_collection_bulk_query(:provision_requests, provision_requests_url, MiqProvisionRequest)
     end
 
     it "bulk query Rates" do
+      api_basic_authorize("chargeback_rates")
       FactoryGirl.create(:chargeback_rate_detail)
       test_collection_bulk_query(:rates, rates_url, ChargebackRateDetail)
     end
 
     it "bulk query Report Results" do
+      api_basic_authorize("miq_report_view")
       FactoryGirl.create(:miq_report_result)
       test_collection_bulk_query(:results, results_url, MiqReportResult)
     end
 
     it "bulk query Requests" do
+      api_basic_authorize("miq_request_show_list")
       FactoryGirl.create(:vm_migrate_request, :requester => @user)
       test_collection_bulk_query(:requests, requests_url, MiqRequest)
     end
 
     it "bulk query Resource Pools" do
+      api_basic_authorize("resource_pool_show_list")
       FactoryGirl.create(:resource_pool)
       test_collection_bulk_query(:resource_pools, resource_pools_url, ResourcePool)
     end
 
     it "bulk query Roles" do
+      api_basic_authorize("rbac_role_show_list")
       FactoryGirl.create(:miq_user_role)
       test_collection_bulk_query(:roles, roles_url, MiqUserRole)
     end
 
     it "bulk query Security Groups" do
+      api_basic_authorize("security_group_show_list")
       FactoryGirl.create(:security_group)
       test_collection_bulk_query(:security_groups, security_groups_url, SecurityGroup)
     end
 
     it "bulk query Service Catalogs" do
+      api_basic_authorize("svc_catalog_provision")
       FactoryGirl.create(:service_template_catalog)
       test_collection_bulk_query(:service_catalogs, service_catalogs_url, ServiceTemplateCatalog)
     end
 
     it "bulk query Service Dialogs" do
+      api_basic_authorize("miq_ae_customization_explorer")
       FactoryGirl.create(:dialog, :label => "ServiceDialog1")
       test_collection_bulk_query(:service_dialogs, service_dialogs_url, Dialog)
     end
 
     it "bulk query Service Orders" do
+      api_basic_authorize("svc_catalog_provision")
       FactoryGirl.create(:service_order, :user => @user)
       test_collection_bulk_query(:service_orders, service_orders_url, ServiceOrder)
     end
 
     it "bulk query Service Requests" do
+      api_basic_authorize("miq_request_view")
       FactoryGirl.create(:service_template_provision_request, :requester => @user)
       test_collection_bulk_query(:service_requests, service_requests_url, ServiceTemplateProvisionRequest)
     end
 
     it "bulk query Service Templates" do
+      api_basic_authorize("svc_catalog_provision")
       FactoryGirl.create(:service_template)
       test_collection_bulk_query(:service_templates, service_templates_url, ServiceTemplate)
     end
 
     it "bulk query Services" do
+      api_basic_authorize("service_view")
       FactoryGirl.create(:service)
       test_collection_bulk_query(:services, services_url, Service)
     end
 
     it "bulk query Tags" do
+      api_basic_authorize("ops_settings")
       FactoryGirl.create(:classification_cost_center_with_tags)
       test_collection_bulk_query(:tags, tags_url, Tag)
     end
 
     it "bulk query Tasks" do
+      api_basic_authorize("tasks_view")
       FactoryGirl.create(:miq_task)
       test_collection_bulk_query(:tasks, tasks_url, MiqTask)
     end
 
     it "bulk query Templates" do
+      api_basic_authorize("miq_template_show_list")
       template # create resource
       test_collection_bulk_query(:templates, templates_url, MiqTemplate)
     end
@@ -510,18 +590,20 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Users" do
+      api_basic_authorize("rbac_user_show_list")
       FactoryGirl.create(:user)
       test_collection_bulk_query(:users, users_url, User)
     end
 
     it "bulk query Vms" do
+      api_basic_authorize("vm_show_list")
       FactoryGirl.create(:vm_vmware)
       test_collection_bulk_query(:vms, vms_url, Vm)
     end
 
     it "doing a bulk query renders actions for which the user is authorized" do
       vm = FactoryGirl.create(:vm_vmware)
-      api_basic_authorize(collection_action_identifier(:vms, :query), action_identifier(:vms, :start))
+      api_basic_authorize("vm_show_list", "vm_start")
 
       run_post(vms_url, gen_request(:query, [{"id" => vm.id, "href" => vms_url(vm.id)}]))
 
@@ -543,7 +625,7 @@ describe "Rest API Collections" do
 
     it "bulk query Vms with invalid guid fails" do
       FactoryGirl.create(:vm_vmware)
-      api_basic_authorize collection_action_identifier(:vms, :query)
+      api_basic_authorize "vm_show_list"
 
       run_post(vms_url, gen_request(:query, [{"guid" => "B999999D"}]))
 
@@ -552,11 +634,13 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Zones" do
+      api_basic_authorize("zone")
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_bulk_query(:zones, zones_url, Zone)
     end
 
     it 'bulk query LoadBalancers' do
+      api_basic_authorize("load_balancer_show_list")
       FactoryGirl.create(:load_balancer)
       test_collection_bulk_query(:load_balancers, load_balancers_url, LoadBalancer)
     end

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -67,7 +67,7 @@ describe "Conditions API" do
     end
 
     it "creates new condition" do
-      api_basic_authorize collection_action_identifier(:conditions, :create)
+      api_basic_authorize "condition_new"
       run_post(conditions_url, sample_condition)
 
       expect(response).to have_http_status(:ok)
@@ -79,7 +79,7 @@ describe "Conditions API" do
     end
 
     it "creates new conditions" do
-      api_basic_authorize collection_action_identifier(:conditions, :create)
+      api_basic_authorize "condition_new"
       run_post(conditions_url, gen_request(:create, [sample_condition,
                                                      sample_condition.merge(:name => "foo", :description => "bar")]))
       expect(response).to have_http_status(:ok)
@@ -88,7 +88,7 @@ describe "Conditions API" do
     end
 
     it "deletes condition" do
-      api_basic_authorize collection_action_identifier(:conditions, :delete)
+      api_basic_authorize "condition_delete"
       run_post(conditions_url, gen_request(:delete, "name" => condition.name, "href" => condition_url))
 
       expect(response).to have_http_status(:ok)
@@ -97,7 +97,7 @@ describe "Conditions API" do
     end
 
     it "deletes conditions" do
-      api_basic_authorize collection_action_identifier(:conditions, :delete)
+      api_basic_authorize "condition_delete"
       run_post(conditions_url, gen_request(:delete, [{"name" => conditions.first.name,
                                                       "href" => conditions_url(conditions.first.id)},
                                                      {"name" => conditions.second.name,
@@ -109,7 +109,7 @@ describe "Conditions API" do
     end
 
     it "deletes condition via DELETE" do
-      api_basic_authorize collection_action_identifier(:conditions, :delete)
+      api_basic_authorize "condition_delete"
 
       run_delete(conditions_url(condition.id))
 
@@ -118,7 +118,7 @@ describe "Conditions API" do
     end
 
     it "edits condition" do
-      api_basic_authorize collection_action_identifier(:conditions, :edit)
+      api_basic_authorize "condition_edit"
       run_post(conditions_url(condition.id), gen_request(:edit, "description" => "change"))
 
       expect(response).to have_http_status(:ok)
@@ -128,7 +128,7 @@ describe "Conditions API" do
     end
 
     it "edits conditions" do
-      api_basic_authorize collection_action_identifier(:conditions, :edit)
+      api_basic_authorize "condition_edit"
       run_post(conditions_url, gen_request(:edit, [{"id" => conditions.first.id, "description" => "change"},
                                                    {"id" => conditions.second.id, "description" => "change2"}]))
       expect(response).to have_http_status(:ok)
@@ -141,7 +141,7 @@ describe "Conditions API" do
 
   context "Condition collection" do
     it "query invalid collection" do
-      api_basic_authorize collection_action_identifier(:conditions, :read, :get)
+      api_basic_authorize "condition"
 
       run_get conditions_url(999_999)
 
@@ -149,7 +149,7 @@ describe "Conditions API" do
     end
 
     it "query conditions with no conditions defined" do
-      api_basic_authorize collection_action_identifier(:conditions, :read, :get)
+      api_basic_authorize "condition"
 
       run_get conditions_url
 
@@ -157,7 +157,7 @@ describe "Conditions API" do
     end
 
     it "query conditions" do
-      api_basic_authorize collection_action_identifier(:conditions, :read, :get)
+      api_basic_authorize "condition"
       create_conditions(3)
 
       run_get conditions_url
@@ -168,7 +168,7 @@ describe "Conditions API" do
     end
 
     it "query conditions in expanded form" do
-      api_basic_authorize collection_action_identifier(:conditions, :read, :get)
+      api_basic_authorize "condition"
       create_conditions(3)
 
       run_get conditions_url, :expand => "resources"
@@ -203,7 +203,7 @@ describe "Conditions API" do
     end
 
     it "query policy with expanded conditions" do
-      api_basic_authorize action_identifier(:policies, :read, :resource_actions, :get)
+      api_basic_authorize "policy_view"
       create_conditions(3)
       assign_conditions_to(policy)
 

--- a/spec/requests/api/configuration_script_payloads_spec.rb
+++ b/spec/requests/api/configuration_script_payloads_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Configuration Script Payloads API' do
   describe 'GET /api/configuration_script_payloads' do
     it 'lists all the configuration script payloads with an appropriate role' do
       script_payload = FactoryGirl.create(:configuration_script_payload)
-      api_basic_authorize collection_action_identifier(:configuration_script_payloads, :read, :get)
+      api_basic_authorize "embedded_configuration_script_payload_view"
 
       run_get(configuration_script_payloads_url)
 
@@ -30,7 +30,7 @@ RSpec.describe 'Configuration Script Payloads API' do
   describe 'GET /api/configuration_script_payloads/:id' do
     it 'will show an ansible script_payload with an appropriate role' do
       script_payload = FactoryGirl.create(:configuration_script_payload)
-      api_basic_authorize action_identifier(:configuration_script_payloads, :read, :resource_actions, :get)
+      api_basic_authorize "embedded_configuration_script_payload_view"
 
       run_get(configuration_script_payloads_url(script_payload.id))
 

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Configuration Script Sources API' do
   describe 'GET /api/configuration_script_sources' do
     it 'lists all the configuration script sources with an appropriate role' do
       repository = FactoryGirl.create(:configuration_script_source)
-      api_basic_authorize collection_action_identifier(:configuration_script_sources, :read, :get)
+      api_basic_authorize "embedded_configuration_script_source_view"
 
       run_get(configuration_script_sources_url)
 
@@ -28,7 +28,7 @@ RSpec.describe 'Configuration Script Sources API' do
   describe 'GET /api/configuration_script_sources/:id' do
     it 'will show a configuration script source with an appropriate role' do
       repository = FactoryGirl.create(:configuration_script_source)
-      api_basic_authorize collection_action_identifier(:configuration_script_sources, :read, :get)
+      api_basic_authorize "embedded_configuration_script_source_view"
 
       run_get(configuration_script_sources_url(repository.id))
 

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -9,7 +9,7 @@ describe "Container Deployments API" do
 
   it "creates container deployment with POST" do
     allow_any_instance_of(ContainerDeployment).to receive(:create_deployment).and_return(true)
-    api_basic_authorize collection_action_identifier(:container_deployments, :create)
+    api_basic_authorize "container_deployment_create"
     run_post(container_deployments_url, gen_request(:create, :example_data => true))
     expect(response).to have_http_status(:ok)
   end

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -69,8 +69,8 @@ describe "Custom Actions API" do
 
   describe "Querying services with no custom actions" do
     it "returns core actions as authorized" do
-      api_basic_authorize(action_identifier(:services, :edit),
-                          action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize("service_edit",
+                          "service_view")
 
       run_get services_url(svc1.id)
 
@@ -85,8 +85,8 @@ describe "Custom Actions API" do
     end
 
     it "returns core actions as authorized including custom action buttons" do
-      api_basic_authorize(action_identifier(:services, :edit),
-                          action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize("service_edit",
+                          "service_view")
 
       run_get services_url(svc1.id)
 
@@ -95,8 +95,8 @@ describe "Custom Actions API" do
     end
 
     it "supports the custom_actions attribute" do
-      api_basic_authorize(action_identifier(:services, :edit),
-                          action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize("service_edit",
+                          "service_view")
 
       run_get services_url(svc1.id), :attributes => "custom_actions"
 
@@ -105,8 +105,8 @@ describe "Custom Actions API" do
     end
 
     it "supports the custom_action_buttons attribute" do
-      api_basic_authorize(action_identifier(:services, :edit),
-                          action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize("service_edit",
+                          "service_view")
 
       run_get services_url(svc1.id), :attributes => "custom_action_buttons"
 
@@ -121,8 +121,8 @@ describe "Custom Actions API" do
     end
 
     it "returns core actions as authorized excluding custom action buttons" do
-      api_basic_authorize(action_identifier(:service_templates, :edit),
-                          action_identifier(:service_templates, :read, :resource_actions, :get))
+      api_basic_authorize("catalogitem_edit",
+                          "svc_catalog_provision")
 
       run_get service_templates_url(template1.id)
 
@@ -133,7 +133,7 @@ describe "Custom Actions API" do
     end
 
     it "supports the custom_actions attribute" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      api_basic_authorize "svc_catalog_provision"
 
       run_get service_templates_url(template1.id), :attributes => "custom_actions"
 
@@ -142,7 +142,7 @@ describe "Custom Actions API" do
     end
 
     it "supports the custom_action_buttons attribute" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      api_basic_authorize "svc_catalog_provision"
 
       run_get service_templates_url(template1.id), :attributes => "custom_action_buttons"
 
@@ -176,7 +176,7 @@ describe "Custom Actions API" do
 
   describe "Services with custom button dialogs" do
     it "queries for custom_actions returns expanded details for dialog buttons" do
-      api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+      api_basic_authorize "service_view"
 
       template2 = FactoryGirl.create(:service_template, :name => "template2")
       dialog2   = FactoryGirl.create(:dialog, :label => "dialog2")

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -16,7 +16,7 @@ describe "Events API" do
 
   context "Event collection" do
     it "query invalid event" do
-      api_basic_authorize action_identifier(:events, :read, :resource_actions, :get)
+      api_basic_authorize "event"
 
       run_get events_url(999_999)
 
@@ -24,7 +24,7 @@ describe "Events API" do
     end
 
     it "query events with no events defined" do
-      api_basic_authorize collection_action_identifier(:events, :read, :get)
+      api_basic_authorize "event"
 
       run_get events_url
 
@@ -32,7 +32,7 @@ describe "Events API" do
     end
 
     it "query events" do
-      api_basic_authorize collection_action_identifier(:events, :read, :get)
+      api_basic_authorize "event"
       create_events(3)
 
       run_get events_url
@@ -43,7 +43,7 @@ describe "Events API" do
     end
 
     it "query events in expanded form" do
-      api_basic_authorize collection_action_identifier(:events, :read, :get)
+      api_basic_authorize "event"
       create_events(3)
 
       run_get events_url, :expand => "resources"
@@ -84,7 +84,7 @@ describe "Events API" do
     end
 
     it "query policy with expanded events" do
-      api_basic_authorize action_identifier(:policies, :read, :resource_actions, :get)
+      api_basic_authorize "policy_view"
       create_events(3)
       relate_events_to(policy)
 

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -31,7 +31,7 @@ describe "Groups API" do
     end
 
     it "rejects group creation with id specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, "description" => "sample group", "id" => 100)
 
@@ -39,7 +39,7 @@ describe "Groups API" do
     end
 
     it "rejects group creation with invalid role specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, "description" => "sample group", "role" => {"id" => 999_999})
 
@@ -47,7 +47,7 @@ describe "Groups API" do
     end
 
     it "rejects group creation with invalid tenant specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, "description" => "sample group", "tenant" => {"id" => 999_999})
 
@@ -55,7 +55,7 @@ describe "Groups API" do
     end
 
     it "rejects group creation with invalid filters specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, "description" => "sample group", "filters" => {"bogus" => %w(f1 f2)})
 
@@ -63,7 +63,7 @@ describe "Groups API" do
     end
 
     it "supports single group creation" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, sample_group1)
 
@@ -75,7 +75,7 @@ describe "Groups API" do
     end
 
     it "supports single group creation via action" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, gen_request(:create, sample_group1))
 
@@ -87,7 +87,7 @@ describe "Groups API" do
     end
 
     it "supports single group creation via action with role and tenant specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, gen_request(:create,
                                        "description" => "sample_group3",
@@ -109,7 +109,7 @@ describe "Groups API" do
     end
 
     it "supports single group creation with filters specified" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       sample_group = {"description" => "sample_group3",
                       "filters"     => {
@@ -131,7 +131,7 @@ describe "Groups API" do
     end
 
     it "supports multiple group creation" do
-      api_basic_authorize collection_action_identifier(:groups, :create)
+      api_basic_authorize "rbac_group_add"
 
       run_post(groups_url, gen_request(:create, [sample_group1, sample_group2]))
 
@@ -157,7 +157,7 @@ describe "Groups API" do
     end
 
     it "rejects group edits for invalid resources" do
-      api_basic_authorize collection_action_identifier(:groups, :edit)
+      api_basic_authorize "rbac_group_edit"
 
       run_post(groups_url(999_999), gen_request(:edit, "description" => "updated_group"))
 
@@ -165,7 +165,7 @@ describe "Groups API" do
     end
 
     it "supports single group edit" do
-      api_basic_authorize collection_action_identifier(:groups, :edit)
+      api_basic_authorize "rbac_group_edit"
 
       run_post(groups_url(group1.id), gen_request(:edit, "description" => "updated_group"))
 
@@ -175,7 +175,7 @@ describe "Groups API" do
     end
 
     it "supports multiple group edits" do
-      api_basic_authorize collection_action_identifier(:groups, :edit)
+      api_basic_authorize "rbac_group_edit"
 
       run_post(groups_url, gen_request(:edit,
                                        [{"href" => groups_url(group1.id), "description" => "updated_group1"},
@@ -208,7 +208,7 @@ describe "Groups API" do
     end
 
     it "rejects group deletes for invalid groups" do
-      api_basic_authorize collection_action_identifier(:groups, :delete)
+      api_basic_authorize "rbac_group_delete"
 
       run_delete(groups_url(999_999))
 
@@ -216,7 +216,7 @@ describe "Groups API" do
     end
 
     it 'rejects a request to remove a default tenant group' do
-      api_basic_authorize collection_action_identifier(:groups, :delete)
+      api_basic_authorize "rbac_group_delete"
 
       run_delete(groups_url(tenant3.default_miq_group_id))
 
@@ -224,7 +224,7 @@ describe "Groups API" do
     end
 
     it "supports single group delete" do
-      api_basic_authorize collection_action_identifier(:groups, :delete)
+      api_basic_authorize "rbac_group_delete"
 
       g1_id = group1.id
       run_delete(groups_url(g1_id))
@@ -234,7 +234,7 @@ describe "Groups API" do
     end
 
     it "supports single group delete action" do
-      api_basic_authorize collection_action_identifier(:groups, :delete)
+      api_basic_authorize "rbac_group_delete"
 
       g1_id = group1.id
       g1_url = groups_url(g1_id)
@@ -246,7 +246,7 @@ describe "Groups API" do
     end
 
     it "supports multiple group deletes" do
-      api_basic_authorize collection_action_identifier(:groups, :delete)
+      api_basic_authorize "rbac_group_delete"
 
       g1_id, g2_id = group1.id, group2.id
       g1_url, g2_url = groups_url(g1_id), groups_url(g2_id)
@@ -276,7 +276,7 @@ describe "Groups API" do
     it "can assign a tag to a group" do
       group = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:classification_department_with_tags)
-      api_basic_authorize(subcollection_action_identifier(:groups, :tags, :assign))
+      api_basic_authorize("rbac_group_tags_edit")
 
       run_post("#{groups_url(group.id)}/tags", :action => "assign", :category => "department", :name => "finance")
 
@@ -298,7 +298,7 @@ describe "Groups API" do
       group = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:classification_department_with_tags)
       Classification.classify(group, "department", "finance")
-      api_basic_authorize(subcollection_action_identifier(:groups, :tags, :unassign))
+      api_basic_authorize("rbac_group_tags_edit")
 
       run_post("#{groups_url(group.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
 

--- a/spec/requests/api/headers_spec.rb
+++ b/spec/requests/api/headers_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Headers" do
 
   describe "Content-Type" do
     it "accepts JSON by default" do
-      api_basic_authorize(collection_action_identifier(:groups, :create))
+      api_basic_authorize("rbac_group_add")
 
       post groups_url, :params => '{"description": "foo"}', :headers => headers
 
@@ -45,7 +45,7 @@ RSpec.describe "Headers" do
     end
 
     it "will accept JSON when set to application/json" do
-      api_basic_authorize(collection_action_identifier(:groups, :create))
+      api_basic_authorize("rbac_group_add")
 
       post(groups_url,
            :params  => '{"description": "foo"}',
@@ -55,7 +55,7 @@ RSpec.describe "Headers" do
     end
 
     it "will ignore the Content-Type" do
-      api_basic_authorize(collection_action_identifier(:groups, :create))
+      api_basic_authorize("rbac_group_add")
 
       post(groups_url,
            :params  => '{"description": "foo"}',

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "hosts API" do
     context "with an appropriate role" do
       it "can edit the password on a host" do
         host = FactoryGirl.create(:host_with_authentication)
-        api_basic_authorize action_identifier(:hosts, :edit)
+        api_basic_authorize "host_edit"
         options = {:credentials => {:authtype => "default", :password => "abc123"}}
 
         expect do
@@ -14,7 +14,7 @@ RSpec.describe "hosts API" do
 
       it "will update the default authentication if no type is given" do
         host = FactoryGirl.create(:host_with_authentication)
-        api_basic_authorize action_identifier(:hosts, :edit)
+        api_basic_authorize "host_edit"
         options = {:credentials => {:password => "abc123"}}
 
         expect do
@@ -25,7 +25,7 @@ RSpec.describe "hosts API" do
 
       it "sending non-credentials attributes will result in a bad request error" do
         host = FactoryGirl.create(:host_with_authentication)
-        api_basic_authorize action_identifier(:hosts, :edit)
+        api_basic_authorize "host_edit"
         options = {:name => "new name"}
 
         expect do
@@ -37,7 +37,7 @@ RSpec.describe "hosts API" do
       it "can update passwords on multiple hosts by href" do
         host1 = FactoryGirl.create(:host_with_authentication)
         host2 = FactoryGirl.create(:host_with_authentication)
-        api_basic_authorize action_identifier(:hosts, :edit)
+        api_basic_authorize "host_edit"
         options = [
           {:href => hosts_url(host1.id), :credentials => {:password => "abc123"}},
           {:href => hosts_url(host2.id), :credentials => {:password => "def456"}}
@@ -52,7 +52,7 @@ RSpec.describe "hosts API" do
       it "can update passwords on multiple hosts by id" do
         host1 = FactoryGirl.create(:host_with_authentication)
         host2 = FactoryGirl.create(:host_with_authentication)
-        api_basic_authorize action_identifier(:hosts, :edit)
+        api_basic_authorize "host_edit"
         options = [
           {:id => host1.id, :credentials => {:password => "abc123"}},
           {:id => host2.id, :credentials => {:password => "def456"}}

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Instances API" do
 
   context "Instance index" do
     it "lists only the cloud instances (no infrastructure vms)" do
-      api_basic_authorize collection_action_identifier(:instances, :read, :get)
+      api_basic_authorize "instance_show_list"
       instance = FactoryGirl.create(:vm_openstack)
       _vm = FactoryGirl.create(:vm_vmware)
 
@@ -30,7 +30,7 @@ RSpec.describe "Instances API" do
 
   describe "instance terminate action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :terminate)
+      api_basic_authorize "instance_terminate"
 
       run_post(invalid_instance_url, gen_request(:terminate))
 
@@ -46,7 +46,7 @@ RSpec.describe "Instances API" do
     end
 
     it "terminates a single valid Instance" do
-      api_basic_authorize action_identifier(:instances, :terminate)
+      api_basic_authorize "instance_terminate"
 
       run_post(instance_url, gen_request(:terminate))
 
@@ -58,7 +58,7 @@ RSpec.describe "Instances API" do
     end
 
     it "terminates multiple valid Instances" do
-      api_basic_authorize collection_action_identifier(:instances, :terminate)
+      api_basic_authorize "instance_terminate"
 
       run_post(instances_url, gen_request(:terminate, [{"href" => instance1_url}, {"href" => instance2_url}]))
 
@@ -83,7 +83,7 @@ RSpec.describe "Instances API" do
 
   describe "instance stop action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :stop)
+      api_basic_authorize "instance_stop"
 
       run_post(invalid_instance_url, gen_request(:stop))
 
@@ -99,7 +99,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to stop a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :stop)
+      api_basic_authorize "instance_stop"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:stop))
@@ -108,7 +108,7 @@ RSpec.describe "Instances API" do
     end
 
     it "stops a valid instance" do
-      api_basic_authorize action_identifier(:instances, :stop)
+      api_basic_authorize "instance_stop"
 
       run_post(instance_url, gen_request(:stop))
 
@@ -116,7 +116,7 @@ RSpec.describe "Instances API" do
     end
 
     it "stops multiple valid instances" do
-      api_basic_authorize action_identifier(:instances, :stop)
+      api_basic_authorize "instance_stop"
 
       run_post(instances_url, gen_request(:stop, nil, instance1_url, instance2_url))
 
@@ -127,7 +127,7 @@ RSpec.describe "Instances API" do
 
   describe "instance start action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :start)
+      api_basic_authorize "instance_start"
 
       run_post(invalid_instance_url, gen_request(:start))
 
@@ -143,7 +143,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to start a powered on instance" do
-      api_basic_authorize action_identifier(:instances, :start)
+      api_basic_authorize "instance_start"
 
       run_post(instance_url, gen_request(:start))
 
@@ -151,7 +151,7 @@ RSpec.describe "Instances API" do
     end
 
     it "starts an instance" do
-      api_basic_authorize action_identifier(:instances, :start)
+      api_basic_authorize "instance_start"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:start))
@@ -160,7 +160,7 @@ RSpec.describe "Instances API" do
     end
 
     it "starts multiple instances" do
-      api_basic_authorize action_identifier(:instances, :start)
+      api_basic_authorize "instance_start"
       update_raw_power_state("poweredOff", instance1, instance2)
 
       run_post(instances_url, gen_request(:start, nil, instance1_url, instance2_url))
@@ -172,7 +172,7 @@ RSpec.describe "Instances API" do
 
   describe "instance pause action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :pause)
+      api_basic_authorize "instance_pause"
 
       run_post(invalid_instance_url, gen_request(:pause))
 
@@ -188,7 +188,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to pause a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :pause)
+      api_basic_authorize "instance_pause"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:pause))
@@ -197,7 +197,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to pause a paused instance" do
-      api_basic_authorize action_identifier(:instances, :pause)
+      api_basic_authorize "instance_pause"
       update_raw_power_state("paused", instance)
 
       run_post(instance_url, gen_request(:pause))
@@ -206,7 +206,7 @@ RSpec.describe "Instances API" do
     end
 
     it "pauses an instance" do
-      api_basic_authorize action_identifier(:instances, :pause)
+      api_basic_authorize "instance_pause"
 
       run_post(instance_url, gen_request(:pause))
 
@@ -214,7 +214,7 @@ RSpec.describe "Instances API" do
     end
 
     it "pauses multiple instances" do
-      api_basic_authorize action_identifier(:instances, :pause)
+      api_basic_authorize "instance_pause"
 
       run_post(instances_url, gen_request(:pause, nil, instance1_url, instance2_url))
 
@@ -225,7 +225,7 @@ RSpec.describe "Instances API" do
 
   context "Instance suspend action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :suspend)
+      api_basic_authorize "instance_suspend"
 
       run_post(invalid_instance_url, gen_request(:suspend))
 
@@ -241,7 +241,7 @@ RSpec.describe "Instances API" do
     end
 
     it "cannot suspend a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :suspend)
+      api_basic_authorize "instance_suspend"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:suspend))
@@ -250,7 +250,7 @@ RSpec.describe "Instances API" do
     end
 
     it "cannot suspend a suspended instance" do
-      api_basic_authorize action_identifier(:instances, :suspend)
+      api_basic_authorize "instance_suspend"
       update_raw_power_state("suspended", instance)
 
       run_post(instance_url, gen_request(:suspend))
@@ -259,7 +259,7 @@ RSpec.describe "Instances API" do
     end
 
     it "suspends an instance" do
-      api_basic_authorize action_identifier(:instances, :suspend)
+      api_basic_authorize "instance_suspend"
 
       run_post(instance_url, gen_request(:suspend))
 
@@ -267,7 +267,7 @@ RSpec.describe "Instances API" do
     end
 
     it "suspends multiple instances" do
-      api_basic_authorize action_identifier(:instances, :suspend)
+      api_basic_authorize "instance_suspend"
 
       run_post(instances_url, gen_request(:suspend, nil, instance1_url, instance2_url))
 
@@ -278,7 +278,7 @@ RSpec.describe "Instances API" do
 
   context "Instance shelve action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(invalid_instance_url, gen_request(:shelve))
 
@@ -294,7 +294,7 @@ RSpec.describe "Instances API" do
     end
 
     it "shelves a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SHUTOFF", instance)
 
       run_post(instance_url, gen_request(:shelve))
@@ -303,7 +303,7 @@ RSpec.describe "Instances API" do
     end
 
     it "shelves a suspended instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SUSPENDED", instance)
 
       run_post(instance_url, gen_request(:shelve))
@@ -312,7 +312,7 @@ RSpec.describe "Instances API" do
     end
 
     it "shelves a paused instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("PAUSED", instance)
 
       run_post(instance_url, gen_request(:shelve))
@@ -321,7 +321,7 @@ RSpec.describe "Instances API" do
     end
 
     it "cannot shelve a shelved instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SHELVED", instance)
 
       run_post(instance_url, gen_request(:shelve))
@@ -334,7 +334,7 @@ RSpec.describe "Instances API" do
     end
 
     it "shelves an instance" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(instance_url, gen_request(:shelve))
 
@@ -345,7 +345,7 @@ RSpec.describe "Instances API" do
     end
 
     it "shelves multiple instances" do
-      api_basic_authorize action_identifier(:instances, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(instances_url, gen_request(:shelve, nil, instance1_url, instance2_url))
 
@@ -356,7 +356,7 @@ RSpec.describe "Instances API" do
 
   describe "instance reboot guest action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :reboot_guest)
+      api_basic_authorize "instance_guest_restart"
 
       run_post(invalid_instance_url, gen_request(:reboot_guest))
 
@@ -372,7 +372,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to reboot a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :reboot_guest)
+      api_basic_authorize "instance_guest_restart"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:reboot_guest))
@@ -381,7 +381,7 @@ RSpec.describe "Instances API" do
     end
 
     it "reboots a valid instance" do
-      api_basic_authorize action_identifier(:instances, :reboot_guest)
+      api_basic_authorize "instance_guest_restart"
 
       run_post(instance_url, gen_request(:reboot_guest))
 
@@ -389,7 +389,7 @@ RSpec.describe "Instances API" do
     end
 
     it "reboots multiple valid instances" do
-      api_basic_authorize action_identifier(:instances, :reboot_guest)
+      api_basic_authorize "instance_guest_restart"
 
       run_post(instances_url, gen_request(:reboot_guest, nil, instance1_url, instance2_url))
 
@@ -400,7 +400,7 @@ RSpec.describe "Instances API" do
 
   describe "instance reset action" do
     it "responds not found for an invalid instance" do
-      api_basic_authorize action_identifier(:instances, :reset)
+      api_basic_authorize "instance_reset"
 
       run_post(invalid_instance_url, gen_request(:reset))
 
@@ -416,7 +416,7 @@ RSpec.describe "Instances API" do
     end
 
     it "fails to reset a powered off instance" do
-      api_basic_authorize action_identifier(:instances, :reset)
+      api_basic_authorize "instance_reset"
       update_raw_power_state("poweredOff", instance)
 
       run_post(instance_url, gen_request(:reset))
@@ -425,7 +425,7 @@ RSpec.describe "Instances API" do
     end
 
     it "resets a valid instance" do
-      api_basic_authorize action_identifier(:instances, :reset)
+      api_basic_authorize "instance_reset"
 
       run_post(instance_url, gen_request(:reset))
 
@@ -433,7 +433,7 @@ RSpec.describe "Instances API" do
     end
 
     it "resets multiple valid instances" do
-      api_basic_authorize action_identifier(:instances, :reset)
+      api_basic_authorize "instance_reset"
 
       run_post(instances_url, gen_request(:reset, nil, instance1_url, instance2_url))
 
@@ -456,7 +456,7 @@ RSpec.describe "Instances API" do
     end
 
     it 'queries all load balancers on an instance' do
-      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      api_basic_authorize "load_balancer_show"
       expected = {
         'name'      => 'load_balancers',
         'resources' => [
@@ -470,7 +470,7 @@ RSpec.describe "Instances API" do
     end
 
     it 'queries a single load balancer on an instance' do
-      api_basic_authorize subcollection_action_identifier(:instances, :load_balancers, :show, :get)
+      api_basic_authorize "load_balancer_show"
       run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/load_balancers_spec.rb
+++ b/spec/requests/api/load_balancers_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'LoadBalancers API' do
   describe 'GET /api/load_balancers' do
     it 'lists all load balancers with an appropriate role' do
       load_balancer = FactoryGirl.create(:load_balancer)
-      api_basic_authorize collection_action_identifier(:load_balancers, :read, :get)
+      api_basic_authorize "load_balancer_show_list"
 
       expected = {
         'count'     => 1,
@@ -30,7 +30,7 @@ RSpec.describe 'LoadBalancers API' do
   describe 'GET /api/load_balancers/:id' do
     it 'will show a load balancer with an appropriate role' do
       load_balancer = FactoryGirl.create(:load_balancer)
-      api_basic_authorize action_identifier(:load_balancers, :read, :resource_actions, :get)
+      api_basic_authorize "load_balancer_show"
 
       run_get(load_balancers_url(load_balancer.id))
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -30,7 +30,7 @@ describe "Logging" do
     end
 
     it "logs hashed details about the request" do
-      api_basic_authorize collection_action_identifier(:users, :read, :get)
+      api_basic_authorize "rbac_user_show_list"
 
       log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
         "Request" => a_hash_including(:path          => "/api/users",
@@ -59,7 +59,7 @@ describe "Logging" do
     end
 
     it "filters password attributes in nested parameters" do
-      api_basic_authorize collection_action_identifier(:services, :create)
+      api_basic_authorize "service_create"
 
       log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
         "Parameters" => a_hash_including(

--- a/spec/requests/api/normalization_spec.rb
+++ b/spec/requests/api/normalization_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Normalization of objects API" do
   it "represents datetimes in ISO8601 format" do
-    api_basic_authorize action_identifier(:hosts, :read, :resource_actions, :get)
+    api_basic_authorize "host_show"
     host = FactoryGirl.create(:host)
 
     run_get(hosts_url(host.id))

--- a/spec/requests/api/orchestration_template_spec.rb
+++ b/spec/requests/api/orchestration_template_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Orchestration Template API' do
       FactoryGirl.create(:orchestration_template_hot_with_content)
       FactoryGirl.create(:orchestration_template_vnfd_with_content)
 
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :read, :get)
+      api_basic_authorize "orchestration_templates_view"
       run_get(orchestration_templates_url)
       expect_query_result(:orchestration_templates, 3, 3)
     end
@@ -45,7 +45,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'supports single HOT orchestration_template creation' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+      api_basic_authorize "orchestration_template_add"
 
       expect do
         run_post(orchestration_templates_url, request_body_hot)
@@ -53,7 +53,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'supports single CFN orchestration_template creation' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+      api_basic_authorize "orchestration_template_add"
 
       expect do
         run_post(orchestration_templates_url, request_body_cfn)
@@ -61,7 +61,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'supports single VNFd orchestration_template creation' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+      api_basic_authorize "orchestration_template_add"
 
       expect do
         run_post(orchestration_templates_url, request_body_vnfd)
@@ -69,7 +69,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'supports orchestration_template creation via action' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+      api_basic_authorize "orchestration_template_add"
 
       expect do
         run_post(orchestration_templates_url, gen_request(:create, request_body_hot))
@@ -77,7 +77,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'rejects a request with an id' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
+      api_basic_authorize "orchestration_template_add"
 
       run_post(orchestration_templates_url, request_body_hot.merge(:id => 1))
 
@@ -89,7 +89,7 @@ RSpec.describe 'Orchestration Template API' do
     it 'supports single orchestration_template edit' do
       hot = FactoryGirl.create(:orchestration_template_hot_with_content, :name => "New Hot Template")
 
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :edit)
+      api_basic_authorize "orchestration_template_edit"
 
       edited_name = "Edited Hot Template"
       run_post(orchestration_templates_url(hot.id), gen_request(:edit, :name => edited_name))
@@ -100,11 +100,11 @@ RSpec.describe 'Orchestration Template API' do
 
   context 'orchestration_template delete' do
     it 'supports single orchestration_template delete' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
+      api_basic_authorize "orchestration_template_remove"
 
       cfn = FactoryGirl.create(:orchestration_template_cfn_with_content)
 
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
+      api_basic_authorize "orchestration_template_remove"
 
       run_delete(orchestration_templates_url(cfn.id))
 
@@ -113,7 +113,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'supports multiple orchestration_template delete' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
+      api_basic_authorize "orchestration_template_remove"
 
       cfn = FactoryGirl.create(:orchestration_template_cfn_with_content)
       hot = FactoryGirl.create(:orchestration_template_hot_with_content)
@@ -142,7 +142,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'forbids orchestration template copy with no content specified' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :copy)
+      api_basic_authorize "orchestration_template_copy"
 
       orchestration_template = FactoryGirl.create(:orchestration_template_cfn)
 
@@ -152,7 +152,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'can copy single orchestration template with a different content' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :copy)
+      api_basic_authorize "orchestration_template_copy"
 
       orchestration_template = FactoryGirl.create(:orchestration_template_cfn)
       new_content            = "{ 'Description': 'Test content 1' }\n"
@@ -178,7 +178,7 @@ RSpec.describe 'Orchestration Template API' do
     end
 
     it 'can copy multiple orchestration templates with a different content' do
-      api_basic_authorize collection_action_identifier(:orchestration_templates, :copy)
+      api_basic_authorize "orchestration_template_copy"
 
       orchestration_template   = FactoryGirl.create(:orchestration_template_cfn)
       new_content              = "{ 'Description': 'Test content 1' }\n"

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -34,7 +34,7 @@ describe "Pictures" do
 
   describe "Queries of Service Templates" do
     it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      api_basic_authorize "svc_catalog_provision"
 
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
@@ -44,7 +44,7 @@ describe "Pictures" do
 
   describe "Queries of Services" do
     it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+      api_basic_authorize "service_view"
 
       run_get services_url(service.id), :attributes => "picture,picture.image_href"
 
@@ -54,7 +54,7 @@ describe "Pictures" do
 
   describe "Queries of Service Requests" do
     it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:service_requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url(service_request.id), :attributes => "picture,picture.image_href"
 
@@ -88,7 +88,7 @@ describe "Pictures" do
     end
 
     it 'creates a new picture' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+      api_basic_authorize "picture_new"
 
       expected = {
         'results' => [a_hash_including('id')]
@@ -102,7 +102,7 @@ describe "Pictures" do
     end
 
     it 'creates multiple pictures' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+      api_basic_authorize "picture_new"
 
       expected = {
         'results' => [a_hash_including('id'), a_hash_including('id')]
@@ -119,7 +119,7 @@ describe "Pictures" do
     end
 
     it 'requires an extension' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+      api_basic_authorize "picture_new"
 
       run_post pictures_url, :content => content
 
@@ -133,7 +133,7 @@ describe "Pictures" do
     end
 
     it 'requires content' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+      api_basic_authorize "picture_new"
 
       run_post pictures_url, :extension => 'png'
 
@@ -147,7 +147,7 @@ describe "Pictures" do
     end
 
     it 'requires content with valid base64' do
-      api_basic_authorize collection_action_identifier(:pictures, :create)
+      api_basic_authorize "picture_new"
 
       run_post pictures_url, :content => 'not base64', :extension => 'png'
 

--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -53,16 +53,16 @@ describe "Policies Assignment API" do
     expect(response).to have_http_status(:forbidden)
   end
 
-  def test_policy_assign_invalid_policy(object_policies_url, collection, subcollection)
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
+  def test_policy_assign_invalid_policy(object_policies_url, identifier, subcollection)
+    api_basic_authorize identifier
 
     run_post(object_policies_url, gen_request(:assign, :href => "/api/#{subcollection}/999999"))
 
     expect(response).to have_http_status(:not_found)
   end
 
-  def test_policy_assign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
+  def test_policy_assign_invalid_policy_guid(object_url, object_policies_url, identifier)
+    api_basic_authorize identifier
 
     run_post(object_policies_url, gen_request(:assign, :guid => "xyzzy"))
 
@@ -71,8 +71,8 @@ describe "Policies Assignment API" do
     expect_results_to_match_hash("results", results_hash)
   end
 
-  def test_assign_multiple_policies(object_url, object_policies_url, collection, subcollection, options = {})
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :assign)
+  def test_assign_multiple_policies(object_url, object_policies_url, identifier, subcollection, options = {})
+    api_basic_authorize identifier
 
     object = options[:object]
     policies = options[:policies]
@@ -97,16 +97,16 @@ describe "Policies Assignment API" do
     expect(response).to have_http_status(:forbidden)
   end
 
-  def test_policy_unassign_invalid_policy(object_policies_url, collection, subcollection)
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
+  def test_policy_unassign_invalid_policy(object_policies_url, identifier, subcollection)
+    api_basic_authorize identifier
 
     run_post(object_policies_url, gen_request(:unassign, :href => "/api/#{subcollection}/999999"))
 
     expect(response).to have_http_status(:not_found)
   end
 
-  def test_policy_unassign_invalid_policy_guid(object_url, object_policies_url, collection, subcollection)
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
+  def test_policy_unassign_invalid_policy_guid(object_url, object_policies_url, identifier)
+    api_basic_authorize identifier
 
     run_post(object_policies_url, gen_request(:unassign, :guid => "xyzzy"))
 
@@ -115,8 +115,8 @@ describe "Policies Assignment API" do
     expect_results_to_match_hash("results", results_hash)
   end
 
-  def test_unassign_multiple_policies(object_policies_url, collection, subcollection, options = {})
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
+  def test_unassign_multiple_policies(object_policies_url, identifier, options = {})
+    api_basic_authorize identifier
 
     object = options[:object]
 
@@ -128,8 +128,8 @@ describe "Policies Assignment API" do
     expect(object.get_policies.first.guid).to eq(p1.guid)
   end
 
-  def test_unassign_multiple_policy_profiles(object_policies_url, collection, subcollection, options = {})
-    api_basic_authorize subcollection_action_identifier(collection, subcollection, :unassign)
+  def test_unassign_multiple_policy_profiles(object_policies_url, identifier, options = {})
+    api_basic_authorize identifier
 
     object = options[:object]
     [ps1, ps2].each { |ps| object.add_policy(ps) }
@@ -150,17 +150,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Provider policy with invalid href" do
-      test_policy_assign_invalid_policy(provider_policies_url, :providers, :policies)
+      test_policy_assign_invalid_policy(provider_policies_url, "ems_infra_protect", :policies)
     end
 
     it "assign Provider policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(provider_url, provider_policies_url, :providers, :policies)
+      test_policy_assign_invalid_policy_guid(provider_url, provider_policies_url, "ems_infra_protect")
     end
 
     it "assign Provider multiple policies" do
       test_assign_multiple_policies(provider_url,
                                     provider_policies_url,
-                                    :providers,
+                                    "ems_infra_protect",
                                     :policies,
                                     :object   => provider,
                                     :policies => [p1, p2])
@@ -171,15 +171,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy with invalid href" do
-      test_policy_unassign_invalid_policy(provider_policies_url, :providers, :policies)
+      test_policy_unassign_invalid_policy(provider_policies_url, "ems_infra_protect", :policies)
     end
 
     it "unassign Provider policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(provider_url, provider_policies_url, :providers, :policies)
+      test_policy_unassign_invalid_policy_guid(provider_url, provider_policies_url, "ems_infra_protect")
     end
 
     it "unassign Provider multiple policies" do
-      test_unassign_multiple_policies(provider_policies_url, :providers, :policies, :object => provider)
+      test_unassign_multiple_policies(provider_policies_url, "ems_infra_protect", :object => provider)
     end
   end
 
@@ -193,17 +193,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Provider policy profile with invalid href" do
-      test_policy_assign_invalid_policy(provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_assign_invalid_policy(provider_policy_profiles_url, "ems_infra_protect", :policy_profiles)
     end
 
     it "assign Provider policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(provider_url, provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(provider_url, provider_policy_profiles_url, "ems_infra_protect")
     end
 
     it "assign Provider multiple policy profiles" do
       test_assign_multiple_policies(provider_url,
                                     provider_policy_profiles_url,
-                                    :providers,
+                                    "ems_infra_protect",
                                     :policy_profiles,
                                     :object   => provider,
                                     :policies => [ps1, ps2])
@@ -214,21 +214,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Provider policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(provider_policy_profiles_url, :providers, :policy_profiles)
+      test_policy_unassign_invalid_policy(provider_policy_profiles_url, "ems_infra_protect", :policy_profiles)
     end
 
     it "unassign Provider policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(provider_url,
-                                               provider_policy_profiles_url,
-                                               :providers,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(provider_url, provider_policy_profiles_url, "ems_infra_protect")
     end
 
     it "unassign Provider multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(provider_policy_profiles_url,
-                                             :providers,
-                                             :policy_profiles,
-                                             :object => provider)
+      test_unassign_multiple_policy_profiles(provider_policy_profiles_url, "ems_infra_protect", :object => provider)
     end
   end
 
@@ -242,17 +236,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Host policy with invalid href" do
-      test_policy_assign_invalid_policy(host_policies_url, :hosts, :policies)
+      test_policy_assign_invalid_policy(host_policies_url, "host_protect", :policies)
     end
 
     it "assign Host policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(host_url, host_policies_url, :hosts, :policies)
+      test_policy_assign_invalid_policy_guid(host_url, host_policies_url, "host_protect")
     end
 
     it "assign Host multiple policies" do
       test_assign_multiple_policies(host_url,
                                     host_policies_url,
-                                    :hosts,
+                                    "host_protect",
                                     :policies,
                                     :object   => host,
                                     :policies => [p1, p2])
@@ -263,15 +257,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy with invalid href" do
-      test_policy_unassign_invalid_policy(host_policies_url, :hosts, :policies)
+      test_policy_unassign_invalid_policy(host_policies_url, "host_protect", :policies)
     end
 
     it "unassign Host policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(host_url, host_policies_url, :hosts, :policies)
+      test_policy_unassign_invalid_policy_guid(host_url, host_policies_url, "host_protect")
     end
 
     it "unassign Host multiple policies" do
-      test_unassign_multiple_policies(host_policies_url, :hosts, :policies, :object => host)
+      test_unassign_multiple_policies(host_policies_url, "host_protect", :object => host)
     end
   end
 
@@ -285,17 +279,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Host policy profile with invalid href" do
-      test_policy_assign_invalid_policy(host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_assign_invalid_policy(host_policy_profiles_url, "host_protect", :policy_profiles)
     end
 
     it "assign Host policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(host_url, host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(host_url, host_policy_profiles_url, "host_protect")
     end
 
     it "assign Host multiple policy profiles" do
       test_assign_multiple_policies(host_url,
                                     host_policy_profiles_url,
-                                    :hosts,
+                                    "host_protect",
                                     :policy_profiles,
                                     :object   => host,
                                     :policies => [ps1, ps2])
@@ -306,21 +300,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Host policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(host_policy_profiles_url, :hosts, :policy_profiles)
+      test_policy_unassign_invalid_policy(host_policy_profiles_url, "host_protect", :policy_profiles)
     end
 
     it "unassign Host policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(host_url,
-                                               host_policy_profiles_url,
-                                               :hosts,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(host_url, host_policy_profiles_url, "host_protect")
     end
 
     it "unassign Host multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(host_policy_profiles_url,
-                                             :hosts,
-                                             :policy_profiles,
-                                             :object => host)
+      test_unassign_multiple_policy_profiles(host_policy_profiles_url, "host_protect", :object => host)
     end
   end
 
@@ -334,17 +322,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Resource Pool policy with invalid href" do
-      test_policy_assign_invalid_policy(rp_policies_url, :resource_pools, :policies)
+      test_policy_assign_invalid_policy(rp_policies_url, "resource_pool_protect", :policies)
     end
 
     it "assign Resource Pool policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(rp_url, rp_policies_url, :resource_pools, :policies)
+      test_policy_assign_invalid_policy_guid(rp_url, rp_policies_url, "resource_pool_protect")
     end
 
     it "assign Resource Pool multiple policies" do
       test_assign_multiple_policies(rp_url,
                                     rp_policies_url,
-                                    :resource_pools,
+                                    "resource_pool_protect",
                                     :policies,
                                     :object   => rp,
                                     :policies => [p1, p2])
@@ -355,15 +343,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy with invalid href" do
-      test_policy_unassign_invalid_policy(rp_policies_url, :resource_pools, :policies)
+      test_policy_unassign_invalid_policy(rp_policies_url, "resource_pool_protect", :policies)
     end
 
     it "unassign Resource Pool policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(rp_url, rp_policies_url, :resource_pools, :policies)
+      test_policy_unassign_invalid_policy_guid(rp_url, rp_policies_url, "resource_pool_protect")
     end
 
     it "unassign Resource Pool multiple policies" do
-      test_unassign_multiple_policies(rp_policies_url, :resource_pools, :policies, :object => rp)
+      test_unassign_multiple_policies(rp_policies_url, "resource_pool_protect", :object => rp)
     end
   end
 
@@ -377,17 +365,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Resource Pool policy profile with invalid href" do
-      test_policy_assign_invalid_policy(rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_assign_invalid_policy(rp_policy_profiles_url, "resource_pool_protect", :policy_profiles)
     end
 
     it "assign Resource Pool policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(rp_url, rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(rp_url, rp_policy_profiles_url, "resource_pool_protect")
     end
 
     it "assign Resource Pool multiple policy profiles" do
       test_assign_multiple_policies(rp_url,
                                     rp_policy_profiles_url,
-                                    :resource_pools,
+                                    "resource_pool_protect",
                                     :policy_profiles,
                                     :object   => rp,
                                     :policies => [ps1, ps2])
@@ -398,21 +386,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Resource Pool policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(rp_policy_profiles_url, :resource_pools, :policy_profiles)
+      test_policy_unassign_invalid_policy(rp_policy_profiles_url, "resource_pool_protect", :policy_profiles)
     end
 
     it "unassign Resource Pool policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(rp_url,
-                                               rp_policy_profiles_url,
-                                               :resource_pools,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(rp_url, rp_policy_profiles_url, "resource_pool_protect")
     end
 
     it "unassign Resource Pool multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(rp_policy_profiles_url,
-                                             :resource_pools,
-                                             :policy_profiles,
-                                             :object => rp)
+      test_unassign_multiple_policy_profiles(rp_policy_profiles_url, "resource_pool_protect", :object => rp)
     end
   end
 
@@ -426,17 +408,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Cluster policy with invalid href" do
-      test_policy_assign_invalid_policy(cluster_policies_url, :clusters, :policies)
+      test_policy_assign_invalid_policy(cluster_policies_url, "ems_cluster_protect", :policies)
     end
 
     it "assign Cluster policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(cluster_url, cluster_policies_url, :clusters, :policies)
+      test_policy_assign_invalid_policy_guid(cluster_url, cluster_policies_url, "ems_cluster_protect")
     end
 
     it "assign Cluster multiple policies" do
       test_assign_multiple_policies(cluster_url,
                                     cluster_policies_url,
-                                    :clusters,
+                                    "ems_cluster_protect",
                                     :policies,
                                     :object   => cluster,
                                     :policies => [p1, p2])
@@ -447,15 +429,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy with invalid href" do
-      test_policy_unassign_invalid_policy(cluster_policies_url, :clusters, :policies)
+      test_policy_unassign_invalid_policy(cluster_policies_url, "ems_cluster_protect", :policies)
     end
 
     it "unassign Cluster policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(cluster_url, cluster_policies_url, :clusters, :policies)
+      test_policy_unassign_invalid_policy_guid(cluster_url, cluster_policies_url, "ems_cluster_protect")
     end
 
     it "unassign Cluster multiple policies" do
-      test_unassign_multiple_policies(cluster_policies_url, :clusters, :policies, :object => cluster)
+      test_unassign_multiple_policies(cluster_policies_url, "ems_cluster_protect", :object => cluster)
     end
   end
 
@@ -469,17 +451,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Cluster policy profile with invalid href" do
-      test_policy_assign_invalid_policy(cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_assign_invalid_policy(cluster_policy_profiles_url, "ems_cluster_protect", :policy_profiles)
     end
 
     it "assign Cluster policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(cluster_url, cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(cluster_url, cluster_policy_profiles_url, "ems_cluster_protect")
     end
 
     it "assign Cluster multiple policy profiles" do
       test_assign_multiple_policies(cluster_url,
                                     cluster_policy_profiles_url,
-                                    :clusters,
+                                    "ems_cluster_protect",
                                     :policy_profiles,
                                     :object   => cluster,
                                     :policies => [ps1, ps2])
@@ -490,21 +472,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Cluster policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(cluster_policy_profiles_url, :clusters, :policy_profiles)
+      test_policy_unassign_invalid_policy(cluster_policy_profiles_url, "ems_cluster_protect", :policy_profiles)
     end
 
     it "unassign Cluster policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(cluster_url,
-                                               cluster_policy_profiles_url,
-                                               :clusters,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(cluster_url, cluster_policy_profiles_url, "ems_cluster_protect")
     end
 
     it "unassign Cluster multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(cluster_policy_profiles_url,
-                                             :clusters,
-                                             :policy_profiles,
-                                             :object => cluster)
+      test_unassign_multiple_policy_profiles(cluster_policy_profiles_url, "ems_cluster_protect", :object => cluster)
     end
   end
 
@@ -518,17 +494,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Vm policy with invalid href" do
-      test_policy_assign_invalid_policy(vm_policies_url, :vms, :policies)
+      test_policy_assign_invalid_policy(vm_policies_url, "vm_protect", :policies)
     end
 
     it "assign Vm policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(vm_url, vm_policies_url, :vms, :policies)
+      test_policy_assign_invalid_policy_guid(vm_url, vm_policies_url, "vm_protect")
     end
 
     it "assign Vm multiple policies" do
       test_assign_multiple_policies(vm_url,
                                     vm_policies_url,
-                                    :vms,
+                                    "vm_protect",
                                     :policies,
                                     :object   => vm,
                                     :policies => [p1, p2])
@@ -539,15 +515,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy with invalid href" do
-      test_policy_unassign_invalid_policy(vm_policies_url, :vms, :policies)
+      test_policy_unassign_invalid_policy(vm_policies_url, "vm_protect", :policies)
     end
 
     it "unassign Vm policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(vm_url, vm_policies_url, :vms, :policies)
+      test_policy_unassign_invalid_policy_guid(vm_url, vm_policies_url, "vm_protect")
     end
 
     it "unassign Vm multiple policies" do
-      test_unassign_multiple_policies(vm_policies_url, :vms, :policies, :object => vm)
+      test_unassign_multiple_policies(vm_policies_url, "vm_protect", :object => vm)
     end
   end
 
@@ -561,17 +537,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Vm policy profile with invalid href" do
-      test_policy_assign_invalid_policy(vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_assign_invalid_policy(vm_policy_profiles_url, "vm_protect", :policy_profiles)
     end
 
     it "assign Vm policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(vm_url, vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(vm_url, vm_policy_profiles_url, "vm_protect")
     end
 
     it "assign Vm multiple policy profiles" do
       test_assign_multiple_policies(vm_url,
                                     vm_policy_profiles_url,
-                                    :vms,
+                                    "vm_protect",
                                     :policy_profiles,
                                     :object   => vm,
                                     :policies => [ps1, ps2])
@@ -582,21 +558,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Vm policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(vm_policy_profiles_url, :vms, :policy_profiles)
+      test_policy_unassign_invalid_policy(vm_policy_profiles_url, "vm_protect", :policy_profiles)
     end
 
     it "unassign Vm policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(vm_url,
-                                               vm_policy_profiles_url,
-                                               :vms,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(vm_url, vm_policy_profiles_url, "vm_protect")
     end
 
     it "unassign Vm multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(vm_policy_profiles_url,
-                                             :vms,
-                                             :policy_profiles,
-                                             :object => vm)
+      test_unassign_multiple_policy_profiles(vm_policy_profiles_url, "vm_protect", :object => vm)
     end
   end
 
@@ -610,17 +580,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Template policy with invalid href" do
-      test_policy_assign_invalid_policy(template_policies_url, :templates, :policies)
+      test_policy_assign_invalid_policy(template_policies_url, "miq_template_protect", :policies)
     end
 
     it "assign Template policy with invalid guid" do
-      test_policy_assign_invalid_policy_guid(template_url, template_policies_url, :templates, :policies)
+      test_policy_assign_invalid_policy_guid(template_url, template_policies_url, "miq_template_protect")
     end
 
     it "assign Template multiple policies" do
       test_assign_multiple_policies(template_url,
                                     template_policies_url,
-                                    :templates,
+                                    "miq_template_protect",
                                     :policies,
                                     :object   => template,
                                     :policies => [p1, p2])
@@ -631,15 +601,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy with invalid href" do
-      test_policy_unassign_invalid_policy(template_policies_url, :templates, :policies)
+      test_policy_unassign_invalid_policy(template_policies_url, "miq_template_protect", :policies)
     end
 
     it "unassign Template policy with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(template_url, template_policies_url, :templates, :policies)
+      test_policy_unassign_invalid_policy_guid(template_url, template_policies_url, "miq_template_protect")
     end
 
     it "unassign Template multiple policies" do
-      test_unassign_multiple_policies(template_policies_url, :templates, :policies, :object => template)
+      test_unassign_multiple_policies(template_policies_url, "miq_template_protect", :object => template)
     end
   end
 
@@ -653,17 +623,17 @@ describe "Policies Assignment API" do
     end
 
     it "assign Template policy profile with invalid href" do
-      test_policy_assign_invalid_policy(template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_assign_invalid_policy(template_policy_profiles_url, "miq_template_protect", :policy_profiles)
     end
 
     it "assign Template policy profile with invalid guid" do
-      test_policy_assign_invalid_policy_guid(template_url, template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_assign_invalid_policy_guid(template_url, template_policy_profiles_url, "miq_template_protect")
     end
 
     it "assign Template multiple policy profiles" do
       test_assign_multiple_policies(template_url,
                                     template_policy_profiles_url,
-                                    :templates,
+                                    "miq_template_protect",
                                     :policy_profiles,
                                     :object   => template,
                                     :policies => [ps1, ps2])
@@ -674,21 +644,15 @@ describe "Policies Assignment API" do
     end
 
     it "unassign Template policy profile with invalid href" do
-      test_policy_unassign_invalid_policy(template_policy_profiles_url, :templates, :policy_profiles)
+      test_policy_unassign_invalid_policy(template_policy_profiles_url, "miq_template_protect", :policy_profiles)
     end
 
     it "unassign Template policy profile with invalid guid" do
-      test_policy_unassign_invalid_policy_guid(template_url,
-                                               template_policy_profiles_url,
-                                               :templates,
-                                               :policy_profiles)
+      test_policy_unassign_invalid_policy_guid(template_url, template_policy_profiles_url, "miq_template_protect")
     end
 
     it "unassign Template multiple policy profiles" do
-      test_unassign_multiple_policy_profiles(template_policy_profiles_url,
-                                             :templates,
-                                             :policy_profiles,
-                                             :object => template)
+      test_unassign_multiple_policy_profiles(template_policy_profiles_url, "miq_template_protect", :object => template)
     end
   end
 end

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -101,7 +101,7 @@ describe "Policies API" do
 
   context "Policy collection" do
     it "query invalid policy" do
-      api_basic_authorize action_identifier(:policies, :read, :resource_actions, :get)
+      api_basic_authorize "policy_view"
 
       run_get policies_url(999_999)
 
@@ -109,7 +109,7 @@ describe "Policies API" do
     end
 
     it "query policies" do
-      api_basic_authorize collection_action_identifier(:policies, :read, :get)
+      api_basic_authorize "policy_view"
 
       run_get policies_url
 
@@ -119,7 +119,7 @@ describe "Policies API" do
     end
 
     it "query policies in expanded form" do
-      api_basic_authorize collection_action_identifier(:policies, :read, :get)
+      api_basic_authorize "policy_view"
 
       run_get policies_url, :expand => "resources"
 
@@ -133,7 +133,7 @@ describe "Policies API" do
     let(:policy_profile_url) { policy_profiles_url(policy_profile.id) }
 
     it "query invalid policy profile" do
-      api_basic_authorize action_identifier(:policy_profiles, :read, :resource_actions, :get)
+      api_basic_authorize "policy_profile_view"
 
       run_get policy_profiles_url(999_999)
 
@@ -141,7 +141,7 @@ describe "Policies API" do
     end
 
     it "query Policy Profiles" do
-      api_basic_authorize collection_action_identifier(:policy_profiles, :read, :get)
+      api_basic_authorize "policy_profile_view"
 
       run_get policy_profiles_url
 
@@ -151,7 +151,7 @@ describe "Policies API" do
     end
 
     it "query individual Policy Profile" do
-      api_basic_authorize action_identifier(:policy_profiles, :read, :resource_actions, :get)
+      api_basic_authorize "policy_profile_view"
 
       run_get policy_profile_url
 
@@ -170,7 +170,7 @@ describe "Policies API" do
     end
 
     it "query Policy Profile with expanded policies subcollection" do
-      api_basic_authorize action_identifier(:policy_profiles, :read, :resource_actions, :get)
+      api_basic_authorize "policy_profile_view"
 
       run_get policy_profile_url, :expand => "policies"
 
@@ -373,7 +373,7 @@ describe "Policies API" do
     end
 
     it "creates new policy" do
-      api_basic_authorize collection_action_identifier(:policies, :create)
+      api_basic_authorize "policy_new"
       run_post(policies_url, sample_policy.merge!(miq_policy_contents))
       policy = MiqPolicy.find(response.parsed_body["results"].first["id"])
       expect(response.parsed_body["results"].first["name"]).to eq("sample policy")
@@ -386,14 +386,14 @@ describe "Policies API" do
     end
 
     it "shouldn't creates new policy with missing params" do
-      api_basic_authorize collection_action_identifier(:policies, :create)
+      api_basic_authorize "policy_new"
       run_post(policies_url, sample_policy)
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body["error"]["message"]).to include(miq_policy_contents.keys.join(", "))
     end
 
     it "deletes policy" do
-      api_basic_authorize collection_action_identifier(:policies, :delete)
+      api_basic_authorize "policy_delete"
       run_post(policies_url, gen_request(:delete, "href" => policies_url(miq_policy.id)))
       policy_id = response.parsed_body["results"].first["id"]
       expect(MiqPolicy.exists?(policy_id)).to be_falsey
@@ -401,7 +401,7 @@ describe "Policies API" do
     end
 
     it "edits policy actions events and conditions" do
-      api_basic_authorize collection_action_identifier(:policies, :edit)
+      api_basic_authorize "policy_edit"
       miq_policy.conditions << conditions
       expect(miq_policy.conditions.count).to eq(2)
       expect(miq_policy.actions.count).to eq(0)

--- a/spec/requests/api/policy_actions_spec.rb
+++ b/spec/requests/api/policy_actions_spec.rb
@@ -18,7 +18,7 @@ describe "Policy Actions API" do
 
   context "Policy Action collection" do
     it "query invalid action" do
-      api_basic_authorize action_identifier(:policy_actions, :read, :resource_actions, :get)
+      api_basic_authorize "control_explorer_view"
 
       run_get policy_actions_url(999_999)
 
@@ -26,7 +26,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy actions with no actions defined" do
-      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+      api_basic_authorize "control_explorer_view"
 
       run_get policy_actions_url
 
@@ -34,7 +34,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy actions" do
-      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+      api_basic_authorize "control_explorer_view"
       create_actions(4)
 
       run_get policy_actions_url
@@ -45,7 +45,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy actions in expanded form" do
-      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+      api_basic_authorize "control_explorer_view"
       create_actions(4)
 
       run_get policy_actions_url, :expand => "resources"
@@ -67,7 +67,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy actions with no actions defined" do
-      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+      api_basic_authorize "control_explorer_view"
 
       run_get policy_actions_url
 
@@ -75,7 +75,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy actions" do
-      api_basic_authorize collection_action_identifier(:policy_actions, :read, :get)
+      api_basic_authorize "control_explorer_view"
       create_actions(4)
       relate_actions_to(policy)
 
@@ -86,7 +86,7 @@ describe "Policy Actions API" do
     end
 
     it "query policy with expanded policy actions" do
-      api_basic_authorize action_identifier(:policies, :read, :resource_actions, :get)
+      api_basic_authorize "policy_view"
       create_actions(4)
       relate_actions_to(policy)
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -179,7 +179,7 @@ describe "Providers API" do
     end
 
     it "getting custom_attributes from a provider using expand" do
-      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+      api_basic_authorize "ems_infra_show"
       provider.custom_attributes = [ca1, ca2]
 
       run_get provider_url, :expand => "custom_attributes"
@@ -199,7 +199,7 @@ describe "Providers API" do
     end
 
     it "delete a custom_attribute from a provider via the delete action" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
       provider.custom_attributes = [ca1]
 
       run_post(provider_ca_url, gen_request(:delete, nil, ca1_url))
@@ -210,7 +210,7 @@ describe "Providers API" do
     end
 
     it "add custom attribute to a provider without a name" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       run_post(provider_ca_url, gen_request(:add, "value" => "value1"))
 
@@ -218,7 +218,7 @@ describe "Providers API" do
     end
 
     it "prevents adding custom attribute to a provider with forbidden section" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       run_post(provider_ca_url, gen_request(:add, [{"name" => "name3", "value" => "value3",
                                                     "section" => "bad_section"}]))
@@ -228,7 +228,7 @@ describe "Providers API" do
     end
 
     it "add custom attributes to a provider" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       run_post(provider_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
                                                    {"name" => "name2", "value" => "value2", "section" => "metadata"}]))
@@ -246,7 +246,7 @@ describe "Providers API" do
     end
 
     it "formats custom attribute of type date" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
       date_field = DateTime.new.in_time_zone
 
       run_post(provider_ca_url, gen_request(:add, [{"name"       => "name1",
@@ -261,7 +261,7 @@ describe "Providers API" do
     end
 
     it "edit a custom attribute by name" do
-      api_basic_authorize action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
       provider.custom_attributes = [ca1]
 
       run_post(provider_ca_url, gen_request(:edit, "name" => "name1", "value" => "value one"))
@@ -294,7 +294,7 @@ describe "Providers API" do
     end
 
     it "supports requests with valid provider_class" do
-      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+      api_basic_authorize "ems_infra_show_list"
 
       FactoryGirl.build(:provider_foreman)
       run_get providers_url, :provider_class => "provider", :expand => "resources"
@@ -305,7 +305,7 @@ describe "Providers API" do
     end
 
     it 'creates valid foreman provider' do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       # TODO: provider_class in params, when supported (https://github.com/brynary/rack-test/issues/150)
       run_post(providers_url + '?provider_class=provider', gen_request(:create, sample_foreman))
@@ -331,7 +331,7 @@ describe "Providers API" do
     end
 
     it "rejects provider creation with id specified" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, "name" => "sample provider", "id" => 100)
 
@@ -339,7 +339,7 @@ describe "Providers API" do
     end
 
     it "rejects provider creation with invalid type specified" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, "name" => "sample provider", "type" => "BogusType")
 
@@ -347,7 +347,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, sample_rhevm)
 
@@ -372,7 +372,7 @@ describe "Providers API" do
         it "supports creation with auth_key specified" do
           skip if name != "Openshift"
 
-          api_basic_authorize collection_action_identifier(:providers, :create)
+          api_basic_authorize "ems_infra_new"
 
           run_post(providers_url, sample_containers.merge("credentials" => [containers_credentials]))
 
@@ -394,7 +394,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation via action" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, gen_request(:create, sample_rhevm))
 
@@ -411,7 +411,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation with simple credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, sample_vmware.merge("credentials" => default_credentials))
 
@@ -431,7 +431,7 @@ describe "Providers API" do
     end
 
     it "supports single provider creation with compound credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, sample_rhevm.merge("credentials" => compound_credentials))
 
@@ -453,7 +453,7 @@ describe "Providers API" do
     end
 
     it "supports multiple provider creation" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
+      api_basic_authorize "ems_infra_new"
 
       run_post(providers_url, gen_request(:create, [sample_vmware, sample_rhevm]))
 
@@ -481,7 +481,7 @@ describe "Providers API" do
         end
 
         it "supports provider with multiple endpoints creation" do
-          api_basic_authorize collection_action_identifier(:providers, :create)
+          api_basic_authorize "ems_infra_new"
 
           run_post(providers_url, gen_request(:create, sample_containers_multi_end_point))
 
@@ -517,7 +517,7 @@ describe "Providers API" do
     end
 
     it "rejects edits for invalid resources" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       run_post(providers_url(999_999), gen_request(:edit, "name" => "updated provider name"))
 
@@ -525,7 +525,7 @@ describe "Providers API" do
     end
 
     it "supports single resource edit" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
 
@@ -537,7 +537,7 @@ describe "Providers API" do
     end
 
     it "only returns real attributes" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
 
@@ -549,7 +549,7 @@ describe "Providers API" do
     end
 
     it "supports updates of credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       provider = FactoryGirl.create(:ext_management_system, sample_vmware)
       provider.update_authentication(:default => default_credentials.symbolize_keys)
@@ -568,7 +568,7 @@ describe "Providers API" do
         let(:containers_class) { klass }
 
         it "does not schedule a new credentials check if endpoint does not change" do
-          api_basic_authorize collection_action_identifier(:providers, :edit)
+          api_basic_authorize "ems_infra_edit"
 
           provider = FactoryGirl.create(:ext_management_system, sample_containers_multi_end_point)
           MiqQueue.where(:method_name => "authentication_check_types",
@@ -587,7 +587,7 @@ describe "Providers API" do
         end
 
         it "schedules a new credentials check if endpoint change" do
-          api_basic_authorize collection_action_identifier(:providers, :edit)
+          api_basic_authorize "ems_infra_edit"
 
           provider = FactoryGirl.create(:ext_management_system, sample_containers_multi_end_point)
           MiqQueue.where(:method_name => "authentication_check_types",
@@ -612,7 +612,7 @@ describe "Providers API" do
     end
 
     it "supports additions of credentials" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
       provider.update_authentication(:default => default_credentials.symbolize_keys)
@@ -628,7 +628,7 @@ describe "Providers API" do
     end
 
     it "supports multiple resource edits" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
+      api_basic_authorize "ems_infra_edit"
 
       p1 = FactoryGirl.create(:ems_redhat, :name => "name1")
       p2 = FactoryGirl.create(:ems_redhat, :name => "name2")
@@ -664,7 +664,7 @@ describe "Providers API" do
     end
 
     it "rejects deletes for invalid providers" do
-      api_basic_authorize collection_action_identifier(:providers, :delete)
+      api_basic_authorize "ems_infra_delete"
 
       run_delete(providers_url(999_999))
 
@@ -672,7 +672,7 @@ describe "Providers API" do
     end
 
     it "supports single provider delete" do
-      api_basic_authorize collection_action_identifier(:providers, :delete)
+      api_basic_authorize "ems_infra_delete"
 
       provider = FactoryGirl.create(:ext_management_system, :name => "provider", :hostname => "provider.com")
 
@@ -682,7 +682,7 @@ describe "Providers API" do
     end
 
     it "supports single provider delete action" do
-      api_basic_authorize collection_action_identifier(:providers, :delete)
+      api_basic_authorize "ems_infra_delete"
 
       provider = FactoryGirl.create(:ext_management_system, :name => "provider", :hostname => "provider.com")
 
@@ -695,7 +695,7 @@ describe "Providers API" do
     end
 
     it "supports multiple provider deletes" do
-      api_basic_authorize collection_action_identifier(:providers, :delete)
+      api_basic_authorize "ems_infra_delete"
 
       p1 = FactoryGirl.create(:ext_management_system, :name => "provider name 1")
       p2 = FactoryGirl.create(:ext_management_system, :name => "provider name 2")
@@ -723,7 +723,7 @@ describe "Providers API" do
     end
 
     it "supports single provider refresh" do
-      api_basic_authorize collection_action_identifier(:providers, :refresh)
+      api_basic_authorize "ems_infra_refresh"
 
       provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
@@ -734,7 +734,7 @@ describe "Providers API" do
     end
 
     it "supports multiple provider refreshes" do
-      api_basic_authorize collection_action_identifier(:providers, :refresh)
+      api_basic_authorize "ems_infra_refresh"
 
       p1 = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
       p1.update_authentication(:default => default_credentials.symbolize_keys)
@@ -786,7 +786,7 @@ describe "Providers API" do
     end
 
     it 'enqueues a correct import request' do
-      api_basic_authorize action_identifier(:providers, :import_vm)
+      api_basic_authorize "ems_infra_import_vm"
 
       run_post(provider_url, gen_import_request)
 
@@ -809,7 +809,7 @@ describe "Providers API" do
     describe 'query custom_attributes' do
       let!(:generic_provider) { FactoryGirl.create(:provider) }
       it 'does not blow-up on provider without custom_attributes' do
-        api_basic_authorize collection_action_identifier(:providers, :read, :get)
+        api_basic_authorize "ems_infra_show_list"
         run_get(providers_url, :expand => 'resources,custom_attributes', :provider_class => 'provider')
         expect_query_result(:providers, 1, 1)
       end
@@ -832,7 +832,7 @@ describe "Providers API" do
     end
 
     it 'queries all load balancers' do
-      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+      api_basic_authorize "load_balancer_show"
       expected = {
         'resources' => [
           { 'href' => a_string_matching("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}") }
@@ -846,7 +846,7 @@ describe "Providers API" do
     end
 
     it 'queries a single load balancer' do
-      api_basic_authorize subcollection_action_identifier(:providers, :load_balancers, :show, :get)
+      api_basic_authorize "load_balancer_show"
 
       run_get("#{providers_url(@provider.id)}/load_balancers/#{@load_balancer.id}")
 
@@ -865,13 +865,13 @@ describe "Providers API" do
       end
 
       it 'cannot add a custom_attribute' do
-        api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :add, :post)
+        api_basic_authorize "ems_infra_edit"
         run_post(url, gen_request(:add, :name => 'x'))
         expect_bad_request("#{generic_provider.class.name} does not support management of custom attributes")
       end
 
       it 'cannot edit custom_attribute' do
-        api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :edit, :post)
+        api_basic_authorize "ems_infra_edit"
         run_post(url, gen_request(:edit, :href => custom_attributes_url(attr.id)))
         expect_bad_request("#{generic_provider.class.name} does not support management of custom attributes")
       end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -52,7 +52,7 @@ describe "Provision Requests API" do
     end
 
     it "supports single request with normal post" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :create)
+      api_basic_authorize "vm_miq_request_new"
 
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, single_provision_request)
@@ -66,7 +66,7 @@ describe "Provision Requests API" do
     end
 
     it "supports single request with create action" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :create)
+      api_basic_authorize "vm_miq_request_new"
 
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, gen_request(:create, single_provision_request))
@@ -80,7 +80,7 @@ describe "Provision Requests API" do
     end
 
     it "supports multiple requests" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :create)
+      api_basic_authorize "vm_miq_request_new"
 
       dialog  # Create the Provisioning dialog
       run_post(provision_requests_url, gen_request(:create, [single_provision_request, single_provision_request]))
@@ -106,7 +106,7 @@ describe "Provision Requests API" do
     let(:provreqs_list) { [provreq1_url, provreq2_url] }
 
     it "supports approving a request" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(provreq1_url, gen_request(:approve))
 
@@ -115,7 +115,7 @@ describe "Provision Requests API" do
     end
 
     it "supports denying a request" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(provreq2_url, gen_request(:deny))
 
@@ -124,7 +124,7 @@ describe "Provision Requests API" do
     end
 
     it "supports approving multiple requests" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(provision_requests_url, gen_request(:approve, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 
@@ -147,7 +147,7 @@ describe "Provision Requests API" do
     end
 
     it "supports denying multiple requests" do
-      api_basic_authorize collection_action_identifier(:provision_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(provision_requests_url, gen_request(:deny, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -18,7 +18,7 @@ describe "Queries API" do
 
   describe "Query collections" do
     it "returns resource lists with only hrefs" do
-      api_basic_authorize collection_action_identifier(:vms, :read, :get)
+      api_basic_authorize "vm_show_list"
       create_vms(3)
 
       run_get vms_url
@@ -28,7 +28,7 @@ describe "Queries API" do
     end
 
     it "returns seperate ids and href when expanded" do
-      api_basic_authorize collection_action_identifier(:vms, :read, :get)
+      api_basic_authorize "vm_show_list"
       create_vms(3)
 
       run_get vms_url, :expand => "resources"
@@ -43,7 +43,7 @@ describe "Queries API" do
     end
 
     it "always return ids and href when asking for specific attributes" do
-      api_basic_authorize collection_action_identifier(:vms, :read, :get)
+      api_basic_authorize "vm_show_list"
       vm1   # create resource
 
       run_get vms_url, :expand => "resources", :attributes => "guid"
@@ -55,7 +55,7 @@ describe "Queries API" do
 
   describe "Query resource" do
     it "returns both id and href" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
       vm1   # create resource
 
       run_get vm1_url
@@ -64,7 +64,7 @@ describe "Queries API" do
     end
 
     it 'supports compressed ids' do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
 
       run_get vms_url(ApplicationRecord.compress_id(vm1.id))
 
@@ -72,7 +72,7 @@ describe "Queries API" do
     end
 
     it 'returns 404 on url with trailing garbage' do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
       vm1   # create resource
 
       run_get vm1_url + 'garbage'
@@ -141,7 +141,7 @@ describe "Queries API" do
 
   describe "Querying encrypted attributes" do
     it "hides them from database records" do
-      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+      api_basic_authorize "ems_infra_show"
 
       credentials = {:userid => "admin", :password => "super_password"}
 
@@ -159,7 +159,7 @@ describe "Queries API" do
     end
 
     it "hides them from provisioning hashes" do
-      api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
 
       password_field = ::MiqRequestWorkflow.all_encrypted_options_fields.last.to_s
       options = {:attrs => {:userid => "admin", password_field.to_sym => "super_password"}}

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -16,7 +16,7 @@ describe "Querying" do
   let(:vm1) { FactoryGirl.create(:vm_vmware, :name => "vm1") }
 
   describe "Querying vms" do
-    before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
+    before { api_basic_authorize "vm_show_list" }
 
     it "supports offset" do
       create_vms_by_name(%w(aa bb cc))
@@ -63,7 +63,7 @@ describe "Querying" do
   end
 
   describe "Sorting vms by attribute" do
-    before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
+    before { api_basic_authorize "vm_show_list" }
 
     it "supports ascending order" do
       create_vms_by_name %w(cc aa bb)
@@ -132,7 +132,7 @@ describe "Querying" do
   end
 
   describe "Filtering vms" do
-    before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
+    before { api_basic_authorize "vm_show_list" }
 
     it "supports attribute equality test using double quotes" do
       _vm1, vm2 = create_vms_by_name(%w(aa bb))
@@ -445,7 +445,7 @@ describe "Querying" do
     it "can do fuzzy matching on strings with forward slashes" do
       tag_1 = FactoryGirl.create(:tag, :name => "/managed/foo")
       _tag_2 = FactoryGirl.create(:tag, :name => "/managed/bar")
-      api_basic_authorize collection_action_identifier(:tags, :read, :get)
+      api_basic_authorize "ops_settings"
 
       run_get(tags_url, :filter => ["name='*/foo'"])
 
@@ -503,7 +503,7 @@ describe "Querying" do
 
   describe "Querying vm attributes" do
     it "supports requests specific attributes" do
-      api_basic_authorize collection_action_identifier(:vms, :read, :get)
+      api_basic_authorize "vm_show_list"
       vm = create_vms_by_name(%w(aa)).first
 
       run_get vms_url, :expand => "resources", :attributes => "name,vendor"
@@ -526,7 +526,7 @@ describe "Querying" do
     end
 
     it "skips requests of invalid attributes" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
 
       run_get vms_url(vm1.id), :attributes => "bogus"
 
@@ -537,7 +537,7 @@ describe "Querying" do
 
   describe "Querying vms by tag" do
     it "is supported" do
-      api_basic_authorize collection_action_identifier(:vms, :read, :get)
+      api_basic_authorize "vm_show_list"
       vm1, _vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 
       dept = FactoryGirl.create(:classification_department)
@@ -553,7 +553,7 @@ describe "Querying" do
   end
 
   describe "Querying vms" do
-    before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
+    before { api_basic_authorize "vm_show_list" }
 
     it "and sorted by name succeeeds with unreferenced class" do
       run_get vms_url, :sort_by => "name", :expand => "resources"
@@ -613,7 +613,7 @@ describe "Querying" do
 
   describe "Querying resources" do
     it "does not return actions if not entitled" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
 
       run_get vms_url(vm1.id)
 
@@ -622,7 +622,7 @@ describe "Querying" do
     end
 
     it "returns actions if authorized" do
-      api_basic_authorize action_identifier(:vms, :edit), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_edit", "vm_show"
 
       run_get vms_url(vm1.id)
 
@@ -631,7 +631,7 @@ describe "Querying" do
     end
 
     it "returns correct actions if authorized as such" do
-      api_basic_authorize action_identifier(:vms, :suspend), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_suspend", "vm_show"
 
       run_get vms_url(vm1.id)
 
@@ -643,9 +643,9 @@ describe "Querying" do
     end
 
     it "returns multiple actions if authorized as such" do
-      api_basic_authorize(action_identifier(:vms, :start),
-                          action_identifier(:vms, :stop),
-                          action_identifier(:vms, :read, :resource_actions, :get))
+      api_basic_authorize("vm_start",
+                          "vm_stop",
+                          "vm_show")
 
       run_get vms_url(vm1.id)
 
@@ -655,7 +655,7 @@ describe "Querying" do
     end
 
     it "returns actions if asked for with physical attributes" do
-      api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_start", "vm_show"
 
       run_get vms_url(vm1.id), :attributes => "name,vendor,actions"
 
@@ -664,7 +664,7 @@ describe "Querying" do
     end
 
     it "does not return actions if asking for a physical attribute" do
-      api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_start", "vm_show"
 
       run_get vms_url(vm1.id), :attributes => "name"
 
@@ -673,7 +673,7 @@ describe "Querying" do
     end
 
     it "does return actions if asking for virtual attributes" do
-      api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_start", "vm_show"
 
       run_get vms_url(vm1.id), :attributes => "disconnected"
 
@@ -682,7 +682,7 @@ describe "Querying" do
     end
 
     it "does not return actions if asking for physical and virtual attributes" do
-      api_basic_authorize action_identifier(:vms, :start), action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_start", "vm_show"
 
       run_get vms_url(vm1.id), :attributes => "name,disconnected"
 

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "reports API" do
     report_1 = FactoryGirl.create(:miq_report_with_results)
     report_2 = FactoryGirl.create(:miq_report_with_results)
 
-    api_basic_authorize collection_action_identifier(:reports, :read, :get)
+    api_basic_authorize "miq_report_saved_reports_view"
     run_get reports_url
 
     expect_result_resources_to_include_hrefs(
@@ -20,7 +20,7 @@ RSpec.describe "reports API" do
   it "can fetch a report" do
     report = FactoryGirl.create(:miq_report_with_results)
 
-    api_basic_authorize action_identifier(:reports, :read, :resource_actions, :get)
+    api_basic_authorize "miq_report_saved_reports_view"
     run_get reports_url(report.id)
 
     expect_result_to_match_hash(
@@ -71,7 +71,7 @@ RSpec.describe "reports API" do
     report = FactoryGirl.create(:miq_report_with_results)
     result = report.miq_report_results.first
 
-    api_basic_authorize collection_action_identifier(:results, :read, :get)
+    api_basic_authorize "miq_report_view"
     run_get results_url
 
     expect_result_resources_to_include_hrefs(
@@ -93,7 +93,7 @@ RSpec.describe "reports API" do
     allow(report).to receive(:table).and_return(table)
     allow_any_instance_of(MiqReportResult).to receive(:report_results).and_return(report)
 
-    api_basic_authorize action_identifier(:results, :read, :resource_actions, :get)
+    api_basic_authorize "miq_report_view"
     run_get results_url(report_result.id)
 
     expect_result_to_match_hash(response.parsed_body, "result_set" => [{"foo" => "bar"}, {"foo" => "baz"}])
@@ -110,7 +110,7 @@ RSpec.describe "reports API" do
     schedule_1 = FactoryGirl.create(:miq_schedule, :filter => exp)
     schedule_2 = FactoryGirl.create(:miq_schedule, :filter => exp)
 
-    api_basic_authorize collection_action_identifier(:schedules, :read, :get)
+    api_basic_authorize "miq_report_view"
     run_get "/api/reports/#{report.id}/schedules"
 
     expect_result_resources_to_include_hrefs(
@@ -132,7 +132,7 @@ RSpec.describe "reports API" do
 
     schedule = FactoryGirl.create(:miq_schedule, :name => 'unit_test', :filter => exp)
 
-    api_basic_authorize collection_action_identifier(:schedules, :read, :get)
+    api_basic_authorize "miq_report_view"
     run_get "/api/reports/#{report.id}/schedules/#{schedule.id}"
 
     expect_result_to_match_hash(
@@ -160,7 +160,7 @@ RSpec.describe "reports API" do
       report = FactoryGirl.create(:miq_report)
 
       expect do
-        api_basic_authorize action_identifier(:reports, :run)
+        api_basic_authorize "miq_report_run"
         run_post reports_url(report.id).to_s, :action => "run"
       end.to change(MiqReportResult, :count).by(1)
       expect_single_action_result(
@@ -174,7 +174,7 @@ RSpec.describe "reports API" do
       report = FactoryGirl.create(:miq_report)
 
       expect do
-        api_basic_authorize action_identifier(:reports, :schedule)
+        api_basic_authorize "miq_report_schedule_add"
         run_post reports_url(report.id),
                  :action      => 'schedule',
                  :name        => 'schedule_name',
@@ -203,7 +203,7 @@ RSpec.describe "reports API" do
       }
       options = {:save => true}
 
-      api_basic_authorize collection_action_identifier(:reports, :import)
+      api_basic_authorize "miq_report_export"
 
       expect do
         run_post reports_url, gen_request(:import, :report => serialized_report, :options => options)
@@ -247,7 +247,7 @@ RSpec.describe "reports API" do
       }
       options = {:save => true}
 
-      api_basic_authorize collection_action_identifier(:reports, :import)
+      api_basic_authorize "miq_report_export"
 
       expect do
         run_post(

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Requests API" do
                          :requester   => other_user,
                          :source_id   => template.id,
                          :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+      api_basic_authorize "miq_request_show_list"
 
       run_get requests_url
 
@@ -30,7 +30,7 @@ RSpec.describe "Requests API" do
                                            :requester   => other_user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
 
       run_get requests_url(service_request.id)
 
@@ -48,7 +48,7 @@ RSpec.describe "Requests API" do
                                             :requester   => @user,
                                             :source_id   => template.id,
                                             :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+      api_basic_authorize "miq_request_show_list"
 
       run_get requests_url
 
@@ -61,7 +61,7 @@ RSpec.describe "Requests API" do
                                            :requester   => @user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
 
       run_get requests_url(service_request.id)
 
@@ -81,7 +81,7 @@ RSpec.describe "Requests API" do
                                              :requester   => @user,
                                              :source_id   => template.id,
                                              :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+      api_basic_authorize "miq_request_show_list"
 
       run_get requests_url
 
@@ -104,7 +104,7 @@ RSpec.describe "Requests API" do
                                            :requester   => other_user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
 
       run_get requests_url(service_request.id)
 
@@ -245,7 +245,7 @@ RSpec.describe "Requests API" do
       t = Classification.where(:description => 'Department', :parent_id => 0).includes(:tag).first
       request.add_tag(t.name, t.children.first.name)
 
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
       run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
 
       expected_response = a_hash_including(
@@ -268,7 +268,7 @@ RSpec.describe "Requests API" do
                                    :source_id   => vm_template.id,
                                    :source_type => vm_template.class.name)
 
-      api_basic_authorize action_identifier(:requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_show"
       run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
 
       expected_response = a_hash_including(
@@ -293,7 +293,7 @@ RSpec.describe "Requests API" do
     end
 
     it "fails with an invalid request id" do
-      api_basic_authorize collection_action_identifier(:requests, :edit)
+      api_basic_authorize "miq_request_edit"
 
       run_post(requests_url(999_999), gen_request(:edit, :options => { :some_option => "some_value" }))
 
@@ -307,7 +307,7 @@ RSpec.describe "Requests API" do
     end
 
     it "succeed" do
-      api_basic_authorize collection_action_identifier(:requests, :edit)
+      api_basic_authorize "miq_request_edit"
 
       service = FactoryGirl.create(:service, :name => "service1")
       request = ServiceReconfigureRequest.create_request({ :src_id => service.id }, @user, false)
@@ -334,7 +334,7 @@ RSpec.describe "Requests API" do
     let(:request2_url)  { requests_url(request2.id) }
 
     it "supports approving a request" do
-      api_basic_authorize collection_action_identifier(:requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request1_url, gen_request(:approve, :reason => "approval reason"))
 
@@ -343,7 +343,7 @@ RSpec.describe "Requests API" do
     end
 
     it "fails approving a request if the reason is missing" do
-      api_basic_authorize collection_action_identifier(:requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request1_url, gen_request(:approve))
 
@@ -352,7 +352,7 @@ RSpec.describe "Requests API" do
     end
 
     it "supports denying a request" do
-      api_basic_authorize collection_action_identifier(:requests, :deny)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request1_url, gen_request(:deny, :reason => "denial reason"))
 
@@ -361,7 +361,7 @@ RSpec.describe "Requests API" do
     end
 
     it "fails denying a request if the reason is missing" do
-      api_basic_authorize collection_action_identifier(:requests, :deny)
+      api_basic_authorize "miq_request_approval"
 
       run_post(request1_url, gen_request(:deny))
 
@@ -370,7 +370,7 @@ RSpec.describe "Requests API" do
     end
 
     it "supports approving multiple requests" do
-      api_basic_authorize collection_action_identifier(:requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(requests_url, gen_request(:approve, [{:href => request1_url, :reason => "approval reason"},
                                                     {:href => request2_url, :reason => "approval reason"}]))
@@ -394,7 +394,7 @@ RSpec.describe "Requests API" do
     end
 
     it "supports denying multiple requests" do
-      api_basic_authorize collection_action_identifier(:requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(requests_url, gen_request(:deny, [{:href => request1_url, :reason => "denial reason"},
                                                  {:href => request2_url, :reason => "denial reason"}]))

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -60,7 +60,7 @@ describe "Roles API" do
   end
 
   def test_features_query(role, role_url, klass, attr = :id)
-    api_basic_authorize action_identifier(:roles, :read, :resource_actions, :get)
+    api_basic_authorize "rbac_role_show"
 
     run_get role_url, :expand => "features"
     expect(response).to have_http_status(:ok)
@@ -92,7 +92,7 @@ describe "Roles API" do
     end
 
     it "rejects role creation with id specified" do
-      api_basic_authorize collection_action_identifier(:roles, :create)
+      api_basic_authorize "rbac_role_add"
 
       run_post(roles_url, "name" => "sample role", "id" => 100)
 
@@ -100,7 +100,7 @@ describe "Roles API" do
     end
 
     it "supports single role creation" do
-      api_basic_authorize collection_action_identifier(:roles, :create)
+      api_basic_authorize "rbac_role_add"
 
       run_post(roles_url, sample_role1)
 
@@ -120,7 +120,7 @@ describe "Roles API" do
     end
 
     it "supports single role creation via action" do
-      api_basic_authorize collection_action_identifier(:roles, :create)
+      api_basic_authorize "rbac_role_add"
 
       run_post(roles_url, gen_request(:create, sample_role1))
 
@@ -136,7 +136,7 @@ describe "Roles API" do
     end
 
     it "supports multiple role creation" do
-      api_basic_authorize collection_action_identifier(:roles, :create)
+      api_basic_authorize "rbac_role_add"
 
       run_post(roles_url, gen_request(:create, [sample_role1, sample_role2]))
 
@@ -171,7 +171,7 @@ describe "Roles API" do
     end
 
     it "rejects role edits for invalid resources" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
 
       run_post(roles_url(999_999), gen_request(:edit, "name" => "updated role name"))
 
@@ -179,7 +179,7 @@ describe "Roles API" do
     end
 
     it "supports single role edit" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
 
       role = FactoryGirl.create(:miq_user_role)
 
@@ -194,7 +194,7 @@ describe "Roles API" do
     end
 
     it "supports multiple role edits" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
 
       r1 = FactoryGirl.create(:miq_user_role, :name => "role1")
       r2 = FactoryGirl.create(:miq_user_role, :name => "role2")
@@ -214,7 +214,7 @@ describe "Roles API" do
 
   describe "Role Feature Assignments" do
     it "supports assigning just a single product feature" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
       role = FactoryGirl.create(:miq_user_role, :features => "miq_request_approval")
 
       new_feature = {:identifier => "miq_request_view"}
@@ -235,7 +235,7 @@ describe "Roles API" do
     end
 
     it "supports assigning multiple product features" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
       role = FactoryGirl.create(:miq_user_role, :features => "miq_request_approval")
 
       url = "#{roles_url}/#{role.id}/features"
@@ -257,7 +257,7 @@ describe "Roles API" do
     end
 
     it "supports un-assigning just a single product feature" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
       role = FactoryGirl.create(:miq_user_role, :miq_product_features => @product_features)
 
       removed_feature = {:identifier => "ems_infra_tag"}
@@ -282,7 +282,7 @@ describe "Roles API" do
     end
 
     it "supports un-assigning multiple product features" do
-      api_basic_authorize collection_action_identifier(:roles, :edit)
+      api_basic_authorize "rbac_role_edit"
       role = FactoryGirl.create(:miq_user_role, :miq_product_features => @product_features)
 
       url = "#{roles_url}/#{role.id}/features"
@@ -327,7 +327,7 @@ describe "Roles API" do
     end
 
     it "rejects role deletes for invalid roles" do
-      api_basic_authorize collection_action_identifier(:roles, :delete)
+      api_basic_authorize "rbac_role_delete"
 
       run_delete(roles_url(999_999))
 
@@ -335,7 +335,7 @@ describe "Roles API" do
     end
 
     it "supports single role delete" do
-      api_basic_authorize collection_action_identifier(:roles, :delete)
+      api_basic_authorize "rbac_role_delete"
 
       role = FactoryGirl.create(:miq_user_role, :name => "role1")
 
@@ -346,7 +346,7 @@ describe "Roles API" do
     end
 
     it "supports single role delete action" do
-      api_basic_authorize collection_action_identifier(:roles, :delete)
+      api_basic_authorize "rbac_role_delete"
 
       role = FactoryGirl.create(:miq_user_role, :name => "role1")
 
@@ -357,7 +357,7 @@ describe "Roles API" do
     end
 
     it "supports multiple role deletes" do
-      api_basic_authorize collection_action_identifier(:roles, :delete)
+      api_basic_authorize "rbac_role_delete"
 
       r1 = FactoryGirl.create(:miq_user_role, :name => "role name 1")
       r2 = FactoryGirl.create(:miq_user_role, :name => "role name 2")

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -42,7 +42,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects resource creation with id specified" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+      api_basic_authorize "st_catalog_new"
 
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog", "id" => 100))
 
@@ -50,7 +50,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single resource creation" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+      api_basic_authorize "st_catalog_new"
 
       run_post(service_catalogs_url, gen_request(:add, "name" => "sample service catalog"))
 
@@ -71,7 +71,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single resource creation via create action" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+      api_basic_authorize "st_catalog_new"
 
       run_post(service_catalogs_url, "name" => "sample service catalog")
 
@@ -92,7 +92,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports multiple resource creation" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+      api_basic_authorize "st_catalog_new"
 
       run_post(service_catalogs_url, gen_request(:add, [{"name" => "sc1"}, {"name" => "sc2"}]))
 
@@ -112,7 +112,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single resource creation with service templates" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :add)
+      api_basic_authorize "st_catalog_new"
 
       st1 = FactoryGirl.create(:service_template)
       st2 = FactoryGirl.create(:service_template)
@@ -145,7 +145,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects edits for invalid resources" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
+      api_basic_authorize "st_catalog_edit"
 
       run_post(service_catalogs_url(999_999), gen_request(:edit, "description" => "updated sc description"))
 
@@ -153,7 +153,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single resource edit" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
+      api_basic_authorize "st_catalog_edit"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
@@ -179,7 +179,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports multiple resource edits" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :edit)
+      api_basic_authorize "st_catalog_edit"
 
       sc1 = FactoryGirl.create(:service_template_catalog, :name => "sc1", :description => "sc1 description")
       sc2 = FactoryGirl.create(:service_template_catalog, :name => "sc2", :description => "sc2 description")
@@ -215,7 +215,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects resource deletes for invalid resources" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :delete)
+      api_basic_authorize "st_catalog_delete"
 
       run_delete(service_catalogs_url(999_999))
 
@@ -223,7 +223,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single resource deletes" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :delete)
+      api_basic_authorize "st_catalog_delete"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
@@ -234,7 +234,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports resource deletes via action" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :delete)
+      api_basic_authorize "st_catalog_delete"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
@@ -245,7 +245,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports multiple resource deletes" do
-      api_basic_authorize collection_action_identifier(:service_catalogs, :delete)
+      api_basic_authorize "st_catalog_delete"
 
       sc1 = FactoryGirl.create(:service_template_catalog, :name => "sc1", :description => "sc1 description")
       sc2 = FactoryGirl.create(:service_template_catalog, :name => "sc2", :description => "sc2 description")
@@ -279,7 +279,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects assign requests with invalid service template" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :assign)
+      api_basic_authorize "st_catalog_edit"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
 
@@ -290,7 +290,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports assign requests" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :assign)
+      api_basic_authorize "st_catalog_edit"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
       st = FactoryGirl.create(:service_template)
@@ -307,7 +307,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports unassign requests" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :assign)
+      api_basic_authorize "st_catalog_edit"
 
       sc = FactoryGirl.create(:service_template_catalog, :name => "sc", :description => "sc description")
       st1 = FactoryGirl.create(:service_template)
@@ -352,8 +352,8 @@ describe "Service Catalogs API" do
     end
 
     it "does not return order action for non-orderable service templates" do
-      api_basic_authorize(subcollection_action_identifier(:service_catalogs, :service_templates, :edit),
-                          subcollection_action_identifier(:service_catalogs, :service_templates, :order))
+      api_basic_authorize("catalogitem_edit",
+                          "svc_catalog_provision")
 
       init_st(st1, ra1)
       sc.service_templates = [st1]
@@ -368,8 +368,8 @@ describe "Service Catalogs API" do
     end
 
     it "returns order action for orderable service templates" do
-      api_basic_authorize(subcollection_action_identifier(:service_catalogs, :service_templates, :edit),
-                          subcollection_action_identifier(:service_catalogs, :service_templates, :order))
+      api_basic_authorize("catalogitem_edit",
+                          "svc_catalog_provision")
 
       init_st(st1, ra1)
       sc.service_templates = [st1]
@@ -389,7 +389,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports single order request" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :order)
+      api_basic_authorize "svc_catalog_provision"
 
       init_st(st1, ra1)
       sc.service_templates = [st1]
@@ -400,7 +400,7 @@ describe "Service Catalogs API" do
     end
 
     it "accepts order requests with required fields" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :order)
+      api_basic_authorize "svc_catalog_provision"
 
       text1.required = true
       init_st(st1, ra1)
@@ -412,7 +412,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects order requests without required fields" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :order)
+      api_basic_authorize "svc_catalog_provision"
 
       text1.required = true
       init_st(st1, ra1)
@@ -424,7 +424,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports multiple order requests" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :order)
+      api_basic_authorize "svc_catalog_provision"
 
       init_st(st1, ra1)
       init_st(st2, ra2)
@@ -467,7 +467,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects refresh dialog fields with unspecified fields" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       sc.service_templates = [st1]
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields))
@@ -476,7 +476,7 @@ describe "Service Catalogs API" do
     end
 
     it "rejects refresh dialog fields of invalid fields" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       init_st_dialog
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
@@ -485,7 +485,7 @@ describe "Service Catalogs API" do
     end
 
     it "supports refresh dialog fields of valid fields" do
-      api_basic_authorize subcollection_action_identifier(:service_catalogs, :service_templates, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       init_st_dialog
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -22,7 +22,7 @@ describe "Service Dialogs API" do
     before { template.resource_actions = [ra1, ra2] }
 
     it "query only returns href" do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :read, :get)
+      api_basic_authorize "miq_ae_customization_explorer"
       run_get service_dialogs_url
 
       expected = {
@@ -36,7 +36,7 @@ describe "Service Dialogs API" do
     end
 
     it "query with expanded resources to include content" do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :read, :get)
+      api_basic_authorize "miq_ae_customization_explorer"
       run_get service_dialogs_url, :expand => "resources"
 
       expect_query_result(:service_dialogs, Dialog.count, Dialog.count)
@@ -44,7 +44,7 @@ describe "Service Dialogs API" do
     end
 
     it "query single dialog to include content" do
-      api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
+      api_basic_authorize "miq_ae_customization_explorer"
       run_get service_dialogs_url(dialog1.id)
 
       expect_single_resource_query(
@@ -56,7 +56,7 @@ describe "Service Dialogs API" do
     end
 
     it "query single dialog to exclude content when attributes are asked for" do
-      api_basic_authorize action_identifier(:service_dialogs, :read, :resource_actions, :get)
+      api_basic_authorize "miq_ae_customization_explorer"
 
       run_get service_dialogs_url(dialog1.id), :attributes => "id,label"
 
@@ -66,7 +66,7 @@ describe "Service Dialogs API" do
     context 'Delete Service Dialogs' do
       it 'DELETE /api/service_dialogs/:id' do
         dialog = FactoryGirl.create(:dialog)
-        api_basic_authorize collection_action_identifier(:service_dialogs, :delete)
+        api_basic_authorize "dialog_delete"
 
         expect do
           run_delete(service_dialogs_url(dialog.id))
@@ -76,7 +76,7 @@ describe "Service Dialogs API" do
 
       it 'POST /api/service_dialogs/:id deletes a single service dialog' do
         dialog = FactoryGirl.create(:dialog)
-        api_basic_authorize collection_action_identifier(:service_dialogs, :delete)
+        api_basic_authorize "dialog_delete"
 
         expect do
           run_post(service_dialogs_url(dialog.id), 'action' => 'delete')
@@ -86,7 +86,7 @@ describe "Service Dialogs API" do
 
       it 'POST /api/service_dialogs deletes a single service dialog' do
         dialog = FactoryGirl.create(:dialog)
-        api_basic_authorize collection_action_identifier(:service_dialogs, :delete)
+        api_basic_authorize "dialog_delete"
 
         expect do
           run_post(service_dialogs_url, 'action' => 'delete', 'resources' => [{ 'id' => dialog.id }])
@@ -96,7 +96,7 @@ describe "Service Dialogs API" do
 
       it 'POST /api/service_dialogs deletes multiple service dialogs' do
         dialog_a, dialog_b = FactoryGirl.create_list(:dialog, 2)
-        api_basic_authorize collection_action_identifier(:service_dialogs, :delete)
+        api_basic_authorize "dialog_delete"
 
         expect do
           run_post(service_dialogs_url, 'action'    => 'delete',
@@ -118,7 +118,7 @@ describe "Service Dialogs API" do
       end
 
       it 'POST /api/service_dialogs/:id updates a service dialog' do
-        api_basic_authorize collection_action_identifier(:service_dialogs, :edit)
+        api_basic_authorize "dialog_edit"
         dialog_tab = dialog.dialog_tabs.first
         dialog_group = dialog_tab.dialog_groups.first
         dialog_field = dialog_group.dialog_fields.first
@@ -158,7 +158,7 @@ describe "Service Dialogs API" do
       it 'POST /api/service_dialogs updates multiple service dialog' do
         dialog2 = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
 
-        api_basic_authorize collection_action_identifier(:service_dialogs, :edit)
+        api_basic_authorize "dialog_edit"
 
         run_post(service_dialogs_url, :action => 'edit', :resources => [{:id => dialog.id, 'label' => 'foo bar'},
                                                                         {:id => dialog2.id, :label => 'bar'}
@@ -195,7 +195,7 @@ describe "Service Dialogs API" do
       it 'Can copy multiple service dialogs' do
         dialog1 = FactoryGirl.create(:dialog_with_tab_and_group_and_field, :label => 'foo')
         dialog2 = FactoryGirl.create(:dialog_with_tab_and_group_and_field, :label => 'bar')
-        api_basic_authorize collection_action_identifier(:service_dialogs, :copy)
+        api_basic_authorize "dialog_copy"
 
         expected = {
           'results' => a_collection_containing_exactly(
@@ -218,7 +218,7 @@ describe "Service Dialogs API" do
 
       it 'Can copy a single service dialog' do
         dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field, :label => 'foo')
-        api_basic_authorize collection_action_identifier(:service_dialogs, :copy)
+        api_basic_authorize "dialog_copy"
 
         expected = {
           'label' => "Copy of foo"
@@ -233,7 +233,7 @@ describe "Service Dialogs API" do
 
       it 'Can copy a service dialog with a new label' do
         dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field, :label => 'bar')
-        api_basic_authorize collection_action_identifier(:service_dialogs, :copy)
+        api_basic_authorize "dialog_copy"
 
         expected = {
           'label' => 'foo'
@@ -305,7 +305,7 @@ describe "Service Dialogs API" do
     end
 
     it "rejects refresh dialog fields with unspecified fields" do
-      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       init_dialog
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields))
@@ -314,7 +314,7 @@ describe "Service Dialogs API" do
     end
 
     it "rejects refresh dialog fields of invalid fields" do
-      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       init_dialog
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(bad_field)))
@@ -323,7 +323,7 @@ describe "Service Dialogs API" do
     end
 
     it "supports refresh dialog fields of valid fields" do
-      api_basic_authorize action_identifier(:service_dialogs, :refresh_dialog_fields)
+      api_basic_authorize "svc_catalog_provision"
       init_dialog
 
       run_post(service_dialogs_url(dialog1.id), gen_request(:refresh_dialog_fields, "fields" => %w(text1)))
@@ -373,7 +373,7 @@ describe "Service Dialogs API" do
     end
 
     it 'rejects service dialog creation with an href specified' do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :create)
+      api_basic_authorize "dialog_new"
 
       run_post(service_dialogs_url, dialog_request.merge!("href" => service_dialogs_url(123)))
       expected = {
@@ -387,7 +387,7 @@ describe "Service Dialogs API" do
     end
 
     it 'rejects service dialog creation with an id specified' do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :create)
+      api_basic_authorize "dialog_new"
 
       run_post(service_dialogs_url, dialog_request.merge!("id" => 123))
       expected = {
@@ -401,7 +401,7 @@ describe "Service Dialogs API" do
     end
 
     it 'supports single service dialog creation' do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :create)
+      api_basic_authorize "dialog_new"
 
       expected = {
         "results" => [
@@ -420,7 +420,7 @@ describe "Service Dialogs API" do
     end
 
     it 'supports multiple service dialog creation' do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :create)
+      api_basic_authorize "dialog_new"
       dialog_request_2 = {
         :description => 'Dialog 2',
         :label       => 'dialog_2_label',
@@ -466,7 +466,7 @@ describe "Service Dialogs API" do
     end
 
     it 'returns dialog import service errors' do
-      api_basic_authorize collection_action_identifier(:service_dialogs, :create)
+      api_basic_authorize "dialog_new"
       invalid_request = {
         'description' => 'Dialog',
         'label'       => 'a_dialog'

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "service orders API" do
   it "can list all service orders" do
     service_order = FactoryGirl.create(:shopping_cart, :user => @user)
-    api_basic_authorize collection_action_identifier(:service_orders, :read, :get)
+    api_basic_authorize "svc_catalog_provision"
 
     run_get service_orders_url
 
@@ -12,7 +12,7 @@ RSpec.describe "service orders API" do
   it "won't show another user's service orders" do
     shopping_cart_for_user = FactoryGirl.create(:shopping_cart, :user => @user)
     _shopping_cart_for_some_other_user = FactoryGirl.create(:shopping_cart)
-    api_basic_authorize collection_action_identifier(:service_orders, :read, :get)
+    api_basic_authorize "svc_catalog_provision"
 
     run_get service_orders_url
 
@@ -26,7 +26,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can create a service order" do
-    api_basic_authorize collection_action_identifier(:service_orders, :create)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_post service_orders_url, :name => "service order", :state => "wish"
@@ -36,7 +36,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can create multiple service orders" do
-    api_basic_authorize collection_action_identifier(:service_orders, :create)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_post(service_orders_url,
@@ -47,7 +47,7 @@ RSpec.describe "service orders API" do
   end
 
   specify "the default state for a service order is 'cart'" do
-    api_basic_authorize collection_action_identifier(:service_orders, :create)
+    api_basic_authorize "svc_catalog_provision"
 
     run_post(service_orders_url, :name => "shopping cart")
 
@@ -55,7 +55,7 @@ RSpec.describe "service orders API" do
   end
 
   specify "a service order cannot be created in the 'ordered' state" do
-    api_basic_authorize collection_action_identifier(:service_orders, :create)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_post(service_orders_url, :name => "service order", :state => ServiceOrder::STATE_ORDERED)
@@ -68,7 +68,7 @@ RSpec.describe "service orders API" do
 
   it "can read a service order" do
     service_order = FactoryGirl.create(:service_order, :user => @user)
-    api_basic_authorize action_identifier(:service_orders, :read, :resource_actions, :get)
+    api_basic_authorize "svc_catalog_provision"
 
     run_get service_orders_url(service_order.id)
 
@@ -78,7 +78,7 @@ RSpec.describe "service orders API" do
 
   it "can show the shopping cart" do
     shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user)
-    api_basic_authorize action_identifier(:service_orders, :read, :resource_actions, :get)
+    api_basic_authorize "svc_catalog_provision"
 
     run_get service_orders_url("cart")
 
@@ -88,7 +88,7 @@ RSpec.describe "service orders API" do
   end
 
   it "returns an empty response when there is no shopping cart" do
-    api_basic_authorize action_identifier(:service_orders, :read, :resource_actions, :get)
+    api_basic_authorize "svc_catalog_provision"
 
     run_get service_orders_url("cart")
 
@@ -99,7 +99,7 @@ RSpec.describe "service orders API" do
 
   it "can update a service order" do
     service_order = FactoryGirl.create(:service_order, :name => "old name", :user => @user)
-    api_basic_authorize action_identifier(:service_orders, :edit)
+    api_basic_authorize "svc_catalog_provision"
 
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
@@ -110,7 +110,7 @@ RSpec.describe "service orders API" do
   it "can update multiple service orders" do
     service_order_1 = FactoryGirl.create(:service_order, :user => @user, :name => "old name 1")
     service_order_2 = FactoryGirl.create(:service_order, :user => @user, :name => "old name 2")
-    api_basic_authorize collection_action_identifier(:service_orders, :edit)
+    api_basic_authorize "svc_catalog_provision"
 
     run_post(service_orders_url,
              :action => "edit", :resources => [{:id => service_order_1.id, :name => "new name 1"},
@@ -122,7 +122,7 @@ RSpec.describe "service orders API" do
 
   it "can delete a service order" do
     service_order = FactoryGirl.create(:service_order, :user => @user)
-    api_basic_authorize action_identifier(:service_orders, :delete, :resource_actions, :delete)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_delete service_orders_url(service_order.id)
@@ -132,7 +132,7 @@ RSpec.describe "service orders API" do
 
   it "can delete a service order through POST" do
     service_order = FactoryGirl.create(:service_order, :user => @user)
-    api_basic_authorize action_identifier(:service_orders, :delete)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_post service_orders_url(service_order.id), :action => "delete"
@@ -143,7 +143,7 @@ RSpec.describe "service orders API" do
   it "can delete multiple service orders" do
     service_order_1 = FactoryGirl.create(:service_order, :user => @user, :name => "old name")
     service_order_2 = FactoryGirl.create(:service_order, :user => @user, :name => "old name")
-    api_basic_authorize collection_action_identifier(:service_orders, :delete)
+    api_basic_authorize "svc_catalog_provision"
 
     expect do
       run_post(service_orders_url,
@@ -158,7 +158,7 @@ RSpec.describe "service orders API" do
       it "can list a shopping cart's service requests" do
         service_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
         _shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
-        api_basic_authorize action_identifier(:service_requests, :read, :subcollection_actions, :get)
+        api_basic_authorize "miq_request_view"
 
         url = "#{service_orders_url("cart")}/service_requests"
         run_get url
@@ -174,7 +174,7 @@ RSpec.describe "service orders API" do
       it "can show a shopping cart's service request" do
         service_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
         _shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
-        api_basic_authorize action_identifier(:service_requests, :read, :subresource_actions, :get)
+        api_basic_authorize "miq_request_view"
 
         url = "#{service_orders_url("cart")}/service_requests/#{service_request.id}"
         run_get url
@@ -190,7 +190,7 @@ RSpec.describe "service orders API" do
                                                                 :action => "Provision",
                                                                 :dialog => dialog)
         shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user)
-        api_basic_authorize action_identifier(:service_requests, :add, :subcollection_actions)
+        api_basic_authorize "svc_catalog_provision"
 
         expect do
           run_post("#{service_orders_url("cart")}/service_requests",
@@ -225,7 +225,7 @@ RSpec.describe "service orders API" do
                                                                   :dialog => dialog)
 
         shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user)
-        api_basic_authorize action_identifier(:service_requests, :add, :subcollection_actions)
+        api_basic_authorize "svc_catalog_provision"
 
         expect do
           run_post(
@@ -262,7 +262,7 @@ RSpec.describe "service orders API" do
       it "can remove a service request from a shopping cart" do
         service_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
         shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
-        api_basic_authorize action_identifier(:service_requests, :remove, :subresource_actions)
+        api_basic_authorize "svc_catalog_provision"
 
         run_post "#{service_orders_url("cart")}/service_requests/#{service_request.id}", :action => :remove
 
@@ -284,7 +284,7 @@ RSpec.describe "service orders API" do
         shopping_cart = FactoryGirl.create(:shopping_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
-        api_basic_authorize action_identifier(:service_requests, :remove, :subcollection_actions)
+        api_basic_authorize "svc_catalog_provision"
 
         run_post(
           "#{service_orders_url("cart")}/service_requests",
@@ -323,7 +323,7 @@ RSpec.describe "service orders API" do
         shopping_cart = FactoryGirl.create(:shopping_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
-        api_basic_authorize action_identifier(:service_requests, :remove, :subcollection_actions)
+        api_basic_authorize "svc_catalog_provision"
 
         run_post(
           "#{service_orders_url("cart")}/service_requests",
@@ -362,7 +362,7 @@ RSpec.describe "service orders API" do
         shopping_cart = FactoryGirl.create(:shopping_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
-        api_basic_authorize action_identifier(:service_orders, :clear)
+        api_basic_authorize "svc_catalog_provision"
 
         run_post service_orders_url("cart"), :action => :clear
 
@@ -378,7 +378,7 @@ RSpec.describe "service orders API" do
       it "notifies that a shopping cart cannot be cleared if it has already been checked out" do
         service_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
         shopping_cart = FactoryGirl.create(:shopping_cart, :user => @user, :miq_requests => [service_request])
-        api_basic_authorize action_identifier(:service_orders, :clear)
+        api_basic_authorize "svc_catalog_provision"
 
         shopping_cart.checkout
         run_post service_orders_url(shopping_cart.id), :action => :clear
@@ -400,7 +400,7 @@ RSpec.describe "service orders API" do
         shopping_cart = FactoryGirl.create(:shopping_cart,
                                            :user         => @user,
                                            :miq_requests => [service_request_1, service_request_2])
-        api_basic_authorize action_identifier(:service_orders, :order)
+        api_basic_authorize "svc_catalog_provision"
 
         run_post service_orders_url("cart"), :action => :order
 
@@ -557,7 +557,7 @@ RSpec.describe "service orders API" do
     end
 
     it 'can copy a single service order' do
-      api_basic_authorize action_identifier(:service_orders, :copy)
+      api_basic_authorize "svc_catalog_provision"
 
       expect do
         run_post(service_orders_url(@service_order.id), :action => 'copy', :name => 'foo')
@@ -567,7 +567,7 @@ RSpec.describe "service orders API" do
     end
 
     it 'can copy multiple service orders' do
-      api_basic_authorize collection_action_identifier(:service_orders, :copy)
+      api_basic_authorize "svc_catalog_provision"
 
       expected = {
         'results' => a_collection_including(

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -43,7 +43,7 @@ describe "Service Requests API" do
   describe "Service Requests query" do
     before do
       template.resource_actions = [provision_ra, retire_ra]
-      api_basic_authorize action_identifier(:service_requests, :read, :resource_actions, :get)
+      api_basic_authorize "miq_request_view"
     end
 
     it "can return the provision_dialog" do
@@ -63,7 +63,7 @@ describe "Service Requests API" do
   describe "Service query" do
     before do
       template.resource_actions = [provision_ra, retire_ra]
-      api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)
+      api_basic_authorize "service_view"
     end
 
     it "can return the provision_dialog" do
@@ -98,7 +98,7 @@ describe "Service Requests API" do
     let(:svcreqs_list) { [svcreq1_url, svcreq2_url] }
 
     it "supports approving a request" do
-      api_basic_authorize collection_action_identifier(:service_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(svcreq1_url, gen_request(:approve, :reason => "approve reason"))
 
@@ -107,7 +107,7 @@ describe "Service Requests API" do
     end
 
     it "supports denying a request" do
-      api_basic_authorize collection_action_identifier(:service_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(svcreq2_url, gen_request(:deny, :reason => "deny reason"))
 
@@ -116,7 +116,7 @@ describe "Service Requests API" do
     end
 
     it "supports approving multiple requests" do
-      api_basic_authorize collection_action_identifier(:service_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(service_requests_url, gen_request(:approve, [{"href" => svcreq1_url, "reason" => "approve reason"},
                                                             {"href" => svcreq2_url, "reason" => "approve reason"}]))
@@ -140,7 +140,7 @@ describe "Service Requests API" do
     end
 
     it "supports denying multiple requests" do
-      api_basic_authorize collection_action_identifier(:service_requests, :approve)
+      api_basic_authorize "miq_request_approval"
 
       run_post(service_requests_url, gen_request(:deny, [{"href" => svcreq1_url, "reason" => "deny reason"},
                                                          {"href" => svcreq2_url, "reason" => "deny reason"}]))
@@ -179,7 +179,7 @@ describe "Service Requests API" do
                          :requester   => other_user,
                          :source_id   => template.id,
                          :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url
 
@@ -193,7 +193,7 @@ describe "Service Requests API" do
                                            :requester   => other_user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url(service_request.id)
 
@@ -211,7 +211,7 @@ describe "Service Requests API" do
                                             :requester   => @user,
                                             :source_id   => template.id,
                                             :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url
 
@@ -224,7 +224,7 @@ describe "Service Requests API" do
                                            :requester   => @user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url(service_request.id)
 
@@ -244,7 +244,7 @@ describe "Service Requests API" do
                                              :requester   => @user,
                                              :source_id   => template.id,
                                              :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url
 
@@ -267,7 +267,7 @@ describe "Service Requests API" do
                                            :requester   => other_user,
                                            :source_id   => template.id,
                                            :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+      api_basic_authorize "miq_request_view"
 
       run_get service_requests_url(service_request.id)
 
@@ -290,7 +290,7 @@ describe "Service Requests API" do
     end
 
     it 'can delete a single service request resource' do
-      api_basic_authorize collection_action_identifier(:service_requests, :delete)
+      api_basic_authorize "miq_request_delete"
 
       run_post(service_requests_url(service_request.id), :action => 'delete')
 
@@ -308,7 +308,7 @@ describe "Service Requests API" do
                                              :requester   => @user,
                                              :source_id   => template.id,
                                              :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :delete)
+      api_basic_authorize "miq_request_delete"
 
       run_post(service_requests_url, :action => 'delete', :resources => [
                  { :id => service_request.id }, { :id => service_request_2.id }
@@ -328,7 +328,7 @@ describe "Service Requests API" do
     end
 
     it 'can delete a service request via DELETE' do
-      api_basic_authorize collection_action_identifier(:service_requests, :delete)
+      api_basic_authorize "miq_request_delete"
 
       run_delete(service_requests_url(service_request.id))
 
@@ -348,7 +348,7 @@ describe "Service Requests API" do
     it 'can add a single approver' do
       service_request.miq_approvals << FactoryGirl.create(:miq_approval)
       user = FactoryGirl.create(:user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expect do
         run_post(service_requests_url(service_request.id), :action => 'add_approver', :user_id => user.id)
@@ -365,7 +365,7 @@ describe "Service Requests API" do
                                              :source_id   => template.id,
                                              :source_type => template.class.name)
       service_request_2.miq_approvals << FactoryGirl.create(:miq_approval)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expected = {
         'results' => a_collection_including(
@@ -394,7 +394,7 @@ describe "Service Requests API" do
     it 'supports user reference hash with id' do
       service_request.miq_approvals << FactoryGirl.create(:miq_approval)
       user = FactoryGirl.create(:user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expect do
         run_post(service_requests_url(service_request.id), :action => 'add_approver', :user => { :id => user.id})
@@ -406,7 +406,7 @@ describe "Service Requests API" do
     it 'supports user reference hash with href' do
       service_request.miq_approvals << FactoryGirl.create(:miq_approval)
       user = FactoryGirl.create(:user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expect do
         run_post(service_requests_url(service_request.id),
@@ -417,7 +417,7 @@ describe "Service Requests API" do
     end
 
     it 'raises an error if no user is supplied' do
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expected = {
         'error' => a_hash_including(
@@ -435,7 +435,7 @@ describe "Service Requests API" do
     it 'can remove a single approver' do
       user = FactoryGirl.create(:user)
       service_request.miq_approvals << FactoryGirl.create(:miq_approval, :approver => user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expect do
         run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
@@ -452,7 +452,7 @@ describe "Service Requests API" do
                                             :source_type => template.class.name)
       service_request.miq_approvals << FactoryGirl.create(:miq_approval, :approver => user)
       service_request2.miq_approvals << FactoryGirl.create(:miq_approval, :approver => user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expected = {
         'results' => a_collection_including(
@@ -485,7 +485,7 @@ describe "Service Requests API" do
     it 'supports user reference hash with href' do
       user = FactoryGirl.create(:user)
       service_request.miq_approvals << FactoryGirl.create(:miq_approval, :approver => user)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expect do
         run_post(service_requests_url(service_request.id),
@@ -497,7 +497,7 @@ describe "Service Requests API" do
     end
 
     it 'raises an error if no user is supplied' do
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       expected = {
         'error' => a_hash_including(
@@ -513,7 +513,7 @@ describe "Service Requests API" do
     it 'does not raise error if incorrect user is supplied' do
       user = FactoryGirl.create(:user)
       service_request.miq_approvals << FactoryGirl.create(:miq_approval)
-      api_basic_authorize collection_action_identifier(:service_requests, :add_approver)
+      api_basic_authorize "miq_request_approval"
 
       run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
       expect(response).to have_http_status(:ok)
@@ -531,7 +531,7 @@ describe "Service Requests API" do
     end
 
     it 'updates a single service request' do
-      api_basic_authorize collection_action_identifier(:service_requests, :edit)
+      api_basic_authorize "miq_request_edit"
 
       run_post(service_requests_url(service_request.id), gen_request(:edit, :options => {:foo => "bar"}))
 
@@ -548,7 +548,7 @@ describe "Service Requests API" do
                                              :requester   => @user,
                                              :source_id   => template.id,
                                              :source_type => template.class.name)
-      api_basic_authorize collection_action_identifier(:service_requests, :edit)
+      api_basic_authorize "miq_request_edit"
 
       run_post(service_requests_url,
                :action    => "edit",

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -44,7 +44,7 @@ describe "Service Templates API" do
     end
 
     it "allows queries of the related picture" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      api_basic_authorize "svc_catalog_provision"
 
       run_get service_templates_url(template.id), :attributes => "picture"
 
@@ -54,7 +54,7 @@ describe "Service Templates API" do
     end
 
     it "allows queries of the related picture and image_href" do
-      api_basic_authorize action_identifier(:service_templates, :read, :resource_actions, :get)
+      api_basic_authorize "svc_catalog_provision"
 
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
@@ -77,7 +77,7 @@ describe "Service Templates API" do
     end
 
     it "supports edits of single resource" do
-      api_basic_authorize collection_action_identifier(:service_templates, :edit)
+      api_basic_authorize "catalogitem_edit"
 
       st = FactoryGirl.create(:service_template, :name => "st1")
       run_post(service_templates_url(st.id), gen_request(:edit, "name" => "updated st1"))
@@ -87,7 +87,7 @@ describe "Service Templates API" do
     end
 
     it "supports edits of multiple resources" do
-      api_basic_authorize collection_action_identifier(:service_templates, :edit)
+      api_basic_authorize "catalogitem_edit"
 
       st1 = FactoryGirl.create(:service_template, :name => "st1")
       st2 = FactoryGirl.create(:service_template, :name => "st2")
@@ -124,7 +124,7 @@ describe "Service Templates API" do
     end
 
     it "rejects resource deletes for invalid resources" do
-      api_basic_authorize collection_action_identifier(:service_templates, :delete)
+      api_basic_authorize "catalogitem_delete"
 
       run_delete(service_templates_url(999_999))
 
@@ -132,7 +132,7 @@ describe "Service Templates API" do
     end
 
     it "supports single resource deletes" do
-      api_basic_authorize collection_action_identifier(:service_templates, :delete)
+      api_basic_authorize "catalogitem_delete"
 
       st = FactoryGirl.create(:service_template, :name => "st", :description => "st description")
 
@@ -143,7 +143,7 @@ describe "Service Templates API" do
     end
 
     it "supports multiple resource deletes" do
-      api_basic_authorize collection_action_identifier(:service_templates, :delete)
+      api_basic_authorize "catalogitem_delete"
 
       st1 = FactoryGirl.create(:service_template, :name => "st1", :description => "st1 description")
       st2 = FactoryGirl.create(:service_template, :name => "st2", :description => "st2 description")
@@ -162,7 +162,7 @@ describe "Service Templates API" do
     it "can delete a service template through its nested URI" do
       service_catalog = FactoryGirl.create(:service_template_catalog)
       service_template = FactoryGirl.create(:service_template, :service_template_catalog => service_catalog)
-      api_basic_authorize action_identifier(:service_templates, :delete, :subresource_actions, :delete)
+      api_basic_authorize "catalogitem_delete"
 
       expect do
         run_delete("#{service_catalogs_url(service_catalog.id)}/service_templates/#{service_template.id}")
@@ -178,7 +178,7 @@ describe "Service Templates API" do
       service_request = FactoryGirl.create(:service_template_provision_request,
                                            :requester => @user,
                                            :source    => service_template)
-      api_basic_authorize(action_identifier(:service_requests, :read, :subcollection_actions, :get))
+      api_basic_authorize("miq_request_view")
 
       run_get("#{service_templates_url(service_template.id)}/service_requests")
 

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -37,7 +37,7 @@ describe "Services API" do
     end
 
     it "supports creates of single resource" do
-      api_basic_authorize collection_action_identifier(:services, :create)
+      api_basic_authorize "service_create"
 
       expect do
         run_post(services_url, gen_request(:create, "name" => "svc_new_1"))
@@ -48,7 +48,7 @@ describe "Services API" do
     end
 
     it "supports creates of multiple resources" do
-      api_basic_authorize collection_action_identifier(:services, :create)
+      api_basic_authorize "service_create"
 
       expect do
         run_post(services_url, gen_request(:create,
@@ -73,7 +73,7 @@ describe "Services API" do
     end
 
     it "supports edits of single resource" do
-      api_basic_authorize collection_action_identifier(:services, :edit)
+      api_basic_authorize "service_edit"
 
       run_post(services_url(svc.id), gen_request(:edit, "name" => "updated svc1"))
 
@@ -82,7 +82,7 @@ describe "Services API" do
     end
 
     it "supports edits of single resource via PUT" do
-      api_basic_authorize collection_action_identifier(:services, :edit)
+      api_basic_authorize "service_edit"
 
       run_put(services_url(svc.id), "name" => "updated svc1")
 
@@ -91,7 +91,7 @@ describe "Services API" do
     end
 
     it "supports edits of single resource via PATCH" do
-      api_basic_authorize collection_action_identifier(:services, :edit)
+      api_basic_authorize "service_edit"
 
       run_patch(services_url(svc.id), [{"action" => "edit",   "path" => "name",        "value" => "updated svc1"},
                                        {"action" => "remove", "path" => "description"},
@@ -104,7 +104,7 @@ describe "Services API" do
     end
 
     it "supports edits of multiple resources" do
-      api_basic_authorize collection_action_identifier(:services, :edit)
+      api_basic_authorize "service_edit"
 
       run_post(services_url, gen_request(:edit,
                                          [{"href" => services_url(svc1.id), "name" => "updated svc1"},
@@ -137,7 +137,7 @@ describe "Services API" do
     end
 
     it "rejects requests for invalid resources" do
-      api_basic_authorize collection_action_identifier(:services, :delete)
+      api_basic_authorize "service_delete"
 
       run_delete(services_url(999_999))
 
@@ -145,7 +145,7 @@ describe "Services API" do
     end
 
     it "supports single resource deletes" do
-      api_basic_authorize collection_action_identifier(:services, :delete)
+      api_basic_authorize "service_delete"
 
       run_delete(services_url(svc.id))
 
@@ -154,7 +154,7 @@ describe "Services API" do
     end
 
     it "supports multiple resource deletes" do
-      api_basic_authorize collection_action_identifier(:services, :delete)
+      api_basic_authorize "service_delete"
 
       run_post(services_url, gen_request(:delete,
                                          [{"href" => services_url(svc1.id)},
@@ -189,7 +189,7 @@ describe "Services API" do
     end
 
     it "supports single service retirement now" do
-      api_basic_authorize collection_action_identifier(:services, :retire)
+      api_basic_authorize "service_retire"
 
       expect(MiqEvent).to receive(:raise_evm_event).once
 
@@ -199,7 +199,7 @@ describe "Services API" do
     end
 
     it "supports single service retirement in future" do
-      api_basic_authorize collection_action_identifier(:services, :retire)
+      api_basic_authorize "service_retire"
 
       ret_date = format_retirement_date(Time.now + 5.days)
 
@@ -211,7 +211,7 @@ describe "Services API" do
     end
 
     it "supports multiple service retirement now" do
-      api_basic_authorize collection_action_identifier(:services, :retire)
+      api_basic_authorize "service_retire"
 
       expect(MiqEvent).to receive(:raise_evm_event).twice
 
@@ -223,7 +223,7 @@ describe "Services API" do
     end
 
     it "supports multiple service retirement in future" do
-      api_basic_authorize collection_action_identifier(:services, :retire)
+      api_basic_authorize "service_retire"
 
       ret_date = format_retirement_date(Time.now + 2.days)
 
@@ -258,9 +258,9 @@ describe "Services API" do
     end
 
     it "does not return reconfigure action for non-reconfigurable services" do
-      api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get),
-                          action_identifier(:services, :retire),
-                          action_identifier(:services, :reconfigure))
+      api_basic_authorize("service_view",
+                          "service_retire",
+                          "service_reconfigure")
 
       run_get services_url(svc1.id)
 
@@ -269,9 +269,9 @@ describe "Services API" do
     end
 
     it "returns reconfigure action for reconfigurable services" do
-      api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get),
-                          action_identifier(:services, :retire),
-                          action_identifier(:services, :reconfigure))
+      api_basic_authorize("service_view",
+                          "service_retire",
+                          "service_reconfigure")
 
       st1.resource_actions = [ra1]
       svc1.service_template_id = st1.id
@@ -285,7 +285,7 @@ describe "Services API" do
 
     it "accepts action when service is reconfigurable" do
       api_basic_authorize
-      update_user_role(@role, action_identifier(:services, :reconfigure))
+      update_user_role(@role, "service_reconfigure")
 
       st1.resource_actions = [ra1]
       svc1.service_template_id = st1.id
@@ -305,7 +305,7 @@ describe "Services API" do
     let(:vm2) { FactoryGirl.create(:vm_vmware, :hardware => hw2) }
 
     before do
-      api_basic_authorize(action_identifier(:services, :read, :resource_actions, :get))
+      api_basic_authorize("service_view")
 
       svc1 << vm1
       svc1 << vm2
@@ -359,7 +359,7 @@ describe "Services API" do
     describe "start" do
       it "will start a service for a user with appropriate role" do
         service = FactoryGirl.create(:service)
-        api_basic_authorize(action_identifier(:services, :start))
+        api_basic_authorize("service_admin")
 
         run_post(services_url(service.id), :action => "start")
 
@@ -374,7 +374,7 @@ describe "Services API" do
 
       it "can start multiple services for a user with appropriate role" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
-        api_basic_authorize(collection_action_identifier(:services, :start))
+        api_basic_authorize("service_admin")
 
         run_post(services_url, :action => "start", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 
@@ -409,7 +409,7 @@ describe "Services API" do
     describe "stop" do
       it "will stop a service for a user with appropriate role" do
         service = FactoryGirl.create(:service)
-        api_basic_authorize(action_identifier(:services, :stop))
+        api_basic_authorize("service_admin")
 
         run_post(services_url(service.id), :action => "stop")
 
@@ -424,7 +424,7 @@ describe "Services API" do
 
       it "can stop multiple services for a user with appropriate role" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
-        api_basic_authorize(collection_action_identifier(:services, :stop))
+        api_basic_authorize("service_admin")
 
         run_post(services_url, :action => "stop", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 
@@ -459,7 +459,7 @@ describe "Services API" do
     describe "suspend" do
       it "will suspend a service for a user with appropriate role" do
         service = FactoryGirl.create(:service)
-        api_basic_authorize(action_identifier(:services, :suspend))
+        api_basic_authorize("service_admin")
 
         run_post(services_url(service.id), :action => "suspend")
 
@@ -474,7 +474,7 @@ describe "Services API" do
 
       it "can suspend multiple services for a user with appropriate role" do
         service_1, service_2 = FactoryGirl.create_list(:service, 2)
-        api_basic_authorize(collection_action_identifier(:services, :suspend))
+        api_basic_authorize("service_admin")
 
         run_post(services_url, :action => "suspend", :resources => [{:id => service_1.id}, {:id => service_2.id}])
 

--- a/spec/requests/api/set_ownership_spec.rb
+++ b/spec/requests/api/set_ownership_spec.rb
@@ -17,7 +17,7 @@ describe "Set Ownership" do
     let(:svc) { FactoryGirl.create(:service, :name => "svc", :description => "svc description") }
 
     it "to an invalid service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
@@ -33,7 +33,7 @@ describe "Set Ownership" do
     end
 
     it "with missing owner or group" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership))
 
@@ -41,7 +41,7 @@ describe "Set Ownership" do
     end
 
     it "with invalid owner" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
@@ -49,7 +49,7 @@ describe "Set Ownership" do
     end
 
     it "to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -57,7 +57,7 @@ describe "Set Ownership" do
     end
 
     it "by owner name to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
@@ -65,7 +65,7 @@ describe "Set Ownership" do
     end
 
     it "by owner href to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
 
@@ -73,7 +73,7 @@ describe "Set Ownership" do
     end
 
     it "by owner id to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
@@ -81,7 +81,7 @@ describe "Set Ownership" do
     end
 
     it "by group id to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
@@ -89,7 +89,7 @@ describe "Set Ownership" do
     end
 
     it "by group description to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
@@ -97,7 +97,7 @@ describe "Set Ownership" do
     end
 
     it "with owner and group to a service" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       run_post(services_url(svc.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -105,7 +105,7 @@ describe "Set Ownership" do
     end
 
     it "to multiple services" do
-      api_basic_authorize action_identifier(:services, :set_ownership)
+      api_basic_authorize "service_ownership"
 
       svc1 = FactoryGirl.create(:service, :name => "svc1", :description => "svc1 description")
       svc2 = FactoryGirl.create(:service, :name => "svc2", :description => "svc2 description")
@@ -124,7 +124,7 @@ describe "Set Ownership" do
     let(:vm) { FactoryGirl.create(:vm, :name => "vm", :description => "vm description") }
 
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
@@ -140,7 +140,7 @@ describe "Set Ownership" do
     end
 
     it "with missing owner or group" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership))
 
@@ -148,7 +148,7 @@ describe "Set Ownership" do
     end
 
     it "with invalid owner" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
@@ -156,7 +156,7 @@ describe "Set Ownership" do
     end
 
     it "to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -164,7 +164,7 @@ describe "Set Ownership" do
     end
 
     it "by owner name to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
@@ -172,7 +172,7 @@ describe "Set Ownership" do
     end
 
     it "by owner href to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
 
@@ -180,7 +180,7 @@ describe "Set Ownership" do
     end
 
     it "by owner id to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
@@ -188,7 +188,7 @@ describe "Set Ownership" do
     end
 
     it "by group id to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
@@ -196,7 +196,7 @@ describe "Set Ownership" do
     end
 
     it "by group description to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "group" => {"description" => @group.description}))
 
@@ -204,7 +204,7 @@ describe "Set Ownership" do
     end
 
     it "with owner and group to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       run_post(vms_url(vm.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -212,7 +212,7 @@ describe "Set Ownership" do
     end
 
     it "to multiple vms" do
-      api_basic_authorize action_identifier(:vms, :set_ownership)
+      api_basic_authorize "vm_ownership"
 
       vm1 = FactoryGirl.create(:vm, :name => "vm1", :description => "vm1 description")
       vm2 = FactoryGirl.create(:vm, :name => "vm2", :description => "vm2 description")
@@ -231,7 +231,7 @@ describe "Set Ownership" do
     let(:template) { FactoryGirl.create(:template_vmware, :name => "template") }
 
     it "to an invalid template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(999_999), gen_request(:set_ownership, "owner" => {"id" => 1}))
 
@@ -247,7 +247,7 @@ describe "Set Ownership" do
     end
 
     it "with missing owner or group" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership))
 
@@ -255,7 +255,7 @@ describe "Set Ownership" do
     end
 
     it "with invalid owner" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => 999_999}))
 
@@ -263,7 +263,7 @@ describe "Set Ownership" do
     end
 
     it "to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -271,7 +271,7 @@ describe "Set Ownership" do
     end
 
     it "by owner name to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"name" => @user.name}))
 
@@ -279,7 +279,7 @@ describe "Set Ownership" do
     end
 
     it "by owner href to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"href" => users_url(@user.id)}))
 
@@ -287,7 +287,7 @@ describe "Set Ownership" do
     end
 
     it "by owner id to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"id" => @user.id}))
 
@@ -295,7 +295,7 @@ describe "Set Ownership" do
     end
 
     it "by group id to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "group" => {"id" => @group.id}))
 
@@ -303,7 +303,7 @@ describe "Set Ownership" do
     end
 
     it "by group description to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id),
                gen_request(:set_ownership, "group" => {"description" => @group.description}))
@@ -312,7 +312,7 @@ describe "Set Ownership" do
     end
 
     it "with owner and group to a template" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       run_post(templates_url(template.id), gen_request(:set_ownership, "owner" => {"userid" => api_config(:user)}))
 
@@ -320,7 +320,7 @@ describe "Set Ownership" do
     end
 
     it "to multiple templates" do
-      api_basic_authorize action_identifier(:templates, :set_ownership)
+      api_basic_authorize "miq_template_ownership"
 
       template1 = FactoryGirl.create(:template_vmware, :name => "template1")
       template2 = FactoryGirl.create(:template_vmware, :name => "template2")

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -6,7 +6,7 @@ describe "Settings API" do
 
   context "Settings Queries" do
     it "tests queries of all exposed settings" do
-      api_basic_authorize action_identifier(:settings, :read, :collection_actions, :get)
+      api_basic_authorize "ops_settings"
 
       run_get settings_url
 
@@ -14,7 +14,7 @@ describe "Settings API" do
     end
 
     it "tests query for a specific setting category" do
-      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       category = api_settings.first
       run_get settings_url(category)
@@ -23,7 +23,7 @@ describe "Settings API" do
     end
 
     it "tests that query for a specific setting category matches the Settings hash" do
-      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       category = api_settings.first
       run_get settings_url(category)
@@ -32,7 +32,7 @@ describe "Settings API" do
     end
 
     it "rejects query for an invalid setting category " do
-      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       run_get settings_url("invalid_setting")
 

--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Snapshots API" do
   describe "as a subcollection of VMs" do
     describe "GET /api/vms/:c_id/snapshots" do
       it "can list the snapshots of a VM" do
-        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
+        api_basic_authorize("vm_snapshot_view")
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
         _other_snapshot = FactoryGirl.create(:snapshot)
@@ -34,7 +34,7 @@ RSpec.describe "Snapshots API" do
 
     describe "GET /api/vms/:c_id/snapshots/:s_id" do
       it "can show a VM's snapshot" do
-        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :read, :get))
+        api_basic_authorize("vm_snapshot_view")
         vm = FactoryGirl.create(:vm_vmware)
         create_time = Time.zone.parse("2017-01-11T00:00:00Z")
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm, :create_time => create_time)
@@ -64,7 +64,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/vms/:c_id/snapshots" do
       it "can queue the creation of a snapshot" do
-        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
+        api_basic_authorize("vm_snapshot_add")
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
@@ -86,7 +86,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if snapshotting is not supported" do
-        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
+        api_basic_authorize("vm_snapshot_add")
         vm = FactoryGirl.create(:vm_vmware)
 
         run_post("#{vms_url(vm.id)}/snapshots", :name => "Alice's snapsnot")
@@ -104,7 +104,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if a name is not provided" do
-        api_basic_authorize(subcollection_action_identifier(:vms, :snapshots, :create))
+        api_basic_authorize("vm_snapshot_add")
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
@@ -135,7 +135,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/vms/:c_id/snapshots/:s_id with delete action" do
       it "can queue a snapshot for deletion" do
-        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("vm_snapshot_delete")
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice's VM", :host => host, :ext_management_system => ems)
@@ -154,7 +154,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if deleting is not supported" do
-        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :post))
+        api_basic_authorize("vm_snapshot_delete")
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
@@ -181,7 +181,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/vms/:c_id/snapshots with delete action" do
       it "can queue multiple snapshots for deletion" do
-        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("vm_snapshot_delete")
         ems = FactoryGirl.create(:ext_management_system)
         host = FactoryGirl.create(:host, :ext_management_system => ems)
         vm = FactoryGirl.create(:vm_vmware, :name => "Alice and Bob's VM", :host => host, :ext_management_system => ems)
@@ -220,7 +220,7 @@ RSpec.describe "Snapshots API" do
 
     describe "DELETE /api/vms/:c_id/snapshots/:s_id" do
       it "can delete a snapshot" do
-        api_basic_authorize(action_identifier(:vms, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("vm_snapshot_delete")
         vm = FactoryGirl.create(:vm_vmware)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => vm)
 
@@ -244,7 +244,7 @@ RSpec.describe "Snapshots API" do
   describe "as a subcollection of instances" do
     describe "GET /api/instances/:c_id/snapshots" do
       it "can list the snapshots of an Instance" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :read, :get))
+        api_basic_authorize("cloud_volume_snapshot_view")
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
         _other_snapshot = FactoryGirl.create(:snapshot)
@@ -276,7 +276,7 @@ RSpec.describe "Snapshots API" do
 
     describe "GET /api/instances/:c_id/snapshots/:s_id" do
       it "can show an Instance's snapshot" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :read, :get))
+        api_basic_authorize("cloud_volume_snapshot_view")
         instance = FactoryGirl.create(:vm_openstack)
         create_time = Time.zone.parse("2017-01-11T00:00:00Z")
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance, :create_time => create_time)
@@ -306,7 +306,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/instances/:c_id/snapshots" do
       it "can queue the creation of a snapshot" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :create))
+        api_basic_authorize("cloud_volume_snapshot_create")
         ems = FactoryGirl.create(:ems_openstack_infra)
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
         instance = FactoryGirl.create(:vm_openstack, :name => "Alice's Instance", :ext_management_system => ems, :host => host)
@@ -328,7 +328,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if snapshotting is not supported" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :create))
+        api_basic_authorize("cloud_volume_snapshot_create")
         instance = FactoryGirl.create(:vm_openstack)
 
         run_post("#{instances_url(instance.id)}/snapshots", :name => "Alice's snapsnot")
@@ -346,7 +346,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if a name is not provided" do
-        api_basic_authorize(subcollection_action_identifier(:instances, :snapshots, :create))
+        api_basic_authorize("cloud_volume_snapshot_create")
         ems = FactoryGirl.create(:ems_openstack_infra)
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
         instance = FactoryGirl.create(:vm_openstack, :name => "Alice's Instance", :ext_management_system => ems, :host => host)
@@ -377,7 +377,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/instances/:c_id/snapshots/:s_id with delete action" do
       it "can queue a snapshot for deletion" do
-        api_basic_authorize(action_identifier(:instances, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("cloud_volume_snapshot_delete")
 
         ems = FactoryGirl.create(:ems_openstack_infra)
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
@@ -397,7 +397,7 @@ RSpec.describe "Snapshots API" do
       end
 
       it "renders a failed action response if deleting is not supported" do
-        api_basic_authorize(action_identifier(:instances, :delete, :snapshots_subresource_actions, :post))
+        api_basic_authorize("cloud_volume_snapshot_delete")
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 
@@ -424,7 +424,7 @@ RSpec.describe "Snapshots API" do
 
     describe "POST /api/instances/:c_id/snapshots with delete action" do
       it "can queue multiple snapshots for deletion" do
-        api_basic_authorize(action_identifier(:instances, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("cloud_volume_snapshot_delete")
 
         ems = FactoryGirl.create(:ems_openstack_infra)
         host = FactoryGirl.create(:host_openstack_infra, :ext_management_system => ems)
@@ -464,7 +464,7 @@ RSpec.describe "Snapshots API" do
 
     describe "DELETE /api/instances/:c_id/snapshots/:s_id" do
       it "can delete a snapshot" do
-        api_basic_authorize(action_identifier(:instances, :delete, :snapshots_subresource_actions, :delete))
+        api_basic_authorize("cloud_volume_snapshot_delete")
         instance = FactoryGirl.create(:vm_openstack)
         snapshot = FactoryGirl.create(:snapshot, :vm_or_template => instance)
 

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -55,7 +55,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Provider" do
-      api_basic_authorize subcollection_action_identifier(:providers, :tags, :assign)
+      api_basic_authorize "ems_infra_tag"
 
       run_post(provider_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -71,7 +71,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Provider" do
-      api_basic_authorize subcollection_action_identifier(:providers, :tags, :unassign)
+      api_basic_authorize "ems_infra_tag"
       classify_resource(provider)
 
       run_post(provider_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -104,7 +104,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Host" do
-      api_basic_authorize subcollection_action_identifier(:hosts, :tags, :assign)
+      api_basic_authorize "host_tag"
 
       run_post(host_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -120,7 +120,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Host" do
-      api_basic_authorize subcollection_action_identifier(:hosts, :tags, :unassign)
+      api_basic_authorize "host_tag"
       classify_resource(host)
 
       run_post(host_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -154,7 +154,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Data Store" do
-      api_basic_authorize subcollection_action_identifier(:data_stores, :tags, :assign)
+      api_basic_authorize "storage_tag"
 
       run_post(ds_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -170,7 +170,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Data Store" do
-      api_basic_authorize subcollection_action_identifier(:data_stores, :tags, :unassign)
+      api_basic_authorize "storage_tag"
       classify_resource(ds)
 
       run_post(ds_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -204,7 +204,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Resource Pool" do
-      api_basic_authorize subcollection_action_identifier(:resource_pools, :tags, :assign)
+      api_basic_authorize "resource_pool_tag"
 
       run_post(rp_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -220,7 +220,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Resource Pool" do
-      api_basic_authorize subcollection_action_identifier(:resource_pools, :tags, :unassign)
+      api_basic_authorize "resource_pool_tag"
       classify_resource(rp)
 
       run_post(rp_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -261,7 +261,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Cluster" do
-      api_basic_authorize subcollection_action_identifier(:clusters, :tags, :assign)
+      api_basic_authorize "ems_cluster_tag"
 
       run_post(cluster_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -277,7 +277,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Cluster" do
-      api_basic_authorize subcollection_action_identifier(:clusters, :tags, :unassign)
+      api_basic_authorize "ems_cluster_tag"
       classify_resource(cluster)
 
       run_post(cluster_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -311,7 +311,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Service" do
-      api_basic_authorize subcollection_action_identifier(:services, :tags, :assign)
+      api_basic_authorize "service_tag"
 
       run_post(service_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -327,7 +327,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Service" do
-      api_basic_authorize subcollection_action_identifier(:services, :tags, :unassign)
+      api_basic_authorize "service_tag"
       classify_resource(service)
 
       run_post(service_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -361,7 +361,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Service Template" do
-      api_basic_authorize subcollection_action_identifier(:service_templates, :tags, :assign)
+      api_basic_authorize "catalogitem_tag"
 
       run_post(service_template_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -377,7 +377,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Service Template" do
-      api_basic_authorize subcollection_action_identifier(:service_templates, :tags, :unassign)
+      api_basic_authorize "catalogitem_tag"
       classify_resource(service_template)
 
       run_post(service_template_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -411,7 +411,7 @@ describe "Tag Collections API" do
     end
 
     it "assigns a tag to a Tenant" do
-      api_basic_authorize subcollection_action_identifier(:tenants, :tags, :assign)
+      api_basic_authorize "rbac_tenant_tags_edit"
 
       run_post(tenant_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -427,7 +427,7 @@ describe "Tag Collections API" do
     end
 
     it "unassigns a tag from a Tenant" do
-      api_basic_authorize subcollection_action_identifier(:tenants, :tags, :unassign)
+      api_basic_authorize "rbac_tenant_tags_edit"
       classify_resource(tenant)
 
       run_post(tenant_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
@@ -448,7 +448,7 @@ describe "Tag Collections API" do
     end
 
     it "can assign a tag to a blueprint with an appropriate role" do
-      api_basic_authorize subcollection_action_identifier(:blueprints, :tags, :assign)
+      api_basic_authorize "blueprint_tag"
       blueprint = FactoryGirl.create(:blueprint)
 
       run_post("#{blueprints_url(blueprint.id)}/tags",
@@ -460,7 +460,7 @@ describe "Tag Collections API" do
     end
 
     it "can unassign a tag from a bluepring with an appropriate role" do
-      api_basic_authorize subcollection_action_identifier(:blueprints, :tags, :unassign)
+      api_basic_authorize "blueprint_tag"
       blueprint = FactoryGirl.create(:blueprint)
       classify_resource(blueprint)
 
@@ -504,7 +504,7 @@ describe "Tag Collections API" do
     let(:vm2)                { FactoryGirl.create(:vm_vmware,    :host => host, :ems_id => ems.id) }
 
     it 'can bulk assign tags to multiple vms' do
-      api_basic_authorize collection_action_identifier(:vms, :assign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -530,7 +530,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags to multiple vms by href' do
-      api_basic_authorize collection_action_identifier(:vms, :assign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -556,7 +556,7 @@ describe "Tag Collections API" do
     end
 
     it 'will return success and failure messages for each vm and tag' do
-      api_basic_authorize collection_action_identifier(:vms, :assign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -594,7 +594,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags by href' do
-      api_basic_authorize collection_action_identifier(:vms, :assign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -620,7 +620,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags by id' do
-      api_basic_authorize collection_action_identifier(:vms, :assign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -652,7 +652,7 @@ describe "Tag Collections API" do
     let(:service2)                { FactoryGirl.create(:service) }
 
     it 'can bulk assign tags to multiple services' do
-      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -678,7 +678,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags to multiple services by href' do
-      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -704,7 +704,7 @@ describe "Tag Collections API" do
     end
 
     it 'will return success and failure messages for each service and tag' do
-      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -742,7 +742,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags by href' do
-      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -768,7 +768,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk assign tags by id' do
-      api_basic_authorize collection_action_identifier(:services, :assign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'assign_tags',
         'resources' => [
@@ -805,7 +805,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags on multiple services' do
-      api_basic_authorize collection_action_identifier(:services, :unassign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -831,7 +831,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags to multiple services by href' do
-      api_basic_authorize collection_action_identifier(:services, :unassign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -857,7 +857,7 @@ describe "Tag Collections API" do
     end
 
     it 'will return success and failure messages for each service and tag' do
-      api_basic_authorize collection_action_identifier(:services, :unassign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -896,7 +896,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags by href' do
-      api_basic_authorize collection_action_identifier(:services, :unassign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -922,7 +922,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags by id' do
-      api_basic_authorize collection_action_identifier(:services, :unassign_tags)
+      api_basic_authorize "service_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -959,7 +959,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags on multiple vms' do
-      api_basic_authorize collection_action_identifier(:vms, :unassign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -985,7 +985,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags to multiple vms by href' do
-      api_basic_authorize collection_action_identifier(:vms, :unassign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -1011,7 +1011,7 @@ describe "Tag Collections API" do
     end
 
     it 'will return success and failure messages for each vm and tag' do
-      api_basic_authorize collection_action_identifier(:vms, :unassign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -1050,7 +1050,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags by href' do
-      api_basic_authorize collection_action_identifier(:vms, :unassign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [
@@ -1076,7 +1076,7 @@ describe "Tag Collections API" do
     end
 
     it 'can bulk unassign tags by id' do
-      api_basic_authorize collection_action_identifier(:vms, :unassign_tags)
+      api_basic_authorize "vm_tag"
       request_body = {
         'action'    => 'unassign_tags',
         'resources' => [

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -18,7 +18,7 @@ describe "Tags API" do
 
   context "Tag collection" do
     it "query all tags" do
-      api_basic_authorize collection_action_identifier(:tags, :read, :get)
+      api_basic_authorize "ops_settings"
 
       run_get tags_url
 
@@ -27,7 +27,7 @@ describe "Tags API" do
 
     context "with an appropriate role" do
       it "can create a tag with category by href" do
-        api_basic_authorize collection_action_identifier(:tags, :create)
+        api_basic_authorize "ops_settings"
         category = FactoryGirl.create(:category)
         options = {:name => "test_tag", :description => "Test Tag", :category => {:href => categories_url(category.id)}}
 
@@ -41,7 +41,7 @@ describe "Tags API" do
       end
 
       it "can create a tag with a category by id" do
-        api_basic_authorize collection_action_identifier(:tags, :create)
+        api_basic_authorize "ops_settings"
         category = FactoryGirl.create(:category)
 
         expect do
@@ -56,7 +56,7 @@ describe "Tags API" do
       end
 
       it "can create a tag with a category by name" do
-        api_basic_authorize collection_action_identifier(:tags, :create)
+        api_basic_authorize "ops_settings"
         category = FactoryGirl.create(:category)
 
         expect do
@@ -71,7 +71,7 @@ describe "Tags API" do
       end
 
       it "can create a tag as a subresource of a category" do
-        api_basic_authorize collection_action_identifier(:tags, :create)
+        api_basic_authorize "ops_settings"
         category = FactoryGirl.create(:category)
 
         expect do
@@ -85,7 +85,7 @@ describe "Tags API" do
       end
 
       it "returns bad request when the category doesn't exist" do
-        api_basic_authorize collection_action_identifier(:tags, :create)
+        api_basic_authorize "ops_settings"
 
         run_post tags_url, :name => "test_tag", :description => "Test Tag"
 
@@ -93,7 +93,7 @@ describe "Tags API" do
       end
 
       it "can update a tag's name" do
-        api_basic_authorize action_identifier(:tags, :edit)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         category = FactoryGirl.create(:category, :children => [classification])
         tag = classification.tag
@@ -106,7 +106,7 @@ describe "Tags API" do
       end
 
       it "can update a tag's description" do
-        api_basic_authorize action_identifier(:tags, :edit)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         FactoryGirl.create(:category, :children => [classification])
         tag = classification.tag
@@ -119,7 +119,7 @@ describe "Tags API" do
       end
 
       it "can delete a tag through POST" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         tag = classification.tag
 
@@ -129,7 +129,7 @@ describe "Tags API" do
       end
 
       it "can delete a tag through DELETE" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         tag = classification.tag
 
@@ -139,7 +139,7 @@ describe "Tags API" do
       end
 
       it "will respond with 404 not found when deleting a non-existent tag through DELETE" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         tag_id = classification.tag.id
         classification.destroy!
@@ -150,7 +150,7 @@ describe "Tags API" do
       end
 
       it "will respond with 404 not found when deleting a non-existent tag through POST" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification = FactoryGirl.create(:classification_tag)
         tag_id = classification.tag.id
         classification.destroy!
@@ -161,7 +161,7 @@ describe "Tags API" do
       end
 
       it "can delete multiple tags within a category by id" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification1 = FactoryGirl.create(:classification_tag)
         classification2 = FactoryGirl.create(:classification_tag)
         category = FactoryGirl.create(:category, :children => [classification1, classification2])
@@ -184,7 +184,7 @@ describe "Tags API" do
       end
 
       it "can delete multiple tags within a category by name" do
-        api_basic_authorize action_identifier(:tags, :delete)
+        api_basic_authorize "ops_settings"
         classification1 = FactoryGirl.create(:classification_tag)
         classification2 = FactoryGirl.create(:classification_tag)
         category = FactoryGirl.create(:category, :children => [classification1, classification2])
@@ -250,7 +250,7 @@ describe "Tags API" do
     end
 
     it "query a tag with an invalid Id" do
-      api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       run_get invalid_tag_url
 
@@ -258,7 +258,7 @@ describe "Tags API" do
     end
 
     it "query tags with expanded resources" do
-      api_basic_authorize collection_action_identifier(:tags, :read, :get)
+      api_basic_authorize "ops_settings"
 
       run_get tags_url, :expand => "resources"
 
@@ -267,7 +267,7 @@ describe "Tags API" do
     end
 
     it "query tag details with multiple virtual attributes" do
-      api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       tag = Tag.last
       attr_list = "category.name,category.description,classification.name,classification.description"
@@ -283,7 +283,7 @@ describe "Tags API" do
     end
 
     it "query tag details with categorization" do
-      api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       tag = Tag.last
       run_get tags_url(tag.id), :attributes => "categorization"
@@ -302,7 +302,7 @@ describe "Tags API" do
     end
 
     it "query all tags with categorization" do
-      api_basic_authorize action_identifier(:tags, :read, :resource_actions, :get)
+      api_basic_authorize "ops_settings"
 
       run_get tags_url, :expand => "resources", :attributes => "categorization"
 

--- a/spec/requests/api/templates_spec.rb
+++ b/spec/requests/api/templates_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Templates API" do
     it "can assign a tag to a template" do
       template = FactoryGirl.create(:template)
       FactoryGirl.create(:classification_department_with_tags)
-      api_basic_authorize(subcollection_action_identifier(:templates, :tags, :assign))
+      api_basic_authorize("miq_template_tag")
 
       run_post("#{templates_url(template.id)}/tags", :action => "assign", :category => "department", :name => "finance")
 
@@ -37,7 +37,7 @@ RSpec.describe "Templates API" do
       template = FactoryGirl.create(:template)
       FactoryGirl.create(:classification_department_with_tags)
       Classification.classify(template, "department", "finance")
-      api_basic_authorize(subcollection_action_identifier(:templates, :tags, :unassign))
+      api_basic_authorize("miq_template_tag")
 
       run_post("#{templates_url(template.id)}/tags",
                :action   => "unassign",

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -3,7 +3,7 @@ describe "tenant quotas API" do
 
   context "with an appropriate role" do
     it "can list all the quotas form a tenant" do
-      api_basic_authorize action_identifier(:quotas, :read, :subcollection_actions, :get)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota_1 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
       quota_2 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :mem_allocated, :value => 20)
@@ -22,7 +22,7 @@ describe "tenant quotas API" do
     end
 
     it "can show a single quota from a tenant" do
-      api_basic_authorize action_identifier(:quotas, :read, :subresource_actions, :get)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 
@@ -41,7 +41,7 @@ describe "tenant quotas API" do
     end
 
     it "can create a quota from a tenant" do
-      api_basic_authorize action_identifier(:quotas, :create, :subcollection_actions, :post)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       expect do
         run_post "/api/tenants/#{tenant.id}/quotas/", :name => :cpu_allocated, :value => 1
@@ -51,7 +51,7 @@ describe "tenant quotas API" do
     end
 
     it "can update a quota from a tenant with POST" do
-      api_basic_authorize action_identifier(:quotas, :edit, :subresource_actions, :post)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 
@@ -65,7 +65,7 @@ describe "tenant quotas API" do
     end
 
     it "can update a quota from a tenant with PUT" do
-      api_basic_authorize action_identifier(:quotas, :edit, :subresource_actions, :put)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 
@@ -79,7 +79,7 @@ describe "tenant quotas API" do
     end
 
     it "can update multiple quotas from a tenant with POST" do
-      api_basic_authorize action_identifier(:quotas, :edit, :subcollection_actions, :post)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota_1 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
       quota_2 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :mem_allocated, :value => 2)
@@ -102,7 +102,7 @@ describe "tenant quotas API" do
     end
 
     it "can delete a quota from a tenant with POST" do
-      api_basic_authorize action_identifier(:quotas, :delete, :subresource_actions, :post)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 
@@ -114,7 +114,7 @@ describe "tenant quotas API" do
     end
 
     it "can delete a quota from a tenant with DELETE" do
-      api_basic_authorize action_identifier(:quotas, :delete, :subresource_actions, :delete)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
 
@@ -126,7 +126,7 @@ describe "tenant quotas API" do
     end
 
     it "can delete multiple quotas from a tenant with POST" do
-      api_basic_authorize action_identifier(:quotas, :delete, :subcollection_actions, :post)
+      api_basic_authorize "rbac_tenant_manage_quotas"
 
       quota_1 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :cpu_allocated, :value => 1)
       quota_2 = FactoryGirl.create(:tenant_quota, :tenant_id => tenant.id, :name => :mem_allocated, :value => 2)

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "tenants API" do
   let!(:root_tenant) { Tenant.seed }
 
   it "can list all the tenants" do
-    api_basic_authorize action_identifier(:tenants, :read, :collection_actions, :get)
+    api_basic_authorize "rbac_tenant_view"
     tenant_1 = FactoryGirl.create(:tenant, :parent => root_tenant)
     tenant_2 = FactoryGirl.create(:tenant, :parent => root_tenant)
 
@@ -21,7 +21,7 @@ RSpec.describe "tenants API" do
   end
 
   it "can show a single tenant" do
-    api_basic_authorize action_identifier(:tenants, :read, :resource_actions, :get)
+    api_basic_authorize "rbac_tenant_view"
     tenant = FactoryGirl.create(
       :tenant,
       :parent      => root_tenant,
@@ -43,7 +43,7 @@ RSpec.describe "tenants API" do
 
   context "with an appropriate role" do
     it "can create a tenant" do
-      api_basic_authorize collection_action_identifier(:tenants, :create)
+      api_basic_authorize "rbac_tenant_add"
 
       expect do
         run_post tenants_url, :parent => {:id => root_tenant.id}
@@ -53,7 +53,7 @@ RSpec.describe "tenants API" do
     end
 
     it "will not create a tenant with an invalid parent" do
-      api_basic_authorize collection_action_identifier(:tenants, :create)
+      api_basic_authorize "rbac_tenant_add"
       invalid_tenant = FactoryGirl.create(:tenant, :parent => root_tenant).destroy
 
       expect do
@@ -64,7 +64,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can update a tenant with POST" do
-      api_basic_authorize action_identifier(:tenants, :edit)
+      api_basic_authorize "rbac_tenant_edit"
       tenant = FactoryGirl.create(
         :tenant,
         :parent      => root_tenant,
@@ -82,7 +82,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can update a tenant with PUT" do
-      api_basic_authorize action_identifier(:tenants, :edit)
+      api_basic_authorize "rbac_tenant_edit"
       tenant = FactoryGirl.create(
         :tenant,
         :parent      => root_tenant,
@@ -107,7 +107,7 @@ RSpec.describe "tenants API" do
       end
 
       it "shows properties from configuration settings" do
-        api_basic_authorize action_identifier(:tenants, :read, :resource_actions, :get)
+        api_basic_authorize "rbac_tenant_view"
         run_get tenants_url(root_tenant.id)
 
         expect_result_to_match_hash(response.parsed_body,
@@ -120,7 +120,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can update multiple tenants with POST" do
-      api_basic_authorize action_identifier(:tenants, :edit)
+      api_basic_authorize "rbac_tenant_edit"
       tenant_1 = FactoryGirl.create(
         :tenant,
         :parent => root_tenant,
@@ -149,7 +149,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can delete a tenant with POST" do
-      api_basic_authorize action_identifier(:tenants, :delete)
+      api_basic_authorize "rbac_tenant_delete"
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_post tenants_url(tenant.id), gen_request(:delete) }.to change(Tenant, :count).by(-1)
@@ -157,7 +157,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can delete a tenant with DELETE" do
-      api_basic_authorize action_identifier(:tenants, :delete)
+      api_basic_authorize "rbac_tenant_delete"
       tenant = FactoryGirl.create(:tenant, :parent => root_tenant)
 
       expect { run_delete tenants_url(tenant.id) }.to change(Tenant, :count).by(-1)
@@ -165,7 +165,7 @@ RSpec.describe "tenants API" do
     end
 
     it "can delete multiple tenants with POST" do
-      api_basic_authorize action_identifier(:tenants, :delete)
+      api_basic_authorize "rbac_tenant_delete"
       tenant_1 = FactoryGirl.create(:tenant, :parent => root_tenant)
       tenant_2 = FactoryGirl.create(:tenant, :parent => root_tenant)
       options = [

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "users API" do
 
   context "with an appropriate role" do
     it "can change the user's password" do
-      api_basic_authorize action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       expect do
         run_post users_url(@user.id), gen_request(:edit, :password => "new_password")
@@ -37,7 +37,7 @@ RSpec.describe "users API" do
     end
 
     it "can change another user's password" do
-      api_basic_authorize action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
       user = FactoryGirl.create(:user)
 
       expect do
@@ -60,7 +60,7 @@ RSpec.describe "users API" do
     end
 
     it "can change the user's own email" do
-      api_basic_authorize action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       expect do
         run_post users_url(@user.id), gen_request(:edit, :email => "tom@cartoons.com")
@@ -70,7 +70,7 @@ RSpec.describe "users API" do
     end
 
     it "can change the user's own settings" do
-      api_basic_authorize action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       expect do
         run_post users_url(@user.id), gen_request(:edit, :settings => {:cartoon => {:tom_jerry => 'y'}})
@@ -122,7 +122,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user creation with id specified" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, "userid" => "userid1", "id" => 100)
 
@@ -130,7 +130,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user creation with invalid group specified" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, sample_user2.merge("group" => {"id" => 999_999}))
 
@@ -138,7 +138,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user creation with missing attribute" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, sample_user2.except(:userid))
 
@@ -146,7 +146,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user creation" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, sample_user1)
 
@@ -158,7 +158,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user creation via action" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, gen_request(:create, sample_user1))
 
@@ -170,7 +170,7 @@ RSpec.describe "users API" do
     end
 
     it "supports multiple user creation" do
-      api_basic_authorize collection_action_identifier(:users, :create)
+      api_basic_authorize "rbac_user_add"
 
       run_post(users_url, gen_request(:create, [sample_user1, sample_user2]))
 
@@ -196,7 +196,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user edits for invalid resources" do
-      api_basic_authorize collection_action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       run_post(users_url(999_999), gen_request(:edit, "name" => "updated name"))
 
@@ -204,7 +204,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user edit" do
-      api_basic_authorize collection_action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       run_post(users_url(user1.id), gen_request(:edit, "name" => "updated name"))
 
@@ -213,7 +213,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user edit of other attributes including group change" do
-      api_basic_authorize collection_action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       run_post(users_url(user1.id), gen_request(:edit,
                                                 "email" => "user1@email.com",
@@ -225,7 +225,7 @@ RSpec.describe "users API" do
     end
 
     it "supports multiple user edits" do
-      api_basic_authorize collection_action_identifier(:users, :edit)
+      api_basic_authorize "rbac_user_edit"
 
       run_post(users_url, gen_request(:edit,
                                       [{"href" => users_url(user1.id), "first_name" => "John"},
@@ -258,7 +258,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user deletes for invalid users" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       run_delete(users_url(999_999))
 
@@ -266,7 +266,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user delete of requesting user via action" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       run_post(users_url, gen_request(:delete, "href" => users_url(@user.id)))
 
@@ -274,7 +274,7 @@ RSpec.describe "users API" do
     end
 
     it "rejects user delete of requesting user" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       run_delete(users_url(@user.id))
 
@@ -282,7 +282,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user delete" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       user1_id = user1.id
       run_delete(users_url(user1_id))
@@ -292,7 +292,7 @@ RSpec.describe "users API" do
     end
 
     it "supports single user delete action" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       user1_id = user1.id
       user1_url = users_url(user1_id)
@@ -304,7 +304,7 @@ RSpec.describe "users API" do
     end
 
     it "supports multiple user deletes" do
-      api_basic_authorize collection_action_identifier(:users, :delete)
+      api_basic_authorize "rbac_user_delete"
 
       user1_id, user2_id = user1.id, user2.id
       user1_url, user2_url = users_url(user1_id), users_url(user2_id)
@@ -334,7 +334,7 @@ RSpec.describe "users API" do
     it "can assign a tag to a user" do
       user = FactoryGirl.create(:user)
       FactoryGirl.create(:classification_department_with_tags)
-      api_basic_authorize(subcollection_action_identifier(:users, :tags, :assign))
+      api_basic_authorize("rbac_user_tags_edit")
 
       run_post("#{users_url(user.id)}/tags", :action => "assign", :category => "department", :name => "finance")
 
@@ -356,7 +356,7 @@ RSpec.describe "users API" do
       user = FactoryGirl.create(:user)
       FactoryGirl.create(:classification_department_with_tags)
       Classification.classify(user, "department", "finance")
-      api_basic_authorize(subcollection_action_identifier(:users, :tags, :unassign))
+      api_basic_authorize("rbac_user_tags_edit")
 
       run_post("#{users_url(user.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
 

--- a/spec/requests/api/virtual_templates_spec.rb
+++ b/spec/requests/api/virtual_templates_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Virtual Template API' do
 
   context 'virtual templates index' do
     it 'can list all the virtual templates' do
-      api_basic_authorize collection_action_identifier(:virtual_templates, :read, :get)
+      api_basic_authorize "virtual_template_show"
       FactoryGirl.create(:virtual_template, :ems_id => ems.id)
       FactoryGirl.create(:virtual_template_google,
                          :ems_id               => ems.id,
@@ -27,7 +27,7 @@ RSpec.describe 'Virtual Template API' do
     end
 
     it 'only lists virtual templates (no other templates)' do
-      api_basic_authorize collection_action_identifier(:virtual_templates, :read, :get)
+      api_basic_authorize "virtual_template_show"
       FactoryGirl.create(:virtual_template, :ems_id => ems.id)
       FactoryGirl.create(:template_google, :ems_id => ems.id)
 
@@ -48,7 +48,7 @@ RSpec.describe 'Virtual Template API' do
     end
 
     it "accepts resource get requests with appropriate role" do
-      api_basic_authorize action_identifier(:virtual_templates, :read, :resource_actions, :get)
+      api_basic_authorize "virtual_template_show"
 
       vt = FactoryGirl.create(:virtual_template, :ems_id => ems.id)
 

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -74,7 +74,7 @@ describe "Vms API" do
     end
 
     it "query VM accounts subcollection with two related accounts using expand directive" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
       # create resources
       acct1
       acct2
@@ -131,7 +131,7 @@ describe "Vms API" do
     end
 
     it "query VM software subcollection with two related software using expand directive" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
       # create resources
       sw1
       sw2
@@ -145,7 +145,7 @@ describe "Vms API" do
 
   context "Vm start action" do
     it "starts an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :start)
+      api_basic_authorize "vm_start"
 
       run_post(invalid_vm_url, gen_request(:start))
 
@@ -161,7 +161,7 @@ describe "Vms API" do
     end
 
     it "starts a powered on vm" do
-      api_basic_authorize action_identifier(:vms, :start)
+      api_basic_authorize "vm_start"
 
       run_post(vm_url, gen_request(:start))
 
@@ -169,7 +169,7 @@ describe "Vms API" do
     end
 
     it "starts a vm" do
-      api_basic_authorize action_identifier(:vms, :start)
+      api_basic_authorize "vm_start"
       update_raw_power_state("poweredOff", vm)
 
       run_post(vm_url, gen_request(:start))
@@ -178,7 +178,7 @@ describe "Vms API" do
     end
 
     it "starting a vm queues it properly" do
-      api_basic_authorize action_identifier(:vms, :start)
+      api_basic_authorize "vm_start"
       update_raw_power_state("poweredOff", vm)
 
       run_post(vm_url, gen_request(:start))
@@ -191,7 +191,7 @@ describe "Vms API" do
     end
 
     it "starts multiple vms" do
-      api_basic_authorize action_identifier(:vms, :start)
+      api_basic_authorize "vm_start"
       update_raw_power_state("poweredOff", vm1, vm2)
 
       run_post(vms_url, gen_request(:start, nil, vm1_url, vm2_url))
@@ -203,7 +203,7 @@ describe "Vms API" do
 
   context "Vm stop action" do
     it "stops an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :stop)
+      api_basic_authorize "vm_stop"
 
       run_post(invalid_vm_url, gen_request(:stop))
 
@@ -219,7 +219,7 @@ describe "Vms API" do
     end
 
     it "stops a powered off vm" do
-      api_basic_authorize action_identifier(:vms, :stop)
+      api_basic_authorize "vm_stop"
       update_raw_power_state("poweredOff", vm)
 
       run_post(vm_url, gen_request(:stop))
@@ -228,7 +228,7 @@ describe "Vms API" do
     end
 
     it "stops a vm" do
-      api_basic_authorize action_identifier(:vms, :stop)
+      api_basic_authorize "vm_stop"
 
       run_post(vm_url, gen_request(:stop))
 
@@ -236,7 +236,7 @@ describe "Vms API" do
     end
 
     it "stops multiple vms" do
-      api_basic_authorize action_identifier(:vms, :stop)
+      api_basic_authorize "vm_stop"
 
       run_post(vms_url, gen_request(:stop, nil, vm1_url, vm2_url))
 
@@ -247,7 +247,7 @@ describe "Vms API" do
 
   context "Vm suspend action" do
     it "suspends an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :suspend)
+      api_basic_authorize "vm_suspend"
 
       run_post(invalid_vm_url, gen_request(:suspend))
 
@@ -263,7 +263,7 @@ describe "Vms API" do
     end
 
     it "suspends a powered off vm" do
-      api_basic_authorize action_identifier(:vms, :suspend)
+      api_basic_authorize "vm_suspend"
       update_raw_power_state("poweredOff", vm)
 
       run_post(vm_url, gen_request(:suspend))
@@ -272,7 +272,7 @@ describe "Vms API" do
     end
 
     it "suspends a suspended vm" do
-      api_basic_authorize action_identifier(:vms, :suspend)
+      api_basic_authorize "vm_suspend"
       update_raw_power_state("suspended", vm)
 
       run_post(vm_url, gen_request(:suspend))
@@ -281,7 +281,7 @@ describe "Vms API" do
     end
 
     it "suspends a vm" do
-      api_basic_authorize action_identifier(:vms, :suspend)
+      api_basic_authorize "vm_suspend"
 
       run_post(vm_url, gen_request(:suspend))
 
@@ -289,7 +289,7 @@ describe "Vms API" do
     end
 
     it "suspends multiple vms" do
-      api_basic_authorize action_identifier(:vms, :suspend)
+      api_basic_authorize "vm_suspend"
 
       run_post(vms_url, gen_request(:suspend, nil, vm1_url, vm2_url))
 
@@ -300,7 +300,7 @@ describe "Vms API" do
 
   context "Vm pause action" do
     it "pauses an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :pause)
+      api_basic_authorize "vm_pause"
 
       run_post(invalid_vm_url, gen_request(:pause))
 
@@ -316,7 +316,7 @@ describe "Vms API" do
     end
 
     it "pauses a powered off vm" do
-      api_basic_authorize action_identifier(:vms, :pause)
+      api_basic_authorize "vm_pause"
       update_raw_power_state("off", vm)
 
       run_post(vm_url, gen_request(:pause))
@@ -325,7 +325,7 @@ describe "Vms API" do
     end
 
     it "pauses a pauseed vm" do
-      api_basic_authorize action_identifier(:vms, :pause)
+      api_basic_authorize "vm_pause"
       update_raw_power_state("paused", vm)
 
       run_post(vm_url, gen_request(:pause))
@@ -334,7 +334,7 @@ describe "Vms API" do
     end
 
     it "pauses a vm" do
-      api_basic_authorize action_identifier(:vms, :pause)
+      api_basic_authorize "vm_pause"
 
       run_post(vm_url, gen_request(:pause))
 
@@ -342,7 +342,7 @@ describe "Vms API" do
     end
 
     it "pauses multiple vms" do
-      api_basic_authorize action_identifier(:vms, :pause)
+      api_basic_authorize "vm_pause"
 
       run_post(vms_url, gen_request(:pause, nil, vm1_url, vm2_url))
 
@@ -353,7 +353,7 @@ describe "Vms API" do
 
   context "Vm shelve action" do
     it "shelves an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(invalid_vm_url, gen_request(:shelve))
 
@@ -369,7 +369,7 @@ describe "Vms API" do
     end
 
     it "shelves a powered off vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SHUTOFF", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve))
@@ -378,7 +378,7 @@ describe "Vms API" do
     end
 
     it "shelves a suspended vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SUSPENDED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve))
@@ -387,7 +387,7 @@ describe "Vms API" do
     end
 
     it "shelves a paused off vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("PAUSED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve))
@@ -396,7 +396,7 @@ describe "Vms API" do
     end
 
     it "shelves a shelveed vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
       update_raw_power_state("SHELVED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve))
@@ -407,7 +407,7 @@ describe "Vms API" do
     end
 
     it "shelves a vm" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(vm_openstack_url, gen_request(:shelve))
 
@@ -415,7 +415,7 @@ describe "Vms API" do
     end
 
     it "shelve for a VMWare vm is not supported" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(vm_url, gen_request(:shelve))
 
@@ -426,7 +426,7 @@ describe "Vms API" do
     end
 
     it "shelves multiple vms" do
-      api_basic_authorize action_identifier(:vms, :shelve)
+      api_basic_authorize "instance_shelve"
 
       run_post(vms_url, gen_request(:shelve, nil, vm_openstack1_url, vm_openstack2_url))
 
@@ -437,7 +437,7 @@ describe "Vms API" do
 
   context "Vm shelve offload action" do
     it "shelve_offloads an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
 
       run_post(invalid_vm_url, gen_request(:shelve_offload))
 
@@ -453,7 +453,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a active vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
 
@@ -463,7 +463,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a powered off vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
       update_raw_power_state("SHUTOFF", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
@@ -474,7 +474,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a suspended vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
       update_raw_power_state("SUSPENDED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
@@ -485,7 +485,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a paused off vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
       update_raw_power_state("PAUSED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
@@ -496,7 +496,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a shelve_offloaded vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
       update_raw_power_state("SHELVED_OFFLOADED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
@@ -507,7 +507,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads a shelved vm" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
       update_raw_power_state("SHELVED", vm_openstack)
 
       run_post(vm_openstack_url, gen_request(:shelve_offload))
@@ -518,7 +518,7 @@ describe "Vms API" do
     end
 
     it "shelve_offload for a VMWare vm is not supported" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
 
       run_post(vm_url, gen_request(:shelve_offload))
 
@@ -529,7 +529,7 @@ describe "Vms API" do
     end
 
     it "shelve_offloads multiple vms" do
-      api_basic_authorize action_identifier(:vms, :shelve_offload)
+      api_basic_authorize "instance_shelve_offload"
 
       update_raw_power_state("SHELVED", vm_openstack1)
       update_raw_power_state("SHELVED", vm_openstack2)
@@ -543,7 +543,7 @@ describe "Vms API" do
 
   context "Vm delete action" do
     it "deletes an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :delete)
+      api_basic_authorize "vm_delete"
 
       run_post(invalid_vm_url, gen_request(:delete))
 
@@ -567,7 +567,7 @@ describe "Vms API" do
     end
 
     it "deletes a vm via a resource POST" do
-      api_basic_authorize action_identifier(:vms, :delete)
+      api_basic_authorize "vm_delete"
 
       run_post(vm_url, gen_request(:delete))
 
@@ -575,7 +575,7 @@ describe "Vms API" do
     end
 
     it "deletes a vm via a resource DELETE" do
-      api_basic_authorize action_identifier(:vms, :delete)
+      api_basic_authorize "vm_delete"
 
       run_delete(vm_url)
 
@@ -583,7 +583,7 @@ describe "Vms API" do
     end
 
     it "deletes multiple vms" do
-      api_basic_authorize action_identifier(:vms, :delete)
+      api_basic_authorize "vm_delete"
 
       run_post(vms_url, gen_request(:delete, nil, vm1_url, vm2_url))
 
@@ -593,7 +593,7 @@ describe "Vms API" do
 
   context "Vm set_owner action" do
     it "set_owner to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :set_owner)
+      api_basic_authorize "vm_edit"
 
       run_post(invalid_vm_url, gen_request(:set_owner, "owner" => "admin"))
 
@@ -609,7 +609,7 @@ describe "Vms API" do
     end
 
     it "set_owner with missing owner" do
-      api_basic_authorize action_identifier(:vms, :set_owner)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_url, gen_request(:set_owner))
 
@@ -617,7 +617,7 @@ describe "Vms API" do
     end
 
     it "set_owner with invalid owner" do
-      api_basic_authorize action_identifier(:vms, :set_owner)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_url, gen_request(:set_owner, "owner" => "bad_user"))
 
@@ -625,7 +625,7 @@ describe "Vms API" do
     end
 
     it "set_owner to a vm" do
-      api_basic_authorize action_identifier(:vms, :set_owner)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_url, gen_request(:set_owner, "owner" => api_config(:user)))
 
@@ -634,7 +634,7 @@ describe "Vms API" do
     end
 
     it "set_owner to multiple vms" do
-      api_basic_authorize action_identifier(:vms, :set_owner)
+      api_basic_authorize "vm_edit"
 
       run_post(vms_url, gen_request(:set_owner, {"owner" => api_config(:user)}, vm1_url, vm2_url))
 
@@ -682,7 +682,7 @@ describe "Vms API" do
     end
 
     it "getting custom_attributes from a vm using expand" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      api_basic_authorize "vm_show"
       vm.custom_attributes = [ca1, ca2]
 
       run_get vm_url, :expand => "custom_attributes"
@@ -701,7 +701,7 @@ describe "Vms API" do
     end
 
     it "delete a custom_attribute from a vm via the delete action" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
       vm.custom_attributes = [ca1]
 
       run_post(vm_ca_url, gen_request(:delete, nil, ca1_url))
@@ -711,7 +711,7 @@ describe "Vms API" do
     end
 
     it "add custom attribute to a vm without a name" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_ca_url, gen_request(:add, "value" => "value1"))
 
@@ -719,7 +719,7 @@ describe "Vms API" do
     end
 
     it "add custom attributes to a vm" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
                                              {"name" => "name2", "value" => "value2"}]))
@@ -731,7 +731,7 @@ describe "Vms API" do
     end
 
     it "edit a custom attribute by name" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
       vm.custom_attributes = [ca1]
 
       run_post(vm_ca_url, gen_request(:edit, "name" => "name1", "value" => "value one"))
@@ -742,7 +742,7 @@ describe "Vms API" do
     end
 
     it "edit a custom attribute by href" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
       vm.custom_attributes = [ca1]
 
       run_post(vm_ca_url, gen_request(:edit, "href" => ca1_url, "value" => "new value1"))
@@ -753,7 +753,7 @@ describe "Vms API" do
     end
 
     it "edit multiple custom attributes" do
-      api_basic_authorize action_identifier(:vms, :edit)
+      api_basic_authorize "vm_edit"
       vm.custom_attributes = [ca1, ca2]
 
       run_post(vm_ca_url, gen_request(:edit, [{"name" => "name1", "value" => "new value1"},
@@ -773,7 +773,7 @@ describe "Vms API" do
     end
 
     it "add_lifecycle_event to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :add_lifecycle_event)
+      api_basic_authorize "vm_edit"
 
       run_post(invalid_vm_url, gen_request(:add_lifecycle_event, :event => "event 1"))
 
@@ -789,7 +789,7 @@ describe "Vms API" do
     end
 
     it "add_lifecycle_event to a vm" do
-      api_basic_authorize action_identifier(:vms, :add_lifecycle_event)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_url, gen_request(:add_lifecycle_event, events[0]))
 
@@ -799,7 +799,7 @@ describe "Vms API" do
     end
 
     it "add_lifecycle_event to multiple vms" do
-      api_basic_authorize action_identifier(:vms, :add_lifecycle_event)
+      api_basic_authorize "vm_edit"
 
       run_post(vms_url, gen_request(:add_lifecycle_event,
                                     events.collect { |e| {:href => vm_url}.merge(e) }))
@@ -812,7 +812,7 @@ describe "Vms API" do
 
   context "Vm scan action" do
     it "scans an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :scan)
+      api_basic_authorize "vm_scan"
 
       run_post(invalid_vm_url, gen_request(:scan))
 
@@ -828,7 +828,7 @@ describe "Vms API" do
     end
 
     it "scan a Vm" do
-      api_basic_authorize action_identifier(:vms, :scan)
+      api_basic_authorize "vm_scan"
 
       run_post(vm_url, gen_request(:scan))
 
@@ -836,7 +836,7 @@ describe "Vms API" do
     end
 
     it "scan multiple Vms" do
-      api_basic_authorize action_identifier(:vms, :scan)
+      api_basic_authorize "vm_scan"
 
       run_post(vms_url, gen_request(:scan, nil, vm1_url, vm2_url))
 
@@ -847,7 +847,7 @@ describe "Vms API" do
 
   context "Vm add_event action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :add_event)
+      api_basic_authorize "vm_edit"
 
       run_post(invalid_vm_url, gen_request(:add_event))
 
@@ -863,7 +863,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize collection_action_identifier(:vms, :add_event)
+      api_basic_authorize "vm_edit"
 
       run_post(vm_url, gen_request(:add_event, :event_type => "special", :event_message => "message"))
 
@@ -871,7 +871,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :add_event)
+      api_basic_authorize "vm_edit"
 
       run_post(vms_url,
                gen_request(:add_event,
@@ -899,7 +899,7 @@ describe "Vms API" do
 
   context "Vm retire action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :retire)
+      api_basic_authorize "vm_retire"
 
       run_post(invalid_vm_url, gen_request(:retire))
 
@@ -915,7 +915,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :retire)
+      api_basic_authorize "vm_retire"
 
       run_post(vm_url, gen_request(:retire))
 
@@ -923,7 +923,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :retire)
+      api_basic_authorize "vm_retire"
 
       run_post(vms_url, gen_request(:retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -946,7 +946,7 @@ describe "Vms API" do
     end
 
     it "in the future" do
-      api_basic_authorize action_identifier(:vms, :retire)
+      api_basic_authorize "vm_retire"
       date = 2.weeks.from_now
       run_post(vm_url, gen_request(:retire, :date => date.iso8601))
 
@@ -956,7 +956,7 @@ describe "Vms API" do
 
   context "Vm reset action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :reset)
+      api_basic_authorize "vm_reset"
 
       run_post(invalid_vm_url, gen_request(:reset))
 
@@ -972,7 +972,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :reset)
+      api_basic_authorize "vm_reset"
 
       run_post(vm_url, gen_request(:reset))
 
@@ -980,7 +980,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :reset)
+      api_basic_authorize "vm_reset"
 
       run_post(vms_url, gen_request(:reset, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -1005,7 +1005,7 @@ describe "Vms API" do
 
   context "Vm shutdown guest action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :shutdown_guest)
+      api_basic_authorize "vm_guest_shutdown"
 
       run_post(invalid_vm_url, gen_request(:shutdown_guest))
 
@@ -1021,7 +1021,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :shutdown_guest)
+      api_basic_authorize "vm_guest_shutdown"
 
       run_post(vm_url, gen_request(:shutdown_guest))
 
@@ -1029,7 +1029,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :shutdown_guest)
+      api_basic_authorize "vm_guest_shutdown"
 
       run_post(vms_url, gen_request(:shutdown_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -1054,7 +1054,7 @@ describe "Vms API" do
 
   context "Vm refresh action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :refresh)
+      api_basic_authorize "vm_refresh"
 
       run_post(invalid_vm_url, gen_request(:refresh))
 
@@ -1070,7 +1070,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :refresh)
+      api_basic_authorize "vm_refresh"
 
       run_post(vm_url, gen_request(:refresh))
 
@@ -1078,7 +1078,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :refresh)
+      api_basic_authorize "vm_refresh"
 
       run_post(vms_url, gen_request(:refresh, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -1103,7 +1103,7 @@ describe "Vms API" do
 
   context "Vm reboot guest action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :reboot_guest)
+      api_basic_authorize "vm_guest_restart"
 
       run_post(invalid_vm_url, gen_request(:reboot_guest))
 
@@ -1119,7 +1119,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :reboot_guest)
+      api_basic_authorize "vm_guest_restart"
 
       run_post(vm_url, gen_request(:reboot_guest))
 
@@ -1127,7 +1127,7 @@ describe "Vms API" do
     end
 
     it "to multiple Vms" do
-      api_basic_authorize collection_action_identifier(:vms, :reboot_guest)
+      api_basic_authorize "vm_guest_restart"
 
       run_post(vms_url, gen_request(:reboot_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
@@ -1152,7 +1152,7 @@ describe "Vms API" do
 
   context "Vm request console action" do
     it "to an invalid vm" do
-      api_basic_authorize action_identifier(:vms, :request_console)
+      api_basic_authorize "vm_console"
 
       run_post(invalid_vm_url, gen_request(:request_console))
 
@@ -1168,7 +1168,7 @@ describe "Vms API" do
     end
 
     it "to a single Vm" do
-      api_basic_authorize action_identifier(:vms, :request_console)
+      api_basic_authorize "vm_console"
 
       run_post(vm_url, gen_request(:request_console))
 
@@ -1231,7 +1231,7 @@ describe "Vms API" do
     end
 
     it "assigns a tag to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -1241,7 +1241,7 @@ describe "Vms API" do
     end
 
     it "assigns a tag to a Vm by name path" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, :name => tag1[:path]))
 
@@ -1251,7 +1251,7 @@ describe "Vms API" do
     end
 
     it "assigns a tag to a Vm by href" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, :href => tags_url(Tag.find_by(:name => tag1[:path]).id)))
 
@@ -1261,7 +1261,7 @@ describe "Vms API" do
     end
 
     it "assigns an invalid tag by href to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, :href => invalid_tag_url))
 
@@ -1269,7 +1269,7 @@ describe "Vms API" do
     end
 
     it "assigns an invalid tag to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, :name => "/managed/bad_category/bad_name"))
 
@@ -1279,7 +1279,7 @@ describe "Vms API" do
     end
 
     it "assigns multiple tags to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:name => tag2[:path]}]))
 
@@ -1290,7 +1290,7 @@ describe "Vms API" do
     end
 
     it "assigns tags by mixed specification to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+      api_basic_authorize "vm_tag"
 
       tag = Tag.find_by(:name => tag2[:path])
       run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))
@@ -1310,7 +1310,7 @@ describe "Vms API" do
     end
 
     it "unassigns a tag from a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
+      api_basic_authorize "vm_tag"
 
       run_post(vm2_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
 
@@ -1322,7 +1322,7 @@ describe "Vms API" do
     end
 
     it "unassigns multiple tags from a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
+      api_basic_authorize "vm_tag"
 
       tag = Tag.find_by(:name => tag2[:path])
       run_post(vm2_tags_url, gen_request(:unassign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -103,24 +103,6 @@ module Spec
         @miq_server_guid ||= MiqUUID.new_guid
       end
 
-      def action_identifier(type, action, selection = :resource_actions, method = :post)
-        Api::ApiConfig.collections[type][selection][method]
-          .detect { |spec| spec[:name] == action.to_s }[:identifier]
-      end
-
-      def collection_action_identifier(type, action, method = :post)
-        action_identifier(type, action, :collection_actions, method)
-      end
-
-      def subcollection_action_identifier(type, subtype, action, method = :post)
-        subtype_actions = "#{subtype}_subcollection_actions".to_sym
-        if Api::ApiConfig.collections[type][subtype_actions]
-          action_identifier(type, action, subtype_actions, method)
-        else
-          action_identifier(subtype, action, :subcollection_actions, method)
-        end
-      end
-
       def gen_request(action, data = nil, *hrefs)
         request = {"action" => action.to_s}
         if hrefs.present?


### PR DESCRIPTION
Some recent work has revealed:

1. We had some issues with enforcing access control for some collections
2. It is hard to refactor the api.yml file without breaking tests

Part of this pain I think is due to the fact that all the tests are coupled to the structure of the api.yml file by the way of the `action_identifier` helpers. Replacing them with the identifier literals I think has a few benefits:

1. It decouples the test from the api.yml file structure, meaning things can be moved around if necessary without having to update the tests
2. It deals with the "obscure test" smell, where it's not clear from looking at the body of the test what the players are
3. It decreases the chance of having false positives, in the case that both the test logic and the production logic were in error
4. It removes untested test logic that looks up these identifiers, meaning there are fewer opportunities to go wrong
5. We get better error messages, because the `action_identifier` helpers dive deep into the yaml structure, often failing with a `NoMethodError` on `nil` if a particular key is not found
6. We get some horizontal deletions, because the literals are often very much smaller than the helper needed to generate them
7. It removes another barrier to entry for new contributors, who have to learn three method signatures for these helpers, which all took multiple arguments

Last, I'll just add that in the case that consensus is :-1: on this, putting this PR together was not a big effort as I was able to do the vast majority of substitutions programatically, so no big deal!

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 


