### PR TITLE
[WIP] Add additional options to Authentications 

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  class AuthenticationsController < BaseController
+    def options
+      render_options(:authentications, :fields => build_field_values)
+    end
+
+    private
+
+    def build_field_values
+      values = {}
+      ::Authentication.descendants.each do |subclass|
+        field_values = subclass.try(:fields)
+        values[subclass.to_s] = field_values if field_values
+      end
+      values
+    end
+  end
+end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe 'Authentications API' do
+  describe 'OPTIONS /api/authentications' do
+    it 'will include fields for applicable classes' do
+      api_basic_authorize
+
+      run_options(authentications_url)
+
+      test_klass = ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential
+      expected = {
+        'fields' => a_hash_including(
+          test_klass.to_s => test_klass.fields.deep_stringify_keys
+        )
+      }
+      expect(response.parsed_body['data']).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
add additional options to `/api/authentications` to return fields required for different types.

dependent on #13826 and #13780

@miq-bot add_label wip, enhancement, api

