### PR TITLE
Add the Automation Manager submenu key to the permission yaml file

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -2,6 +2,7 @@
 - :aut
 - :automate
 - :ansible
+- :at
 - :clo
 - :cnt
 - :compute


### PR DESCRIPTION
Add the Automation Manager submenu key to the permission yaml file

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1422533

Steps for Testing/QA 
-------------------------------

copy the config/permissions.tmpl.yml to config/permissions.yml 

Same as https://github.com/ManageIQ/manageiq/pull/13819 - this time for the Ansible Tower sub-menu