### PR TITLE
Enable cloud_tenant based RBAC for additional models 

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -1,6 +1,7 @@
 class CloudNetwork < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -1,4 +1,5 @@
 class CloudObjectStoreContainer < ApplicationRecord
+  include CloudTenancyMixin
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :cloud_tenant
   has_many   :cloud_object_store_objects

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -1,4 +1,5 @@
 class CloudObjectStoreObject < ApplicationRecord
+  include CloudTenancyMixin
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :cloud_tenant
   belongs_to :cloud_object_store_container

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -1,6 +1,7 @@
 class CloudSubnet < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -1,4 +1,5 @@
 class CloudTenant < ApplicationRecord
+  include CloudTenancyMixin
   TENANT_MAPPING_ASSOCIATIONS = %i(vms_and_templates).freeze
 
   include NewWithTypeStiMixin
@@ -157,5 +158,9 @@ class CloudTenant < ApplicationRecord
       :method_name => 'sync_cloud_tenants_with_tenants',
       :zone        => ems.my_zone
     ) if ems.supports_cloud_tenant_mapping?
+  end
+
+  def self.tenant_joins_clause(scope)
+    scope.includes(:source_tenant).includes(:ext_management_system)
   end
 end

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -2,6 +2,7 @@ class CloudVolumeSnapshot < ApplicationRecord
   include NewWithTypeStiMixin
   include ProviderObjectMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -1,5 +1,6 @@
 class Flavor < ApplicationRecord
   include NewWithTypeStiMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 
@@ -32,5 +33,9 @@ class Flavor < ApplicationRecord
       :memory_gigabytes    => memory.bytes / 1.0.gigabytes,
       :root_disk_gigabytes => root_disk_size.nil? ? nil : root_disk_size.bytes / 1.0.gigabytes
     }
+  end
+
+  def self.tenant_joins_clause(scope)
+    scope.includes(:cloud_tenants => "source_tenant").includes(:ext_management_system)
   end
 end

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -1,6 +1,7 @@
 class FloatingIp < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -4,6 +4,7 @@ class LoadBalancer < ApplicationRecord
   include ProcessTasksMixin
   include_concern 'RetirementManagement'
   include TenantIdentityMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -70,6 +70,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def save_on_other_managers
     storage_managers.update_all(:tenant_mapping_enabled => tenant_mapping_enabled)
+    network_manager.tenant_mapping_enabled = tenant_mapping_enabled
+    network_manager.save!
   end
 
   def supports_cloud_tenants?

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -1,5 +1,6 @@
 class NetworkPort < ApplicationRecord
   include NewWithTypeStiMixin
+  include CloudTenancyMixin
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -1,6 +1,7 @@
 class NetworkRouter < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -1,6 +1,7 @@
 class SecurityGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
+  include CloudTenancyMixin
 
   acts_as_miq_taggable
 

--- a/spec/factories/cloud_tenant_flavor.rb
+++ b/spec/factories/cloud_tenant_flavor.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :cloud_tenant_flavor do
+    # mapping of cloud_tenant to flavor
+  end
+end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1393,20 +1393,28 @@ describe Rbac::Filterer do
   describe "cloud_tenant based search" do
     let(:ems_openstack)         { FactoryGirl.create(:ems_cloud) }
     let(:project1_tenant)       { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }
-    let(:project1_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project1_tenant) }
+    let(:project1_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project1_tenant, :ext_management_system => ems_openstack) }
     let(:project1_group)        { FactoryGirl.create(:miq_group, :tenant => project1_tenant) }
     let(:project1_user)         { FactoryGirl.create(:user, :miq_groups => [project1_group]) }
     let(:project1_volume)       { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_openstack, :cloud_tenant => project1_cloud_tenant) }
+    let(:project1_flavor)       { FactoryGirl.create(:flavor, :ext_management_system => ems_openstack) }
+    let(:project1_c_t_flavor)   { FactoryGirl.create(:cloud_tenant_flavor, :cloud_tenant => project1_cloud_tenant, :flavor => project1_flavor) }
     let(:project2_tenant)       { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }
-    let(:project2_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project2_tenant) }
+    let(:project2_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :source_tenant => project2_tenant, :ext_management_system => ems_openstack) }
     let(:project2_group)        { FactoryGirl.create(:miq_group, :tenant => project2_tenant) }
     let(:project2_user)         { FactoryGirl.create(:user, :miq_groups => [project2_group]) }
     let(:project2_volume)       { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_openstack, :cloud_tenant => project2_cloud_tenant) }
+    let(:project2_flavor)       { FactoryGirl.create(:flavor, :ext_management_system => ems_openstack) }
+    let(:project2_c_t_flavor)   { FactoryGirl.create(:cloud_tenant_flavor, :cloud_tenant => project2_cloud_tenant, :flavor => project2_flavor) }
     let(:ems_other)             { FactoryGirl.create(:ems_cloud, :name => 'ems_other', :tenant_mapping_enabled => false) }
     let(:volume_other)          { FactoryGirl.create(:cloud_volume, :ext_management_system => ems_other) }
-    let!(:all_volumes)          { [project1_volume, project2_volume, volume_other] }
+    let(:tenant_other)          { FactoryGirl.create(:tenant, :source_type => 'CloudTenant') }
+    let(:cloud_tenant_other)    { FactoryGirl.create(:cloud_tenant, :source_tenant => tenant_other, :ext_management_system => ems_other) }
+    let(:flavor_other)          { FactoryGirl.create(:flavor, :ext_management_system => ems_other) }
+    let(:c_t_flavor_other)      { FactoryGirl.create(:cloud_tenant_flavor, :cloud_tenant => cloud_tenant_other, :flavor => flavor_other) }
+    let!(:all_objects)          { [project1_volume, project2_volume, volume_other, cloud_tenant_other, project1_c_t_flavor, project2_c_t_flavor, c_t_flavor_other] }
 
-    it "lists its own cloud volumes and other volumes where tenant_mapping is not enabled" do
+    it "lists its own project's objects and other objects where tenant_mapping is not enabled" do
       ems_openstack.tenant_mapping_enabled = true
       ems_openstack.save!
       results = described_class.search(:class => CloudVolume, :user => project1_user).first
@@ -1415,11 +1423,29 @@ describe Rbac::Filterer do
       results = described_class.search(:class => CloudVolume, :user => project2_user).first
       expect(results).to match_array [project2_volume, volume_other]
 
-      results = described_class.search(:class => CloudVolume, :user => owner_user).first
+      results = described_class.search(:class => CloudVolume, :user => other_user).first
       expect(results).to match_array [volume_other]
+
+      results = described_class.search(:class => CloudTenant, :user => project1_user).first
+      expect(results).to match_array [project1_cloud_tenant, cloud_tenant_other]
+
+      results = described_class.search(:class => CloudTenant, :user => project2_user).first
+      expect(results).to match_array [project2_cloud_tenant, cloud_tenant_other]
+
+      results = described_class.search(:class => CloudTenant, :user => other_user).first
+      expect(results).to match_array [cloud_tenant_other]
+
+      results = described_class.search(:class => Flavor, :user => project1_user).first
+      expect(results).to match_array [project1_flavor, flavor_other]
+
+      results = described_class.search(:class => Flavor, :user => project2_user).first
+      expect(results).to match_array [project2_flavor, flavor_other]
+
+      results = described_class.search(:class => Flavor, :user => other_user).first
+      expect(results).to match_array [flavor_other]
     end
 
-    it "all cloud volumes are visible to all users when tenant_mapping is not enabled" do
+    it "all objects are visible to all users when tenant_mapping is not enabled" do
       ems_openstack.tenant_mapping_enabled = false
       ems_openstack.save!
       results = described_class.search(:class => CloudVolume, :user => project1_user).first
@@ -1430,6 +1456,24 @@ describe Rbac::Filterer do
 
       results = described_class.search(:class => CloudVolume, :user => owner_user).first
       expect(results).to match_array [project1_volume, project2_volume, volume_other]
+
+      results = described_class.search(:class => CloudTenant, :user => project1_user).first
+      expect(results).to match_array [project1_cloud_tenant, project2_cloud_tenant, cloud_tenant_other]
+
+      results = described_class.search(:class => CloudTenant, :user => project2_user).first
+      expect(results).to match_array [project1_cloud_tenant, project2_cloud_tenant, cloud_tenant_other]
+
+      results = described_class.search(:class => CloudTenant, :user => other_user).first
+      expect(results).to match_array [project1_cloud_tenant, project2_cloud_tenant, cloud_tenant_other]
+
+      results = described_class.search(:class => Flavor, :user => project1_user).first
+      expect(results).to match_array [project1_flavor, project2_flavor, flavor_other]
+
+      results = described_class.search(:class => Flavor, :user => project2_user).first
+      expect(results).to match_array [project1_flavor, project2_flavor, flavor_other]
+
+      results = described_class.search(:class => Flavor, :user => other_user).first
+      expect(results).to match_array [project1_flavor, project2_flavor, flavor_other]
     end
   end
 


### PR DESCRIPTION
Fixes RBAC for select cloud_tenant based models when tenant_mapping_enabled is turned on. Previously, anyone can see any tenant's objects. The fix adds CloudTenancyMixin to a model which in turn causes the correct AR joins and where clauses to be generated during tenant scoping in Filterer.search.

This patch adds CloudTenancyMixin to
CloudNetwork
CloudObjectStoreContainer
CloudObjectStoreObject
CloudSubnet
CloudTenant
CloudVolumeSnapshot
Flavor
FloatingIp
LoadBalancer
NetworkPort
NetworkRouter
SecurityGroup

Modified OpenStack CloudManager to also update the network
provider's tenant_mapping_enabled value.

Depends on ManageIQ#13535

Steps for Testing/QA 
-------------------------------

1. In your OpenStack cloud environment, create two projects and as admin of each project create an object for each of the models listed above.
2. Tenant Mapping Enabled should be turned on for the cloud provider in ManageIQ.
3. Create admin groups and admin users for he two projects. The admin should have the EvmRole-super_administrator role.
4. Login as an admin of each project and verify you can only see that project's objects.
