### PR TITLE
add authentications sub collection to ConfigurationScriptPayload 

### DIFF
--- a/app/controllers/api/configuration_script_payloads_controller.rb
+++ b/app/controllers/api/configuration_script_payloads_controller.rb
@@ -1,4 +1,5 @@
 module Api
   class ConfigurationScriptPayloadsController < BaseController
+    include Subcollections::Authentications
   end
 end

--- a/app/controllers/api/subcollections/authentications.rb
+++ b/app/controllers/api/subcollections/authentications.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module Authentications
+      def authentications_query_resource(object)
+        object.respond_to?(:authentications) ? object.authentications : []
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -204,6 +204,7 @@
     :description: Authentications
     :options:
     - :collection
+    - :subcollection
     :verbs: *gpd
     :klass: Authentication
     :collection_actions:
@@ -223,6 +224,10 @@
       :delete:
       - :name: delete
         :identifier: embedded_automation_manager_credentials_delete
+    :subcollection_actions:
+      :get:
+      - :name: read
+        :identifier: embedded_automation_manager_credentials_view
   :automate:
     :description: Automate
     :options:
@@ -525,6 +530,8 @@
     - :collection
     :verbs: *g
     :klass: ConfigurationScriptPayload
+    :subcollections:
+      - :authentications
     :collection_actions:
       :get:
       - :name: read

--- a/spec/requests/api/configuration_script_payloads_spec.rb
+++ b/spec/requests/api/configuration_script_payloads_spec.rb
@@ -48,4 +48,38 @@ RSpec.describe 'Configuration Script Payloads API' do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  describe 'GET /api/configuration_script_payloads/:id/authentications' do
+    it 'returns the configuration script sources authentications' do
+      authentication = FactoryGirl.create(:authentication)
+      playbook = FactoryGirl.create(:configuration_script_payload, :authentications => [authentication])
+      api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :read, :get)
+
+      run_get("#{configuration_script_payloads_url(playbook.id)}/authentications", :expand => 'resources')
+
+      expected = {
+        'resources' => [
+          a_hash_including('id' => authentication.id)
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/configuration_script_payloads/:id/authentications/:id' do
+    it 'returns a specific authentication' do
+      authentication = FactoryGirl.create(:authentication)
+      playbook = FactoryGirl.create(:configuration_script_payload, :authentications => [authentication])
+      api_basic_authorize subcollection_action_identifier(:configuration_script_payloads, :authentications, :read, :get)
+
+      run_get("#{configuration_script_payloads_url(playbook.id)}/authentications/#{authentication.id}")
+
+      expected = {
+        'id' => authentication.id
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
This adds an authentications subcollection to ConfigurationScriptPayload as needed to return authentications available on a playbook in the UI.

cc: @h-kataria 
@miq-bot add_label enhancement, api 
@miq-bot assign @abellotti 

