### PR TITLE
Fix datawharehouse provider authentication

### DIFF
--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -60,6 +60,10 @@ module ManageIQ::Providers
       %w(default auth_key)
     end
 
+    def required_credential_fields(_type)
+      [:auth_key]
+    end
+
     def supports_authentication?(authtype)
       supported_auth_types.include?(authtype.to_s)
     end


### PR DESCRIPTION
This issue only occurs when authenticating from API.

Fixed: override required_credential_fields from AuthenticationMixin,
since this provider authenticates using auth_key and not user/password.

@miq-bot add_label bug, providers/hawkular
