### PR TITLE
Add RBAC for rss feeds

### DIFF
--- a/app/models/miq_widget/rss_content.rb
+++ b/app/models/miq_widget/rss_content.rb
@@ -9,22 +9,22 @@ class MiqWidget::RssContent < MiqWidget::ContentGeneration
     resource.nil?
   end
 
-  def generate(_user_or_group)
+  def generate(user_or_group)
     opts = {:tz => timezone}
 
     data = if external?
              opts[:limit_to_count] = widget_options[:row_count] || 5
              external_feed
            else
-             internal_feed
+             internal_feed(user_or_group)
            end
 
     RssFeed.to_html(data, opts)
   end
 
-  def internal_feed
+  def internal_feed(user_or_group)
     resource.options[:limit_to_count] = widget_options[:row_count] || 5
-    SimpleRSS.parse(resource.generate)
+    SimpleRSS.parse(resource.generate(nil, nil, nil, user_or_group))
   end
 
   def external_feed

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -35,7 +35,14 @@ class RssFeed < ApplicationRecord
       }
     }
 
-    feed = Rss.rss_feed_for(find_items, options)
+    rbac_options = {}
+    if user_or_group
+      user_or_group_key = user_or_group.kind_of?(User) ? :user : :miq_group
+      rbac_options[user_or_group_key] = user_or_group
+    end
+
+    filtered_items = Rbac::Filterer.filtered(find_items, rbac_options)
+    feed = Rss.rss_feed_for(filtered_items, options)
     local ? feed : {:text => feed, :content_type => Mime[:rss]}
   end
 

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -17,7 +17,7 @@ class RssFeed < ApplicationRecord
     "#{host_url}#{link}"
   end
 
-  def generate(host = nil, local = false, proto = nil)
+  def generate(host = nil, local = false, proto = nil, user_or_group = nil)
     proto ||= ::Settings.webservices.consume_protocol
     host_url = host.nil? ? "#{proto}://localhost:3000" : "#{proto}://" + host
 

--- a/product/alerts/rss/newest_vms.yml
+++ b/product/alerts/rss/newest_vms.yml
@@ -27,7 +27,7 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby: "vms.created_on DESC"
 
 # Included tables and columns for query performance
 include:

--- a/spec/models/rss_feed/data/newest_vms.yml
+++ b/spec/models/rss_feed/data/newest_vms.yml
@@ -27,7 +27,7 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby: "vms.created_on DESC"
 
 # Included tables and columns for query performance
 include:


### PR DESCRIPTION
First part for https://bugzilla.redhat.com/show_bug.cgi?id=1418961

- Add RBAC for rss feed 
- [fix order clause for rss in yaml ](https://github.com/ManageIQ/manageiq/pull/14041/commits/eacae0e664711b91b8312c2a272caa157c2d4a56) - I added table to avoid ambiguousness in query where is table in :includes (this solution is choosen instead of https://github.com/ManageIQ/manageiq/pull/14001) 
we have 2 yamls for RSS but only in one is orderby clause which is causing errors.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1418961


@miq-bot assign @gtanzillo 
@miq-bot add_label bug, core

