### PR TITLE
Verify container TLS, support custom CA

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
@@ -10,8 +10,12 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
       @hawkular_entrypoint, @hawkular_credentials, @hawkular_options)
   end
 
+  # may be nil
+  def hawkular_endpoint
+    @ext_management_system.connection_configurations.hawkular.try(:endpoint)
+  end
+
   def hawkular_entrypoint
-    hawkular_endpoint = @ext_management_system.connection_configurations.hawkular.try(:endpoint)
     hawkular_endpoint_empty = hawkular_endpoint.try(:hostname).blank?
     worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
 
@@ -26,9 +30,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
   end
 
   def hawkular_options
-    { :tenant         => @tenant,
-      :verify_ssl     => @ext_management_system.verify_ssl_mode,
-      :http_proxy_uri => VMDB::Util.http_proxy_uri.to_s
+    {
+      :tenant         => @tenant,
+      :http_proxy_uri => VMDB::Util.http_proxy_uri.to_s,
+      :verify_ssl     => @ext_management_system.verify_ssl_mode(hawkular_endpoint),
+      :ssl_cert_store => @ext_management_system.ssl_cert_store(hawkular_endpoint),
     }
   end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/hawkular_client_mixin.rb
@@ -2,12 +2,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
   def hawkular_client
     require 'hawkular/hawkular_client'
 
-    @hawkular_entrypoint ||= hawkular_entrypoint
+    @hawkular_uri ||= hawkular_uri
     @hawkular_credentials ||= hawkular_credentials
     @hawkular_options ||= hawkular_options
 
-    Hawkular::Metrics::Client.new(
-      @hawkular_entrypoint, @hawkular_credentials, @hawkular_options)
+    Hawkular::Metrics::Client.new(@hawkular_uri, @hawkular_credentials, @hawkular_options)
   end
 
   # may be nil
@@ -15,7 +14,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Hawkul
     @ext_management_system.connection_configurations.hawkular.try(:endpoint)
   end
 
-  def hawkular_entrypoint
+  def hawkular_uri
     hawkular_endpoint_empty = hawkular_endpoint.try(:hostname).blank?
     worker_class = ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -87,7 +87,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     health_url   = pod_proxy_url(client, INSPECTOR_HEALTH_PATH)
     http_options = {
       :use_ssl     => health_url.scheme == 'https',
-      :verify_mode => ext_management_system.verify_ssl_mode
+      :verify_mode => ext_management_system.verify_ssl_mode,
+      :cert_store  => ext_management_system.ssl_cert_store,
     }
 
     # TODO: move this to a more appropriate place (lib)
@@ -281,7 +282,10 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     ImageInspectorClient::Client.new(
       pod_proxy_url(kubeclient, ''),
       'v1',
-      :ssl_options    => kubeclient.ssl_options,
+      :ssl_options    => {
+        :verify_ssl => ext_management_system.verify_ssl_mode,
+        :cert_store => ext_management_system.ssl_cert_store
+      },
       :auth_options   => kubeclient.auth_options,
       :http_proxy_uri => kubeclient.http_proxy_uri
     )

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -37,7 +37,7 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
       Kubeclient::Client.new(
         raw_api_endpoint(hostname, port, '/oapi'),
         options[:version] || api_version,
-        :ssl_options    => { :verify_ssl => verify_ssl_mode },
+        :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
         :http_proxy_uri => VMDB::Util.http_proxy_uri
       )

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -6,7 +6,7 @@ class MockKubeClient
   end
 
   def proxy_url(*_args)
-    'http://test.com'
+    'https://test.com'
   end
 
   def headers(*_args)

--- a/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/scanning/job.yml
+++ b/spec/vcr_cassettes/manageiq/providers/kubernetes/container_manager/scanning/job.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://test.com/healthz
+    uri: https://test.com/healthz
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Support verifying kubernetes/openshift TLS certificates, including self-signed certificates.

The UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/450 will consistently set endpoint (security_protocol, verify_ssl, certificate_authority) for containers, with 3 modes:
- (`ssl-with-validation`, 1, nil)
- (`ssl-with-validation-custom-ca`, 1, certificate_authority text)
- (`ssl-without-validation`, 0, nil)
[Some providers use just `ssl` but with inconsistent meanings, I opted for long but unambiguous.]

REST API passing these options already possible on master.

## Compatibility:

Existing providers, both via UI and API had no security_protocol, defaulted to verify_ssl == 1 but did not enforce it.
- If they have a globally-trusted cert, they'll silently become secure;
- If they have self-signed cert, **their auth will become "Error" until users Edit the provider** to configure custom CA to trust (or disable validation):
  ![status-error](https://cloud.githubusercontent.com/assets/273688/23214791/accb2ac2-f918-11e6-81f9-6627d026d3d6.png)
  **Is this OK or too aggressive?**

- [x] Verified behavior without hawkular endpoint (kubernetes, openshifts created before darga(?)).  Defaults to secure as expected.

## Verified that various connections still work:
- [x] Refresh.
- [x] Metrics (Hawkular endpoint).
- [x] Event watcher.
- [x] SSA scanning.
  - [ ] Only 70% sure MiqFS part worked, want to re-check.
- [x] fetch_hawk_inv (tested without real data, returned `[]` but connection worked no errors)

## Links
- Container & oVirt combined UI changes: https://github.com/ManageIQ/manageiq-ui-classic/pull/450
- Similar oVirt backend change: #14004
- Similar Hawkular changes: backed #14054, UI https://github.com/ManageIQ/manageiq-ui-classic/pull/460
- This builds on https://github.com/ManageIQ/manageiq/pull/13567 [merged] for storing the certificate_authority field,  
and https://github.com/ManageIQ/manageiq-gems-pending/pull/51 [merged] for passing https options to container MiqFS.

@miq-bot add-label providers/containers, security, bug, enhancement

@Fryguy @blomquisg @moolitayer please review.  cc @jhernand @simon3z 
