### PR TITLE
Ruby 2.2 fix for #13802

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -10,8 +10,8 @@ class EmbeddedAnsible
   SECRET_KEY_FILE             = "/etc/tower/SECRET_KEY".freeze
   CONFIGURE_EXCLUDE_TAGS      = "packages,migrations,firewall,supervisor".freeze
   START_EXCLUDE_TAGS          = "packages,migrations,firewall".freeze
-  NGINX_HTTP_PORT             = "54321".freeze
-  NGINX_HTTPS_PORT            = "54322".freeze
+  NGINX_HTTP_PORT             = 54_321
+  NGINX_HTTPS_PORT            = 54_322
 
   def self.available?
     path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY


### PR DESCRIPTION
Ruby 2.2 URI required port to be integer, 2.3 admits strings.

Specs were failing on 2.2:
```
$ bundle exec rspec ./spec/lib/embedded_ansible_spec.rb
...

Failures:

  1) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted returns false when a Faraday::ConnectionFailed is raised
     Failure/Error: :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => NGINX_HTTP_PORT).to_s,

     URI::InvalidComponentError:
       bad component(expected port component): "54321"
     # ./lib/embedded_ansible.rb:175:in `api_connection'
     # ./lib/embedded_ansible.rb:37:in `alive?'
     # ./spec/lib/embedded_ansible_spec.rb:136:in `block (5 levels) in <top (required)>'

  2) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted raises when other errors are raised
     Failure/Error: expect { described_class.alive? }.to raise_error(RuntimeError)

       expected RuntimeError, got #<URI::InvalidComponentError: bad component(expected port component): "54321"> with backtrace:
         # ./lib/embedded_ansible.rb:175:in `api_connection'
         # ./lib/embedded_ansible.rb:37:in `alive?'
         # ./spec/lib/embedded_ansible_spec.rb:157:in `block (6 levels) in <top (required)>'
         # ./spec/lib/embedded_ansible_spec.rb:157:in `block (5 levels) in <top (required)>'
     # ./spec/lib/embedded_ansible_spec.rb:157:in `block (5 levels) in <top (required)>'

  3) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted returns false when an AnsibleTowerClient::ConnectionError is raised
     Failure/Error: :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => NGINX_HTTP_PORT).to_s,

     URI::InvalidComponentError:
       bad component(expected port component): "54321"
     # ./lib/embedded_ansible.rb:175:in `api_connection'
     # ./lib/embedded_ansible.rb:37:in `alive?'
     # ./spec/lib/embedded_ansible_spec.rb:147:in `block (5 levels) in <top (required)>'

  4) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted returns false when a Faraday::SSLError is raised
     Failure/Error: :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => NGINX_HTTP_PORT).to_s,

     URI::InvalidComponentError:
       bad component(expected port component): "54321"
     # ./lib/embedded_ansible.rb:175:in `api_connection'
     # ./lib/embedded_ansible.rb:37:in `alive?'
     # ./spec/lib/embedded_ansible_spec.rb:142:in `block (5 levels) in <top (required)>'

  5) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted returns false when an AnsibleTowerClient::ClientError is raised
     Failure/Error: :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => NGINX_HTTP_PORT).to_s,

     URI::InvalidComponentError:
       bad component(expected port component): "54321"
     # ./lib/embedded_ansible.rb:175:in `api_connection'
     # ./lib/embedded_ansible.rb:37:in `alive?'
     # ./spec/lib/embedded_ansible_spec.rb:152:in `block (5 levels) in <top (required)>'

  6) EmbeddedAnsible with an miq_databases row .alive? when a connection is attempted returns true when no error is raised
     Failure/Error: :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => NGINX_HTTP_PORT).to_s,

     URI::InvalidComponentError:
       bad component(expected port component): "54321"
     # ./lib/embedded_ansible.rb:175:in `api_connection'
     # ./lib/embedded_ansible.rb:37:in `alive?'
     # ./spec/lib/embedded_ansible_spec.rb:162:in `block (5 levels) in <top (required)>'
```

This fixes the specs, didn't review code in detail but seems
`api_connection` and `alive?` theselves would crash on 2.2.

cc @carbonin @jrafanie