### PR TITLE
[api] Collections API for VmOrTemplate

### DIFF
--- a/app/controllers/api/vms_or_templates_controller.rb
+++ b/app/controllers/api/vms_or_templates_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  class VmsOrTemplatesController < BaseController
+    include Subcollections::Policies
+    include Subcollections::PolicyProfiles
+    include Subcollections::Tags
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -2267,6 +2267,72 @@
       :delete:
       - :name: delete
         :identifier: vm_snapshot_delete
+  :vms_or_templates:
+    :description: VMs or Templates
+    :identifier: miq_template
+    :options:
+    - :collection
+    :verbs: *gpd
+    :klass: VmOrTemplate
+    :subcollections:
+    - :tags
+    - :policies
+    - :policy_profiles
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_template_show_list
+      :post:
+      - :name: query
+        :identifier: miq_template_show_list
+      - :name: refresh
+        :identifier: miq_template_refresh
+        :disabled: true
+      - :name: edit
+        :identifier: miq_template_edit
+        :disabled: true
+      - :name: set_ownership
+        :identifier: miq_template_ownership
+      - :name: delete
+        :identifier: miq_template_delete
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_template_show
+      :post:
+      - :name: refresh
+        :identifier: miq_template_refresh
+        :disabled: true
+      - :name: edit
+        :identifier: miq_template_edit
+        :disabled: true
+      - :name: set_ownership
+        :identifier: miq_template_ownership
+      :delete:
+      - :name: delete
+        :identifier: miq_template_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: miq_template_tag
+      - :name: unassign
+        :identifier: miq_template_tag
+    :policies_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: miq_template_protect
+      - :name: unassign
+        :identifier: miq_template_protect
+      - :name: resolve
+        :identifier: miq_template_policy_sim
+    :policy_profiles_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: miq_template_protect
+      - :name: unassign
+        :identifier: miq_template_protect
+      - :name: resolve
+        :identifier: miq_template_policy_sim
   :zones:
     :description: Zones
     :identifier: zone

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -264,6 +264,11 @@ describe "Rest API Collections" do
       test_collection_query(:vms, vms_url, Vm, :guid)
     end
 
+    it "query Vms or Templates" do
+      FactoryGirl.create(:vm_vmware)
+      test_collection_query(:vms_or_templates, vms_or_templates_url, VmOrTemplate, :guid)
+    end
+
     it "query Zones" do
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_query(:zones, zones_url, Zone)


### PR DESCRIPTION
Collections API for `VmOrTemplate`

Required in SUI to retrieve the `platform` attribute on a GET request like --

`/api/vms_or_templates/12?attributes=platform`

I've used the `miq_template` identifiers for the `collection_actions` since there are no identifiers for `VmOrTemplate` as such.