### PR TITLE
Removed supports_snapshots? methods which were not using supportsFeatureMixin

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -11,6 +11,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
     end
   end
 
+  supports :snapshots
+
   POWER_STATES = {
     "ACTIVE"            => "on",
     "SHUTOFF"           => "off",
@@ -159,10 +161,6 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   end
 
   def memory_mb_available?
-    true
-  end
-
-  def supports_snapshots?
     true
   end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1801,9 +1801,7 @@ class VmOrTemplate < ApplicationRecord
     MiqTemplate.where(:id => ids).exists?
   end
 
-  def supports_snapshots?
-    false
-  end
+  supports_not :snapshots
 
   def self.batch_operation_supported?(operation, ids)
     VmOrTemplate.where(:id => ids).all? do |vm_or_template|


### PR DESCRIPTION
Few files had "supports_snapshots?" methods defined as against using the supportsFeatureMixin to define which feature is supported and which is not.

Removed such instances and replaced them by "supports :snapshots"
