### PR TITLE
Change headline of migration in rake output

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -64,7 +64,7 @@ module ManageIQ
     end
 
     def self.migrate_database
-      puts "\n== Updating database =="
+      puts "\n== Migrating database =="
       run_rake_task("db:migrate")
     end
 


### PR DESCRIPTION
Change
```
== Updating database ==
Database 'vmdb_development' already exists
Database 'vmdb_test' already exists

== Updating database ==
** Using session_store: ActionDispatch::Session::MemCacheStore
== 20170203161253 AddScmAttributesToConfigurationScriptSource: migrating ======
...
```

To

```
== Updating database ==
Database 'vmdb_development' already exists
Database 'vmdb_test' already exists

== Migrating database ==
** Using session_store: ActionDispatch::Session::MemCacheStore
== 20170203161253 AddScmAttributesToConfigurationScriptSource: migrating ======
...
```
