### PR TITLE
[WIP] miq_queue.miq_callback to support multiple callbacks

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -380,7 +380,13 @@ class MiqQueue < ApplicationRecord
   def delivered(state, msg, result)
     self.state = state
     _log.info("#{MiqQueue.format_short_log_msg(self)}, State: [#{state}], Delivered in [#{Time.now - delivered_on}] seconds")
-    m_callback(msg, result) unless miq_callback.blank?
+    if miq_callback.key?(:CALLBACKS)
+      miq_callback[:CALLBACKS].each do |call_back|
+        m_callback(call_back, result)
+      end
+    else
+      m_callback(msg, result) unless miq_callback.blank?
+    end
   rescue => err
     _log.error("#{MiqQueue.format_short_log_msg(self)}, #{err.message}")
   ensure


### PR DESCRIPTION
To allow multiple callbacks to a queued item.

(We can have each callback to enqueue another item to allow multiple workers to process these work items.)