### PR TITLE
Add :event_catcher_openstack_service setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1283,6 +1283,7 @@
         :poll: 10.seconds
       :event_catcher_swift:
         :poll: 10.seconds
+      :event_catcher_openstack_service: "auto"
     :queue_worker_base:
       :defaults:
         :cpu_usage_threshold: 100.percent


### PR DESCRIPTION
Adding setting which allows switch Openstack Event provider service into settings.yml.

The switch is needed because OSP telemetry services (like Event providing service) can be disabled, installed on older OSP versions or manually changed. These cases might not be handled by automatic selection of Events service well (proven on Metric telemetry services).

This setting will be used by https://github.com/ManageIQ/manageiq-gems-pending/pull/57

Possible values:
 * "ceilometer"
 * "panko"
 * "auto" (and any other string means automatic selection)

Links
----------------

* https://github.com/ManageIQ/manageiq-gems-pending/pull/57
