### PR TITLE
Remove the mechanisms around "configuring" central admin

### DIFF
--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -58,11 +58,6 @@ module InterRegionApiMethodRelay
   def self.api_client_connection_for_region(region_number, user = User.current_userid)
     region = MiqRegion.find_by(:region => region_number)
 
-    unless region.auth_key_configured?
-      _log.error("Region #{region_number} is not configured for central administration")
-      raise "Region #{region_number} is not configured for central administration"
-    end
-
     url = region.remote_ws_url
     if url.nil?
       _log.error("The remote region [#{region_number}] does not have a web service address.")

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -62,7 +62,6 @@ class PglogicalSubscription < ActsAsArModel
 
   def delete
     pglogical.subscription_drop(id, true)
-    MiqRegion.find_by_region(provider_region).remove_auth_key
     MiqRegion.destroy_region(connection, provider_region)
     if self.class.count == 0
       pglogical.node_drop(MiqPglogical.local_node_name, true)

--- a/db/migrate/20170217220618_remove_central_admin_region_auth_records.rb
+++ b/db/migrate/20170217220618_remove_central_admin_region_auth_records.rb
@@ -1,0 +1,7 @@
+class RemoveCentralAdminRegionAuthRecords < ActiveRecord::Migration[5.0]
+  class Authentication < ActiveRecord::Base; end
+
+  def up
+    Authentication.where(:resource_type => 'MiqRegion').delete_all
+  end
+end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -105,6 +105,4 @@ FactoryGirl.define do
   factory :ansible_network_credential,
           :parent => :automation_manager_authentication,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential"
-
-  factory :auth_token, :class => "AuthToken"
 end

--- a/spec/migrations/20170217220618_remove_central_admin_region_auth_records_spec.rb
+++ b/spec/migrations/20170217220618_remove_central_admin_region_auth_records_spec.rb
@@ -1,0 +1,18 @@
+require_migration
+
+describe RemoveCentralAdminRegionAuthRecords do
+  let(:authentication_stub) { migration_stub(:Authentication) }
+
+  migration_context :up do
+    it "removes rows that point to MiqRegion" do
+      authentication_stub.create!(:resource_type => "MiqRegion")
+      authentication_stub.create!(:resource_type => "MiqRegion")
+      authentication_stub.create!(:resource_type => "Provider")
+
+      migrate
+
+      expect(authentication_stub.count).to eq(1)
+      expect(authentication_stub.first.resource_type).to eq("Provider")
+    end
+  end
+end

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -370,23 +370,6 @@ describe PglogicalSubscription do
 
       sub.delete
     end
-
-    it "removes the region authentication key if present" do
-      allow(pglogical).to receive(:subscriptions).and_return(subscriptions, [subscriptions.last])
-      expect(pglogical).to receive(:subscription_drop).with("region_#{remote_region1}_subscription", true)
-
-      EvmSpecHelper.create_guid_miq_server_zone
-      auth = FactoryGirl.create(
-        :auth_token,
-        :resource_id   => remote_region.id,
-        :resource_type => "MiqRegion",
-        :auth_key      => "this is the encryption key!",
-        :authtype      => "system_api"
-      )
-
-      sub.delete
-      expect(AuthToken.find_by_id(auth.id)).to be_nil
-    end
   end
 
   describe "#validate" do


### PR DESCRIPTION
This was put in place because the authentication method we were using involved encrypting a token using a remote region's v2_key.

The initial assumption was that regions could have different keys so we needed to do some configuration to fetch the remote key for each subscription.

That assumption has been proven incorrect; all regions in the enterprise should be using the same v2_key. This allows us to authenticate with remote regions as soon as replication is configured.

Related UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/421