### PR TITLE
Refactor MiqRequest factories

### DIFF
--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :miq_request do
+    requester { create(:user) }
+
     factory :miq_host_provision_request,         :class => "MiqHostProvisionRequest"
     factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest"
     factory :vm_migrate_request,                 :class => "VmMigrateRequest"

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     requester { create(:user) }
 
     factory :miq_host_provision_request,         :class => "MiqHostProvisionRequest"
+    factory :service_reconfigure_request,        :class => "ServiceReconfigureRequest"
     factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest"
     factory :vm_migrate_request,                 :class => "VmMigrateRequest"
     factory :vm_reconfigure_request,             :class => "VmReconfigureRequest"

--- a/spec/factories/service_reconfigure_request.rb
+++ b/spec/factories/service_reconfigure_request.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :service_reconfigure_request do
-  end
-end

--- a/spec/models/miq_host_provision_request_spec.rb
+++ b/spec/models/miq_host_provision_request_spec.rb
@@ -1,8 +1,4 @@
 describe MiqHostProvisionRequest do
-  it "validates userid" do
-    expect { FactoryGirl.create(:miq_host_provision_request, :userid => 'barney') }.to raise_error(ActiveRecord::RecordInvalid)
-  end
-
   it "validates a requester is specified" do
     expect { FactoryGirl.create(:miq_host_provision_request, :requester => nil) }.to raise_error(ActiveRecord::RecordInvalid)
   end

--- a/spec/models/miq_host_provision_request_spec.rb
+++ b/spec/models/miq_host_provision_request_spec.rb
@@ -4,7 +4,7 @@ describe MiqHostProvisionRequest do
   end
 
   it "validates a requester is specified" do
-    expect { FactoryGirl.create(:miq_host_provision_request) }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { FactoryGirl.create(:miq_host_provision_request, :requester => nil) }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
   context "with a valid userid and host," do


### PR DESCRIPTION
A small refactoring that does two things:

EDIT:
~~* removes the "abstract" factory for `MiqRequest` because it's not used/needed and fails Factory Girl's built-in linter~~
~~* gives the "concrete" factories a requester, because it's required~~

* gives all the request factories a requester, because it's required
* removes a test that was passing for the wrong reason - it now fails. It doesn't appear to describe how the request object works - if it's checking that requester is required then the correct test for that exists below it

@miq-bot add-label test, refactoring
