### PR TITLE
Add Openstack metric service to Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1306,6 +1306,7 @@
         :ems_metrics_collector_worker_openstack_network: {}
         :ems_metrics_collector_worker_redhat: {}
         :ems_metrics_collector_worker_vmware: {}
+        :ems_metrics_openstack_default_service: "auto"
       :ems_metrics_processor_worker:
         :count: 2
         :memory_threshold: 600.megabytes


### PR DESCRIPTION
Openstack Metrics capture service can be specified in settings.yml file.

Valid values are "gnocchi", "ceilometer". All other values means autodetection.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1421729
