### PR TITLE
Migrate Ansible Tower ConfigurationManager Job to AutomationManager

### DIFF
--- a/db/migrate/20170217163547_migrate_tower_job_sti_type_to_automation_manager.rb
+++ b/db/migrate/20170217163547_migrate_tower_job_sti_type_to_automation_manager.rb
@@ -1,0 +1,21 @@
+class MigrateTowerJobStiTypeToAutomationManager < ActiveRecord::Migration[5.0]
+  class OrchestrationStack < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Migrating STI type of ansible_tower jobs to be of automation_manager') do
+      OrchestrationStack.where(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job'
+      )
+    end
+  end
+
+  def down
+    say_with_time('Migrating STI type of ansible_tower jobs to be of configuration_managers') do
+      OrchestrationStack.where(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job').update_all(
+        :type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job'
+      )
+    end
+  end
+end

--- a/spec/migrations/20170217163547_migrate_tower_job_sti_type_to_automation_manager_spec.rb
+++ b/spec/migrations/20170217163547_migrate_tower_job_sti_type_to_automation_manager_spec.rb
@@ -1,0 +1,33 @@
+require_migration
+
+describe MigrateTowerJobStiTypeToAutomationManager do
+  let(:job_stub) { migration_stub(:OrchestrationStack) }
+
+  migration_context :up do
+    it 'migrates Ansible Tower Jobs to be of AutomationManager type' do
+      job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
+
+      migrate
+
+      expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+    end
+
+    it 'will not migrate Jobs other than those of Ansible Tower ConfigurationManager' do
+      job = job_stub.create!(:type => 'ManageIQ::Providers::SomeManager::Job')
+
+      migrate
+
+      expect(job.reload.type).to eq('ManageIQ::Providers::SomeManager::Job')
+    end
+  end
+
+  migration_context :down do
+    it 'migrates Ansible Tower AutomationManager Jobs to ConfigurationManager type' do
+      job = job_stub.create!(:type => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Job')
+
+      migrate
+
+      expect(job.reload.type).to eq('ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job')
+    end
+  end
+end


### PR DESCRIPTION
The Ansible Tower `Job` is using the table `orchestration_stacks`, not `jobs`.  This PR patches the attempted `Job` migration in #13720 which pined the wrong table.