### PR TITLE
Add a virtual for icon in container node

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -29,12 +29,17 @@ class ContainerNode < ApplicationRecord
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
   virtual_column :system_distribution, :type => :string
   virtual_column :kernel_version, :type => :string
+  virtual_column :icon_url, :type => :string
 
   # Needed for metrics
   delegate :my_zone, :to => :ext_management_system
 
   def ready_condition
     container_conditions.find_by(:name => "Ready")
+  end
+
+  def icon_url
+    "/assets/100/container_node.png"
   end
 
   def ready_condition_status


### PR DESCRIPTION
The purpose of this is to be able to get the icon url for a container node through the  Api.
