### PR TITLE
Add registered_provider_plugins to Vmdb::Plugins

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -4,9 +4,11 @@ module Vmdb
 
     attr_reader :vmdb_plugins
     attr_reader :registered_automate_domains
+    attr_reader :registered_provider_plugins
 
     def initialize
       @registered_automate_domains = []
+      @registered_provider_plugins = []
       @vmdb_plugins = []
     end
 
@@ -14,19 +16,35 @@ module Vmdb
       @vmdb_plugins << engine
 
       register_automate_domains(engine)
+      register_provider_plugin(engine)
 
       # make sure STI models are recognized
       DescendantLoader.instance.descendants_paths << engine.root.join('app')
+    end
+
+    def provider_plugin_names
+      @provider_plugins_names ||= registered_provider_plugins.collect do |plugin|
+        ManageIQ::Providers::Inflector.provider_name(plugin).downcase.to_sym
+      end
+    end
+
+    def system_automate_domains
+      registered_automate_domains.select(&:system?)
+    end
+
+    private
+
+    def register_provider_plugin(engine)
+      if engine.class.name.start_with?("ManageIQ::Providers::")
+        @registered_provider_plugins << engine
+        @provider_plugins_names = nil
+      end
     end
 
     def register_automate_domains(engine)
       Dir.glob(engine.root.join("content", "automate", "*")).each do |domain_directory|
         @registered_automate_domains << AutomateDomain.new(domain_directory)
       end
-    end
-
-    def system_automate_domains
-      registered_automate_domains.select(&:system?)
     end
   end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -4,11 +4,10 @@ module Vmdb
 
     attr_reader :vmdb_plugins
     attr_reader :registered_automate_domains
-    attr_reader :registered_provider_plugins
 
     def initialize
       @registered_automate_domains = []
-      @registered_provider_plugins = []
+      @registered_provider_plugin_map = {}
       @vmdb_plugins = []
     end
 
@@ -22,10 +21,12 @@ module Vmdb
       DescendantLoader.instance.descendants_paths << engine.root.join('app')
     end
 
-    def provider_plugin_names
-      @provider_plugins_names ||= registered_provider_plugins.collect do |plugin|
-        ManageIQ::Providers::Inflector.provider_name(plugin).downcase.to_sym
-      end
+    def registered_provider_plugin_names
+      @registered_provider_plugin_map.keys
+    end
+
+    def registered_provider_plugins
+      @registered_provider_plugin_map.values
     end
 
     def system_automate_domains
@@ -36,8 +37,8 @@ module Vmdb
 
     def register_provider_plugin(engine)
       if engine.class.name.start_with?("ManageIQ::Providers::")
-        @registered_provider_plugins << engine
-        @provider_plugins_names = nil
+        provider_name = ManageIQ::Providers::Inflector.provider_name(engine).underscore.to_sym
+        @registered_provider_plugin_map[provider_name] = engine
       end
     end
 


### PR DESCRIPTION
this allows for querying which providers are registered via plugins.
it also provides a helper method to query for provider names of all registered providers

extracted from https://github.com/ManageIQ/manageiq/pull/13942

@miq-bot add_labels pluggable providers, enhancement
@miq-bot assign @bdunne 