### PR TITLE
Add OrchestrationStackResource#start_time and #finish_time

### DIFF
--- a/db/migrate/20170217170604_add_times_to_orchestration_stack_resources.rb
+++ b/db/migrate/20170217170604_add_times_to_orchestration_stack_resources.rb
@@ -1,0 +1,6 @@
+class AddTimesToOrchestrationStackResources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :orchestration_stack_resources, :start_time,  :timestamp
+    add_column :orchestration_stack_resources, :finish_time, :timestamp
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6016,6 +6016,8 @@ orchestration_stack_resources:
 - last_updated
 - stack_id
 - ems_ref
+- start_time
+- finish_time
 orchestration_stacks:
 - id
 - name


### PR DESCRIPTION
These columns will be used to track the start time and finish time of Ansible Plays, allowing us to display the length of time elapsed on a play.