### PR TITLE
Fix deletion of object storage objects that creates zombies

### DIFF
--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -6,4 +6,17 @@ class CloudObjectStoreObject < ApplicationRecord
   acts_as_miq_taggable
 
   alias_attribute :name, :key
+
+  def disconnect_inv
+    # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a
+    # relation in the ems is missing a :dependent => :destroy on :cloud_object_store_objects relation, it does not
+    # delete any records. The :dependent => :destroy was removed by https://github.com/ManageIQ/manageiq/pull/14009
+    #
+    # Method disconnect_inv is called on each record separately, so it will destroy records as expected.
+    # The fact that refresh deletes a non existent records from our DB is tested by AWS S3 stubbed specs.
+    #
+    # TODO(lsmola) investigate rails weird behavior, write a reproducer and delete this when fixed. Unless this is an
+    # expected behaviour.
+    destroy
+  end
 end

--- a/app/models/ems_refresh/save_inventory_object_storage.rb
+++ b/app/models/ems_refresh/save_inventory_object_storage.rb
@@ -77,7 +77,7 @@ module EmsRefresh::SaveInventoryObjectStorage
       h[:cloud_object_store_container_id] = h.fetch_path(:container, :id)
     end
 
-    save_inventory_multi(ems.cloud_object_store_objects, hashes, deletes, [:ems_ref], nil, [:tenant, :container])
+    save_inventory_multi(ems.cloud_object_store_objects, hashes, deletes, [:ems_ref], nil, [:tenant, :container], true)
     store_ids_for_new_records(ems.cloud_object_store_objects, hashes, :ems_ref)
   end
 end


### PR DESCRIPTION
Fix deletion of object storage objects that creates zombies

The issue was brought by https://github.com/ManageIQ/manageiq/pull/14009#issuecomment-281653462

This PR will allow the specs in https://github.com/ManageIQ/manageiq-providers-amazon/pull/150 pass