### PR TITLE
Expose job_template from a service template

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -1,4 +1,6 @@
 class ServiceAnsiblePlaybook < ServiceGeneric
+  delegate :job_template, :to => :service_template, :allow_nil => true
+
   # A chance for taking options from automate script to override options from a service dialog
   def preprocess(action, add_options = {})
     save_job_options(action, add_options)
@@ -37,10 +39,6 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   private
-
-  def job_template(action)
-    service_template.resource_actions.find_by!(:action => action).configuration_template
-  end
 
   def get_job_options(action)
     job_opts = options["#{action.downcase}_job_options".to_sym].deep_dup

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -7,9 +7,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     '/Service/Generic/StateMachines/GenericLifecycle/retire'
   end
 
-  def job_template(service_action)
-    item = resource_actions.detect { |ra| ra.action == service_action }
-    item.configuration_template if item
+  def job_template(action)
+    resource_actions.find_by!(:action => action).configuration_template
   end
 
   # create ServiceTemplate and supporting ServiceResources and ResourceActions

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -7,6 +7,11 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     '/Service/Generic/StateMachines/GenericLifecycle/retire'
   end
 
+  def job_template(service_action)
+    item = resource_actions.detect { |ra| ra.action == service_action }
+    item.configuration_template if item
+  end
+
   # create ServiceTemplate and supporting ServiceResources and ResourceActions
   # options
   #   :name

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_ansible_playbook.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_ansible_playbook.rb
@@ -1,4 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceServiceTemplateAnsiblePlaybook < MiqAeServiceServiceTemplateGeneric
+    expose :job_template
   end
 end

--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -4,4 +4,6 @@ FactoryGirl.define do
 
   factory :service_template_orchestration, :class => 'ServiceTemplateOrchestration', :parent => :service_template do
   end
+
+  factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
 end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -5,7 +5,7 @@ describe(ServiceAnsiblePlaybook) do
   let(:action)         { ResourceAction::PROVISION }
 
   let(:loaded_service) do
-    service_template = FactoryGirl.create(:service_template)
+    service_template = FactoryGirl.create(:service_template_ansible_playbook)
     service_template.resource_actions.build(:action => action, :configuration_template => tower_job_temp)
     service_template.save!
     FactoryGirl.create(:service_ansible_playbook, :options => provision_options, :service_template => service_template)


### PR DESCRIPTION
Automate methods need to get to the credentials from a service template.
The ServiceTemplateAnsiblePlaybook exposes the job_template method.
Given a job_template we can get to the manager and from the manager get the credentials.

Will add specs later once the spec file changes have been finalized from PR #13736 

Links 
------
* https://www.pivotaltracker.com/story/show/137304515


