### PR TITLE
Drop eslint engine and files we don't want to analyze

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -36,10 +36,8 @@ engines:
       concurrency: 1
       languages:
       - ruby
-      - javascript
   eslint:
-    enabled: true
-    channel: "eslint-3"
+    enabled: false
   fixme:
     # let's enable later
     enabled: false
@@ -58,14 +56,5 @@ prepare:
 ratings:
   paths:
   - Gemfile.lock
-  - "**.erb"
-  - "**.haml"
   - "**.rake"
   - "**.rb"
-  - "**.rhtml"
-  - "**.slim"
-  - "**.css"
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"


### PR DESCRIPTION
[skip-ci]

Codeclimate builds were failing running eslint, which we don't need to
do anymore since we moved the javascript out of the main repo.

Below is an example run showing that we try and fail to run eslint on a repo with no javascript 🙀 

![image](https://cloud.githubusercontent.com/assets/19339/23278370/44b4761a-f9df-11e6-96af-cb978ba054f1.png)
