### PR TITLE
ansible event catcher - mark event_monitor_runnning when there are no events at startup

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/runner.rb
@@ -5,9 +5,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
 
   def monitor_events
     event_monitor_handle.start
+    event_monitor_running
     event_monitor_handle.poll do |event|
       _log.debug { "#{log_prefix} Received event #{event.id}" }
-      event_monitor_running
       @queue.enq event
     end
   ensure


### PR DESCRIPTION
The reason the EventCatcher would not start was that it did not send `event_monitor_running` when there are no events coming in.

So I moved that up, before the loop.

@miq-bot add_labels providers/ansible_tower, bug
@miq-bot assign @jrafanie 

@jrafanie please review and merge - because you are the worker tamer 🦁 