### PR TITLE
Warn if OpenSCAP binary not available

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -157,6 +157,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def collect_compliance_data(image)
+    unless OpenscapResult.openscap_available?
+      _log.warn "OpenSCAP Binary missing, skipping scan"
+      return nil
+    end
     _log.info "collecting compliance data for #{options[:docker_image_id]}"
     openscap_result = image.openscap_result || OpenscapResult.new(:container_image => image)
     openscap_result.attach_raw_result(image_inspector_client.fetch_oscap_arf)

--- a/app/models/openscap_result.rb
+++ b/app/models/openscap_result.rb
@@ -51,7 +51,7 @@ class OpenscapResult < ApplicationRecord
   end
 
   def with_openscap_arf(raw)
-    self.class.openscap_available?
+    return unless self.class.openscap_available?
     begin
       OpenSCAP.oscap_init
       # ARF - nist standardized 'Asset Reporting Format' Full representation if a scap scan result.


### PR DESCRIPTION
In the appliance and podified ManageIQ the OpenSCAP Binary is installed. I added some warning at require failures so that customers that encounter the problem on a new environment that has it's own dependency management (like we recently had with podified ManageIQ) will be able to easily report what is wrong.

See See https://github.com/ManageIQ/guides/pull/189