### PR TITLE
Add missing `ConfigurationScriptSource` hierarchy and Automate models

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   require_nested :VmwareCredential
 
   require_nested :ConfigurationScript
+  require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :EventCatcher
   require_nested :EventParser

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
@@ -1,2 +1,3 @@
-class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource < ConfigurationScriptSource
+class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource <
+  ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptSource
 end

--- a/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory/parser/automation_manager.rb
@@ -87,7 +87,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
                                 when 'net' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential'
                                 when 'ssh' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential'
                                 when 'vmware' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential'
-                                # when 'scm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
+                                when 'scm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential'
                                 when 'aws' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential'
                                 when 'rax' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::RackspaceCredential'
                                 when 'satellite6' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential'
@@ -96,7 +96,7 @@ class ManageIQ::Providers::AnsibleTower::Inventory::Parser::AutomationManager < 
                                 # when 'azure' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::???Credential'
                                 when 'azure_rm' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential'
                                 when 'openstack' then 'ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential'
-                                else 'ManageIQ::Providers::AutomationManager::Authentication'
+                                else 'ManageIQ::Providers::AnsibleTower::AutomationManager::Credential'
                                 end
     end
   end

--- a/app/models/manageiq/providers/ansible_tower/inventory_collection_default/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/inventory_collection_default/automation_manager.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::AnsibleTower::InventoryCollectionDefault::AutomationM
   class << self
     def inventory_root_groups(extra_attributes = {})
       attributes = {
-        :model_class => ManageIQ::Providers::AutomationManager::InventoryRootGroup,
+        :model_class => ManageIQ::Providers::AnsibleTower::AutomationManager::InventoryRootGroup,
         :association => :inventory_root_groups,
       }
       attributes.merge!(extra_attributes)
@@ -28,7 +28,7 @@ class ManageIQ::Providers::AnsibleTower::InventoryCollectionDefault::AutomationM
 
     def configuration_script_sources(extra_attributes = {})
       attributes = {
-        :model_class => ConfigurationScriptSource,
+        :model_class => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource,
         :association => :configuration_script_sources,
         :manager_ref => [:manager_ref],
       }
@@ -46,7 +46,7 @@ class ManageIQ::Providers::AnsibleTower::InventoryCollectionDefault::AutomationM
 
     def credentials(extra_attributes = {})
       attributes = {
-        :model_class => ManageIQ::Providers::AutomationManager::Authentication,
+        :model_class => ManageIQ::Providers::AnsibleTower::AutomationManager::Credential,
         :association => :credentials,
         :manager_ref => [:manager_ref],
       }

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
   require_nested :Authentication
   require_nested :ConfigurationScript
   require_nested :ConfigurationScriptPayload
+  require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :InventoryGroup
   require_nested :InventoryRootGroup

--- a/app/models/manageiq/providers/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_script_source.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AutomationManager::ConfigurationScriptSource < ConfigurationScriptSource
+end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :VmwareCredential
 
   require_nested :ConfigurationScript
+  require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :Job
   require_nested :Playbook

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource <
+  ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
+end

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
   require_nested :Authentication
   require_nested :ConfigurationScript
   require_nested :ConfigurationScriptPayload
+  require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource <
+  ManageIQ::Providers::AutomationManager::ConfigurationScriptSource
+end

--- a/app/models/manageiq/providers/external_automation_manager.rb
+++ b/app/models/manageiq/providers/external_automation_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::ExternalAutomationManager < ManageIQ::Providers::Auto
   require_nested :Authentication
   require_nested :ConfigurationScript
   require_nested :ConfigurationScriptPayload
+  require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
 end

--- a/app/models/manageiq/providers/external_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/external_automation_manager/configuration_script_source.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptSource <
+  ManageIQ::Providers::AutomationManager::ConfigurationScriptSource
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_configuration_script_source.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceConfigurationScriptSource < MiqAeServiceModelBase
+    expose :manager,        :association => true
+    expose :authentication, :association => true
+    expose :configuration_script_payloads
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script_source.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScriptSource <
+    MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScriptSource
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-configuration_script_source.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AutomationManager_ConfigurationScriptSource <
+    MiqAeServiceConfigurationScriptSource
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-configuration_script_source.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_AutomationManager_ConfigurationScriptSource <
+    MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_ConfigurationScriptSource
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-configuration_script_source.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_ConfigurationScriptSource <
+    MiqAeServiceManageIQ_Providers_AutomationManager_ConfigurationScriptSource
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-external_automation_manager-configuration_script_source.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-external_automation_manager-configuration_script_source.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScriptSource <
+    MiqAeServiceManageIQ_Providers_AutomationManager_ConfigurationScriptSource
+  end
+end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb
@@ -109,7 +109,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def assert_configuration_script_sources
     expect(automation_manager.configuration_script_sources.count).to eq(6)
-    expect(expected_configuration_script_source).to be_an_instance_of(ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource)
     expect(expected_configuration_script_source).to have_attributes(
       :name        => 'Demo Project',
       :description => 'A great demo',

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
@@ -80,7 +80,7 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
 
   def assert_configuration_script_sources
     expect(automation_manager.configuration_script_sources.count).to eq(6)
-    expect(expected_configuration_script_source).to be_an_instance_of(ConfigurationScriptSource)
+    expect(expected_configuration_script_source).to be_an_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource)
     expect(expected_configuration_script_source).to have_attributes(
       :name        => 'db-projects',
       :description => 'projects',


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/13879

When adding (and rebasing and rebasing and rebasing) #13879, the changes to ConfigurationScriptSource` model hierarchy were dropped.

This adds the model hierarchy back in and adds the appropriate automate models.

This also fixes the AnsibleTower inventory collection to specify the correct models in the InventoryCollectionDefault, the Parser (for credential records), and the Refresher spec (for ConfigurationScriptSource).