### PR TITLE
don't debug assets

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,8 @@ Vmdb::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
+  config.assets.quiet = true
+
   # Include miq_debug in the list of assets here because it is only used in development
   config.assets.precompile << 'miq_debug.js'
   config.assets.precompile << 'miq_debug.css'


### PR DESCRIPTION
In development, rails logs which assets are downloaded.
Sometimes a hundred of these are downloaded for a single page.

```
Started GET "/assets/container_providers_dashboard.self-1593cea9c6dab87a825e72da33f35fe44b9e7a885b7b75ccdede225065ccb0aa.css?body=1" for ::1 at 2017-02-13 13:11:36 -0500
Started GET "/assets/wizard.self-c15c8792b33aee2ebdbaa3b19966e6f65656c93a5c7bd5f64a869871a899f46a.css?body=1" for ::1 at 2017-02-13 13:11:36 -0500
```

Don't display these debug lines anymore.