### PR TITLE
Use eager_load for extra_resources

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -57,6 +57,8 @@ class ChargebackVm < Chargeback
   def self.extra_resources_without_rollups
     # support hyper-v for which we do not collect metrics yet
     scope = ManageIQ::Providers::Microsoft::InfraManager::Vm
+    scope = scope.eager_load(:hardware, :taggings, :tags, :host, :ems_cluster, :storage, :ext_management_system,
+                             :tenant)
     if @options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope.find_tagged_with(:any => @options[:tag], :ns => '*')
     else


### PR DESCRIPTION
These associations are touched in `ConsumptionWithoutRollup` and `RateCache`, they can be loaded in one query
 
@miq-bot add_label chargeback, performance

There are some stats `rows_by_class:` and `:total_queries:,`
after: left - before: right

![screen shot 2017-02-14 at 10 39 32](https://cloud.githubusercontent.com/assets/14937244/22923475/ea95439c-f2a1-11e6-9a03-beee802b085b.png)

cc @isimluk 
@miq-bot assign @gtanzillo 