### PR TITLE
Use the provided database name during metric collection

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -184,6 +184,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   end
 
   def history_database_name
+    @history_database_name = connection_configurations.try(:metrics).try(:endpoint).try(:path)
     @history_database_name ||= begin
                                  version = version_3_0? ? '3_0' : '>3_0'
                                  self.class.history_database_name_for(version)


### PR DESCRIPTION
If a user provided a database name different from the default one
it is was saved but not actually used when collecting the data.
Instead the default one was used which caused a bug.