### PR TITLE
Drop unused default settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1053,8 +1053,6 @@
   :history:
     :keep_reports: 6.months
     :purge_window_size: 100
-  :precision_by_column:
-    :slope: 4
   :queue_timeout: 1.hour
 :repository_scanning:
   :defaultsmartproxy:


### PR DESCRIPTION
Unused after manageiq#13899 and manageiq-ui-classic#376 are merged.

@miq-bot add_label technical debt
@miq-bot assign @martinpovolny 