### PR TITLE
Don't catch general Exception for MiqQueue#deliver

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -357,13 +357,11 @@ class MiqQueue < ApplicationRecord
         _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_TIMEOUT
       end
-    rescue SystemExit
-      raise
     rescue MiqException::MiqQueueExpired
       message = "Expired on [#{expires_on}]"
       _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
       status = STATUS_EXPIRED
-    rescue Exception => error
+    rescue StandardError, SyntaxError => error
       _log.error("#{MiqQueue.format_short_log_msg(self)}, Error: [#{error}]")
       _log.log_backtrace(error) unless error.kind_of?(MiqException::Error)
       status = STATUS_ERROR

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -42,7 +42,7 @@ describe MiqQueue do
     end
 
     it "sets last_exception on raised Exception" do
-      allow(MiqServer).to receive(:foobar).and_raise(Exception)
+      allow(MiqServer).to receive(:foobar).and_raise(StandardError)
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar')
       status, message, result = msg.deliver
       expect(status).to eq(MiqQueue::STATUS_ERROR)


### PR DESCRIPTION
We are catching too many exceptions in `MiqQueue#deliver`. Originally made in 2009 in 49e66c99

This reduces the scope of the rescue from the liberal `Exception` back to `StandardException` but also including `SyntaxError`