### PR TITLE
Update service template API

### DIFF
--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -14,6 +14,13 @@ module Api
       raise BadRequestError, "Could not create Service Template - #{err}"
     end
 
+    def edit_resource(type, id, data)
+      catalog_item = resource_search(id, type, collection_class(:service_templates))
+      catalog_item.update_catalog_item(data.deep_symbolize_keys, @auth_user)
+    rescue => err
+      raise BadRequestError, "Could not update Service Template - #{err}"
+    end
+
     private
 
     def set_additional_attributes

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -93,7 +93,10 @@ class ServiceTemplate < ApplicationRecord
 
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
-    return update_attributes!(options) unless config_info
+    unless config_info
+      update_attributes!(options)
+      return reload
+    end
     transaction do
       update_from_options(options)
 

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -79,11 +79,44 @@ describe "Service Templates API" do
   end
 
   describe "Service Templates edit" do
+    let(:ems) { FactoryGirl.create(:ems_amazon) }
+    let(:new_vm) { FactoryGirl.create(:vm_amazon, :ext_management_system => ems) }
+    let(:vm) { FactoryGirl.create(:vm_amazon, :ems_id => ems.id) }
+    let(:flavor) { FactoryGirl.create(:flavor_amazon) }
+    let(:dialog) { FactoryGirl.create(:miq_dialog_provision) }
+    let(:request_dialog) { FactoryGirl.create(:miq_dialog_provision) }
+    let(:service_dialog) { FactoryGirl.create(:dialog) }
+    let(:updated_catalog_item_options) do
+      {
+        :name        => 'Updated Template Name',
+        :display     => 'false',
+        :description => 'a description',
+        :config_info => {
+          :miq_request_dialog_name => request_dialog.name,
+          :placement_auto          => [true, 1],
+          :number_of_vms           => [1, '1'],
+          :src_vm_id               => [new_vm.id, new_vm.name],
+          :vm_name                 => new_vm.name,
+          :schedule_type           => ['immediately', 'Immediately on Approval'],
+          :instance_type           => [flavor.id, flavor.name],
+          :src_ems_id              => [ems.id, ems.name],
+          :provision               => {
+            :fqname    => ra1.fqname,
+            :dialog_id => nil
+          },
+          :reconfigure             => {
+            :fqname    => ra2.fqname,
+            :dialog_id => service_dialog.id
+          }
+        }
+      }
+    end
+
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
       st = FactoryGirl.create(:service_template, :name => "st")
-      run_post(service_templates_url(st.id), gen_request(:edit, "name" => "sample service template"))
+      run_post(service_templates_url(st.id), gen_request(:edit, updated_catalog_item_options))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -92,10 +125,10 @@ describe "Service Templates API" do
       api_basic_authorize collection_action_identifier(:service_templates, :edit)
 
       st = FactoryGirl.create(:service_template, :name => "st1")
-      run_post(service_templates_url(st.id), gen_request(:edit, "name" => "updated st1"))
+      run_post(service_templates_url(st.id), gen_request(:edit, updated_catalog_item_options))
 
-      expect_single_resource_query("id" => st.id, "href" => service_templates_url(st.id), "name" => "updated st1")
-      expect(st.reload.name).to eq("updated st1")
+      expect_single_resource_query("id" => st.id, "href" => service_templates_url(st.id), "name" => "Updated Template Name")
+      expect(st.reload.name).to eq("Updated Template Name")
     end
 
     it "supports edits of multiple resources" do
@@ -104,17 +137,29 @@ describe "Service Templates API" do
       st1 = FactoryGirl.create(:service_template, :name => "st1")
       st2 = FactoryGirl.create(:service_template, :name => "st2")
 
-      run_post(service_templates_url, gen_request(:edit,
-                                                  [{"href" => service_templates_url(st1.id), "name" => "updated st1"},
-                                                   {"href" => service_templates_url(st2.id), "name" => "updated st2"}]))
+      run_post(service_templates_url, gen_request(:edit, [updated_catalog_item_options.merge('id' => st1.id),
+                                                          updated_catalog_item_options.merge('id' => st2.id)]))
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
-                                   [{"id" => st1.id, "name" => "updated st1"},
-                                    {"id" => st2.id, "name" => "updated st2"}])
+                                   [{"id" => st1.id, "name" => "Updated Template Name"},
+                                    {"id" => st2.id, "name" => "Updated Template Name"}])
+      expect(st1.reload.name).to eq("Updated Template Name")
+      expect(st2.reload.name).to eq("Updated Template Name")
+    end
 
-      expect(st1.reload.name).to eq("updated st1")
-      expect(st2.reload.name).to eq("updated st2")
+    it 'can update without config info' do
+      api_basic_authorize collection_action_identifier(:service_templates, :edit)
+      st1 = FactoryGirl.create(:service_template, :name => 'st1')
+
+      run_post(service_templates_url(st1.id), gen_request(:edit, 'name' => 'updated template'))
+
+      expected = {
+        'id'   => st1.id,
+        'name' => 'updated template'
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
     end
   end
 


### PR DESCRIPTION
This PR updates the way update on a service template works. 

Previously, it was using the generic method, but it requires the `update_catalog_item` method added in #13811 with the same format required in `create` and returned via `show`:
```
        {
          :name        => 'Updated Template Name',
          :display     => 'false',
          :description => 'a description',
          :config_info => {
            :miq_request_dialog_name => request_dialog.name,
            :placement_auto          => [true, 1],
            :number_of_vms           => [1, '1'],
            :src_vm_id               => [new_vm.id, new_vm.name],
            :vm_name                 => new_vm.name,
            :schedule_type           => ['immediately', 'Immediately on Approval'],
            :instance_type           => [flavor.id, flavor.name],
            :src_ems_id              => [ems.id, ems.name],
            :provision               => {
              :fqname    => ra1.fqname,
              :dialog_id => nil
            },
            :reconfigure             => {
              :fqname    => ra3.fqname,
              :dialog_id => service_dialog.id
            }
          }
        }
```

@abellotti since update was already implemented, I am not sure if this is considered a breaking change that requires a version bump. 

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 