### PR TITLE
Add amazon events to settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -197,6 +197,9 @@
       - REPLICATOR_SUCCESSFULCREATE
       - REPLICATOR_FAILEDCREATE
       - CONTAINER_CREATED
+      - AWS_EC2_Instance_CREATE
+      - AWS_EC2_Instance_UPDATE
+      - AWS_EC2_Instance_DELETE
       :detail:
       - CloneVM_Task
       - CloneVM_Task_Complete
@@ -706,6 +709,9 @@
       - NODE_REBOOTED
       - NODE_NODESCHEDULABLE
       - NODE_NODENOTSCHEDULABLE
+      - AWS_EC2_Instance_running
+      - AWS_EC2_Instance_shutting-down
+      - AWS_EC2_Instance_stopped
       :detail:
       - PowerOffVM_Task
       - PowerOffVM_Task_Complete


### PR DESCRIPTION
timelines have been enabled for aws for a long time
and we have been collecting events for some time.
We just did not display any events by default.
Display those 6 EC2 events because we already have them
in [automate](https://github.com/ManageIQ/manageiq-content/tree/6be7ec14216da302f9fc3f805670c8ac340211e4/content/automate/ManageIQ/System/Event/EmsEvent/Amazon.class) triggering a refresh

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1392391

I would add this in the amazon repo, but cannot because of https://github.com/ManageIQ/manageiq-providers-amazon/pull/138

@blomquisg @bronaghs please review

@miq-bot add_labels providers/amazon, enhancement