### PR TITLE
Add a cache for full Feature objects

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -190,19 +190,12 @@ class MiqProductFeature < ApplicationRecord
 
   def self.obj_feature_ancestors(identifier)
     feature = obj_features[identifier.to_s]
-    ancestors = []
+    return [] unless feature
 
-    if feature
-      parent = obj_features[feature[:parent]][:feature]
+    parent_feature = obj_features[feature[:parent]].try(:[], :feature)
+    return [] unless parent_feature
 
-      until parent.nil?
-        feature = obj_features[parent.identifier]
-        ancestors << parent
-        parent = obj_features[feature[:parent]].try(:[], :feature)
-      end
-    end
-
-    ancestors
+    obj_feature_ancestors(parent_feature.identifier).unshift(parent_feature)
   end
 
   ### Instance methods

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -31,6 +31,7 @@ module EvmSpecHelper
 
     clear_instance_variables(MiqEnvironment::Command)
     clear_instance_variable(MiqProductFeature, :@feature_cache) if defined?(MiqProductFeature)
+    clear_instance_variable(MiqProductFeature, :@obj_cache) if defined?(MiqProductFeature)
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
 
     # Clear the thread local variable to prevent test contamination


### PR DESCRIPTION
This speeds up RBAC features tree significantly by adding cached methods that return full objects.