### PR TITLE
move plugin initializer code into Vmdb::Plugins

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -114,13 +114,6 @@ module Vmdb
     # on the top to bottom order of initializer calls in the file.
     # Because this is easy to mess up, keep your initializers in order.
     # register plugins even before loading settings, as plugins can bring their own settings
-    initializer :register_vmdb_plugins, :before => :load_vmdb_settings do
-      Rails.application.railties.each do |railtie|
-        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
-        Vmdb::Plugins.instance.register_vmdb_plugin(railtie)
-      end
-    end
-
     initializer :load_vmdb_settings, :before => :load_config_initializers do
       Vmdb::Settings.init
       Vmdb::Loggers.apply_config(::Settings.log)

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -8,6 +8,11 @@ module Vmdb
     def initialize
       @registered_automate_domains = []
       @vmdb_plugins = []
+
+      Rails.application.railties.each do |railtie|
+        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
+        register_vmdb_plugin(railtie)
+      end
     end
 
     def register_vmdb_plugin(engine)


### PR DESCRIPTION
the reasoning behind this is, that in a rails console `reload!` will
reset all classes and also this Vmdb::Plugins singleton

Moving the code that registers all plugins to the initializer makes
sure the all plugins are registered even after a reload.

I think it will save future developers some frustration, when doing stuff in the console or even development mode, when more and more parts of the app rely on the arrays `@vmdb_plugins` and `@registered_automate_domains` to be filled.

Its also safe to assume the singleton is accessed _after_ all rails initializers are run - if there is a way to check this, I could add it to the initializer of the singleton class.

@miq-bot add_labels developer, enhacement
@miq-bot assign @bdunne 
cc @Fryguy 