### PR TITLE
Update catalog item for playbooks

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -25,21 +25,20 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
 
       # Get the record in our database
       # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.queue_refresh(manager, nil) if manager.authentication_status_ok?
+      EmsRefresh.queue_refresh(manager, nil, true)
     end
 
     def update_in_provider_queue(manager_id, params, auth_user = nil)
-      create_or_update_in_provider_queue(manager_id, params, auth_user)
+      create_or_update_in_provider_queue('update', manager_id, params, auth_user)
     end
 
     def create_in_provider_queue(manager_id, params, auth_user = nil)
-      create_or_update_in_provider_queue(manager_id, params, auth_user)
+      create_or_update_in_provider_queue('create', manager_id, params, auth_user)
     end
 
     private
 
-    def create_or_update_in_provider_queue(manager_id, params, auth_user)
-      action = params[:manager_ref] ? "update" : "create"
+    def create_or_update_in_provider_queue(action, manager_id, params, auth_user)
       manager = ExtManagementSystem.find(manager_id)
 
       task_opts = {

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -28,7 +28,17 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
       EmsRefresh.queue_refresh(manager, nil) if manager.authentication_status_ok?
     end
 
+    def update_in_provider_queue(manager_id, params, auth_user = nil)
+      create_or_update_in_provider_queue(manager_id, params, auth_user)
+    end
+
     def create_in_provider_queue(manager_id, params, auth_user = nil)
+      create_or_update_in_provider_queue(manager_id, params, auth_user)
+    end
+
+    private
+
+    def create_or_update_in_provider_queue(manager_id, params, auth_user)
       action = params[:manager_ref] ? "update" : "create"
       manager = ExtManagementSystem.find(manager_id)
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -17,24 +17,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
       find_by!(:manager_id => manager.id, :manager_ref => job_template.id)
     end
 
-    def create_in_provider_queue(manager_id, params, auth_user = nil)
-      manager = ExtManagementSystem.find(manager_id)
-      task_opts = {
-        :action => "Creating Ansible Tower Job Template",
-        :userid => auth_user || "system"
-      }
-      queue_opts = {
-        :args        => [manager_id, params],
-        :class_name  => self.name,
-        :method_name => "create_in_provider",
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => manager.my_zone
-      }
-
-      MiqTask.generic_action_with_callback(task_opts, queue_opts)
-    end
-
     def update_in_provider(manager_id, params)
       manager = ExtManagementSystem.find(manager_id)
       manager.with_provider_connection do |connection|
@@ -46,18 +28,18 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
       EmsRefresh.queue_refresh(manager, nil) if manager.authentication_status_ok?
     end
 
-    def update_in_provider_queue(manager_id, params, auth_user = nil)
-      task_opts = {
-        :action => "Updating Ansible Tower Job Template",
-        :userid => auth_user || "system"
-      }
-
+    def create_in_provider_queue(manager_id, params, auth_user = nil)
+      action = params[:manager_ref] ? "update" : "create"
       manager = ExtManagementSystem.find(manager_id)
 
+      task_opts = {
+        :action => "#{(action == "create" ? "Creating" : "Updating")} Ansible Tower Job Template",
+        :userid => auth_user || "system"
+      }
       queue_opts = {
         :args        => [manager_id, params],
-        :class_name  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
-        :method_name => "update_in_provider",
+        :class_name  => self.name,
+        :method_name => "#{action}_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => "ems_operations",
         :zone        => manager.my_zone

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -126,7 +126,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   private_class_method :validate_config_info
 
   def job_template(action)
-    resource_actions.find_by!(:action => action).configuration_template
+    resource_actions.find_by!(:action => action.to_s.capitalize).configuration_template
   end
 
   def update_catalog_item(options, auth_user = nil)
@@ -141,8 +141,9 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
       params[:manager_ref] = job_template(action).manager_ref
 
-      self.class.job_template_class.update_in_provider_queue(tower.id, params, auth_user)
-      self.class.send(:create_new_dialog, info[:new_dialog_name], job_template) if info[:new_dialog_name]
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
+
+      self.class.send(:create_new_dialog, info[:new_dialog_name], job_template(action)) if info[:new_dialog_name]
     end
     super
   end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -141,7 +141,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
       params[:manager_ref] = job_template(action).manager_ref
 
-      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.update_in_provider_queue(tower.id, params, auth_user)
 
       self.class.send(:create_new_dialog, info[:new_dialog_name], job_template(action)) if info[:new_dialog_name]
     end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -141,7 +141,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
       params[:manager_ref] = job_template(action).manager_ref
 
-      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.update_in_provider_queue(tower.id, params, auth_user)
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.update_in_provider_queue(tower.id, params, auth_user)
 
       self.class.send(:create_new_dialog, info[:new_dialog_name], job_template(action)) if info[:new_dialog_name]
     end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
@@ -146,6 +146,21 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScri
       )
     end
 
+    it ".update_in_provider_queue" do
+      EvmSpecHelper.local_miq_server
+      params[:manager_ref] = 10
+      task_id = described_class.update_in_provider_queue(manager.id, params)
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating Ansible Tower Job Template")
+      expect(MiqQueue.first).to have_attributes(
+        :args        => [manager.id, params],
+        :class_name  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
+        :method_name => "update_in_provider",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => manager.zone.name
+      )
+    end
+
     def store_new_job_template(job_template, manager)
       described_class.create!(
         :manager     => manager,

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -205,7 +205,7 @@ describe ServiceTemplateAnsiblePlaybook do
     it 'updates and returns the modified catalog item' do
       service_template = prebuild_service_template
       expect(described_class).to receive(:create_new_dialog)
-
+      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
       service_template.update_catalog_item(catalog_item_options_three, user)
 
       expect(service_template.name).to eq(catalog_item_options_three[:name])
@@ -226,6 +226,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
       expect(described_class).to receive(:create_new_dialog).never
+      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
 
       service_template.update_catalog_item(catalog_item_options_three, user)
       service_template.reload

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -205,7 +205,7 @@ describe ServiceTemplateAnsiblePlaybook do
     it 'updates and returns the modified catalog item' do
       service_template = prebuild_service_template
       expect(described_class).to receive(:create_new_dialog)
-      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
       service_template.update_catalog_item(catalog_item_options_three, user)
 
       expect(service_template.name).to eq(catalog_item_options_three[:name])
@@ -226,7 +226,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
       expect(described_class).to receive(:create_new_dialog).never
-      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
 
       service_template.update_catalog_item(catalog_item_options_three, user)
       service_template.reload


### PR DESCRIPTION
1. Created the `update_catalog_item` method
2. Queues a job to update the existing job template and run a refresh (async)
3. Calls `ServiceTemplate#update_catalog_item` to handle updating the resource actions etc.
4. If a new dialog name is passed in a new dialog is created.
5. If the id of the existing dialog is passed in, no changes are made to that dialog

https://www.pivotaltracker.com/story/show/139020599