### PR TITLE
Fix "Multiple Parents Found" issue when moving a relationship.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -104,7 +104,7 @@ class Account < ApplicationRecord
   end
 
   def add_user(owns)
-    with_valid_account_type('group') { set_child(owns) }
+    with_valid_account_type('group') { add_child(owns) }
   end
 
   def remove_user(owns)
@@ -120,7 +120,7 @@ class Account < ApplicationRecord
   end
 
   def add_group(owner)
-    with_valid_account_type('user') { set_parent(owner) }
+    with_valid_account_type('user') { add_parent(owner) }
   end
 
   def remove_group(owner)

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -522,7 +522,7 @@ module RelationshipMixin
     Relationship.resource_types(child_rels(*args))
   end
 
-  def parent=(parent)
+  def add_parent(parent)
     parent.with_relationship_type(relationship_type) { parent.add_child(self) }
   end
 
@@ -560,25 +560,28 @@ module RelationshipMixin
   end
   alias_method :add_child, :add_children
 
-  #
-  # Backward compatibility methods
-  #
-
-  alias_method :set_parent, :parent=
-  alias_method :set_child,  :add_children
-
-  def replace_parent(parent)
+  def parent=(parent)
     if parent.nil?
       remove_all_parents
     else
       parent.with_relationship_type(relationship_type) do
         parent_rel = parent.init_relationship
         init_relationship(parent_rel)  # TODO: Deal with any multi-instances
+
+        parent.clear_relationships_cache
       end
     end
 
     clear_relationships_cache
   end
+  alias_method :replace_parent, :parent=
+
+  #
+  # Backward compatibility methods
+  #
+
+  alias_method :set_parent, :parent=
+  alias_method :set_child,  :add_children
 
   def replace_children(*child_objs)
     child_objs = child_objs.flatten

--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -33,8 +33,7 @@ module ActsAsMiqSetMember
   end # module SingletonMethods
 
   def make_memberof(set)
-    raise "object of type #{self.class} may not be a member of a set of type #{set.class}" unless self.kind_of?(set.class.model_class)
-    with_relationship_type("membership") { self.parent = set }
+    set.add_member(self)
   end
 end # module ActsAsMiqSetMember
 


### PR DESCRIPTION
Originally, `.parent=` was written in terms of `add_children`.  However,
`add_children` supports duplicating nodes in the tree.  This is reasonable
because you may have a tree where multiple entries make sense, and for
those things that have multiple entries, you wouldn't call `.parent`, you
would probably call `.parents` and it is expected that calling `.parent`
would blow up with the "Multiple Parents Found" error.  However, the
expectation of calling `.parent=` is that it will become the new, sole,
parent, and so implementing it via add_children is wrong because it
creates an oddity in that you can call `.parent=` and then not be able to
call `.parent` afterwards.


https://bugzilla.redhat.com/show_bug.cgi?id=1379464
https://bugzilla.redhat.com/show_bug.cgi?id=1391850
https://bugzilla.redhat.com/show_bug.cgi?id=1406431