### PR TITLE
Add generating_ems on ems events

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -4,6 +4,7 @@ class EventStream < ApplicationRecord
 
   belongs_to :target, :polymorphic => true
   belongs_to :ext_management_system, :foreign_key => :ems_id
+  belongs_to :generating_ems, :class_name => "ExtManagementSystem"
 
   belongs_to :vm_or_template
   alias_method :src_vm_or_template, :vm_or_template

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -45,6 +45,8 @@ class ExtManagementSystem < ApplicationRecord
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order "timestamp" }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
                                                       :inverse_of => :ext_management_system
+  has_many :generated_events, -> { order "timestamp" }, :class_name => "EmsEvent", :foreign_key => "generating_ems_id",
+                                                          :inverse_of => :generating_ems
   has_many :policy_events,  -> { order "timestamp" }, :class_name => "PolicyEvent", :foreign_key => "ems_id"
 
   has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system

--- a/db/migrate/20161211162552_add_generating_ems_to_event_streams.rb
+++ b/db/migrate/20161211162552_add_generating_ems_to_event_streams.rb
@@ -1,0 +1,5 @@
+class AddGeneratingEmsToEventStreams < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :event_streams, :generating_ems, :type => :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1245,6 +1245,7 @@ event_streams:
 - middleware_server_name
 - middleware_deployment_id
 - middleware_deployment_name
+- generating_ems_id
 ext_management_systems:
 - id
 - name

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -1,4 +1,15 @@
 describe EmsEvent do
+  context "model" do
+    let(:ems1) { FactoryGirl.create(:ems_kubernetes) }
+    let(:ems2) { FactoryGirl.create(:ems_hawkular_datawarehouse) }
+
+    it "Find ems events and generated events for ext management systems" do
+      generated_event = FactoryGirl.create(:ems_event, :ext_management_system => ems1, :generating_ems => ems2)
+      expect(ems1.ems_events).to match_array([generated_event])
+      expect(ems2.generated_events).to match_array([generated_event])
+    end
+  end
+
   context "container events" do
     let(:ems_ref) { "test_ems_ref" }
 


### PR DESCRIPTION
An ems event represents something that happened on an external system.
This adds a link to another ems which is not directly related to the event but generated it into the system.

Extracted from https://github.com/ManageIQ/manageiq/pull/12773