### PR TITLE
Prevent NoMethodError when api_version is nil in VmImport

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -31,7 +31,7 @@ module ManageIQ::Providers::Redhat::InfraManager::VmImport
   end
 
   def validate_import_vm
-    api_version >= '4.0'
+    api_version && api_version >= '4.0'
   end
 
   private


### PR DESCRIPTION
When the provider was not yet refreshed (and thus api_version was `nil`) the `validate_import_vm` method would raise an exception.