### PR TITLE
change ConfigurationScriptSource to new STI class

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
@@ -109,7 +109,9 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def assert_configuration_script_sources
     expect(automation_manager.configuration_script_sources.count).to eq(6)
-    expect(expected_configuration_script_source).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to be_an_instance_of(
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource
+    )
     expect(expected_configuration_script_source).to have_attributes(
       :name        => 'Demo Project',
       :description => 'A great demo',

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
@@ -80,7 +80,9 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def assert_configuration_script_sources
     expect(automation_manager.configuration_script_sources.count).to eq(6)
-    expect(expected_configuration_script_source).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to be_an_instance_of(
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource
+    )
     expect(expected_configuration_script_source).to have_attributes(
       :name        => 'db-projects',
       :description => 'projects',


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq/pull/13683 got merged `ConfigurationScriptSource` got treated with STI

@miq-bot add_labels providers/ansible_tower, bug
@miq-bot assign @blomquisg 

@jameswnl please review