### PR TITLE
Encrypt/decrypt the password fields in options for ServiceTemplate and Service.

### DIFF
--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -31,20 +31,31 @@ describe(ServiceAnsiblePlaybook) do
   let(:override_options) do
     {
       :hosts      => 'host3',
-      :extra_vars => { 'var1' => 'new_val1' }
+      :extra_vars => {
+        'var1'         => 'new_val1',
+        'new_password' => 'secret'
+      }
     }
   end
 
   let(:provision_options) { {:provision_job_options => override_options} }
 
   describe '#preprocess' do
-    it 'prepares options for action' do
+    before do
       basic_service.preprocess(action, override_options)
       basic_service.reload
+    end
+
+    it 'prepares options for action' do
       expect(basic_service.options[:provision_job_options]).to have_attributes(
         :hosts         => 'host3',
-        :credential_id => 1,
-        :extra_vars    => {'var1' => 'new_val1', 'var2' => 'value2'}
+        :credential_id => 1
+      )
+
+      expect(basic_service.options.fetch_path(:provision_job_options, :extra_vars)).to have_attributes(
+        'var1'         => 'new_val1',
+        'var2'         => 'value2',
+        'new_password' => 'v2:{c5qTeiuz6JgbBOiDqp3eiQ==}'
       )
     end
   end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -521,9 +521,12 @@ describe ServiceTemplate do
           :schedule_type           => ['immediately', 'Immediately on Approval'],
           :instance_type           => [flavor.id, flavor.name],
           :src_ems_id              => [ems.id, ems.name],
+          :a_password              => 'secret',
           :provision               => {
-            :fqname    => ra1.fqname,
-            :dialog_id => service_dialog.id
+            :fqname     => ra1.fqname,
+            :dialog_id  => service_dialog.id,
+            :b_password => 'secret',
+            :extra_vars => { 'some_password' => 'secret'}
           },
           :retirement              => {
             :fqname    => ra2.fqname,
@@ -532,6 +535,7 @@ describe ServiceTemplate do
         }
       }
     end
+    let(:reg_password_field) { /password/i }
 
     it 'creates and returns a catalog item' do
       service_template = ServiceTemplate.create_catalog_item(catalog_item_options, user)
@@ -545,6 +549,9 @@ describe ServiceTemplate do
       expect(service_template.resource_actions.first.dialog).to eq(service_dialog)
       expect(service_template.resource_actions.last.dialog).to eq(service_dialog)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.options.fetch_path(:config_info, :a_password)).to be_encrypted('secret')
+      expect(service_template.options.fetch_path(:config_info, :provision, :b_password)).to be_encrypted('secret')
+      expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars, 'some_password')).to be_encrypted('secret')
     end
   end
 end


### PR DESCRIPTION
**Blocked:**
- [ ] https://github.com/ManageIQ/manageiq-gems-pending/pull/63.

Encrypt the password fields when saving options into DB.
Decrypt the password fields when reading options from DB.

https://www.pivotaltracker.com/n/projects/1937537/stories/139479571

cc @gmcculloug @bzwei 