### PR TITLE
Configure apache balancer with up to 10 members at startup

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -85,10 +85,10 @@ module MiqServer::EnvironmentManagement
     def prep_apache_proxying
       return unless MiqEnvironment::Command.supports_apache?
 
-      MiqApache::Control.stop
       MiqUiWorker.install_apache_proxy_config
       MiqWebServiceWorker.install_apache_proxy_config
       MiqWebsocketWorker.install_apache_proxy_config
+      MiqApache::Control.restart
     end
   end
 

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -26,4 +26,25 @@ describe MiqUiWorker do
       expect(MiqUiWorker.all_ports_in_use).to eq([3000])
     end
   end
+
+  it ".port_range" do
+    expect(described_class.port_range.to_a).to eq((3000..3009).to_a)
+  end
+
+  describe ".reserve_port" do
+    it "returns next free port" do
+      ports = (3000..3001).to_a
+      expect(described_class.reserve_port(ports)).to eq(3002)
+    end
+
+    it "raises if no ports available" do
+      ports = (3000..3009).to_a
+      expect { described_class.reserve_port(ports) }.to raise_error(NoFreePortError)
+    end
+
+    it "returns free port between used ports" do
+      ports = [3000, 3002]
+      expect(described_class.reserve_port(ports)).to eq(3001)
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1422988

Start Ui, Web Service, Web Socket, etc. puma workers bound to a port
from STARTING_PORT to the maximum worker count port (3000 to 3009 if max
worker count is 10).  Configure apache at boot with these ports as
balancer members.

Fixes a failure after we start new puma workers and try to gracefully
restart apache.  The next request will fail since apache is waiting for
active connections to close before restarting.  The subsequent request will
then be ok since the failure would cause the websocket connections to
close, allowing apaache to restart fully.

Previously, we would add and remove members in the balancer configuration
when starting or stopping puma workers.  We would then gracefully restart
apache since the new workers wouldn't be used until apache reloaded the
configuration.  Note, we didn't do anything after removing members from
the balancer configuration because apache's mod_proxy_balancer gracefully
handles dead members by marking them as in Error and not retrying them for
60 seconds by default. Therefore, it's not necessary to restart apache to
"remove" members.

The problem is when we would try to add balancer members to the
configuration and gracefully restart apache.  It turns out, our web
socket workers maintain active connections to apache so apache wouldn't
restart until those connections were closed.

Now, we take the idea mentioned above of the mod_proxy_balancer
keeping track of which members are alive or in error by configuring up
to 10, maximum_workers_count, members at server startup.  We can then
start and stop workers and let apache route traffic to the members that
are alive.  We no longer have to update the apache configuration and
restart it when a worker starts or stops.

Note, apache has a graceful reload option that could allow us to
maintain an accurate list of balancer members as workers start and stop
and tell apache workers to gracefully reload the configuration.  This
option was buggy until fixed in [1]. It also required us to keep
touching the balancer configuration which we probably shouldn't have ben
doing in the first place.

[1] https://bz.apache.org/bugzilla/show_bug.cgi?id=44736