### PR TITLE
Add Alert Definitions (MiqAlert) REST API support

### DIFF
--- a/app/controllers/api/alert_definitions_controller.rb
+++ b/app/controllers/api/alert_definitions_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  class AlertDefinitionsController < BaseController
+    REQUIRED_FIELDS = %w(description db expression options).freeze
+
+    def create_resource(type, id, data = {})
+      assert_id_not_specified(data, type)
+      assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
+      begin
+        data["expression"] = MiqExpression.new(data["expression"])
+        data["enabled"] = true if data["enabled"].nil?
+        super(type, id, data)
+      rescue => err
+        raise BadRequestError, "Failed to create a new alert definition - #{err}"
+      end
+    end
+
+    def edit_resource(type, id = nil, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+      begin
+        data["expression"] = MiqExpression.new(data["expression"]) if data["expression"]
+        super(type, id, data)
+      rescue => err
+        raise BadRequestError, "Failed to update alert definition - #{err}"
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -88,6 +88,34 @@
        :post:
        - :name: create
          :identifier: alert_status_action_new
+  :alert_definitions:
+    :description: Alert Definitions
+    :identifier: alert_definition
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: MiqAlert
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: alert_definitions_show_list
+      :post:
+      - :name: create
+        :identifier: alert_definition_new
+      - :name: delete
+        :identifier: alert_definition_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: alert_definition_show
+      :post:
+      - :name: edit
+        :identifier: alert_definition_edit
+      - :name: delete
+        :identifier: alert_definition_delete
+      :delete:
+      - :name: delete
+        :identifier: alert_definition_delete
   :alerts:
     :description: Alerts
     :identifier: alert

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1967,6 +1967,47 @@
       :description: Display Individual Alert Status
       :feature_type: admin
       :identifier: alert_status_action_new
+  - :name: Alert Definitions
+    :description: Everything under Alert Definitions
+    :feature_type: node
+    :hidden: true
+    :identifier: alert_definition
+    :children:
+    - :name: View
+      :description: View Alert Definitions
+      :feature_type: view
+      :identifier: alert_definition_view
+      :children:
+      - :name: List
+        :description: Display List of Alert Definitions
+        :feature_type: view
+        :identifier: alert_definitions_show_list
+      - :name: Show
+        :description: Display Individual Alert Definition
+        :feature_type: view
+        :identifier: alert_definition_show
+    - :name: Modify
+      :description: Modify Alert Definitions
+      :feature_type: admin
+      :hidden: true
+      :identifier: alert_definition_admin
+      :children:
+      - :name: Add
+        :description: Add an Alert Definition
+        :feature_type: admin
+        :hidden: true
+        :identifier: alert_definition_new
+      - :name: Edit
+        :description: Edit an Alert Definition
+        :feature_type: admin
+        :hidden: true
+        :identifier: alert_definition_edit
+      - :name: Delete
+        :description: Delete an Alert Definition
+        :feature_type: admin
+        :hidden: true
+        :identifier: alert_definition_delete
+
 # Policy Simulation
 - :name: Simulation
   :description: Policy Simulation

--- a/spec/requests/api/alert_definitions_spec.rb
+++ b/spec/requests/api/alert_definitions_spec.rb
@@ -1,0 +1,131 @@
+#
+# REST API Request Tests - Alert Definitions
+#
+# Alert Definitions primary collections:
+#   /api/alert_definitions
+#
+
+describe "Alerts Definitions API" do
+  it "forbids access to alert definitions list without an appropriate role" do
+    api_basic_authorize
+    run_get(alert_definitions_url)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "reads 2 alert definitions as a collection" do
+    api_basic_authorize collection_action_identifier(:alert_definitions, :read, :get)
+    alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
+    run_get(alert_definitions_url)
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to include(
+      "name"      => "alert_definitions",
+      "count"     => 2,
+      "subcount"  => 2,
+      "resources" => [
+        {
+          "href" => a_string_matching(alert_definitions_url(alert_definitions[0].id))
+        },
+        {
+          "href" => a_string_matching(alert_definitions_url(alert_definitions[1].id))
+        }
+      ]
+    )
+  end
+
+  it "forbids access to an alert definition resource without an appropriate role" do
+    api_basic_authorize
+    alert_definition = FactoryGirl.create(:miq_alert)
+    run_get(alert_definitions_url(alert_definition.id))
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "reads an alert as a resource" do
+    api_basic_authorize action_identifier(:alert_definitions, :read, :resource_actions, :get)
+    alert_definition = FactoryGirl.create(:miq_alert)
+    run_get(alert_definitions_url(alert_definition.id))
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to include(
+      "href"        => a_string_matching(alert_definitions_url(alert_definition.id)),
+      "id"          => alert_definition.id,
+      "description" => alert_definition.description,
+      "guid"        => alert_definition.guid
+    )
+  end
+
+  it "forbids creation of an alert definition without an appropriate role" do
+    api_basic_authorize
+    alert_definition = {
+      "description" => "Test Alert Definition",
+      "db"          => "ContainerNode"
+    }
+    run_post(alert_definitions_url, alert_definition)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "creates an alert definition" do
+    sample_alert_definition = {
+      "description" => "Test Alert Definition",
+      "db"          => "ContainerNode",
+      "expression"  => { "eval_method" => "dwh_generic", "mode" => "internal", "options" => {} },
+      "options"     => { "notifications" => {"delay_next_evaluation" => 600, "evm_event" => {} } },
+      "enabled"     => true
+    }
+    api_basic_authorize collection_action_identifier(:alert_definitions, :create)
+    run_post(alert_definitions_url, sample_alert_definition)
+    expect(response).to have_http_status(:ok)
+    alert_definition = MiqAlert.find(response.parsed_body["results"].first["id"])
+    expect(alert_definition).to be_truthy
+    expect(alert_definition.expression.class).to eq(MiqExpression)
+    expect(alert_definition.expression.exp).to eq(sample_alert_definition["expression"])
+    expect(response.parsed_body["results"].first).to include(
+      "description" => sample_alert_definition["description"],
+      "db"          => sample_alert_definition["db"],
+      "expression"  => a_hash_including(
+        "exp" => sample_alert_definition["expression"]
+      )
+    )
+  end
+
+  it "deletes an alert definition via POST" do
+    api_basic_authorize action_identifier(:alert_definitions, :delete, :resource_actions, :post)
+    alert_definition = FactoryGirl.create(:miq_alert)
+    run_post(alert_definitions_url(alert_definition.id), gen_request(:delete))
+    expect(response).to have_http_status(:ok)
+    expect_single_action_result(:success => true,
+                                :message => "alert_definitions id: #{alert_definition.id} deleting",
+                                :href    => alert_definitions_url(alert_definition.id))
+  end
+
+  it "deletes an alert definition via DELETE" do
+    api_basic_authorize action_identifier(:alert_definitions, :delete, :resource_actions, :delete)
+    alert_definition = FactoryGirl.create(:miq_alert)
+    run_delete(alert_definitions_url(alert_definition.id))
+    expect(response).to have_http_status(:no_content)
+    expect(MiqAlert.exists?(alert_definition.id)).to be_falsey
+  end
+
+  it "deletes alert definitions" do
+    api_basic_authorize collection_action_identifier(:alert_definitions, :delete)
+    alert_definitions = FactoryGirl.create_list(:miq_alert, 2)
+    run_post(alert_definitions_url, gen_request(:delete, [{"id" => alert_definitions.first.id},
+                                                          {"id" => alert_definitions.second.id}]))
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["results"].count).to eq(2)
+  end
+
+  it "edits an alert definition" do
+    sample_alert_definition = {
+      :description => "Test Alert Definition",
+      :db          => "ContainerNode",
+      :expression  => { :eval_method => "dwh_generic", :mode => "internal", :options => {} },
+      :options     => { :notifications => {:delay_next_evaluation => 600, :evm_event => {} } },
+      :enabled     => true
+    }
+    updated_options = { :notifications => {:delay_next_evaluation => 60, :evm_event => {} } }
+    api_basic_authorize action_identifier(:alert_definitions, :edit, :resource_actions, :post)
+    alert_definition = FactoryGirl.create(:miq_alert, sample_alert_definition)
+    run_post(alert_definitions_url(alert_definition.id), gen_request(:edit, :options => updated_options))
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["options"]).to eq(updated_options.deep_stringify_keys)
+  end
+end


### PR DESCRIPTION
Adding CRUD actions support to alert definitions API endpoint.