### PR TITLE
Remove duplicated data in graph refresh

### DIFF
--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -52,24 +52,11 @@ module ManagerRefresh::SaveCollection
       association.find_each do |record|
         index = inventory_collection.object_index_with_keys(unique_index_keys, record)
         if record_index[index]
-          # We have a duplicate in the DB, destroy it
-          record_for_destruction = nil
-
-          if record.respond_to?(:service)
-            # TODO(lsmola) Should we be also checking for tags, a record with less tags would get deleted?
-            # If there is possible service association, we need to keep the record that has the relation to a service
-            # and delete the one without. Service association is something we can't renew by the refresh.
-            if record_index[index].service.nil? && !record.service.nil?
-              record_for_destruction = record_index[index]
-              record_index[index]    = record
-            else
-              record_for_destruction = record
-            end
-          end
-
+          # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
+          # so we always keep the oldest record in the case of duplicates.
           _log.warn("A duplicate record was detected and destroyed, inventory_collection: '#{inventory_collection}', "\
-                    "record: '#{record_for_destruction}', duplicate_index: '#{index}'")
-          record_for_destruction.destroy
+                    "record: '#{record}', duplicate_index: '#{index}'")
+          record.destroy
         else
           record_index[index] = record
         end

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -464,6 +464,124 @@ describe ManagerRefresh::SaveInventory do
             }
           )
         end
+
+        it "cleans up duplicates, leaving the one with service relation" do
+          initialize_mocked_records
+
+          service = FactoryGirl.create(:service)
+
+          @vm1_dup1 = FactoryGirl.create(
+            :vm_cloud,
+            vm_data(1).merge(
+              :flavor                => @flavor_1,
+              :genealogy_parent      => @image1,
+              :key_pairs             => [@key_pair1],
+              :location              => 'host_10_10_10_1_dup_1.com',
+              :ext_management_system => @ems,
+            )
+          )
+
+          # Add service to this Vm
+          service.add_resource!(@vm1_dup1)
+
+          @vm1_dup2 = FactoryGirl.create(
+            :vm_cloud,
+            vm_data(1).merge(
+              :flavor                => @flavor_1,
+              :genealogy_parent      => @image1,
+              :key_pairs             => [@key_pair1],
+              :location              => 'host_10_10_10_1_dup_2.com',
+              :ext_management_system => @ems,
+            )
+          )
+
+          # Assert that the mocked data in the DB have the duplicates
+          assert_all_records_match_hashes(
+            [Vm.all, @ems.vms],
+            {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1_dup_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1_dup_2.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_12",
+              :name     => "vm_name_12",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_2",
+              :name     => "vm_name_2",
+              :location => "host_10_10_10_2.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_4",
+              :name     => "vm_name_4",
+              :location => "default_value_unknown",
+            }
+          )
+
+          # Now save the records using InventoryCollections
+          # Fill the InventoryCollections with data, that have a modified name
+          initialize_data_and_inventory_collections
+          add_data_to_inventory_collection(@data[:vms],
+                                           @vm_data_1.merge(:name => "vm_name_1_changed"),
+                                           @vm_data_12.merge(:name => "vm_name_12_changed"),
+                                           @vm_data_2.merge(:name => "vm_name_2_changed"),
+                                           @vm_data_4.merge(:name => "vm_name_4_changed"),
+                                           vm_data(5))
+          add_data_to_inventory_collection(@data[:miq_templates], @image_data_1, @image_data_2, @image_data_3)
+          add_data_to_inventory_collection(@data[:key_pairs], @key_pair_data_1, @key_pair_data_12, @key_pair_data_2,
+                                           @key_pair_data_3)
+          add_data_to_inventory_collection(@data[:hardwares], @hardware_data_1, @hardware_data_2, @hardware_data_12)
+          add_data_to_inventory_collection(@data[:disks],
+                                           @disk_data_1.merge(:device_type => "nvme_ssd_1"),
+                                           @disk_data_12.merge(:device_type => "nvme_ssd_12"),
+                                           @disk_data_13.merge(:device_type => "nvme_ssd_13"),
+                                           @disk_data_2.merge(:device_type => "nvme_ssd_2"))
+          add_data_to_inventory_collection(@data[:networks], @public_network_data_1, @public_network_data_12,
+                                           @public_network_data_13, @public_network_data_14, @public_network_data_2)
+          add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
+
+          # Invoke the InventoryCollections saving
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
+
+          # Assert that saved data have the updated values and we kept the Vm with service association while deleting
+          # others
+          assert_all_records_match_hashes(
+            [Vm.all, @ems.vms],
+            {
+              :id       => @vm1_dup1.id, # The vm with service relation remains in the DB
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1_changed",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :id       => @vm12.id,
+              :ems_ref  => "vm_ems_ref_12",
+              :name     => "vm_name_12_changed",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :id       => @vm2.id,
+              :ems_ref  => "vm_ems_ref_2",
+              :name     => "vm_name_2_changed",
+              :location => "host_10_10_10_2.com",
+            }, {
+              :id       => @vm4.id,
+              :ems_ref  => "vm_ems_ref_4",
+              :name     => "vm_name_4_changed",
+              :location => "default_value_unknown",
+            }, {
+              :id       => anything,
+              :ems_ref  => "vm_ems_ref_5",
+              :name     => "vm_name_5",
+              :location => "vm_location_5",
+            }
+          )
+        end
       end
 
       context "lazy_find vs find" do

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -469,6 +469,8 @@ describe ManagerRefresh::SaveInventory do
           initialize_mocked_records
 
           service = FactoryGirl.create(:service)
+          # Add service to this Vm1
+          service.add_resource!(@vm1)
 
           @vm1_dup1 = FactoryGirl.create(
             :vm_cloud,
@@ -480,9 +482,6 @@ describe ManagerRefresh::SaveInventory do
               :ext_management_system => @ems,
             )
           )
-
-          # Add service to this Vm
-          service.add_resource!(@vm1_dup1)
 
           @vm1_dup2 = FactoryGirl.create(
             :vm_cloud,
@@ -555,7 +554,7 @@ describe ManagerRefresh::SaveInventory do
           assert_all_records_match_hashes(
             [Vm.all, @ems.vms],
             {
-              :id       => @vm1_dup1.id, # The vm with service relation remains in the DB
+              :id       => @vm1.id, # The vm with service relation remains in the DB
               :ems_ref  => "vm_ems_ref_1",
               :name     => "vm_name_1_changed",
               :location => "host_10_10_10_1.com",

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -352,6 +352,118 @@ describe ManagerRefresh::SaveInventory do
           expect(vm12.key_pairs.pluck(:id)).to match_array([@key_pair1.id, @key_pair12.id])
           expect(vm2.key_pairs.pluck(:id)).to match_array([@key_pair2.id])
         end
+
+        it "cleans up duplicates while" do
+          initialize_mocked_records
+
+          @vm1_dup1 = FactoryGirl.create(
+            :vm_cloud,
+            vm_data(1).merge(
+              :flavor                => @flavor_1,
+              :genealogy_parent      => @image1,
+              :key_pairs             => [@key_pair1],
+              :location              => 'host_10_10_10_1.com',
+              :ext_management_system => @ems,
+            )
+          )
+
+          @vm1_dup2 = FactoryGirl.create(
+            :vm_cloud,
+            vm_data(1).merge(
+              :flavor                => @flavor_1,
+              :genealogy_parent      => @image1,
+              :key_pairs             => [@key_pair1],
+              :location              => 'host_10_10_10_1.com',
+              :ext_management_system => @ems,
+            )
+          )
+
+          # Assert that the mocked data in the DB do have duplicate vm_ems_ref_1
+          assert_all_records_match_hashes(
+            [Vm.all, @ems.vms],
+            {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_12",
+              :name     => "vm_name_12",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_2",
+              :name     => "vm_name_2",
+              :location => "host_10_10_10_2.com",
+            }, {
+              :ems_ref  => "vm_ems_ref_4",
+              :name     => "vm_name_4",
+              :location => "default_value_unknown",
+            }
+          )
+
+          # Now save the records using InventoryCollections
+          # Fill the InventoryCollections with data, that have a modified name
+          initialize_data_and_inventory_collections
+          add_data_to_inventory_collection(@data[:vms],
+                                           @vm_data_1.merge(:name => "vm_name_1_changed"),
+                                           @vm_data_12.merge(:name => "vm_name_12_changed"),
+                                           @vm_data_2.merge(:name => "vm_name_2_changed"),
+                                           @vm_data_4.merge(:name => "vm_name_4_changed"),
+                                           vm_data(5))
+          add_data_to_inventory_collection(@data[:miq_templates], @image_data_1, @image_data_2, @image_data_3)
+          add_data_to_inventory_collection(@data[:key_pairs], @key_pair_data_1, @key_pair_data_12, @key_pair_data_2,
+                                           @key_pair_data_3)
+          add_data_to_inventory_collection(@data[:hardwares], @hardware_data_1, @hardware_data_2, @hardware_data_12)
+          add_data_to_inventory_collection(@data[:disks],
+                                           @disk_data_1.merge(:device_type => "nvme_ssd_1"),
+                                           @disk_data_12.merge(:device_type => "nvme_ssd_12"),
+                                           @disk_data_13.merge(:device_type => "nvme_ssd_13"),
+                                           @disk_data_2.merge(:device_type => "nvme_ssd_2"))
+          add_data_to_inventory_collection(@data[:networks], @public_network_data_1, @public_network_data_12,
+                                           @public_network_data_13, @public_network_data_14, @public_network_data_2)
+          add_data_to_inventory_collection(@data[:flavors], @flavor_data_1, @flavor_data_2, @flavor_data_3)
+
+          # Invoke the InventoryCollections saving
+          ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
+
+          # Assert that saved data have the updated values and the duplicate vm_ems_ref_1 are gone
+          assert_all_records_match_hashes(
+            [Vm.all, @ems.vms],
+            {
+              :id       => anything, # There is no guarantee which duplicates are deleted
+              :ems_ref  => "vm_ems_ref_1",
+              :name     => "vm_name_1_changed",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :id       => @vm12.id,
+              :ems_ref  => "vm_ems_ref_12",
+              :name     => "vm_name_12_changed",
+              :location => "host_10_10_10_1.com",
+            }, {
+              :id       => @vm2.id,
+              :ems_ref  => "vm_ems_ref_2",
+              :name     => "vm_name_2_changed",
+              :location => "host_10_10_10_2.com",
+            }, {
+              :id       => @vm4.id,
+              :ems_ref  => "vm_ems_ref_4",
+              :name     => "vm_name_4_changed",
+              :location => "default_value_unknown",
+            }, {
+              :id       => anything,
+              :ems_ref  => "vm_ems_ref_5",
+              :name     => "vm_name_5",
+              :location => "vm_location_5",
+            }
+          )
+        end
       end
 
       context "lazy_find vs find" do


### PR DESCRIPTION
Make sure the refresh deletes a possible duplicate data, while keeping an important service relation intact. Specs included