### PR TITLE
remove unused :events feature

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -82,7 +82,6 @@ module SupportsFeatureMixin
     :disassociate_floating_ip   => 'Disassociate a Floating IP',
     :discovery                  => 'Discovery of Managers for a Provider',
     :evacuate                   => 'Evacuation',
-    :events                     => 'Query for events',
     :launch_cockpit             => 'Launch Cockpit UI',
     :live_migrate               => 'Live Migration',
     :migrate                    => 'Migration',


### PR DESCRIPTION
this was intended to replace `supports :timeline` (as in https://github.com/ManageIQ/manageiq/pull/10588) but never got refactored by me 😢 

I'd like to remove it before we confuse more people.

@miq-bot add_label refactoring, euwe/no, pluggable providers
@miq-bot assign @agrare 