### PR TITLE
Add relationship between VM and ResourceGroup.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   belongs_to :flavor
   belongs_to :orchestration_stack
   belongs_to :cloud_tenant
+  belongs_to :resource_group
 
   has_many :network_ports, :as => :device
   has_many :cloud_subnets, -> { distinct }, :through => :network_ports

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -1,2 +1,3 @@
 class ResourceGroup < ApplicationRecord
+  has_many :vms
 end

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -1,6 +1,16 @@
 describe VmCloud do
   subject { FactoryGirl.create(:vm_cloud) }
 
+  context "relationships" do
+    let(:resource_group) { FactoryGirl.create(:resource_group) }
+    before { subject.resource_group = resource_group }
+
+    it "has one resource group" do
+      expect(subject).to respond_to(:resource_group)
+      expect(subject.resource_group).to eql(resource_group)
+    end
+  end
+
   it "#post_create_actions" do
     expect(subject).to receive(:reconnect_events)
     expect(subject).to receive(:classify_with_parent_folder_path)

--- a/spec/models/resource_group_spec.rb
+++ b/spec/models/resource_group_spec.rb
@@ -1,0 +1,30 @@
+describe ResourceGroup do
+  let(:resource_group) do
+    FactoryGirl.create(
+      :resource_group,
+      :type    => "ResourceGroup",
+      :name    => "foo",
+      :ems_ref => "/subscriptions/xxx/resourceGroups/foo"
+    )
+  end
+
+  context "properties" do
+    it "has the expected resource group" do
+      expect(resource_group.type).to eql("ResourceGroup")
+    end
+
+    it "has the expected name" do
+      expect(resource_group.name).to eql("foo")
+    end
+
+    it "has the expected ems_ref" do
+      expect(resource_group.ems_ref).to eql("/subscriptions/xxx/resourceGroups/foo")
+    end
+  end
+
+  context "relationships" do
+    it "has many vms" do
+      expect(resource_group).to respond_to(:vms)
+    end
+  end
+end


### PR DESCRIPTION
There is currently no relationship setup between the Vm model and the ResourceGroup model. This addresses that, and adds in some initial specs for the ResourceGroup model.