### PR TITLE
Adding Firmwares migration

### DIFF
--- a/db/migrate/20170222192610_create_firmwares.rb
+++ b/db/migrate/20170222192610_create_firmwares.rb
@@ -8,7 +8,7 @@ class CreateFirmwares < ActiveRecord::Migration[5.0]
       t.bigint   :resource_id
       t.string   :resource_type
       t.timestamps
-      t.index %w(resource_id resource_type), :name => "index_firmwares_on_resource_id_and_resource_type", :using => :btree
+      t.index %w(resource_id resource_type)
     end
   end
 end

--- a/db/migrate/20170222192610_create_firmwares.rb
+++ b/db/migrate/20170222192610_create_firmwares.rb
@@ -1,0 +1,14 @@
+class CreateFirmwares < ActiveRecord::Migration[5.0]
+  def change
+    create_table :firmwares do |t|
+      t.string   :name
+      t.string   :build
+      t.string   :version
+      t.datetime :release_date
+      t.bigint   :resource_id
+      t.string   :resource_type
+      t.timestamps
+      t.index %w(resource_id resource_type), :name => "index_firmwares_on_resource_id_and_resource_type", :using => :btree
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1327,6 +1327,13 @@ firewall_rules:
 - source_ip_range
 - ems_ref
 - network_protocol
+firmwares:
+- name
+- build
+- version
+- release_date
+- resource_id
+- resource_type
 flavors:
 - id
 - ems_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1328,12 +1328,15 @@ firewall_rules:
 - ems_ref
 - network_protocol
 firmwares:
+- id
 - name
 - build
 - version
 - release_date
 - resource_id
 - resource_type
+- created_at
+- updated_at
 flavors:
 - id
 - ems_id


### PR DESCRIPTION
The rational for this is that many hardware types require firmware
metadata. For example, `physical_server` (via `guest_device`), `disks`,
`switches`, etc.

Firmware is polymorphic so that we can ask questions like,
Give me all the firmwares of type x that are running non-compliant
firmware.

We tried to fit firmware into `Operating System`, or as extra fields
on `Guest Device`, but it feels like it should be its own thing.