### PR TITLE
Remove stale comment RE: now ye olde ruby 2.1

### DIFF
--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -73,7 +73,6 @@ class EvmServer
   ##
   # Sets the server process' name if it is possible.
   #
-  # Will do nothing on ruby<2.1, because .setproctitle was introduced in 2.1
   def set_process_title
     Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
   end


### PR DESCRIPTION
I could remove the conditional `if Process.respond_to?(:setproctitle)` but there's really no reason to do that.  It's not worth seeing if all platforms and >2.1 rubies (jruby) implement it and not raise.

cc @chrisarcand