### PR TITLE
[WIP] Remove folder causes link inventory error

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -608,7 +608,7 @@ module RelationshipMixin
   end
 
   def remove_children(*child_objs)
-    child_objs = child_objs.flatten
+    child_objs = child_objs.flatten.compact
     return child_objs if child_objs.empty?
 
     child_rels = self.child_rels


### PR DESCRIPTION
When updating folder relationships for a deleted folder the following exception is logged:

```
[----] I, [2017-02-13T14:19:59.673672 #17601:2af9a12430cc]  INFO -- : MIQ(EmsRefresh.link_ems_inventory) EMS: [VC41Test-Prod], id: [233] Updating EMS root folder relationship.
[----] I, [2017-02-13T14:19:59.680955 #17601:2af9a12430cc]  INFO -- : MIQ(EmsRefresh.update_relats) Updating Folders To Folders relationships.
[----] E, [2017-02-13T14:19:59.836671 #17601:2af9a12430cc] ERROR -- : MIQ(EmsRefresh.update_relats_by_ids) An error occurred while disconnecting id [640]: undefined method `base_class' for NilClass:Class
[----] E, [2017-02-13T14:19:59.837764 #17601:2af9a12430cc] ERROR -- : [NoMethodError]: undefined method `base_class' for NilClass:Class  Method:[rescue in block in update_relats_by_ids]
[----] E, [2017-02-13T14:19:59.838054 #17601:2af9a12430cc] ERROR -- : /home/agrare/workspace/redhat/manageiq/app/models/mixins/relationship_mixin.rb:617:in `block in remove_children'
/home/agrare/workspace/redhat/manageiq/app/models/mixins/relationship_mixin.rb:617:in `collect'
/home/agrare/workspace/redhat/manageiq/app/models/mixins/relationship_mixin.rb:617:in `remove_children'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:32:in `block (2 levels) in link_ems_inventory'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:171:in `block in update_relats_by_ids'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:169:in `each'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:169:in `update_relats_by_ids'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:156:in `block in update_relats'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:154:in `each'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:154:in `update_relats'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/link_inventory.rb:29:in `link_ems_inventory'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/save_inventory_infra.rb:80:in `save_ems_infra_inventory'
/home/agrare/workspace/redhat/manageiq/app/models/ems_refresh/save_inventory.rb:14:in `save_ems_inventory'
```

This change would remove any `nil`s from the `child_objs` passed to `remove_children`
The `nil` originates [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_refresh/link_inventory.rb#L32) with `folder.remove_folder(instance_with_id(EmsFolder, f2))` where f2 is the id of the deleted folder, so `EmsFolder.where(f2)` returns `nil`.

Fixes https://github.com/ManageIQ/manageiq/issues/13831