### PR TITLE
[WIP] Fix rbac for string in order clause

### DIFF
--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -490,6 +490,13 @@ describe Rbac::Filterer do
           @template = FactoryGirl.create(:template_vmware, :name => "Template1", :host => @host1, :ext_management_system => @ems)
         end
 
+        it 'works with string in order paremeter' do
+          result = described_class.filtered(Vm, :include_for_find => {:host => {}, :order => 'created_on DESC'})
+          
+          expect { result.to_a }.not_to raise_error
+          expect(result.to_a).to match_array([@vm])
+        end
+
         it "honors ems_id conditions" do
           results = described_class.search(:class => "ManageIQ::Providers::Vmware::InfraManager::Template", :conditions => ["ems_id IS NULL"])
           objects = results.first


### PR DESCRIPTION
This was throwing error
```
Rbac::Filterer.filtered(Vm, {:include_for_find => {:host=> {}}, :order=>'created_on DESC'}).to_a
```
about `ambiguous column`


for example:
I am going to add RBAC for rss feed [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/rss_feed.rb#L38) and there is passed order clause as string (filled from 
https://github.com/ManageIQ/manageiq/blob/master/product/alerts/rss/newest_vms.yml#L30)

cc @kbrock 

@miq-bot assign @gtanzillo 
