### PR TITLE
Perfomance fix for Object Storage Manager deletion

### DIFF
--- a/app/models/manageiq/providers/storage_manager/object_mixin.rb
+++ b/app/models/manageiq/providers/storage_manager/object_mixin.rb
@@ -3,8 +3,16 @@ module ManageIQ::Providers::StorageManager::ObjectMixin
 
   included do
     has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_object_store_objects,    :foreign_key => :ems_id
 
     supports :object_storage
+
+    after_destroy :cleanup_objects
+
+    private
+
+    def cleanup_objects
+      cloud_object_store_objects.includes(:taggings).find_each(&:destroy)
+    end
   end
 end


### PR DESCRIPTION
Recently, the inventorying of S3 objects was merged to the master. 
https://github.com/ManageIQ/manageiq-providers-amazon/pull/123
Since a lot of objects could be stored on S3, user wouldn't be able to delete Amazon provider.

This fix allows destroying of storage manager with 40K objects in 40 seconds.

@roliveri please, review

@miq-bot add_label euwe/no, providers, providers/storage, performance