### PR TITLE
add missing authentication require_nested

### DIFF
--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
   require_nested :InventoryGroup
   require_nested :InventoryRootGroup
+  require_nested :Authentication
 
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"


### PR DESCRIPTION
otherwise we encounter the dreaded 

```
warning: toplevel constant Authentication referenced by ManageIQ::Providers::AutomationManager::Authentication
```

warning

@miq-bot add_labels bug, providers/ansible_tower
@miq-bot assign @agrare 