### PR TITLE
Fix amazon cloud volume spec failures

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_legacy.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_legacy.rb
@@ -10,8 +10,8 @@ module MiqAeMethodService
       # Amazon
       'auth_key_pair_amazon'                         => 'ManageIQ_Providers_Amazon_CloudManager_AuthKeyPair',
       'availability_zone_amazon'                     => 'ManageIQ_Providers_Amazon_CloudManager_AvailabilityZone',
-      'cloud_volume_amazon'                          => 'ManageIQ_Providers_Amazon_CloudManager_CloudVolume',
-      'cloud_volume_snapshot_amazon'                 => 'ManageIQ_Providers_Amazon_CloudManager_CloudVolumeSnapshot',
+      'cloud_volume_amazon'                          => 'ManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolume',
+      'cloud_volume_snapshot_amazon'                 => 'ManageIQ_Providers_Amazon_StorageManager_Ebs_CloudVolumeSnapshot',
       'flavor_amazon'                                => 'ManageIQ_Providers_Amazon_CloudManager_Flavor',
       'floating_ip_amazon'                           => 'ManageIQ_Providers_Amazon_NetworkManager_FloatingIp',
       'orchestration_stack_amazon'                   => 'ManageIQ_Providers_Amazon_CloudManager_OrchestrationStack',

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-cloud_volume.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_CloudManager_CloudVolume < MiqAeServiceCloudVolume
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-cloud_volume_snapshot.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager-cloud_volume_snapshot.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Amazon_CloudManager_CloudVolumeSnapshot < MiqAeServiceCloudVolumeSnapshot
-  end
-end

--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -2,9 +2,6 @@ FactoryGirl.define do
   factory :cloud_volume do
   end
 
-  factory :cloud_volume_amazon, :class => "ManageIQ::Providers::Amazon::CloudManager::CloudVolume", :parent => :cloud_volume do
-  end
-
   factory :cloud_volume_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume", :parent => :cloud_volume do
     status "available"
   end

--- a/spec/models/cloud_volume_spec.rb
+++ b/spec/models/cloud_volume_spec.rb
@@ -1,8 +1,8 @@
 describe CloudVolume do
   it ".available" do
     disk = FactoryGirl.create(:disk)
-    cv1 = FactoryGirl.create(:cloud_volume_amazon, :attachments => [disk])
-    cv2 = FactoryGirl.create(:cloud_volume_amazon)
+    cv1 = FactoryGirl.create(:cloud_volume, :attachments => [disk])
+    cv2 = FactoryGirl.create(:cloud_volume)
 
     expect(described_class.available).to eq([cv2])
   end


### PR DESCRIPTION
Amazon CloudVolumes are now defined in the `StorageManager` per https://github.com/ManageIQ/manageiq-providers-amazon/pull/136

This fixes the associated spec tests failures

cc @durandom @mkanoor 