### PR TITLE
Fix authentication of metrics credentials in RHV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -134,7 +134,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     server   = options[:hostname] || metrics_hostname || hostname
     username = options[:user] || authentication_userid(:metrics)
     password = options[:pass] || authentication_password(:metrics)
-    database = options[:database]
+    database = options[:database] || history_database_name
 
     {
       :host     => server,
@@ -184,24 +184,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
   end
 
   def history_database_name
-    @history_database_name = connection_configurations.try(:metrics).try(:endpoint).try(:path)
-    @history_database_name ||= begin
-                                 version = version_3_0? ? '3_0' : '>3_0'
-                                 self.class.history_database_name_for(version)
-                               end
-  end
-
-  def version_3_0?
-    if @version_3_0.nil?
-      @version_3_0 =
-        if api_version.nil?
-          with_provider_connection(&:version_3_0?)
-        else
-          api_version.starts_with?("3.0")
-        end
-    end
-
-    @version_3_0
+    connection_configurations.try(:metrics).try(:endpoint).try(:path) || self.class.default_history_database_name
   end
 
   # Adding disks is supported only by API version 4.0
@@ -293,14 +276,9 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       const.new(params)
     end
 
-    def history_database_name_for(api_version)
+    def default_history_database_name
       require 'ovirt_metrics'
-      case api_version
-      when '3_0'
-        OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME_3_0
-      else
-        OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME
-      end
+      OvirtMetrics::DEFAULT_HISTORY_DATABASE_NAME
     end
 
     # Calculates an "ems_ref" from the "href" attribute provided by the oVirt REST API, removing the

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -22,6 +22,24 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       expect(ems.rhevm_metrics_connect_options(:hostname => "different.tld")[:host])
         .to eq("different.tld")
     end
+
+    it "rhevm_metrics_connect_options fetches the default database name" do
+      expect(ems.rhevm_metrics_connect_options[:database])
+        .to eq(ems.class.default_history_database_name)
+    end
+
+    context "non default metrics database name" do
+      let(:ems) do
+        FactoryGirl.create(:ems_redhat,
+                           :hostname                  => "some.thing.tld",
+                           :connection_configurations => [{:endpoint => {:role => :metrics,
+                                                                         :path => "some.database"}}])
+      end
+
+      it "fetches the set database name" do
+        expect(ems.rhevm_metrics_connect_options[:database]).to eq("some.database")
+      end
+    end
   end
 
   context "#vm_reconfigure" do


### PR DESCRIPTION
When the database name was not the default one the RHV metrics credentials
would not use the right database name during authentication and fail.