### PR TITLE
Remove agent_state and agent_name related logic from Job model

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,7 +29,7 @@ class Job < ApplicationRecord
     job.initialize_attributes
     job.save
     job.create_miq_task(job.attributes_for_task)
-    $log.info "Job created: guid: [#{job.guid}], userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], agent class: [#{job.agent_class}], agent id: [#{job.agent_id}], zone: [#{job.zone}]"
+    $log.info "Job created: guid: [#{job.guid}], userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], server id: [#{job.agent_id}], zone: [#{job.zone}]"
     job.signal(:initializing)
     job
   end
@@ -56,18 +56,18 @@ class Job < ApplicationRecord
 
   def check_active_on_destroy
     if self.is_active?
-      _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+      _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], server id: [#{agent_id}], zone: [#{zone}]"
       throw :abort
     end
 
-    _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+    _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], server id: [#{agent_id}], zone: [#{zone}]"
     true
   end
 
-  def self.agent_state_update_queue(jobid, state, message = nil)
+  def self.agent_message_update_queue(jobid, message)
     job = Job.where("guid = ?", jobid).select("id, state, guid").first
     unless job.nil?
-      job.agent_state_update(state, message)
+      job.agent_message_update(message)
     else
       _log.warn "jobid: [#{jobid}] not found"
     end
@@ -76,12 +76,9 @@ class Job < ApplicationRecord
     _log.log_backtrace(err)
   end
 
-  def agent_state_update(agent_state, agent_message = nil)
-    # Handle a single array parm coming from the queue
-    agent_state, agent_message = agent_state if agent_state.kind_of?(Array)
-
-    $log.info("JOB([#{guid}] Agent state update: state: [#{agent_state}], message: [#{agent_message}]")
-    update_attributes(:agent_state => agent_state, :agent_message => agent_message)
+  def agent_message_update(agent_message)
+    $log.info("JOB([#{guid}] Agent message update: [#{agent_message}]")
+    update_attributes(:agent_message => agent_message)
 
     return unless self.is_active?
 
@@ -184,10 +181,8 @@ class Job < ApplicationRecord
           next unless job.updated_on < job.current_job_timeout(job.timeout_adjustment).seconds.ago
 
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
-          if job.agent_class == "MiqServer"
-            # TODO: can we add method_name, queue_name, role, instance_id to the exists?
-            next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => job.agent_class)
-          end
+          # TODO: can we add method_name, queue_name, role, instance_id to the exists?
+          next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => "MiqServer")
           job.timeout!
         end
     rescue Exception

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -210,7 +210,6 @@ module ScanningMixin
     ost.xml_class = XmlHash::Document
 
     _log.debug "Scanning - Initializing scan"
-    update_agent_state(ost, "Scanning", "Initializing scan")
     bb, last_err = nil
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
@@ -246,10 +245,9 @@ module ScanningMixin
       _log.debug "categories = [ #{categories.join(', ')} ]"
 
       categories.each do |c|
-        update_agent_state(ost, "Scanning", "Scanning #{c}")
         _log.info "Scanning [#{c}] information.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         st = Time.now
-        xml = extractor.extract(c) { |scan_data| update_agent_state(ost, "Scanning", scan_data[:msg]) }
+        xml = extractor.extract(c)
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         if xml
@@ -277,7 +275,6 @@ module ScanningMixin
       last_err = scanErr
     ensure
       bb.close if bb
-      update_agent_state(ost, "Scanning", "Scanning completed.")
 
       # If we are sent a TaskId transfer a end of job summary xml.
       _log.info "Starting: Sending scan summary to server.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
@@ -327,7 +324,6 @@ module ScanningMixin
       )
       bb = Manageiq::BlackBox.new(guid, ost)
 
-      update_agent_state(ost, "Synchronize", "Synchronization in progress")
       categories.each do |c|
         c.delete!("\"")
         c.strip!
@@ -368,16 +364,8 @@ module ScanningMixin
       save_metadata_op(xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       _log.info "Completed: Sending target summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
 
-      update_agent_state(ost, "Synchronize", "Synchronization complete")
-
       raise syncErr if syncErr
     end
     ost.value = "OK\n"
-  end
-
-  def update_agent_state(ost, state, message)
-    ost.agent_state = state
-    ost.agent_message = message
-    agent_job_state_op(ost.taskid, ost.agent_state, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
   end
 end

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -29,27 +29,6 @@ module ScanningOperationsMixin
     true
   end
 
-  def agent_job_state_op(jobid, state, message = nil)
-    _log.info "jobid: [#{jobid}] starting"
-    begin
-      Timeout.timeout(WS_TIMEOUT) do
-        MiqQueue.put(
-          :class_name  => "Job",
-          :method_name => "agent_state_update_queue",
-          :args        => [jobid, state, message],
-          :task_id     => "agent_job_state_#{Time.now.to_i}",
-          :zone        => MiqServer.my_zone,
-          :role        => "smartstate"
-        )
-        return true
-      end
-    rescue Exception => err
-      _log.log_backtrace(err)
-      ScanningOperations.reconnect_to_db
-      return false
-    end
-  end
-
   def task_update_op(task_id, state, status, message)
     _log.info "task_id: [#{task_id}] starting"
     begin

--- a/product/views/Job.yaml
+++ b/product/views/Job.yaml
@@ -27,7 +27,6 @@ cols:
 - message
 - name
 - userid
-- agent_name
 - agent_message
 - target_class
 - target_id
@@ -44,7 +43,6 @@ col_order:
 - message
 - name
 - userid
-- agent_name
 - agent_message
 
 # Column titles, in order
@@ -56,7 +54,6 @@ headers:
 - Message
 - Task Name
 - User
-- Owner
 - Owner Message
 
 # Condition(s) string for the SQL query


### PR DESCRIPTION
We are not using agents anymore. All agents/proxy are instances of ```MiqServer``` and all logic related to agents could be removed. It would help (in some distant future) to merge ```jobs``` and ```miq_tasks``` tables.

In this PR:
- hide ```Owner```  column on ```My VM and Container Analysis Tasks``` and ```All VM and Container Analysis Tasks``` screens
- remove code related to ```agent_state``` and ```agent_name``` columns on ```jobs``` table. 
'agent_state' is not used anywhere and concept of another state (in addition to job state and job status) is confusing

We are keeping ```agent_message``` at this point.
It looks like there are 2 types of messages recorded in ```agent_message```:
-  mirroring ```job.state``` messages (like "Initializing Scan", "Synchronization in progress", "Synchronization complete", "Scanning completed."). 
- message to reflect progress or some details of scanning:
 ``` categories.each do |c|  ... agent_message = "Scanning #{c}"```
        ```... |scan_data|  agent_message =  scan_data[:msg]```

 Does it make sense to merge 2 message related columns in ```jobs``` table - ```message``` and ```agent_message``` ?
  
jobs screen BEFORE:
![before](https://cloud.githubusercontent.com/assets/6556758/23038304/87dd2b5e-f457-11e6-9676-f3f5ea521a68.png)


jobs screen AFTER hiding ```Owner``` column:
<img width="1228" alt="after1" src="https://cloud.githubusercontent.com/assets/6556758/23409881/3b1c5a7c-fd9b-11e6-83af-f8d94544da0f.png">




@miq-bot add-label core

\cc @Fryguy 