### PR TITLE
[DARGA] Travis JS failures - fail early when bower install fails

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -16,8 +16,7 @@ export BUNDLE_GEMFILE=${PWD}/Gemfile
 
 # suites that need bower assets to work: javascript, vmdb
 if [[ "$TEST_SUITE" = "javascript" ]] || [[ "$TEST_SUITE" = "vmdb" ]]; then
-  which bower || npm install -g bower
-  bower install --allow-root -F --config.analytics=false
+  source $TRAVIS_BUILD_DIR/tools/ci/setup_js_env.sh
 fi
 
 set +v

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,2 +1,8 @@
 which bower || npm install -g bower
 bower install --allow-root -F --config.analytics=false
+STATUS=$?
+echo bower exit code: $STATUS
+
+# fail the whole test suite if bower install failed
+[ $STATUS = 0 ] || exit 1
+[ -d vendor/assets/bower_components ] || exit 1

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,0 +1,2 @@
+which bower || npm install -g bower
+bower install --allow-root -F --config.analytics=false


### PR DESCRIPTION
This is a darga version of #12509 - Updating tools/ci/setup_js_env to fail the whole test suite if bower install fails.

This first commit is extracted from d7cca07 - #12279, making the second one a clean cherry-pick of #12509. Mostly so that #12519 backports cleanly after this..

(This is exactly equivalent to the [euwe version](https://github.com/ManageIQ/manageiq/pull/12548).)