### PR TITLE
Update spice-html5-bower to 1.6.3, fixing an extra GET .../null request

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "qs": "~0.3.10",
     "rx-angular": "rx.angular#~1.1.3",
     "rxjs": "~4.1.0",
-    "spice-html5-bower": "himdel/spice-html5-bower#~0.1.6",
+    "spice-html5-bower": "himdel/spice-html5-bower#~1.6.3",
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
     "tota11y": "~0.1.6",


### PR DESCRIPTION
Updating to newer version of `spice-html5-bower`.

(Yes, the jump from 0.1.6 to 1.6.3 is intentional, `0.1.6` was actually `0.1.6.1` upstream (spice-html5, not spice-html5-bower), but since bower nor npm support 4-digit versions, I dropped the leading 0.)

https://bugzilla.redhat.com/show_bug.cgi?id=1421086