### PR TITLE
Remove the unused jQplot charting provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ gem "novnc-rails",                    "~>0.2"
 gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
-gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "ovirt-engine-sdk",               "~>4.0.6",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "pg-pglogical",                   "~>1.0.0",       :require => false

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -16,8 +16,8 @@ describe MiqReport do
     @show_title   = true
     @options = MiqReport.graph_options(600, 400)
 
-    allow(Charting).to receive(:backend).and_return(:jqplot)
-    allow(Charting).to receive(:format).and_return(:jqplot)
+    allow(Charting).to receive(:backend).and_return(:c3)
+    allow(Charting).to receive(:format).and_return(:c3)
   end
 
   context 'graph_options' do
@@ -48,9 +48,7 @@ describe MiqReport do
       rpt.to_chart(@report_theme, @show_title, @options)
       chart = rpt.chart
 
-      # {:data=>[[nil]], :options=>{:title=>"No records found for this chart"}}
-      expect(chart[:data][0][0]).to be_nil
-      expect(chart[:options][:title]).to eq('No records found for this chart')
+      expect(chart[:data][:columns][0]).to be_nil
     end
 
     it "returns a valid chart for a report with data" do
@@ -62,8 +60,7 @@ describe MiqReport do
       rpt.to_chart(@report_theme, @show_title, @options)
       chart = rpt.chart
 
-      expect(chart[:data][0][0]).to eq(5)
-      expect(chart[:options][:title]).to eq(name)
+      expect(chart[:data][:columns][0][1]).to eq(5)
     end
   end
 end

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -86,7 +86,7 @@ describe MiqReportResult do
       @show_title   = true
       @options = MiqReport.graph_options(600, 400)
 
-      allow(Charting).to receive(:detect_available_plugin).and_return(JqplotCharting)
+      allow(Charting).to receive(:detect_available_plugin).and_return(C3Charting)
     end
 
     it "should save the original report metadata and the generated table as a binary blob" do


### PR DESCRIPTION
Since we're using C3 for charting, this library got obsolete and it can be :scissors: :scissors: :toilet: :toilet:-ed

UI part: https://github.com/ManageIQ/manageiq-ui-classic/pull/445
Pivotal story: https://www.pivotaltracker.com/story/show/140411763