### PR TITLE
Remove possibly never used is_current_process? method

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -484,10 +484,6 @@ class MiqWorker < ApplicationRecord
     update_attribute(:last_heartbeat, Time.now.utc)
   end
 
-  def is_current_process?
-    Process.pid == pid
-  end
-
   def self.config_settings_path
     @config_settings_path ||= [:workers] + path_to_my_worker_settings
   end


### PR DESCRIPTION
It was added in the commit below and isn't in use:

a1dc5ac043393cebaa5df237a2bad63d7aa53eb2
Date:   Thu Jan 6 20:02:48 2011 +0000

    Job model cleanup
    ...
    - Added MiqWorker.is_current_process? for later use
    ...
    BugzID:11137