### PR TITLE
Add cloud types to authentication options

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -20,9 +20,9 @@ module Api
     end
 
     def build_additional_fields
-      {
-        :cloud_types => ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.credential_types
-      }
+      ::Authentication.descendants.each_with_object({}) do |klass, fields|
+        fields[klass.name] = klass::API_OPTIONS if defined? klass::API_OPTIONS
+      end
     end
   end
 end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -10,7 +10,7 @@ module Api
     end
 
     def options
-      render_options(:authentications, build_additional_fields)
+      render_options(:authentications, :credential_types => build_additional_fields)
     end
 
     private

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -20,7 +20,20 @@ module Api
     end
 
     def build_additional_fields
-      ::Authentication.descendants.each_with_object({}) do |klass, fields|
+      {
+        :ansible_tower_credentials    => build_ansible_tower_creds,
+        :embedded_ansible_credentials => build_embedded_ansible_creds
+      }
+    end
+
+    def build_ansible_tower_creds
+      ManageIQ::Providers::AnsibleTower::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
+        fields[klass.name] = klass::API_OPTIONS if defined? klass::API_OPTIONS
+      end
+    end
+
+    def build_embedded_ansible_creds
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
         fields[klass.name] = klass::API_OPTIONS if defined? klass::API_OPTIONS
       end
     end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -10,7 +10,7 @@ module Api
     end
 
     def options
-      render_options(:authentications, :credential_types => build_additional_fields)
+      render_options(:authentications, build_additional_fields)
     end
 
     private
@@ -21,21 +21,8 @@ module Api
 
     def build_additional_fields
       {
-        :ansible_tower_credentials    => build_ansible_tower_creds,
-        :embedded_ansible_credentials => build_embedded_ansible_creds
+        :credential_types => ::Authentication.build_credential_options
       }
-    end
-
-    def build_ansible_tower_creds
-      ManageIQ::Providers::AnsibleTower::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
-        fields[klass.name] = klass::API_OPTIONS if defined? klass::API_OPTIONS
-      end
-    end
-
-    def build_embedded_ansible_creds
-      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
-        fields[klass.name] = klass::API_OPTIONS if defined? klass::API_OPTIONS
-      end
     end
   end
 end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -9,10 +9,20 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def options
+      render_options(:authentications, build_additional_fields)
+    end
+
     private
 
     def authentication_ident(auth)
       "Authentication id:#{auth.id} name: '#{auth.name}'"
+    end
+
+    def build_additional_fields
+      {
+        :cloud_types => ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.credential_types
+      }
     end
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/cloud_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/cloud_credential.rb
@@ -1,8 +1,2 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::Credential
-  def self.credential_types
-    subclasses.sort_by(&:name).each_with_object({}) do |subclass, credential_types|
-      provider_name = subclass.name.demodulize.split('Credential').first
-      credential_types[provider_name] = subclass.name
-    end
-  end
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/cloud_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/cloud_credential.rb
@@ -1,2 +1,8 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::Credential
+  def self.credential_types
+    subclasses.sort_by(&:name).each_with_object({}) do |subclass, credential_types|
+      provider_name = subclass.name.demodulize.split('Credential').first
+      credential_types[provider_name] = subclass.name
+    end
+  end
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -23,4 +23,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => 'Amazon',
+    :attributes => API_ATTRIBUTES
+  }.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
 
   API_OPTIONS = {
     :type       => 'cloud',
-    :label      => 'Amazon',
+    :label      => N_('Amazon'),
     :attributes => API_ATTRIBUTES
   }.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -54,7 +54,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
-    :label      => 'Machine',
+    :label      => N_('Machine'),
     :type       => 'machine',
     :attributes => API_ATTRIBUTES
   }.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -52,4 +52,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => 'Machine',
+    :type       => 'machine',
+    :attributes => API_ATTRIBUTES
+  }.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
-    :label      => 'Scm',
+    :label      => N_('Scm'),
     :type       => 'scm',
     :attributes => API_ATTRIBUTES
   }.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -28,4 +28,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => 'Scm',
+    :type       => 'scm',
+    :attributes => API_ATTRIBUTES
+  }.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -23,4 +23,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => 'VMware',
+    :type       => 'cloud',
+    :attributes => API_ATTRIBUTES
+  }.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -25,7 +25,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 
   API_OPTIONS = {
-    :label      => 'VMware',
+    :label      => N_('VMware'),
     :type       => 'cloud',
     :attributes => API_ATTRIBUTES
   }.freeze

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -183,22 +183,10 @@ RSpec.describe 'Arbitration Rule API' do
     it 'returns arbitration rule field_values' do
       api_basic_authorize
 
-      attributes = (ArbitrationRule.attribute_names - ArbitrationRule.virtual_attribute_names).sort.as_json
-      reflections = (ArbitrationRule.reflections.keys | ArbitrationRule.virtual_reflections.keys.collect(&:to_s)).sort
-      subcollections = Array(Api::ApiConfig.collections[:arbitration_rules].subcollections).collect(&:to_s).sort
-      expected = {
-        'attributes'         => attributes,
-        'virtual_attributes' => ArbitrationRule.virtual_attribute_names.sort.as_json,
-        'relationships'      => reflections,
-        'subcollections'     => subcollections,
-        'data'               => {
-          'field_values' => ArbitrationRule.field_values
-        }
-      }
-
       run_options(arbitration_rules_url)
-      expect(response.parsed_body).to eq(expected)
-      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+
+      additional_options = { 'field_values' => ArbitrationRule.field_values }
+      expect_options_results(:arbitration_rules, additional_options)
     end
   end
 end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -172,7 +172,15 @@ RSpec.describe 'Authentications API' do
 
       run_options(authentications_url)
 
-      additional_options = { 'cloud_types' => ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.credential_types}
+      additional_options = Authentication.descendants.each_with_object({}) do |klass, fields|
+        next unless defined? klass::API_OPTIONS
+        klass::API_OPTIONS.tap do |options|
+          options[:attributes].each do |_k, v|
+            v[:type] = v[:type].to_s if v[:type]
+          end
+          fields[klass.name] = options
+        end
+      end.deep_stringify_keys
       expect_options_results(:authentications, additional_options)
     end
   end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe 'Authentications API' do
           fields[klass.name] = options
         end
       end.deep_stringify_keys
-      expect_options_results(:authentications, additional_options)
+      expect_options_results(:authentications, 'credential_types' => additional_options)
     end
   end
 end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -165,4 +165,15 @@ RSpec.describe 'Authentications API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'OPTIONS /api/authentications' do
+    it 'returns expected and additional attributes' do
+      api_basic_authorize
+
+      run_options(authentications_url)
+
+      additional_options = { 'cloud_types' => ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential.credential_types}
+      expect_options_results(:authentications, additional_options)
+    end
+  end
 end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -173,35 +173,22 @@ RSpec.describe 'Authentications API' do
       run_options(authentications_url)
 
       additional_options = {
-        'credential_types' => {
-          'ansible_tower_credentials'    => build_ansible_tower_creds,
-          'embedded_ansible_credentials' => build_embedded_ansible_creds
-        }
+        'credential_types' => build_credential_options
       }
       expect_options_results(:authentications, additional_options)
     end
   end
 
-  def build_ansible_tower_creds
-    ManageIQ::Providers::AnsibleTower::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
-      next unless defined? klass::API_OPTIONS
-      klass::API_OPTIONS.tap do |options|
-        options[:attributes].each do |_k, v|
-          v[:type] = v[:type].to_s if v[:type]
+  def build_credential_options
+    Authentication::CREDENTIAL_TYPES.each_with_object({}) do |(description, klass), hash|
+      hash[description] = klass.constantize.descendants.each_with_object({}) do |subklass, fields|
+        next unless defined? subklass::API_OPTIONS
+        subklass::API_OPTIONS.tap do |options|
+          options[:attributes].each do |_k, val|
+            val[:type] = val[:type].to_s if val[:type]
+          end
+          fields[subklass.name] = options
         end
-        fields[klass.name] = options
-      end
-    end.deep_stringify_keys
-  end
-
-  def build_embedded_ansible_creds
-    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
-      next unless defined? klass::API_OPTIONS
-      klass::API_OPTIONS.tap do |options|
-        options[:attributes].each do |_k, v|
-          v[:type] = v[:type].to_s if v[:type]
-        end
-        fields[klass.name] = options
       end
     end.deep_stringify_keys
   end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -172,16 +172,37 @@ RSpec.describe 'Authentications API' do
 
       run_options(authentications_url)
 
-      additional_options = Authentication.descendants.each_with_object({}) do |klass, fields|
-        next unless defined? klass::API_OPTIONS
-        klass::API_OPTIONS.tap do |options|
-          options[:attributes].each do |_k, v|
-            v[:type] = v[:type].to_s if v[:type]
-          end
-          fields[klass.name] = options
-        end
-      end.deep_stringify_keys
-      expect_options_results(:authentications, 'credential_types' => additional_options)
+      additional_options = {
+        'credential_types' => {
+          'ansible_tower_credentials'    => build_ansible_tower_creds,
+          'embedded_ansible_credentials' => build_embedded_ansible_creds
+        }
+      }
+      expect_options_results(:authentications, additional_options)
     end
+  end
+
+  def build_ansible_tower_creds
+    ManageIQ::Providers::AnsibleTower::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
+      next unless defined? klass::API_OPTIONS
+      klass::API_OPTIONS.tap do |options|
+        options[:attributes].each do |_k, v|
+          v[:type] = v[:type].to_s if v[:type]
+        end
+        fields[klass.name] = options
+      end
+    end.deep_stringify_keys
+  end
+
+  def build_embedded_ansible_creds
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential.descendants.each_with_object({}) do |klass, fields|
+      next unless defined? klass::API_OPTIONS
+      klass::API_OPTIONS.tap do |options|
+        options[:attributes].each do |_k, v|
+          v[:type] = v[:type].to_s if v[:type]
+        end
+        fields[klass.name] = options
+      end
+    end.deep_stringify_keys
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -269,12 +269,12 @@ module Spec
 
       def expect_options_results(type, data = {})
         klass = Api::ApiConfig.collections[type].klass.constantize
-        attributes = (klass.attribute_names - klass.virtual_attribute_names).sort.as_json
+        attributes = (klass.attribute_names - klass.virtual_attribute_names).sort
         attributes.delete('password')
         reflections = (klass.reflections.keys | klass.virtual_reflections.keys.collect(&:to_s)).sort
         subcollections = Array(Api::ApiConfig.collections[type].subcollections).collect(&:to_s).sort
         expected = {
-          'attributes'         => attributes,
+          'attributes'         => attributes.as_json,
           'virtual_attributes' => klass.virtual_attribute_names.sort.as_json,
           'relationships'      => reflections,
           'subcollections'     => subcollections,

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -266,6 +266,23 @@ module Spec
           )
         end
       end
+
+      def expect_options_results(type, data = {})
+        klass = Api::ApiConfig.collections[type].klass.constantize
+        attributes = (klass.attribute_names - klass.virtual_attribute_names).sort.as_json
+        attributes.delete('password')
+        reflections = (klass.reflections.keys | klass.virtual_reflections.keys.collect(&:to_s)).sort
+        subcollections = Array(Api::ApiConfig.collections[type].subcollections).collect(&:to_s).sort
+        expected = {
+          'attributes'         => attributes,
+          'virtual_attributes' => klass.virtual_attribute_names.sort.as_json,
+          'relationships'      => reflections,
+          'subcollections'     => subcollections,
+          'data'               => data
+        }
+        expect(response.parsed_body).to eq(expected)
+        expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      end
     end
   end
 end


### PR DESCRIPTION
The UI needs a way to populate a dropdown menu with the different ansible cloud credential type names and know the subclass to filter on for those credentials:

Sample output: (not all included - because it's long)
```
"data":{  
   "credential_types":{  
      "external_ansible_credentials":{  
         "ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential":{  
            "type":"cloud",
            "label":"Amazon",
            "attributes":{  
               "userid":{  
                  "label":"Access Key",
                  "help_text":"AWS Access Key for this credential"
               },
               "password":{  
                  "type":"password",
                  "label":"Secret Key",
                  "help_text":"AWS Secret Key for this credential"
               },
               "security_token":{  
                  "type":"password",
                  "label":"STS Token",
                  "help_text":"Security Token Service(STS) Token for this credential",
                  "max_length":1024
               }
            }
         }
      },
      "embedded_ansible_credentials":{  
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential":{  
            "label":"Scm",
            "type":"scm",
            "attributes":{  
               "userid":{  
                  "label":"Access Key",
                  "help_text":"AWS Access Key for this credential"
               },
               "password":{  
                  "type":"password",
                  "label":"Secret Key",
                  "help_text":"AWS Secret Key for this credential"
               },
               "ssh_key_unlock":{  
                  "type":"password",
                  "label":"Private key passphrase",
                  "help_text":"Passphrase to unlock SSH private key if encrypted",
                  "max_length":1024
               },
               "ssh_key_data":{  
                  "type":"password",
                  "label":"Private key",
                  "help_text":"RSA or DSA private key to be used instead of password"
               }
            }
         },
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential":{  
            "type":"cloud",
            "label":"Amazon",
            "attributes":{  
               "userid":{  
                  "label":"Access Key",
                  "help_text":"AWS Access Key for this credential"
               },
               "password":{  
                  "type":"password",
                  "label":"Secret Key",
                  "help_text":"AWS Secret Key for this credential"
               },
               "security_token":{  
                  "type":"password",
                  "label":"STS Token",
                  "help_text":"Security Token Service(STS) Token for this credential",
                  "max_length":1024
               }
            }
         },
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential":{  
            "label":"VMware",
            "type":"cloud",
            "attributes":{  
               "userid":{  
                  "label":"Username",
                  "help_text":"Username for this credential"
               },
               "password":{  
                  "type":"password",
                  "label":"Password",
                  "help_text":"Password for this credential"
               },
               "host":{  
                  "type":"string",
                  "label":"vCenter Host",
                  "help_text":"The hostname or IP address of the vCenter Host",
                  "max_length":1024
               }
            }
         }
      }
   }
```

@miq-bot add_label api, enhancement, euwe/no
@miq-bot assign @abellotti 

cc: @h-kataria @bdunne 
