### PR TITLE
API - VMs collection - replace decorators with SupportsFeatureMixin

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -35,16 +35,6 @@ module Api
         search_options.map(&:downcase).include?(what.to_s)
       end
 
-      def decorator_selection
-        params['decorators'].to_s.split(",")
-      end
-
-      def decorator_selection_for(collection)
-        decorator_selection.collect do |attr|
-          /\A#{collection}\.(?<name>.*)\z/.match(attr) { |m| m[:name] }
-        end.compact
-      end
-
       def attribute_selection
         if !@req.attributes.empty? || @additional_attributes
           @req.attributes | Array(@additional_attributes) | ID_ATTRS

--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -40,9 +40,14 @@ module Api
       end
 
       def create_vm_decorators_hash(vm_decorators, vm)
-        vm_decorators.each_with_object({}) do |name, hash|
-          hash[name] = vm.decorate.public_send(name.to_sym) if vm.decorate.respond_to?(name.to_sym)
-        end.compact
+        hash = {}
+        if vm_decorators.include? 'supports_console?'
+          hash['supports_console?'] = vm.supports_console?
+        end
+        if vm_decorators.include? 'supports_cockpit?'
+          hash['supports_cockpit?'] = vm.supports_launch_cockpit?
+        end
+        hash
       end
     end
   end

--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -23,6 +23,16 @@ module Api
 
       private
 
+      def decorator_selection
+        params['decorators'].to_s.split(",")
+      end
+
+      def decorator_selection_for(collection)
+        decorator_selection.collect do |attr|
+          /\A#{collection}\.(?<name>.*)\z/.match(attr) { |m| m[:name] }
+        end.compact
+      end
+
       def create_vm_attributes_hash(vm_attrs, vm)
         vm_attrs.each_with_object({}) do |attr, hash|
           hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -75,6 +75,7 @@ module SupportsFeatureMixin
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',
     :create_security_group      => 'Security Group Creation',
+    :console                    => 'Remote Console',
     :external_logging           => 'Launch External Logging UI',
     :swift_service              => 'Swift storage service',
     :delete                     => 'Deletion',

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1839,6 +1839,12 @@ class VmOrTemplate < ApplicationRecord
     user
   end
 
+  supports :console do
+    unless console_supported?('spice') || console_supported?('vnc')
+      unsupported_reason_add(:console, N_("Console not supported"))
+    end
+  end
+
   private
 
   def set_tenant_from_group


### PR DESCRIPTION
This removes the only remaining use of decorators from manageiq (not ui).

Service UI is using `?decorators=vms.supports_console?,vms.supports_cockpit?`, so I suppose we need to preserve that. - Implementing only those two, by calling `vm.supports_*?`.

Since console support is not using the `SupportsFeatureMixin`, added it to `VmOrTemplate`, using the same code that was previously in `VmOrTemplateDecorator`.

Cockpit support *is* using `SupportsFeatureMixin`, but uses a different name than the decorator (`supports_cockpit?` vs `supports_launch_cockpit?`).

(Related to (but not dependent upon) https://github.com/ManageIQ/manageiq-ui-classic/pull/237.)

Testing: (with a valid service ID, which has multiple vms..) `GET /api/services/10000000000245?expand=vms&decorators=vms.supports_console%3F%2Cvms.supports_cockpit%3F`

Closes https://github.com/ManageIQ/manageiq-ui-classic/issues/3

@abellotti, @jntullo WDYT? :)