### PR TITLE
[EUWE] remove duplicate :terminate entry

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -108,7 +108,6 @@ module SupportsFeatureMixin
     :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',
     :ems_network_new            => 'New EMS Network Provider',
     :update_security_group      => 'Security Group Update',
-    :terminate                => 'Terminate a VM'
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
Looks like a double entry of `:terminate` made it into `supports_feature_mixin` causing rake to complain 

```
multiple entries for  :terminate key in supports_feature_mixin.rb file at line 103 and 111
```

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1420284

@miq-bot assign @agrare 
@miq-bot add_labels bug, pluggable providers

@agrare do you also merge euwe prs?