### PR TITLE
API Enhancement to support fine-grained settings whitelisting

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -1,22 +1,39 @@
 module Api
   class SettingsController < BaseController
     def index
-      render_resource :settings, slice_settings(exposed_settings)
+      render_resource :settings, whitelist_settings(settings_hash)
     end
 
     def show
-      raise NotFoundError, "Settings category #{@req.c_id} not found" unless exposed_settings.include?(@req.c_id)
-      render_resource :settings, slice_settings(@req.c_id)
+      settings_value = entry_value(whitelist_settings(settings_hash), @req.c_suffix)
+
+      raise NotFoundError, "Settings entry #{@req.c_suffix} not found" if settings_value.nil?
+      render_resource :settings, settings_entry_to_hash(@req.c_suffix, settings_value)
     end
 
     private
 
-    def exposed_settings
-      ApiConfig.collections[:settings][:categories]
+    def whitelist_settings(settings)
+      result_hash = {}
+      ApiConfig.collections[:settings][:categories].each do |category_path|
+        result_hash.deep_merge!(settings_entry_to_hash(category_path, entry_value(settings, category_path)))
+      end
+      result_hash
     end
 
-    def slice_settings(keys)
-      ::Settings.to_hash.slice(*Array(keys).collect(&:to_sym))
+    def settings_hash
+      @settings_hash ||= Settings.to_hash.deep_stringify_keys
+    end
+
+    def entry_value(settings, path)
+      settings.fetch_path(path.split('/'))
+    end
+
+    def settings_entry_to_hash(path, value)
+      path_elements = path.split("/")
+      result_hash = {path_elements.last => value}
+      path_elements[0..-2].reverse.each { |entry| result_hash = { entry => result_hash } } if path_elements.length > 1
+      result_hash
     end
   end
 end

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -30,10 +30,7 @@ module Api
     end
 
     def settings_entry_to_hash(path, value)
-      path_elements = path.split("/")
-      result_hash = {path_elements.last => value}
-      path_elements[0..-2].reverse.each { |entry| result_hash = { entry => result_hash } } if path_elements.length > 1
-      result_hash
+      {}.tap { |h| h.store_path(path.split("/"), value) }
     end
   end
 end

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -75,12 +75,23 @@ describe "Settings API" do
       }')
     end
 
+    # TODO: as the api.yml settings/categories expand in the future to include
+    # different types of categories, full, partial and single entries, we would no
+    # longer need this stubbing logic or the above sample_settings as we can
+    # test the different cases with the default api.yml categories provided.
+    #
+    def stub_api_settings_categories(value)
+      settings_config = Api::ApiConfig.collections["settings"].dup
+      settings_config["categories"] = value
+      allow(Api::ApiConfig.collections).to receive("settings") { settings_config }
+    end
+
     before do
       stub_settings_merge(sample_settings)
     end
 
     it "supports multiple categories" do
-      stub_api_collection_config("settings", "categories", %w(product authentication server))
+      stub_api_settings_categories(%w(product authentication server))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       run_get settings_url
@@ -93,7 +104,7 @@ describe "Settings API" do
     end
 
     it "supports partial categories" do
-      stub_api_collection_config("settings", "categories", %w(product server/role))
+      stub_api_settings_categories(%w(product server/role))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       run_get settings_url
@@ -105,7 +116,7 @@ describe "Settings API" do
     end
 
     it "supports second level partial categories" do
-      stub_api_collection_config("settings", "categories", %w(product server/role server/worker_monitor/sync_interval))
+      stub_api_settings_categories(%w(product server/role server/worker_monitor/sync_interval))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       run_get settings_url
@@ -120,7 +131,7 @@ describe "Settings API" do
     end
 
     it "supports multiple and partial categories" do
-      stub_api_collection_config("settings", "categories", %w(product server/role server/worker_monitor authentication))
+      stub_api_settings_categories(%w(product server/role server/worker_monitor authentication))
       api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
 
       run_get settings_url

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -4,6 +4,22 @@
 describe "Settings API" do
   let(:api_settings) { Api::ApiConfig.collections[:settings][:categories] }
 
+  def normalize_settings(settings)
+    normalize_hash(settings.to_hash.deep_stringify_keys)
+  end
+
+  def normalize_hash(settings)
+    settings.keys.each_with_object({}) do |key, hash|
+      value = settings[key]
+      new_value = case value
+                  when Hash   then normalize_hash(value)
+                  when Symbol then value.to_s
+                  else value
+                  end
+      hash[key] = new_value unless new_value.nil?
+    end
+  end
+
   context "Settings Queries" do
     it "tests queries of all exposed settings" do
       api_basic_authorize action_identifier(:settings, :read, :collection_actions, :get)
@@ -37,6 +53,62 @@ describe "Settings API" do
       run_get settings_url("invalid_setting")
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it "supports multiple categories" do
+      stub_api_collection_config("settings", "categories", %w(product authentication server))
+      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+
+      run_get settings_url
+
+      expect(response.parsed_body).to match(
+        "product"        => normalize_settings(Settings.product),
+        "authentication" => normalize_settings(Settings.authentication),
+        "server"         => normalize_settings(Settings.server)
+      )
+    end
+
+    it "supports partial categories" do
+      stub_api_collection_config("settings", "categories", %w(product server/role))
+      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+
+      run_get settings_url
+
+      expect(response.parsed_body).to match(
+        "product" => normalize_settings(Settings.product),
+        "server"  => { "role" => Settings.server.role }
+      )
+    end
+
+    it "supports second level partial categories" do
+      stub_api_collection_config("settings", "categories", %w(product server/role server/worker_monitor/sync_interval))
+      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+
+      run_get settings_url
+
+      expect(response.parsed_body).to match(
+        "product" => normalize_settings(Settings.product),
+        "server"  => {
+          "role"           => Settings.server.role,
+          "worker_monitor" => { "sync_interval" => Settings.server.worker_monitor.sync_interval }
+        }
+      )
+    end
+
+    it "supports multiple and partial categories" do
+      stub_api_collection_config("settings", "categories", %w(product server/role server/worker_monitor authentication))
+      api_basic_authorize action_identifier(:settings, :read, :resource_actions, :get)
+
+      run_get settings_url
+
+      expect(response.parsed_body).to match(
+        "product"        => normalize_settings(Settings.product),
+        "server"         => {
+          "role"           => Settings.server.role,
+          "worker_monitor" => normalize_settings(Settings.server.worker_monitor),
+        },
+        "authentication" => normalize_settings(Settings.authentication)
+      )
     end
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -112,12 +112,6 @@ module Spec
         allow(Api::ApiConfig.collections[collection][action_type]).to receive(method) { updated_method }
       end
 
-      def stub_api_collection_config(collection, attr, value)
-        collection_config = Api::ApiConfig.collections[collection].dup
-        collection_config[attr] = value
-        allow(Api::ApiConfig.collections).to receive(collection) { collection_config }
-      end
-
       def action_identifier(type, action, selection = :resource_actions, method = :post)
         Api::ApiConfig.collections[type][selection][method]
           .detect { |spec| spec[:name] == action.to_s }[:identifier]

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -112,6 +112,12 @@ module Spec
         allow(Api::ApiConfig.collections[collection][action_type]).to receive(method) { updated_method }
       end
 
+      def stub_api_collection_config(collection, attr, value)
+        collection_config = Api::ApiConfig.collections[collection].dup
+        collection_config[attr] = value
+        allow(Api::ApiConfig.collections).to receive(collection) { collection_config }
+      end
+
       def action_identifier(type, action, selection = :resource_actions, method = :post)
         Api::ApiConfig.collections[type][selection][method]
           .detect { |spec| spec[:name] == action.to_s }[:identifier]


### PR DESCRIPTION
- Adding support for arbitrary path categories, can include top level  categories like it does today like product, authentication, server, but also sub pathing, server/role, session/timeout even lower level entries like server/worker_monitor/start_algorithm/value

- Exposes the subset of the settings as driven by the new categories

- Can fetch top level categories or any setting entry path:

  GET /api/settings/product, or GET /api/settings/server/role (if exposed)

- Added rspecs