### PR TITLE
Allow cloud volume to provide a list of volumes for attach

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -130,4 +130,7 @@ class CloudVolume < ApplicationRecord
     raise NotImplementedError, _("raw_delete_volume must be implemented in a subclass")
   end
 
+  def available_vms
+    raise NotImplementedError, _("available_vms must be implemented in a subclass")
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -120,6 +120,10 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
       .create_snapshot_queue(userid, self, options)
   end
 
+  def available_vms
+    cloud_tenant.vms
+  end
+
   def provider_object(connection)
     connection.volumes.get(ems_ref)
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -135,4 +135,15 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
       end
     end
   end
+
+  describe "instance linsting for attaching volumes" do
+    let(:first_instance) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems, :ems_ref => "instance_0", :cloud_tenant => tenant) }
+    let(:second_instance) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems, :ems_ref => "instance_1", :cloud_tenant => tenant) }
+    let(:other_tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+    let(:other_instance) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems, :ems_ref => "instance_2", :cloud_tenant => other_tenant) }
+
+    it "supports attachment to only those instances that are in the same tenant" do
+      expect(cloud_volume.available_vms).to contain_exactly(first_instance, second_instance)
+    end
+  end
 end


### PR DESCRIPTION
While opening the view to attach a selected volume to a new instance, the [UI will currently ask](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/cloud_volume_controller.rb#L137) for the VMs that are available in the cloud tenant of the chosen volume. While it works for OpenStack, Amazon has no notion of tenants currently.

Instead of relying on the tenant's VMs, this patch proposes a new method in the cloud volume allowing it to specify the list of VMs this volume can be attached to. In case of OpenStack, this will be delagated to `cloud_tenant` and on Amazon it will be delagated to `availability_zone` (because the volume has to reside in the same AZ).

A simple spec test is provided to validate the `available_vms` only return the list of VMs in the same cloud tenant. I've got the counterpart ready for Amazon, but will wait to see if this change is acceptable.

Is there any alternative to this approach?

@miq-bot add_label providers/openstack/cloud, providers/amazon, providers/storage, ui