### PR TITLE
[WIP] Rails 5.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "pg-pglogical",                   "~>1.0.0",       :require => false
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.0.1"
+gem "rails",                          "5.1.0.beta1"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"


### PR DESCRIPTION
This pull request keeps track of our progress towards supporting Rails 5.1.

*This should only be merged after ManageIQ Fine branch has been cut off from `master`. That is, ManageIQ Euwe shall continue to use Rails 5.0*

**Current status:** Rails 5.1.0.beta1 has been released, which we are now testing here.

Requires:

* ManageIQ/manageiq-ui-classic#482
* ManageIQ/manageiq-gems-pending#77
* ManageIQ/manageiq-api-client#65