### PR TITLE
Build oVirt URL using URI::Generic.build

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -273,9 +273,15 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       # Get the timeout from the configuration:
       timeout, = ems_timeouts(:ems_redhat, service)
 
-      # Create the connection:
+      url = URI::Generic.build(
+        :scheme => scheme,
+        :host   => server,
+        :port   => port,
+        :path   => path
+      )
+
       OvirtSDK4::Connection.new(
-        :url      => "#{scheme}://#{server}:#{port}#{path}",
+        :url      => url.to_s,
         :username => username,
         :password => password,
         :timeout  => timeout,

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :ext_management_system do
     sequence(:name)      { |n| "ems_#{seq_padded_for_sorting(n)}" }
-    sequence(:hostname)  { |n| "ems_#{seq_padded_for_sorting(n)}" }
+    sequence(:hostname)  { |n| "ems-#{seq_padded_for_sorting(n)}" }
     sequence(:ipaddress) { |n| ip_from_seq(n) }
     guid                 { MiqUUID.new_guid }
     zone                 { Zone.first || FactoryGirl.create(:zone) }


### PR DESCRIPTION
Currently the URLs used to connect to oVirt using version 4 of the API
are constructed using string concatenation. This does not work for IPv6
addresses.  That isn't critical, as oVirt doesn't accept requests that
use the IP address: it requires the fully qualified host name. Anyhow,
it is better to construct the URL using the URI::Generic.build, method,
which works correctly for IPv6 addresses.