### PR TITLE
Create a provision request for a service template

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -378,10 +378,14 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def provision_request(userid, options = {})
-    workflow = ResourceActionWorkflow.new({}, User.find_by!(:userid => userid),
-                                          provision_action, :target => self)
-    options.each { |key, value| workflow.set_value(key, value) }
-    workflow.submit_request
+    provision_workflow(userid, options).submit_request
+  end
+
+  def provision_workflow(userid, options = {})
+    ResourceActionWorkflow.new({}, User.find_by!(:userid => userid),
+                               provision_action, :target => self).tap do |wf|
+      options.each { |key, value| wf.set_value(key, value) }
+    end
   end
 
   def self.create_from_options(options)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -377,12 +377,13 @@ class ServiceTemplate < ApplicationRecord
     save!
   end
 
-  def provision_request(userid, options = {})
-    provision_workflow(userid, options).submit_request
+  def provision_request(user, options = nil)
+    provision_workflow(user, options).submit_request
   end
 
-  def provision_workflow(userid, options = {})
-    ResourceActionWorkflow.new({}, User.find_by!(:userid => userid),
+  def provision_workflow(user, options = nil)
+    options ||= {}
+    ResourceActionWorkflow.new({}, user,
                                provision_action, :target => self).tap do |wf|
       options.each { |key, value| wf.set_value(key, value) }
     end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -377,6 +377,13 @@ class ServiceTemplate < ApplicationRecord
     save!
   end
 
+  def provision_request(userid, options = {})
+    workflow = ResourceActionWorkflow.new({}, User.find_by!(:userid => userid),
+                                          provision_action, :target => self)
+    options.each { |key, value| workflow.set_value(key, value) }
+    workflow.submit_request
+  end
+
   def self.create_from_options(options)
     create(options.except(:config_info).merge(:options => { :config_info => options[:config_info] }))
   end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -151,6 +151,11 @@ module MiqAeMethodService
       return nil
     end
 
+    def create_service_provision_request(svc_template, options = nil)
+      result = ar_object(svc_template).provision_request(ar_object(@workspace.ae_user), options)
+      MiqAeServiceModelBase.wrap_results(result)
+    end
+
     def object(path = nil)
       obj = @workspace.get_obj_from_path(path)
       return nil if obj.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -152,7 +152,7 @@ module MiqAeMethodService
     end
 
     def create_service_provision_request(svc_template, options = nil)
-      result = ar_object(svc_template).provision_request(ar_object(@workspace.ae_user), options)
+      result = ar_object(svc_template).provision_request(@workspace.ae_user, options)
       MiqAeServiceModelBase.wrap_results(result)
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -27,5 +27,11 @@ module MiqAeMethodService
         @object.save
       end
     end
+
+    def provision_request(user, options)
+      ar_method do
+        wrap_results(@object.provision_request(user.instance_variable_get("@object"), options))
+      end
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -26,11 +26,5 @@ module MiqAeMethodService
         @object.save
       end
     end
-
-    def provision_request(user, options)
-      ar_method do
-        wrap_results(@object.provision_request(user.instance_variable_get("@object"), options))
-      end
-    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -4,6 +4,7 @@ module MiqAeMethodService
     expose :services,          :association => true
     expose :service_resources, :association => true
     expose :tenant,            :association => true
+    expose :provision_request
 
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -4,7 +4,6 @@ module MiqAeMethodService
     expose :services,          :association => true
     expose :service_resources, :association => true
     expose :tenant,            :association => true
-    expose :provision_request
 
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -253,9 +253,6 @@ module MiqAeServiceSpec
       let(:options) { {:fred => :flintstone} }
       let(:svc_options) { {:dialog_style => "medium"} }
       let(:user) { FactoryGirl.create(:user_with_group) }
-      let(:svc_user) do
-        MiqAeMethodService::MiqAeServiceUser.find(user.id)
-      end
       let(:template) { FactoryGirl.create(:service_template_ansible_playbook) }
       let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
       let(:svc_template) do
@@ -265,13 +262,12 @@ module MiqAeServiceSpec
         double("MiqAeEngine::MiqAeWorkspaceRuntime",
                :root               => options,
                :persist_state_hash => {},
-               :ae_user            => svc_user)
+               :ae_user            => user)
       end
       let(:miq_ae_service) { MiqAeService.new(workspace) }
 
       it "create service request" do
         allow(workspace).to receive(:disable_rbac)
-        expect(svc_user).to receive(:instance_variable_get).with('@object').and_return(user)
         expect(svc_template).to receive(:instance_variable_get).with('@object').and_return(template)
         expect(template).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
 

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -248,5 +248,36 @@ module MiqAeServiceSpec
         end
       end
     end
+
+    context "#create_service_provision_request" do
+      let(:options) { {:fred => :flintstone} }
+      let(:svc_options) { {:dialog_style => "medium"} }
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:svc_user) do
+            MiqAeMethodService::MiqAeServiceUser.find(user.id)
+      end
+      let(:template) { FactoryGirl.create(:service_template_ansible_playbook) }
+      let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
+      let(:svc_template) do
+        MiqAeMethodService::MiqAeServiceServiceTemplate.find(template.id)
+      end
+      let(:workspace) do
+        double("MiqAeEngine::MiqAeWorkspaceRuntime",
+               :root               => options,
+               :persist_state_hash => {},
+               :ae_user            => svc_user)
+      end
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
+
+      it "create service request" do
+        allow(workspace).to receive(:disable_rbac)
+        expect(svc_user).to receive(:instance_variable_get).with('@object').and_return(user)
+        expect(svc_template).to receive(:instance_variable_get).with('@object').and_return(template)
+        expect(template).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
+
+        result = miq_ae_service.create_service_provision_request(svc_template, svc_options)
+        expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      end
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -254,7 +254,7 @@ module MiqAeServiceSpec
       let(:svc_options) { {:dialog_style => "medium"} }
       let(:user) { FactoryGirl.create(:user_with_group) }
       let(:svc_user) do
-            MiqAeMethodService::MiqAeServiceUser.find(user.id)
+        MiqAeMethodService::MiqAeServiceUser.find(user.id)
       end
       let(:template) { FactoryGirl.create(:service_template_ansible_playbook) }
       let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -548,7 +548,7 @@ describe ServiceTemplate do
     end
   end
 
-  describe "#provision" do
+  describe "#provision_request" do
     it "provision's a service template " do
       user = FactoryGirl.create(:user, :userid => "barney")
       resource_action = FactoryGirl.create(:resource_action, :action => "Provision")
@@ -560,7 +560,7 @@ describe ServiceTemplate do
       expect(workflow).to receive(:submit_request)
       expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
 
-      service_template.provision_request('barney', 'ordered_by' => 'fred')
+      service_template.provision_request(user, 'ordered_by' => 'fred')
     end
   end
 end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -555,8 +555,6 @@ describe ServiceTemplate do
       service_template = FactoryGirl.create(:service_template,
                                             :resource_actions => [resource_action])
       workflow = instance_double(ResourceActionWorkflow)
-      allow(User).to receive(:find_by_userid!).and_return(user)
-      expect(service_template).to receive(:provision_action).and_return(resource_action)
       expect(ResourceActionWorkflow).to(receive(:new)
         .with({}, user, resource_action, :target => service_template).and_return(workflow))
       expect(workflow).to receive(:submit_request)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -547,6 +547,24 @@ describe ServiceTemplate do
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
     end
   end
+
+  describe "#provision" do
+    it "provision's a service template " do
+      user = FactoryGirl.create(:user, :userid => "barney")
+      resource_action = FactoryGirl.create(:resource_action, :action => "Provision")
+      service_template = FactoryGirl.create(:service_template,
+                                            :resource_actions => [resource_action])
+      workflow = instance_double(ResourceActionWorkflow)
+      allow(User).to receive(:find_by_userid!).and_return(user)
+      expect(service_template).to receive(:provision_action).and_return(resource_action)
+      expect(ResourceActionWorkflow).to(receive(:new)
+        .with({}, user, resource_action, :target => service_template).and_return(workflow))
+      expect(workflow).to receive(:submit_request)
+      expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
+
+      service_template.provision_request('barney', 'ordered_by' => 'fred')
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
Model method to submit a provision request from a service template.

https://www.pivotaltracker.com/n/projects/1937537/stories/140055813

This method is also accessible from Automate method e.g
```
st = $evm.root["service_template"]
req=$evm.create_service_provision_request(st, {})
```

