### PR TITLE
Create a notification when a snapshot operation fails

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1855,6 +1855,14 @@ class VmOrTemplate < ApplicationRecord
     [true, nil]
   end
 
+  def create_notification(type, options)
+    Notification.create!(
+      :type    => type,
+      :subject => self,
+      :options => options
+    )
+  end
+
   # this is verbose, helper for generating arel
   def self.arel_coalesce(values)
     Arel::Nodes::NamedFunction.new('COALESCE', values)

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -49,6 +49,9 @@ module VmOrTemplate::Operations::Snapshot
 
   def raw_create_snapshot(name, desc = nil, memory)
     run_command_via_parent(:vm_create_snapshot, :name => name, :desc => desc, :memory => memory)
+  rescue => err
+    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
+    raise MiqVmSnapshotError, err.to_s
   end
 
   def create_snapshot(name, desc = nil, memory = false)

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -149,3 +149,8 @@
   :expires_in: 24.hours
   :level: :success
   :audience: global
+- :name: vm_snapshot_failure
+  :message: 'Failed to %{snapshot_op} snapshot of %{subject}: %{error}'
+  :expires_in: 24.hours
+  :level: :warning
+  :audience: global


### PR DESCRIPTION

Snapshot operations are run as asynchronous tasks, when they fail there is no feedback to the user that the operation wasn't successful and the error is only seen in the evm.log.

This will emit a notification when a snapshot create task fails and display the error.

![screenshot from 2017-02-20 15-16-39](https://cloud.githubusercontent.com/assets/12851112/23140450/aba9f49c-f77f-11e6-9455-bac0bc06e541.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1419872