### PR TITLE
Allow create_in_provider to fail

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -11,8 +11,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
 
       # Get the record in our database
       # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.queue_refresh(manager, nil, true) if !manager.missing_credentials? && manager.authentication_status_ok?
-      find_by(:manager_id => manager.id, :manager_ref => job_template.id)
+      EmsRefresh.queue_refresh(manager, nil, true)
+
+      find_by!(:manager_id => manager.id, :manager_ref => job_template.id)
     end
 
     def create_in_provider_queue(manager_id, params, auth_user = nil)

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
@@ -109,12 +109,22 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScri
       }
     end
 
-    it ".create_in_provider" do
-      expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh).and_return(store_new_job_template(job_template, manager))
-      expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+    context ".create_in_provider" do
+      it "successfully created in provider" do
+        expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+        expect(EmsRefresh).to receive(:queue_refresh).and_return(store_new_job_template(job_template, manager))
+        expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
 
-      expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+        expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
+      end
+
+      it "not found during refresh" do
+        expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
+        expect(EmsRefresh).to receive(:queue_refresh)
+        expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
+
+        expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
     it ".create_in_provider_queue" do


### PR DESCRIPTION
Credentials should already be valid at this point, if not, that is the
problem of the refresh.
We should raise an error if the record is not found in our database

Without the `find_by!`, the method returns nil and code will blow up later in the process making it hard to figure out what went wrong.