### PR TITLE
Miq expression#to_ruby extract common vars

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -458,8 +458,9 @@ class MiqExpression
     operator = exp.keys.first
     op_args = exp[operator]
     col_name = op_args["field"] if op_args.kind_of?(Hash)
+    operator = operator.downcase
 
-    case operator.downcase
+    case operator
     when "equal", "=", "<", ">", ">=", "<=", "!="
       operands = operands2rubyvalue(operator, op_args, context_type)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
@@ -484,7 +485,7 @@ class MiqExpression
       clause = "(#{operands[0]} - #{operands[1]}) == []"
     when "like", "not like", "starts with", "ends with", "includes"
       operands = operands2rubyvalue(operator, op_args, context_type)
-      case operator.downcase
+      case operator
       when "starts with"
         operands[1] = "/^" + re_escape(operands[1].to_s) + "/"
       when "ends with"
@@ -493,7 +494,7 @@ class MiqExpression
         operands[1] = "/" + re_escape(operands[1].to_s) + "/"
       end
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
-      clause = "!(" + clause + ")" if operator.downcase == "not like"
+      clause = "!(" + clause + ")" if operator == "not like"
     when "regular expression matches", "regular expression does not match"
       operands = operands2rubyvalue(operator, op_args, context_type)
 
@@ -573,7 +574,7 @@ class MiqExpression
       start_val, end_val = op_args["value"]
       clause = ruby_for_date_compare(col_ruby, col_type, tz, ">=", start_val, "<=", end_val)
     else
-      raise _("operator '%{operator_name}' is not supported") % {:operator_name => operator}
+      raise _("operator '%{operator_name}' is not supported") % {:operator_name => operator.upcase}
     end
 
     # puts "clause: #{clause}"
@@ -919,7 +920,6 @@ class MiqExpression
 
   def self.operands2rubyvalue(operator, ops, context_type)
     # puts "Enter: operands2rubyvalue: operator: #{operator}, ops: #{ops.inspect}"
-    operator = operator.downcase
 
     if ops["field"]
       if ops["field"] == "<count>"
@@ -1070,26 +1070,25 @@ class MiqExpression
   end
 
   def self.normalize_ruby_operator(str)
-    str = str.upcase
     case str
-    when "EQUAL", "="
+    when "equal", "="
       "=="
-    when "NOT"
+    when "not"
       "!"
-    when "LIKE", "NOT LIKE", "STARTS WITH", "ENDS WITH", "INCLUDES", "REGULAR EXPRESSION MATCHES"
+    when "like", "not like", "starts with", "ends with", "includes", "regular expression matches"
       "=~"
-    when "REGULAR EXPRESSION DOES NOT MATCH"
+    when "regular expression does not match"
       "!~"
-    when "IS NULL", "IS EMPTY"
+    when "is null", "is empty"
       "=="
-    when "IS NOT NULL", "IS NOT EMPTY"
+    when "is not null", "is not empty"
       "!="
-    when "BEFORE"
+    when "before"
       "<"
-    when "AFTER"
+    when "after"
       ">"
     else
-      str.downcase
+      str
     end
   end
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -457,20 +457,19 @@ class MiqExpression
 
     operator = exp.keys.first
     op_args = exp[operator]
+    col_name = op_args["field"] if op_args.kind_of?(Hash)
 
     case operator.downcase
     when "equal", "=", "<", ">", ">=", "<=", "!="
       operands = operands2rubyvalue(operator, op_args, context_type)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "before"
-      col_type = get_col_type(op_args["field"]) if op_args["field"]
-      col_name = op_args["field"]
+      col_type = get_col_type(col_name) if col_name
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = op_args["value"]
       clause = ruby_for_date_compare(col_ruby, col_type, tz, "<", val)
     when "after"
-      col_type = get_col_type(op_args["field"]) if op_args["field"]
-      col_name = op_args["field"]
+      col_type = get_col_type(col_name) if col_name
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = op_args["value"]
       clause = ruby_for_date_compare(col_ruby, col_type, tz, nil, nil, ">", val)
@@ -523,7 +522,7 @@ class MiqExpression
       operands = operands2rubyvalue(operator, op_args, context_type)
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "contains"
-      op_args["tag"] ||= op_args["field"]
+      op_args["tag"] ||= col_name
       operands = if context_type != "hash"
                    ref, val = value2tag(preprocess_managed_tag(op_args["tag"]), op_args["value"])
                    ["<exist ref=#{ref}>#{val}</exist>"]
@@ -559,7 +558,6 @@ class MiqExpression
     when "value exists"
       clause = operands2rubyvalue(operator, op_args, context_type)
     when "is"
-      col_name = op_args["field"]
       col_ruby, dummy = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       col_type = get_col_type(col_name)
       value = op_args["value"]
@@ -569,7 +567,6 @@ class MiqExpression
                  ruby_for_date_compare(col_ruby, col_type, tz, ">=", value, "<=", value)
                end
     when "from"
-      col_name = op_args["field"]
       col_ruby, dummy = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       col_type = get_col_type(col_name)
 


### PR DESCRIPTION
High level goal is to rework MiqExpression#to_ruby so it can be enhanced. This is a minor step

MiqExpression is constantly extracting the following concepts:

- the operand arguments
- the lowercase (or uppercase) version of the operator
- the column name

moved them to the top of the method in 3 commits

