### PR TITLE
Ems event groups - allow provider settings

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -25,7 +25,18 @@ class EmsEvent < EventStream
   end
 
   def self.event_groups
-    ::Settings.event_handling.event_groups.to_hash
+    core_event_groups = ::Settings.event_handling.event_groups.to_hash
+    Vmdb::Plugins.instance.registered_provider_plugin_names.each_with_object(core_event_groups) do |provider_key, event_groups|
+      provider_event_groups = ::Settings.fetch_path(provider_key, :event_handling, :event_groups)
+      next unless provider_event_groups
+      event_groups.deep_merge!(provider_event_groups.to_hash) do |_key, event_groups_val, provider_groups_val|
+        if event_groups_val.kind_of?(Array) && provider_groups_val.kind_of?(Array)
+          event_groups_val + provider_groups_val
+        else
+          event_groups_val
+        end
+      end
+    end
   end
 
   def self.bottleneck_event_groups

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -26,8 +26,8 @@ class EmsEvent < EventStream
 
   def self.event_groups
     core_event_groups = ::Settings.event_handling.event_groups.to_hash
-    Vmdb::Plugins.instance.registered_provider_plugin_names.each_with_object(core_event_groups) do |provider_key, event_groups|
-      provider_event_groups = ::Settings.fetch_path(provider_key, :event_handling, :event_groups)
+    Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
+      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
       next unless provider_event_groups
       event_groups.deep_merge!(provider_event_groups.to_hash) do |_key, event_groups_val, provider_groups_val|
         if event_groups_val.kind_of?(Array) && provider_groups_val.kind_of?(Array)

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -215,12 +215,14 @@ describe EmsEvent do
 
     it 'returns the provider event if configured' do
       stub_settings_merge(
-        :some_provider => {
-          :event_handling => {
-            :event_groups => {
-              :addition => {
-                :name     => 'This name will not make it into event_groups',
-                :critical => [provider_event]
+        :ems => {
+          :some_provider => {
+            :event_handling => {
+              :event_groups => {
+                :addition => {
+                  :name     => 'This name will not make it into event_groups',
+                  :critical => [provider_event]
+                }
               }
             }
           }

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -198,4 +198,39 @@ describe EmsEvent do
       end
     end
   end
+
+  context '.event_groups' do
+    let(:provider_event) { 'SomeSpecialProviderEvent' }
+
+    it 'returns a list of groups' do
+      event_group_names = [
+        :addition, :application, :configuration, :console, :deletion, :general, :import_export, :migration, :network,
+        :power, :snapshot, :status, :storage
+      ]
+      expect(described_class.event_groups.keys).to match_array(event_group_names)
+      expect(described_class.event_groups[:addition]).to include(:name => 'Creation/Addition')
+      expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
+      expect(described_class.event_groups[:addition][:critical]).not_to include(provider_event)
+    end
+
+    it 'returns the provider event if configured' do
+      stub_settings_merge(
+        :some_provider => {
+          :event_handling => {
+            :event_groups => {
+              :addition => {
+                :name     => 'This name will not make it into event_groups',
+                :critical => [provider_event]
+              }
+            }
+          }
+        }
+      )
+      allow(Vmdb::Plugins.instance).to receive(:registered_provider_plugin_names).and_return([:some_provider])
+
+      expect(described_class.event_groups[:addition]).to include(:name => 'Creation/Addition')
+      expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
+      expect(described_class.event_groups[:addition][:critical]).to include(provider_event)
+    end
+  end
 end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -4,6 +4,11 @@ def stub_settings(hash)
   allow(Vmdb::Settings).to receive(:for_resource) { settings }
 end
 
+def stub_settings_merge(hash)
+  hash = Settings.to_hash.deep_merge(hash)
+  stub_settings(hash)
+end
+
 def stub_template_settings(hash)
   settings = Config::Options.new.merge!(hash)
   allow(Vmdb::Settings).to receive(:template_settings) { settings }


### PR DESCRIPTION
### Allow provider plugins to participate in setting up `EmsEvent.event_groups`

In order to provide settings for `event_handling.event_groups` every provider had to include its event names into `settings.yml` - which grew massively to beyond recognition.

To split these into `settings.yml` in the provider repos I have to hook into the `event_groups` method (see [1] for reasons).
This patch iterates over all registered provider plugins and looks for the same `event_handling.event_groups` structure under the provider name key.

Eg.
```yaml
:amazon:
  :event_handling:
    :event_groups:
      :addition:
        :critical:
        - AWS_EC2_Instance_CREATE
        - AWS_EC2_Instance_UPDATE
        - AWS_EC2_Instance_DELETE
      :power:
        :critical:
        - AWS_EC2_Instance_running
        - AWS_EC2_Instance_shutting-down
        - AWS_EC2_Instance_stopped
```

Then it merges the hash and more important merges the arrays of events.

see inline comments for questions

Includes https://github.com/ManageIQ/manageiq/pull/13941
Follows the suggestion in [1] 

[1] https://github.com/ManageIQ/manageiq-providers-amazon/pull/138
