### PR TITLE
Remove Draper dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "default_value_for",              "~>3.0.2"
-gem "draper",                         "~>3.0.0.pre1"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     ">=0.5.2",       :require => false


### PR DESCRIPTION
Draper is no longer being used, after https://github.com/ManageIQ/manageiq-ui-classic/pull/237. We can safely remove.

(Decorators are being removed from manageiq in https://github.com/ManageIQ/manageiq/pull/14040, but this does not depend on #14040, since we didn't change the syntax.)
