### PR TITLE
Add a #backlog method to PglogicalSubscription objects 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem "open4",                          "~>1.3.0",       :require => false
 gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "ovirt-engine-sdk",               "~>4.0.6",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.4.0",       :require => false
-gem "pg-pglogical",                   "~>1.0.0",       :require => false
+gem "pg-pglogical",                   "~>1.1.0",       :require => false
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.0.1"

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -164,7 +164,7 @@ class PglogicalSubscription < ActsAsArModel
   private
 
   def remote_region_number
-    MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql") do |_conn|
+    with_remote_connection do |_conn|
       return MiqRegionRemote.region_number_from_sequence
     end
   end
@@ -217,7 +217,7 @@ class PglogicalSubscription < ActsAsArModel
     local_errors = EvmDatabase.check_schema
     raise local_errors if local_errors
     find_password if password.nil?
-    MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql") do |conn|
+    with_remote_connection do |conn|
       remote_errors = EvmDatabase.check_schema(conn)
       raise remote_errors if remote_errors
     end
@@ -236,5 +236,11 @@ class PglogicalSubscription < ActsAsArModel
 
   def decrypted_password
     MiqPassword.try_decrypt(password)
+  end
+
+  def with_remote_connection
+    MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql") do |conn|
+      yield conn
+    end
   end
 end

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -102,12 +102,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def backlog
-    connection.select_value(<<-SQL).to_i
-      SELECT pg_xlog_location_diff(
-        #{connection.quote(remote_node_lsn)},
-        #{connection.quote(remote_replication_lsn)}
-      )
-    SQL
+    connection.xlog_location_diff(remote_node_lsn, remote_replication_lsn)
   end
 
   # translate the output from the pglogical stored proc to our object columns
@@ -254,7 +249,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def remote_node_lsn
-    with_remote_connection { |conn| conn.select_value("SELECT pg_current_xlog_insert_location()") }
+    with_remote_connection(&:xlog_location)
   end
 
   def with_remote_connection

--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -11,6 +11,14 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
     select_value("SELECT pg_backend_pid()").to_i
   end
 
+  def xlog_location
+    select_value("SELECT pg_current_xlog_insert_location()")
+  end
+
+  def xlog_location_diff(lsn1, lsn2)
+    select_value("SELECT pg_xlog_location_diff(#{quote(lsn1)}, #{quote(lsn2)})").to_i
+  end
+
   def client_connections
     data = select(<<-SQL, "Client Connections").to_a
                   SELECT client_addr   AS client_address

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -1,6 +1,18 @@
 describe "ar_dba extension" do
   let(:connection) { ApplicationRecord.connection }
 
+  describe "#xlog_location" do
+    it "returns a valid lsn" do
+      expect(connection.xlog_location).to match(%r{\h+/\h+})
+    end
+  end
+
+  describe "#xlog_location_diff" do
+    it "returns the correct xlog difference" do
+      expect(connection.xlog_location_diff("18/72F84A48", "18/72F615B8")). to eq(144_528)
+    end
+  end
+
   describe "#primary_key_index" do
     it "returns nil when there is no primary key" do
       table_name = "no_pk_test"

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -417,7 +417,7 @@ describe PglogicalSubscription do
 
     it "returns the correct value" do
       expect(MiqRegionRemote).to receive(:with_remote_connection).and_yield(remote_connection)
-      expect(remote_connection).to receive(:select_value).and_return("0/42108F8")
+      expect(remote_connection).to receive(:xlog_location).and_return("0/42108F8")
 
       expect(described_class.first.backlog).to eq(12_120)
     end


### PR DESCRIPTION
This will show the replication backlog in bytes for the particular subscription.

This uses the functionality added to the pg-pglogical gem in ManageIQ/pg-pglogical#8

This will also need a new gem version to pull in the changes so I will mark this as WIP until that is worked out.