### PR TITLE
Disks should be added as 'active' in RHV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/disk_attachment_builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/disk_attachment_builder.rb
@@ -5,7 +5,6 @@ class ManageIQ::Providers::Redhat::InfraManager::DiskAttachmentBuilder
     @name = options[:name]
     @thin_provisioned = BooleanParameter.new(options[:thin_provisioned])
     @bootable = BooleanParameter.new(options[:bootable])
-    @active = options[:active]
     @interface = options[:interface]
   end
 
@@ -14,7 +13,7 @@ class ManageIQ::Providers::Redhat::InfraManager::DiskAttachmentBuilder
     {
       :bootable  => @bootable.true?,
       :interface => @interface || "VIRTIO",
-      :active    => @active,
+      :active    => true,
       :disk      => {
         :name             => @name,
         :provisioned_size => @size_in_mb.to_i.megabytes,

--- a/spec/models/manageiq/providers/redhat/infra_manager/disk_attachment_builder_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/disk_attachment_builder_spec.rb
@@ -36,11 +36,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::DiskAttachmentBuilder do
 
     it "creates disk attachment" do
       builder = described_class.new(:size_in_mb => 10, :storage => storage, :name => "disk-1",
-                                    :thin_provisioned => true, :bootable => true, :active => false, :interface => "IDE")
+                                    :thin_provisioned => true, :bootable => true, :interface => "IDE")
       expected_disk_attachment = {
         :bootable  => true,
         :interface => "IDE",
-        :active    => false,
+        :active    => true,
         :disk      => {
           :name             => "disk-1",
           :provisioned_size => 10 * 1024 * 1024,

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/disk_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/disk_spec.rb
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Disk do
       {
         :bootable  => false,
         :interface => "VIRTIO",
-        :active    => nil,
+        :active    => true,
         :disk      => {
           :name             => nil,
           :provisioned_size => 0,


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/13318 introduced a new
class to handle disk attachments. A disk should be added to RHV as
'active' since there is no method to modify it afterward.

DiskAttachmentBuilder class will set the 'active' as the default
status of the new disk, so any scenario which adds disks (vm
reconfigure, automation request, provision request) will share the same
behavior.

https://bugzilla.redhat.com/show_bug.cgi?id=1422145
