### PR TITLE
Properly monitor the embedded ansible service

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -9,7 +9,7 @@ class EmbeddedAnsibleWorker < MiqWorker
   end
 
   def kill
-    # Does the base class's kill -9 work on the supervisord process as we want?
+    stop
   end
 
   def status_update

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -23,7 +23,6 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
       _log.info("entering ansible monitor loop")
       loop do
-        heartbeat
         do_work
         send(poll_method)
       end
@@ -40,11 +39,10 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def do_work
-    if EmbeddedAnsible.running?
-      _log.info("#{log_prefix} supervisord is ok!")
+    if EmbeddedAnsible.alive?
+      heartbeat
     else
-      _log.warn("#{log_prefix} supervisord is not running, restarting!")
-      EmbeddedAnsible.start
+      EmbeddedAnsible.start unless EmbeddedAnsible.running?
     end
   end
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -48,6 +48,7 @@ class EmbeddedAnsible
   end
 
   def self.start
+    configure_secret_key
     run_setup_script(playbook_extra_variables.merge(:k => START_EXCLUDE_TAGS))
   end
 

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -278,6 +278,7 @@ describe EmbeddedAnsible do
         miq_database.set_ansible_rabbitmq_authentication(:userid => "rabbituser", :password => "rabbitpassword")
         miq_database.set_ansible_database_authentication(:userid => "databaseuser", :password => "databasepassword")
 
+        expect(described_class).to receive(:configure_secret_key)
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
           inventory_file_contents = File.read(params[:i])


### PR DESCRIPTION
This PR mostly handles implementing a better worker lifecycle (start, do_work, kill) for the `EmbeddedAnsibleWorker`

For this we should only heartbeat when the locally running ansible service is alive and start the service if it isn't alive and all the processes are not running (EmbeddedAnsible.running?).

We are aware that this opens the potential for a race condition when the worker is killed and the server starts a replacement before the original worker is completely down.

The combination of implementing `EmbeddedAnsibleWorker#kill` as `#stop` and starting the service every time we can't heartbeat should allow the new worker to recover even if the stop is run after the new worker runs `EmbeddedAnsible.start`

If this does become a problem we will need to implement some new mechanisms for dealing with such "singleton" workers.