### PR TITLE
Refuse tags in miq expression field

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,6 +1,7 @@
 class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
+(?!.*\b(managed|user_tag)\b)
 \.?(?<associations>[a-z_\.]+)?
 -(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe MiqExpression::Field do
       field = "Vm,host+name"
       expect(described_class.parse(field)).to be_nil
     end
+
+    it "will return nil when given a tag" do
+      tag = "Vm.managed-name"
+      expect(described_class.parse(tag)).to be_nil
+
+      tag = "Vm.hosts.managed-name"
+      expect(described_class.parse(tag)).to be_nil
+
+      tag = "Vm.user_tag-name"
+      expect(described_class.parse(tag)).to be_nil
+
+      tag = "Vm.hosts.user_tag-name"
+      expect(described_class.parse(tag)).to be_nil
+    end
   end
 
   describe "#parse!" do


### PR DESCRIPTION
This will simply things, for example in https://github.com/ManageIQ/manageiq/pull/13702

This PR is blocking https://github.com/ManageIQ/manageiq/pull/13702

@miq_bot add_label core, enhancement
@miq-bot assign @gtanzillo 
cc @kbrock @imtayadeway 
