### PR TITLE
Verify oVirt TLS certificates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "novnc-rails",                    "~>0.2"
 gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
-gem "ovirt-engine-sdk",               "~>4.0.6",       :require => false # Required by the oVirt provider
+gem "ovirt-engine-sdk",               "~>4.0.10",      :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "pg-pglogical",                   "~>1.0.0",       :require => false
 gem "puma",                           "~>3.3.0"

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -19,32 +19,36 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     unless options[:skip_supported_api_validation] || supports_the_api_version?(version)
       raise "version #{version} of the api is not supported by the provider"
     end
-    # If there is API path stored in the endpoints table and use it:
+
+    # If the API path is stored in the endpoints table then use it:
     path = options[:path] || default_endpoint.path
     _log.info("Using stored API path '#{path}'.") unless path.blank?
 
-    server   = options[:ip] || address
-    port     = options[:port] || self.port
-    username = options[:user] || authentication_userid(options[:auth_type])
-    password = options[:pass] || authentication_password(options[:auth_type])
-    service  = options[:service] || "Service"
+    # Prepare the options to call the method that creates the actual connection:
+    connect_options = {
+      :server   => options[:ip] || address,
+      :port     => options[:port] || self.port,
+      :username => options[:user] || authentication_userid(options[:auth_type]),
+      :password => options[:pass] || authentication_password(options[:auth_type]),
+      :service  => options[:service] || "Service"
+    }
 
     # Starting with version 4 of oVirt authentication doesn't work when using directly the IP address, it requires
     # the fully qualified host name, so if we received an IP address we try to convert it into the corresponding
     # host name:
     if resolve_ip_addresses?
-      resolved = resolve_ip_address(server)
-      if resolved != server
-        _log.info("IP address '#{server}' has been resolved to host name '#{resolved}'.")
+      resolved = resolve_ip_address(connect_options[:server])
+      if resolved != connect_options[:server]
+        _log.info("IP address '#{connect_options[:server]}' has been resolved to host name '#{resolved}'.")
         default_endpoint.hostname = resolved
-        server = resolved
+        connect_options[:server] = resolved
       end
     end
 
     # Create the underlying connection according to the version of the oVirt API requested by
     # the caller:
     connect_method = "raw_connect_v#{version}".to_sym
-    connection = self.class.public_send(connect_method, server, port, path, username, password, service)
+    connection = self.class.public_send(connect_method, connect_options)
 
     # Copy the API path to the endpoints table:
     default_endpoint.path = version == 4 ? '/ovirt-engine/api' : connection.api_path
@@ -268,23 +272,23 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     end
 
     # Connect to the engine using version 4 of the API and the `ovirt-engine-sdk` gem.
-    def raw_connect_v4(server, port, path, username, password, service, scheme = 'https')
+    def raw_connect_v4(options = {})
       require 'ovirtsdk4'
 
       # Get the timeout from the configuration:
-      timeout, = ems_timeouts(:ems_redhat, service)
+      timeout, = ems_timeouts(:ems_redhat, options[:service])
 
       url = URI::Generic.build(
-        :scheme => scheme,
-        :host   => server,
-        :port   => port,
-        :path   => path
+        :scheme => options[:scheme],
+        :host   => options[:server],
+        :port   => options[:port],
+        :path   => options[:path]
       )
 
       OvirtSDK4::Connection.new(
         :url      => url.to_s,
-        :username => username,
-        :password => password,
+        :username => options[:username],
+        :password => options[:password],
         :timeout  => timeout,
         :insecure => true,
         :log      => $rhevm_log,
@@ -292,24 +296,24 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     end
 
     # Connect to the engine using version 3 of the API and the `ovirt` gem.
-    def raw_connect_v3(server, port, path, username, password, service)
+    def raw_connect_v3(options = {})
       require 'ovirt'
       require 'ovirt_provider/inventory/ovirt_inventory'
       Ovirt.logger = $rhevm_log
 
       params = {
-        :server     => server,
-        :port       => port.presence && port.to_i,
-        :path       => path,
-        :username   => username,
-        :password   => password,
+        :server     => options[:server],
+        :port       => options[:port].presence && options[:port].to_i,
+        :path       => options[:path],
+        :username   => options[:username],
+        :password   => options[:password],
         :verify_ssl => false
       }
 
-      read_timeout, open_timeout = ems_timeouts(:ems_redhat, service)
+      read_timeout, open_timeout = ems_timeouts(:ems_redhat, options[:service])
       params[:timeout]      = read_timeout if read_timeout
       params[:open_timeout] = open_timeout if open_timeout
-      const = service == "Inventory" ? OvirtInventory : Ovirt.const_get(service)
+      const = options[:service] == "Inventory" ? OvirtInventory : Ovirt.const_get(options[:service])
       const.new(params)
     end
 


### PR DESCRIPTION
This patch adds to the oVirt provider support for checking the TLS
certificates of the server, using the recently introduced
`certificate_authority` column of the `endpoints` table.