### PR TITLE
[EUWE] Remove disabling of 'instance_retire' button

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1133,7 +1133,7 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
-      when "instance_retire", "instance_retire_now"
+      when "instance_retire_now"
         return N_("Instance is already retired") if @record.retired
       when "vm_timeline"
         unless @record.has_events? || @record.has_events?(:policy_events)


### PR DESCRIPTION
Leaves the button "Set Retirement Date" enabled even for a retired instance

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1306471

Steps for Testing/QA
-------------------------------
1. retire an instance
2. go to that instance details page
3. click `Lifecycle`
4. button `Set Retirement Date` should be enabled
 
**(see BZ ticket for more info)**