### PR TITLE
Modifies basic settings for PhysicalInfraManager (events, refresher)

### DIFF
--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -42,6 +42,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Vmware::NetworkManager::RefreshWorker
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker
+    ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
@@ -57,6 +58,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::StorageManager::CinderManager::EventCatcher
     ManageIQ::Providers::Vmware::InfraManager::EventCatcher
     ManageIQ::Providers::Vmware::CloudManager::EventCatcher
+    ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher
     EmbeddedAnsibleWorker
     MiqEventHandler
     MiqGenericWorker
@@ -110,6 +112,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshWorker
     ManageIQ::Providers::Hawkular::DatawarehouseManager::RefreshWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker
+    ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker
     ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker
     ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::RefreshWorker
     ManageIQ::Providers::Microsoft::InfraManager::RefreshWorker

--- a/config/api.yml
+++ b/config/api.yml
@@ -621,6 +621,12 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
+  :ems_events:
+     :description: LXCA Events
+     :options:
+     - :collection
+     :verbs: *g
+     :klass: EmsEvent        
   :events:
     :description: Events
     :identifier: event

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1275,6 +1275,8 @@
         :poll: 15.seconds
       :event_catcher_kubernetes:
         :poll: 1.seconds
+      :event_catcher_lenovo:
+        :poll: 4.minutes
       :event_catcher_openshift:
         :poll: 1.seconds
       :event_catcher_openshift_enterprise:
@@ -1333,6 +1335,7 @@
         :ems_refresh_worker_google_network: {}
         :ems_refresh_worker_hawkular: {}
         :ems_refresh_worker_kubernetes: {}
+        :ems_refresh_worker_lenovo_physical_infra: {}
         :ems_refresh_worker_microsoft: {}
         :ems_refresh_worker_openshift: {}
         :ems_refresh_worker_openshift_enterprise: {}


### PR DESCRIPTION
Modify the settings for the PHysicalInfraManager.  Reduces the refresh rate and adds in the refresh and event working settings for the physical providers.

@miq-bot add_label: wip, providers/physical-infrastructure