### PR TITLE
[EUWE] Hash key 'terminate' was duplicated due to backport PR order

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -108,7 +108,6 @@ module SupportsFeatureMixin
     :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',
     :ems_network_new            => 'New EMS Network Provider',
     :update_security_group      => 'Security Group Update',
-    :terminate                => 'Terminate a VM'
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1423470

b6913002e51033 for PR #11418 was backported before
084ecea58bfb4f for PR #11018, causing some git context to bring
over the :terminate key twice.

Note, this does NOT affect master, only euwe.

**Before:**
```
01:32:35 ~/Code/manageiq (euwe) (2.3.3) - be rspec spec/models/host_spec.rb
/Users/joerafaniello/Code/manageiq/app/models/mixins/supports_feature_mixin.rb:103: warning: key :terminate is duplicated and overwritten on line 111

Randomized with seed 51767
...............................................................

Finished in 13.43 seconds (files took 9.13 seconds to load)
63 examples, 0 failures
```

**After:**
```
01:33:06 ~/Code/manageiq (fix_bad_backport_warning) (2.3.3) + be rspec spec/models/host_spec.rb

Randomized with seed 22832
...............................................................

Finished in 7.05 seconds (files took 8.77 seconds to load)
63 examples, 0 failures
```