### PR TITLE
Do not keep all association records in the memory

### DIFF
--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -14,65 +14,53 @@ module ManagerRefresh::SaveCollection
       inventory_collection.saved = true
     end
 
-    def log_format_deletes(deletes)
-      ret = deletes.collect do |d|
-        s = "id: [#{d.id}]"
-
-        [:name, :product_name, :device_name].each do |k|
-          next unless d.respond_to?(k)
-          v = d.send(k)
-          next if v.nil?
-          s << " #{k}: [#{v}]"
-          break
-        end
-
-        s
-      end
-
-      ret.join(", ")
-    end
-
     private
 
     def save_inventory(inventory_collection)
       inventory_collection.parent.reload if inventory_collection.parent
-      association  = inventory_collection.db_collection_for_comparison
-      record_index = {}
+      association = inventory_collection.db_collection_for_comparison
 
-      create_or_update_inventory!(inventory_collection, record_index, association)
-
-      # Delete only if InventoryCollection is complete. If it's not complete, we are sending only subset of the records,
-      # so we cannot invoke deleting of the missing records.
-      delete_inventory!(inventory_collection, record_index, association) if inventory_collection.delete_allowed?
+      save_inventory_collection!(inventory_collection, association)
     end
 
-    def create_or_update_inventory!(inventory_collection, record_index, association)
-      unique_index_keys = inventory_collection.manager_ref_to_cols
+    def save_inventory_collection!(inventory_collection, association)
+      attributes_index        = {}
+      inventory_objects_index = {}
+      inventory_collection.each do |inventory_object|
+        attributes = inventory_object.attributes(inventory_collection)
+        index      = inventory_object.manager_uuid
 
-      association.find_each do |record|
-        index = inventory_collection.object_index_with_keys(unique_index_keys, record)
-        if record_index[index]
-          # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
-          # so we always keep the oldest record in the case of duplicates.
-          _log.warn("A duplicate record was detected and destroyed, inventory_collection: '#{inventory_collection}', "\
-                    "record: '#{record}', duplicate_index: '#{index}'")
-          record.destroy
-        else
-          record_index[index] = record
-        end
+        attributes_index[index]        = attributes
+        inventory_objects_index[index] = inventory_object
       end
 
+      unique_index_keys = inventory_collection.manager_ref_to_cols
+      unique_db_indexes = Set.new
+
       inventory_collection_size = inventory_collection.size
+      deleted_counter           = 0
       created_counter           = 0
-      _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} ***************")
+      _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} *************")
       ActiveRecord::Base.transaction do
-        inventory_collection.each do |inventory_object|
-          hash   = inventory_object.attributes(inventory_collection)
-          record = record_index.delete(inventory_object.manager_uuid)
-          if record.nil?
-            next unless inventory_collection.create_allowed?
-            record = inventory_collection.model_class.create!(hash.except(:id))
-            created_counter += 1
+        association.find_each do |record|
+          index = inventory_collection.object_index_with_keys(unique_index_keys, record)
+          if unique_db_indexes.include?(index) # Include on Set is O(1)
+            # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
+            # so we always keep the oldest record in the case of duplicates.
+            _log.warn("A duplicate record was detected and destroyed, inventory_collection: '#{inventory_collection}', "\
+                      "record: '#{record}', duplicate_index: '#{index}'")
+            record.destroy
+          else
+            unique_db_indexes << index
+          end
+
+          inventory_object = inventory_objects_index.delete(index)
+          hash             = attributes_index.delete(index)
+
+          if inventory_object.nil?
+            next unless inventory_collection.delete_allowed?
+            deleted_counter += 1
+            record.public_send(inventory_collection.delete_method)
           else
             record.assign_attributes(hash.except(:id, :type))
             if inventory_collection.check_changed?
@@ -80,26 +68,26 @@ module ManagerRefresh::SaveCollection
             else
               record.save!
             end
-          end
-          inventory_object.id = record.try(:id)
-        end
-      end
-      _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
-                "updated=#{inventory_collection_size - created_counter} ***************")
-    end
 
-    def delete_inventory!(inventory_collection, record_index, association)
-      # Delete the items no longer found
-      unless record_index.blank?
-        deletes = record_index.values
-        _log.info("*************** DELETING #{inventory_collection} of size #{deletes.size} ***************")
-        type = association.proxy_association.reflection.name
-        _log.info("[#{type}] Deleting with method '#{inventory_collection.delete_method}' #{log_format_deletes(deletes)}")
-        ActiveRecord::Base.transaction do
-          deletes.map(&inventory_collection.delete_method)
+            inventory_object.id = record.try(:id)
+          end
         end
-        _log.info("*************** DELETED #{inventory_collection} ***************")
       end
+
+      if inventory_collection.create_allowed?
+        ActiveRecord::Base.transaction do
+          inventory_objects_index.each do |index, inventory_object|
+            hash            = attributes_index.delete(index)
+            record          = inventory_collection.model_class.create!(hash.except(:id))
+            created_counter += 1
+
+            inventory_object.id = record.try(:id)
+          end
+        end
+      end
+
+      _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
+                "updated=#{inventory_collection_size - created_counter}, deleted=#{deleted_counter} *************")
     end
   end
 end

--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -91,11 +91,7 @@ module ManagerRefresh::SaveCollection
 
     def update_record!(inventory_collection, record, hash, inventory_object)
       record.assign_attributes(hash.except(:id, :type))
-      if inventory_collection.check_changed?
-        record.save! if record.changed?
-      else
-        record.save!
-      end
+      record.save if !inventory_collection.check_changed? || record.changed?
 
       inventory_object.id = record.id
     end

--- a/app/models/manager_refresh/save_collection/helper.rb
+++ b/app/models/manager_refresh/save_collection/helper.rb
@@ -69,7 +69,7 @@ module ManagerRefresh::SaveCollection
               record.save!
             end
 
-            inventory_object.id = record.try(:id)
+            inventory_object.id = record.id
           end
         end
       end
@@ -81,7 +81,7 @@ module ManagerRefresh::SaveCollection
             record          = inventory_collection.model_class.create!(hash.except(:id))
             created_counter += 1
 
-            inventory_object.id = record.try(:id)
+            inventory_object.id = record.id
           end
         end
       end


### PR DESCRIPTION
Depends on
- [x]  https://github.com/ManageIQ/manageiq/pull/13997

This is optimization of second+ refresh, where we always load everything we have in our DB, in order to figure out what needs to be created/delete/updated by comparing to data we got from the API.

The biggest difference is visible on large table, e.g. a lot of templates, s3 objects, etc.

| number of records | before | after  |
|---|---|---|
| 200k mocked MiqTemplates | 2.6GB | 1.3GB  |
| 100k mocked MiqTemplates | 2.3GB | 868MB |
| 78k real AWS public images | 1.5GB | 1.1GB  |

so this can save a lot of memory for large tables (in the real example, the memoory spikes to 1.1GB and does not get GCed, because of aws-sdk)
