### PR TITLE
Create temporary inventory when execute a playbook

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -89,7 +89,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :description              => description || '',
       :project                  => playbook.configuration_script_source.manager_ref,
       :playbook                 => playbook.name,
-      :inventory                => tower.inventory_root_groups.first.ems_ref,
+      :inventory                => tower.inventory_root_groups.find_by!(:name => 'Demo Inventory').ems_ref,
       :ask_variables_on_launch  => true,
       :ask_limit_on_launch      => true,
       :ask_inventory_on_launch  => true,

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -6,7 +6,7 @@ describe ServiceTemplateAnsiblePlaybook do
   let(:config_script) { FactoryGirl.create(:configuration_script) }
   let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
 
-  let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group) }
+  let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
   let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
   let(:ems) do
     FactoryGirl.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group])


### PR DESCRIPTION
Create a temporary inventory and add hosts to it before job execution in the `preprocess` step.
Delete the temporary inventory after job execution in the `postprocess` step

Every job template is created with default inventory `Demo Inventory` which contains `localhost`. `Demo Inventory` comes with tower installation. We can change it if the embedded tower will configure a formal localhost inventory.

Temporary is created with default organization which has id = 1. Again we can change it if the embedded tower will configure a formal default organization.

Will skip the temporary inventory creation/deletion if the playbook runs at localhost.

https://www.pivotaltracker.com/story/show/139020599