### PR TITLE
Remove 'agent_class' related logic from Job model

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,7 +29,7 @@ class Job < ApplicationRecord
     job.initialize_attributes
     job.save
     job.create_miq_task(job.attributes_for_task)
-    $log.info "Job created: guid: [#{job.guid}], userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], agent class: [#{job.agent_class}], agent id: [#{job.agent_id}], zone: [#{job.zone}]"
+    $log.info "Job created: guid: [#{job.guid}], userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], server id: [#{job.agent_id}], zone: [#{job.zone}]"
     job.signal(:initializing)
     job
   end
@@ -56,18 +56,18 @@ class Job < ApplicationRecord
 
   def check_active_on_destroy
     if self.is_active?
-      _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+      _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], server id: [#{agent_id}], zone: [#{zone}]"
       throw :abort
     end
 
-    _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+    _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], server id: [#{agent_id}], zone: [#{zone}]"
     true
   end
 
-  def self.agent_state_update_queue(jobid, state, message = nil)
+  def self.agent_message_update_queue(jobid, message)
     job = Job.where("guid = ?", jobid).select("id, state, guid").first
     unless job.nil?
-      job.agent_state_update(state, message)
+      job.agent_message_update(message)
     else
       _log.warn "jobid: [#{jobid}] not found"
     end
@@ -76,12 +76,9 @@ class Job < ApplicationRecord
     _log.log_backtrace(err)
   end
 
-  def agent_state_update(agent_state, agent_message = nil)
-    # Handle a single array parm coming from the queue
-    agent_state, agent_message = agent_state if agent_state.kind_of?(Array)
-
-    $log.info("JOB([#{guid}] Agent state update: state: [#{agent_state}], message: [#{agent_message}]")
-    update_attributes(:agent_state => agent_state, :agent_message => agent_message)
+  def agent_message_update(agent_message)
+    $log.info("JOB([#{guid}] Agent message update: [#{agent_message}]")
+    update_attributes(:agent_message => agent_message)
 
     return unless self.is_active?
 
@@ -184,10 +181,8 @@ class Job < ApplicationRecord
           next unless job.updated_on < job.current_job_timeout(job.timeout_adjustment).seconds.ago
 
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
-          if job.agent_class == "MiqServer"
-            # TODO: can we add method_name, queue_name, role, instance_id to the exists?
-            next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => job.agent_class)
-          end
+          # TODO: can we add method_name, queue_name, role, instance_id to the exists?
+          next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => "MiqServer")
           job.timeout!
         end
     rescue Exception

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -79,7 +79,7 @@ class JobProxyDispatcher
 
           if proxy
             # Skip this embedded scan if the host/vc we'd need has already exceeded the limit
-            next if self.embedded_resource_limit_exceeded?(job)
+            next if embedded_resource_limit_exceeded?(job)
             _log.info "STARTING job: [#{job.guid}] on proxy: [#{proxy.name}]"
             Benchmark.current_realtime[:start_job_on_proxy_count] += 1
             Benchmark.realtime_block(:start_job_on_proxy) { start_job_on_proxy(job, proxy) }
@@ -167,7 +167,8 @@ class JobProxyDispatcher
     assign_proxy_to_job(proxy, job)
     _log.info "Job [#{job.guid}] update: userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], server id: [#{job.agent_id}]"
     job_options = {:args => ["start"], :zone => MiqServer.my_zone}
-    job_options.merge!(:server_guid => proxy.guid, :role => "smartproxy")
+    job_options[:server_guid => proxy.guid]
+    job_options[:role => "smartproxy"]
     @active_vm_scans_by_zone[MiqServer.my_zone] += 1
     queue_signal(job, job_options)
   end

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -79,7 +79,7 @@ class JobProxyDispatcher
 
           if proxy
             # Skip this embedded scan if the host/vc we'd need has already exceeded the limit
-            next if proxy.kind_of?(MiqServer) && self.embedded_resource_limit_exceeded?(job)
+            next if self.embedded_resource_limit_exceeded?(job)
             _log.info "STARTING job: [#{job.guid}] on proxy: [#{proxy.name}]"
             Benchmark.current_realtime[:start_job_on_proxy_count] += 1
             Benchmark.realtime_block(:start_job_on_proxy) { start_job_on_proxy(job, proxy) }
@@ -165,32 +165,28 @@ class JobProxyDispatcher
 
   def start_job_on_proxy(job, proxy)
     assign_proxy_to_job(proxy, job)
-    _log.info "Job [#{job.guid}] update: userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], agent class: [#{job.agent_class}], agent id: [#{job.agent_id}]"
+    _log.info "Job [#{job.guid}] update: userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], server id: [#{job.agent_id}]"
     job_options = {:args => ["start"], :zone => MiqServer.my_zone}
-    job_options.merge!(:server_guid => proxy.guid, :role => "smartproxy") if proxy.kind_of?(MiqServer)
+    job_options.merge!(:server_guid => proxy.guid, :role => "smartproxy")
     @active_vm_scans_by_zone[MiqServer.my_zone] += 1
     queue_signal(job, job_options)
   end
 
   def assign_proxy_to_job(proxy, job)
     job.agent_id        = proxy.id
-    job.agent_class     = proxy.class.to_s
-    job.agent_name      = proxy.name
     job.started_on      = Time.now.utc
     job.dispatch_status = "active"
     job.save
 
     # Increment the counts for busy proxies and busy hosts for embedded
-    busy_proxies["#{job.agent_class}_#{job.agent_id}"] ||= 0
-    busy_proxies["#{job.agent_class}_#{job.agent_id}"] += 1
+    busy_proxies["MiqServer_#{job.agent_id}"] ||= 0
+    busy_proxies["MiqServer_#{job.agent_id}"] += 1
 
     # Track the host/vc resource for embedded scans so we can limit the resource impact
-    if proxy.kind_of?(MiqServer)
-      key = embedded_scan_resource(@vm)
-      if key
-        busy_resources_for_embedded_scanning[key] ||= 0
-        busy_resources_for_embedded_scanning[key] += 1
-      end
+    key = embedded_scan_resource(@vm)
+    if key
+      busy_resources_for_embedded_scanning[key] ||= 0
+      busy_resources_for_embedded_scanning[key] += 1
     end
   end
 
@@ -246,11 +242,11 @@ class JobProxyDispatcher
   def busy_proxies
     @busy_proxies_hash ||= begin
       Job.where(:dispatch_status => "active")
-      .where("state != ?", "finished")
-      .select([:agent_id, :agent_class])
+         .where("state != ?", "finished")
+         .select([:agent_id])
       .each_with_object({}) do |j, busy_hsh|
-        busy_hsh["#{j.agent_class}_#{j.agent_id}"] ||= 0
-        busy_hsh["#{j.agent_class}_#{j.agent_id}"] += 1
+        busy_hsh["MiqServer_#{j.agent_id}"] ||= 0
+        busy_hsh["MiqServer_#{j.agent_id}"] += 1
       end
     end
   end
@@ -288,7 +284,6 @@ class JobProxyDispatcher
 
     vms_in_embedded_scanning =
       Job.where(:dispatch_status => "active")
-      .where(:agent_class      => "MiqServer")
       .where(:target_class     => "VmOrTemplate")
       .where("state != ?", "finished")
       .pluck(:target_id).compact.uniq

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -210,7 +210,6 @@ module ScanningMixin
     ost.xml_class = XmlHash::Document
 
     _log.debug "Scanning - Initializing scan"
-    update_agent_state(ost, "Scanning", "Initializing scan")
     bb, last_err = nil
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
@@ -246,10 +245,9 @@ module ScanningMixin
       _log.debug "categories = [ #{categories.join(', ')} ]"
 
       categories.each do |c|
-        update_agent_state(ost, "Scanning", "Scanning #{c}")
         _log.info "Scanning [#{c}] information.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         st = Time.now
-        xml = extractor.extract(c) { |scan_data| update_agent_state(ost, "Scanning", scan_data[:msg]) }
+        xml = extractor.extract(c)
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         if xml
@@ -277,7 +275,6 @@ module ScanningMixin
       last_err = scanErr
     ensure
       bb.close if bb
-      update_agent_state(ost, "Scanning", "Scanning completed.")
 
       # If we are sent a TaskId transfer a end of job summary xml.
       _log.info "Starting: Sending scan summary to server.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
@@ -327,7 +324,6 @@ module ScanningMixin
       )
       bb = Manageiq::BlackBox.new(guid, ost)
 
-      update_agent_state(ost, "Synchronize", "Synchronization in progress")
       categories.each do |c|
         c.delete!("\"")
         c.strip!
@@ -368,16 +364,8 @@ module ScanningMixin
       save_metadata_op(xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       _log.info "Completed: Sending target summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
 
-      update_agent_state(ost, "Synchronize", "Synchronization complete")
-
       raise syncErr if syncErr
     end
     ost.value = "OK\n"
-  end
-
-  def update_agent_state(ost, state, message)
-    ost.agent_state = state
-    ost.agent_message = message
-    agent_job_state_op(ost.taskid, ost.agent_state, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
   end
 end

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -29,27 +29,6 @@ module ScanningOperationsMixin
     true
   end
 
-  def agent_job_state_op(jobid, state, message = nil)
-    _log.info "jobid: [#{jobid}] starting"
-    begin
-      Timeout.timeout(WS_TIMEOUT) do
-        MiqQueue.put(
-          :class_name  => "Job",
-          :method_name => "agent_state_update_queue",
-          :args        => [jobid, state, message],
-          :task_id     => "agent_job_state_#{Time.now.to_i}",
-          :zone        => MiqServer.my_zone,
-          :role        => "smartstate"
-        )
-        return true
-      end
-    rescue Exception => err
-      _log.log_backtrace(err)
-      ScanningOperations.reconnect_to_db
-      return false
-    end
-  end
-
   def task_update_op(task_id, state, status, message)
     _log.info "task_id: [#{task_id}] starting"
     begin

--- a/product/views/Job.yaml
+++ b/product/views/Job.yaml
@@ -27,7 +27,6 @@ cols:
 - message
 - name
 - userid
-- agent_name
 - agent_message
 - target_class
 - target_id
@@ -44,7 +43,6 @@ col_order:
 - message
 - name
 - userid
-- agent_name
 - agent_message
 
 # Column titles, in order
@@ -56,7 +54,6 @@ headers:
 - Message
 - Task Name
 - User
-- Owner
 - Owner Message
 
 # Condition(s) string for the SQL query

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -9,7 +9,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
     NUM_OF_STORAGES = 3
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
-      vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"])
+      vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND target_class = ?", "active", "finished", "VmOrTemplate"])
                                     .pluck(:target_id).compact.uniq
       expect(vms_in_embedded_scanning.length).to be > 0
 


### PR DESCRIPTION
We are not using agents anymore and ```agent_class``` related logic could be removed.
This PR will allow to drop ```agent_class``` column from ```jobs``` table and with goal of merging ```Job``` and ```MiqTask``` models, would remove need for migration ```agent_class``` column  to ```miq_tasks``` table

This PR includes https://github.com/ManageIQ/manageiq/pull/13952
Related PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/442

@miq-bot add-label core

\cc @Fryguy @gtanzillo 