### PR TITLE
Add service object to deliver to automate.

### DIFF
--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -136,6 +136,8 @@ class ServiceTemplateProvisionTask < MiqRequestTask
         args[:automate_message] = ra.ae_message   unless ra.ae_message.blank?
         args[:attrs].merge!(ra.ae_attributes)
       end
+
+      args[:attrs].merge!(MiqAeEngine.create_automation_attributes(destination.class.base_model.name => destination))
       args[:user_id]      = get_user.id
       args[:miq_group_id] = get_user.current_group.id
       args[:tenant_id]    = get_user.current_tenant.id

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -75,6 +75,8 @@ describe ServiceTemplateProvisionTask do
 
     describe "#deliver_to_automate" do
       it "delivers to the queue when the state is not active" do
+        @service              = FactoryGirl.create(:service, :name => 'Test Service')
+        @task_0.destination   = @service
         @task_0.state         = 'pending'
         zone                  = FactoryGirl.create(:zone, :name => "special")
         orchestration_manager = FactoryGirl.create(:ext_management_system, :zone => zone)
@@ -86,7 +88,7 @@ describe ServiceTemplateProvisionTask do
           :class_name       => 'ServiceProvision_Template',
           :instance_name    => 'clone_to_service',
           :automate_message => 'create',
-          :attrs            => {'request' => 'clone_to_service'},
+          :attrs            => {'request' => 'clone_to_service', 'Service::Service' => @service.id},
           :user_id          => @admin.id,
           :miq_group_id     => @admin.current_group_id,
           :tenant_id        => @admin.current_tenant.id,


### PR DESCRIPTION
The generic service state machine uses the service object.
We're currently getting the service object from the task which causes a
problem in retirement because we don't have a task.

