### PR TITLE
Expose RHV import methods to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
@@ -1,0 +1,11 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Redhat_InfraManager < MiqAeServiceEmsInfra
+    include MiqAeServiceEmsOperationsMixin
+
+    expose :validate_import_vm
+
+    def import_vm(source_vm_id, target_params, options = {})
+      sync_or_async_ems_operation(options[:sync], "import_vm", [source_vm_id, target_params])
+    end
+  end
+end


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1404920

Expose the `validate_import_vm` and `import_vm` methods on the Red Hat Infra provider to automate in order to enable the implementation of a v2v service dialog in the classical UI. These methods are needed for the "transform vm" service dialog to initiate the conversion process of VM between 2 infra providers (e.g. from vmware to redhat).