### PR TITLE
Ignore custom attributes that have a nil name

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -25,7 +25,7 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name)
+      CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name).compact
     end
 
     def self.load_custom_attributes_for(cols)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1948,6 +1948,20 @@ describe MiqExpression do
     end
   end
 
+  context "._custom_details_for" do
+    let(:klass)        { Vm }
+    let(:vm)           { FactoryGirl.create(:vm) }
+    let(:custom_attr1) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => "CATTR_1", :value => "Value 1") }
+    let(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
+
+    it "ignores custom_attibutes with a nil name" do
+      custom_attr1
+      custom_attr2
+
+      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
+    end
+  end
+
   context ".build_relats" do
     it "includes reflections from descendant classes of Vm" do
       relats = MiqExpression.get_relats(Vm)


### PR DESCRIPTION
Fixes a bug where building reportable fields from custom attributes blows up when the name is nil.

https://bugzilla.redhat.com/show_bug.cgi?id=1426029

/cc @Fryguy @jrafanie @lpichler 