### PR TITLE
Refactor/clean up 'agent' related logic on `Job` model

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -249,6 +249,6 @@ class Job < ApplicationRecord
   end
 
   def attributes_log
-    "guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent id: [#{agent_id}], zone: [#{zone}]"
+    "guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], server id: [#{miq_server_id}], zone: [#{zone}]"
   end
 end # class Job

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -172,15 +172,14 @@ class JobProxyDispatcher
   end
 
   def assign_proxy_to_job(proxy, job)
-    job.agent_id        = proxy.id
     job.miq_server_id   = proxy.id
     job.started_on      = Time.now.utc
     job.dispatch_status = "active"
     job.save
 
     # Increment the counts for busy proxies and busy hosts for embedded
-    busy_proxies["MiqServer_#{job.agent_id}"] ||= 0
-    busy_proxies["MiqServer_#{job.agent_id}"] += 1
+    busy_proxies["MiqServer_#{job.miq_server_id}"] ||= 0
+    busy_proxies["MiqServer_#{job.miq_server_id}"] += 1
 
     # Track the host/vc resource for embedded scans so we can limit the resource impact
     if (key = embedded_scan_resource(@vm))
@@ -242,10 +241,10 @@ class JobProxyDispatcher
     @busy_proxies_hash ||= begin
       Job.where(:dispatch_status => "active")
       .where("state != ?", "finished")
-      .select([:agent_id])
+      .select([:miq_server_id])
       .each_with_object({}) do |j, busy_hsh|
-        busy_hsh["MiqServer_#{j.agent_id}"] ||= 0
-        busy_hsh["MiqServer_#{j.agent_id}"] += 1
+        busy_hsh["MiqServer_#{j.miq_server_id}"] ||= 0
+        busy_hsh["MiqServer_#{j.miq_server_id}"] += 1
       end
     end
   end

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -101,7 +101,7 @@ class VmScan < Job
          vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
         return unless create_snapshot(vm)
       elsif vm.require_snapshot_for_scan?
-        proxy = MiqServer.find(agent_id)
+        proxy = MiqServer.find(miq_server_id)
 
         # Check if the broker is available
         if MiqServer.use_broker_for_embedded_proxy? && !MiqVimBrokerWorker.available?
@@ -155,7 +155,7 @@ class VmScan < Job
     _log.info "Enter"
 
     begin
-      host = MiqServer.find(agent_id)
+      host = MiqServer.find(miq_server_id)
       vm = VmOrTemplate.find(target_id)
       # Send down metadata to allow the host to make decisions.
       scan_args = create_scan_args(vm)
@@ -273,7 +273,7 @@ class VmScan < Job
     _log.info "Enter"
 
     begin
-      host = MiqServer.find(agent_id)
+      host = MiqServer.find(miq_server_id)
       vm = VmOrTemplate.find(target_id)
       vm.sync_metadata(options[:categories],
                        "taskid" => jobid,

--- a/app/models/vm_synchronize.rb
+++ b/app/models/vm_synchronize.rb
@@ -18,7 +18,7 @@ class VmSynchronize < Job
 
     options[:categories] ||= Vm.default_scan_categories
     begin
-      host = Host.find(agent_id)
+      host = MiqServer.find(miq_server_id)
       vm   = VmOrTemplate.find(target_id)
       vm.sync_metadata(options[:categories], "taskid" => jobid, "host" => host)
     rescue Timeout::Error

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -271,11 +271,11 @@ describe JobProxyDispatcher do
   end
 
   context "limiting number of smart state analysis running on one server" do
-    let(:job) { Job.create_job("VmScan", :agent_id => @server.id, :name => "Hello - 1") }
+    let(:job) { Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 1") }
     before(:each) do
-      Job.create_job("VmScan", :agent_id => @server.id, :name => "Hello - 2")
+      Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 2")
          .update_attributes(:dispatch_status => "active")
-      Job.create_job("VmScan", :agent_id => @server.id, :name => "Hello - 3")
+      Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 3")
          .update_attributes(:dispatch_status => "active")
     end
 
@@ -308,7 +308,7 @@ describe JobProxyDispatcher do
 
   describe "#start_job_on_proxy" do
     it "creates job options and passing it to `queue_signal'" do
-      job = Job.create_job("VmScan", :agent_id => @server.id, :name => "Hello, World")
+      job = Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello, World")
       dispatcher.instance_variable_set(:@active_vm_scans_by_zone, @server.my_zone => 0)
 
       job_options = {:args => ["start"], :zone => @server.my_zone, :server_guid => @server.guid, :role => "smartproxy"}

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -251,7 +251,7 @@ describe VmScan do
 
     describe "#call_snapshot_create" do
       context "for providers other than OpenStack and Microsoft" do
-        before(:each) { @job.agent_id = @server.id }
+        before(:each) { @job.miq_server_id = @server.id }
 
         it "does not call #create_snapshot but sends signal :snapshot_complete" do
           expect(@job).to receive(:signal).with(:snapshot_complete)
@@ -304,7 +304,7 @@ describe VmScan do
 
     describe "#call_scan" do
       before(:each) do
-        @job.agent_id = @server.id
+        @job.miq_server_id = @server.id
         allow(VmOrTemplate).to receive(:find).with(@vm.id).and_return(@vm)
         allow(MiqServer).to receive(:find).with(@server.id).and_return(@server)
       end
@@ -336,7 +336,7 @@ describe VmScan do
 
     describe "#call_synchronize" do
       before(:each) do
-        @job.agent_id = @server.id
+        @job.miq_server_id = @server.id
         allow(VmOrTemplate).to receive(:find).with(@vm.id).and_return(@vm)
         allow(MiqServer).to receive(:find).with(@server.id).and_return(@server)
       end


### PR DESCRIPTION
**blocked:**
- [x]   remove references to `jobs.agent_state`   https://github.com/ManageIQ/manageiq/pull/14330
- [x]   remove references to `jobs.agent_class`    https://github.com/ManageIQ/manageiq/pull/14356 
- [x] making `job` belongs_to `miq_server` https://github.com/ManageIQ/manageiq/pull/14385
- [x] use table when generating SQL in Task controller https://github.com/ManageIQ/manageiq-ui-classic/pull/551
- [x]   remove references to `jobs.agent_name` https://github.com/ManageIQ/manageiq/pull/14426

**related:** 
- [x] https://github.com/ManageIQ/manageiq/pull/14364 - Drop 'jobs.agent_state' column
- [x] https://github.com/ManageIQ/manageiq/pull/14380 - Drop 'jobs.agent_class' column
- [ ] https://github.com/ManageIQ/manageiq/pull/14437- Drop 'jobs.agent_name' column

Concept of agents for smart state analysis was simplified and now agent is instance of ```MiqServer```. We can refactor code related to concept of 'agents' by removing not used/redundant attributes from ```Job``` model. It will simplify code, allow to drop ```agent_...```columns from ```jobs``` table and will make future merging of ```Job``` and ```MiqTask``` models simpler. 

in this PR:
- refactor code to use use ```jobs.miq_server_id``` instead of ```jobs.agent_id```.

in blocked PR:
- remove code related to ```jobs.agent_state```.  This attribute  is not shown in UI, not used anywhere and concept of another state (in addition to job state and job status) is confusing
- remove code related to ```jobs.agent_class``` - all instances of agents(or proxy) are instance of ```MiqServer``` and we can use use ```MiqServer``` directly
- rename methods dealing with ```agent_state``` and ```agent_message``` to reflect removal of ```agent_state``` attribute
- make ```job``` ```belongs_to :miq_server```. ```miq_server_id``` column is already present on ```jobs``` table but was not used before
- migration to copy data from ```jobs.agent_id``` to ```jobs_miq_server_id```
- update ```Job.yaml``` (to join ```jobs``` and ```miq_server``` tables) and show ```miq_server.name``` instead of ```jobs.agent_name``` in UI

We are keeping agent_message at this point.  
It looks like there are 2 types of messages recorded in agent_message:
- mirroring ```jobs.state``` messages (like "Initializing Scan", "Synchronization in progress", "Synchronization complete", "Scanning completed.").
- message to reflect progress or some details of scanning:
categories.each do |c| ... agent_message = "Scanning #{c}"
... |scan_data| agent_message = scan_data[:msg]

@Fryguy @roliveri Does it make sense to merge 2 message related columns in jobs table - ```message``` and ```agent_message``` ?


@miq-bot add-label core

\cc @gtanzillo 