### PR TITLE
Fixes issues with accessing attributes of a workflow

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -252,11 +252,11 @@ module Api
       end
 
       def attr_accessible?(object, attr)
-        return false unless object && object.respond_to?(attr)
-        object.class.has_attribute?(attr) ||
-          object.class.reflect_on_association(attr) ||
-          object.class.virtual_attribute?(attr) ||
-          object.class.virtual_reflection?(attr)
+        return true if object && object.respond_to?(attr)
+        (object.class.respond_to?(:has_attribute?) && object.class.has_attribute?(attr)) ||
+          (object.class.respond_to?(:reflect_on_association) && object.class.reflect_on_association(attr)) ||
+          (object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(attr)) ||
+          (object.class.respond_to?(:virtual_reflection?) && object.class.virtual_reflection?(attr))
       end
 
       def attr_virtual?(object, attr)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -253,10 +253,10 @@ module Api
 
       def attr_accessible?(object, attr)
         return true if object && object.respond_to?(attr)
-        (object.class.respond_to?(:has_attribute?) && object.class.has_attribute?(attr)) ||
-          (object.class.respond_to?(:reflect_on_association) && object.class.reflect_on_association(attr)) ||
-          (object.class.respond_to?(:virtual_attribute?) && object.class.virtual_attribute?(attr)) ||
-          (object.class.respond_to?(:virtual_reflection?) && object.class.virtual_reflection?(attr))
+        object.class.try(:has_attribute?, attr) ||
+          object.class.try(:reflect_on_association, attr) ||
+          object.class.try(:virtual_attribute?, attr) ||
+          object.class.try(:virtual_reflection?, attr)
       end
 
       def attr_virtual?(object, attr)


### PR DESCRIPTION
With a request like: GET /api/requests/4?attributes=workflow.values

One would get the following error.

```
{
  "error": {
    "kind": "internal_server_error",
    "message": "undefined method `has_attribute?' for ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow:Class",
    "klass": "NoMethodError"
  }
}
```
The issue at hand was not really workflow related but a bug in the attr_accessible? method, which did not always function properly.

Fixed the method and added rspec to test the above condition.
