### PR TITLE
Add ::Settings option for disabling the asynchronous notifications

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -56,7 +56,8 @@ module Api
 
       def user_settings
         {
-          :locale => I18n.locale.to_s.sub('-', '_'),
+          :locale                     => I18n.locale.to_s.sub('-', '_'),
+          :asynchronous_notifications => ::Settings.server.asynchronous_notifications,
         }.merge(User.current_user.settings)
       end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,6 +8,7 @@ class Notification < ApplicationRecord
 
   accepts_nested_attributes_for :notification_recipients
   before_create :set_notification_recipients
+  # Do not emit notifications if they are not enabled for the server
   after_commit :emit_message, :on => :create
 
   serialize :options, Hash
@@ -35,6 +36,7 @@ class Notification < ApplicationRecord
   private
 
   def emit_message
+    return unless ::Settings.server.asynchronous_notifications
     notification_recipients.pluck(:id, :user_id).each do |id, user|
       to_h[:id] = id
       ActionCable.server.broadcast("notifications_#{user}", to_h)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1062,6 +1062,7 @@
 :repository_scanning:
   :defaultsmartproxy:
 :server:
+  :asynchronous_notifications: true
   :case_sensitive_name_search: false
   :company: My Company
   :console_proxy_disabled: true

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -39,9 +39,7 @@ class WebsocketServer
 
   def call(env)
     if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env)
-
-      # ActionCable causes live reload crashes
-      if env['REQUEST_URI'] =~ %r{^/ws/notifications}
+      if env['REQUEST_URI'] =~ %r{^/ws/notifications} && ::Settings.server.asynchronous_notifications
         ActionCable.server.call(env)
       else
         exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -19,9 +19,25 @@ describe Notification, :type => :model do
         expect(user.unseen_notifications.count).to eq(1)
       end
 
-      it 'broadcasts the message through ActionCable' do
-        expect_any_instance_of(ActionCable::Server::Base).to receive(:broadcast)
-        subject # force the creation of the db object
+      context 'asynchronous notifications' do
+        before { stub_settings(:server => {:asynchronous_notifications => async}) }
+        context 'enabled' do
+          let(:async) { true }
+
+          it 'broadcasts the message through ActionCable' do
+            expect_any_instance_of(ActionCable::Server::Base).to receive(:broadcast)
+            subject # force the creation of the db object
+          end
+        end
+
+        context 'disabled' do
+          let(:async) { false }
+
+          it 'broadcasts the message through ActionCable' do
+            expect_any_instance_of(ActionCable::Server::Base).not_to receive(:broadcast)
+            subject # force the creation of the db object
+          end
+        end
       end
 
       context 'tenant includes user without access to the subject (vm)' do


### PR DESCRIPTION
Some people were asking me how to disable websocket notifications, the possible solutions were:
* Disabling the WebsocketWorker
* Disabling the Websocket Role
* Modifying the `config/routes.rb`
Now you can simply set `::Settings.server.asynchronous_notifications` to `false` in `settings.yml`.

After merging this, the JS should be wrapped by an `if` based on the boolean:
* Classic UI https://github.com/ManageIQ/manageiq-ui-classic/pull/374
* Service UI https://github.com/ManageIQ/manageiq-ui-service/pull/547

https://www.pivotaltracker.com/story/show/140478617