### PR TITLE
Fixed bug in redhat event_catcher refactoring

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
 
   def queue_event(event)
     _log.info "#{log_prefix} Caught event [#{event[:name]}]"
-    event_hash = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    event_hash = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event.to_hash, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end
 


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/13714 broke the VM refresh in RHEVM. Fixing it by passing the event.to_hash instead of event.