### PR TITLE
Enable operations on CloudObjectStoreContainer

### DIFF
--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -5,5 +5,14 @@ class CloudObjectStoreContainer < ApplicationRecord
 
   acts_as_miq_taggable
 
+  include ProviderObjectMixin
+  include NewWithTypeStiMixin
+  include ProcessTasksMixin
+  include SupportsFeatureMixin
+
+  include_concern 'Operations'
+
   alias_attribute :name, :key
+
+  supports_not :delete, :reason => N_("Delete operation is not supported.")
 end

--- a/app/models/cloud_object_store_container/operations.rb
+++ b/app/models/cloud_object_store_container/operations.rb
@@ -1,0 +1,11 @@
+module CloudObjectStoreContainer::Operations
+  extend ActiveSupport::Concern
+
+  def delete_cloud_object_store_container
+    raw_delete
+  end
+
+  def raw_delete
+    raise NotImplementedError, _("must be implemented in subclass")
+  end
+end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -605,6 +605,15 @@
       :description: Edit Tags of Object Store Containers
       :feature_type: control
       :identifier: cloud_object_store_container_tag
+  - :name: Modify
+    :description: Modify Object Store Containers
+    :feature_type: admin
+    :identifier: cloud_object_store_container_admin
+    :children:
+    - :name: Delete
+      :description: Delete Object Store Containers
+      :feature_type: admin
+      :identifier: cloud_object_store_container_delete
 
 # CloudObjectStoreObject
 - :name: Cloud Objects

--- a/db/migrate/20170216124055_add_name_to_cloud_object_store_container.rb
+++ b/db/migrate/20170216124055_add_name_to_cloud_object_store_container.rb
@@ -1,0 +1,5 @@
+class AddNameToCloudObjectStoreContainer < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_object_store_containers, :name, :string
+  end
+end

--- a/db/migrate/20170217085547_add_type_to_cloud_object_store_container.rb
+++ b/db/migrate/20170217085547_add_type_to_cloud_object_store_container.rb
@@ -1,0 +1,6 @@
+class AddTypeToCloudObjectStoreContainer < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_object_store_containers, :type, :string
+    add_index :cloud_object_store_containers, :type
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -313,6 +313,8 @@ cloud_object_store_containers:
 - bytes
 - ems_id
 - cloud_tenant_id
+- name
+- type
 cloud_object_store_objects:
 - id
 - ems_ref


### PR DESCRIPTION
CloudObjectStoreContainer did not support processing async tasks
from MiqQueue. This commit introduces support for this and introduces
the very first operation "raw delete". New permissions fixture had to
be created and two fields (name, type) had to be added to the model to
support task processing.

Links:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/420
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/144

@miq-bot add_label enhancement
@miq-bot assign @blomquisg 
