### PR TITLE
Collect more attributes for Ansible Tower job

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -55,12 +55,17 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
   end
 
   def update_with_provider_object(raw_job)
-    self.ems_ref = raw_job.id
-    self.status = raw_job.status
-    self.parameters =
-      raw_job.extra_vars_hash.collect do |para_key, para_val|
+    self.ems_ref     ||= raw_job.id
+    self.status        = raw_job.status
+    self.start_time  ||= raw_job.started
+    self.finish_time ||= raw_job.finished
+    self.verbosity   ||= raw_job.verbosity
+
+    if parameters.empty?
+      self.parameters = raw_job.extra_vars_hash.collect do |para_key, para_val|
         OrchestrationStackParameter.new(:name => para_key, :value => para_val, :ems_ref => "#{raw_job.id}_#{para_key}")
-      end if parameters.empty?
+      end
+    end
     save!
   end
   private :update_with_provider_object

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -13,6 +13,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
     _log.info("Launching Ansible Tower job with options: #{opts}")
     new_job = ManageIQ::Providers::AnsibleTower::AutomationManager::Job.create_job(jt, opts)
+    update_job_for_playbook(action, new_job, opts[:hosts])
 
     _log.info("Ansible Tower job with ref #{new_job.ems_ref} was created.")
     add_resource!(new_job, :name => action)
@@ -118,5 +119,12 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   def use_default_inventory?(hosts)
     hosts.blank? || hosts == 'localhost'
+  end
+
+  # update job attributes only available to playbook provisioning
+  def update_job_for_playbook(action, job, hosts)
+    hosts = (hosts || 'localhost').split(',')
+    playbook_id = options.fetch_path(:config_info, action.downcase.to_sym, :playbook_id)
+    job.update_attributes(:configuration_script_base_id => playbook_id, :hosts => hosts)
   end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/job_spec.rb
@@ -15,7 +15,10 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
       'id'         => '1',
       'name'       => template.name,
       'status'     => 'Successful',
-      'extra_vars' => {'param1' => 'val1'}.to_json
+      'extra_vars' => {'param1' => 'val1'}.to_json,
+      'verbosity'  => 3,
+      'started'    => Time.current,
+      'finished'   => Time.current,
     ).tap { |rjob| allow(rjob).to receive(:stdout).and_return('job stdout') }
   end
 
@@ -52,6 +55,13 @@ describe ManageIQ::Providers::AnsibleTower::AutomationManager::Job do
 
       it 'syncs the job with the provider' do
         subject.refresh_ems
+        expect(subject).to have_attributes(
+          :ems_ref     => the_raw_job.id,
+          :status      => the_raw_job.status,
+          :start_time  => the_raw_job.started,
+          :finish_time => the_raw_job.finished,
+          :verbosity   => the_raw_job.verbosity
+        )
         expect(subject.ems_ref).to eq(the_raw_job.id)
         expect(subject.status).to  eq(the_raw_job.status)
         expect(subject.parameters.first).to have_attributes(:name => 'param1', :value => 'val1')

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -15,7 +15,10 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
       'id'         => '1',
       'name'       => template.name,
       'status'     => 'Successful',
-      'extra_vars' => {'param1' => 'val1'}.to_json
+      'extra_vars' => {'param1' => 'val1'}.to_json,
+      'verbosity'  => 3,
+      'started'    => Time.current,
+      'finished'   => Time.current,
     ).tap { |rjob| allow(rjob).to receive(:stdout).and_return('job stdout') }
   end
 
@@ -52,6 +55,13 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
 
       it 'syncs the job with the provider' do
         subject.refresh_ems
+        expect(subject).to have_attributes(
+          :ems_ref     => the_raw_job.id,
+          :status      => the_raw_job.status,
+          :start_time  => the_raw_job.started,
+          :finish_time => the_raw_job.finished,
+          :verbosity   => the_raw_job.verbosity
+        )
         expect(subject.ems_ref).to eq(the_raw_job.id)
         expect(subject.status).to  eq(the_raw_job.status)
         expect(subject.parameters.first).to have_attributes(:name => 'param1', :value => 'val1')

--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -65,7 +65,13 @@ describe ServiceAnsibleTower do
         expect(template).to be_kind_of ConfigurationScript
         expect(opts).to have_key(:limit)
         expect(opts).to have_key(:extra_vars)
-      end.and_return(double(:raw_job, :id => 1, :status => "completed", :extra_vars_hash => {'var_name' => 'var_val'}))
+      end.and_return(double(:raw_job,
+                            :id              => 1,
+                            :status          => "completed",
+                            :verbosity       => 0,
+                            :started         => Time.current,
+                            :finished        => Time.current,
+                            :extra_vars_hash => {'var_name' => 'var_val'}))
 
       job_done = service_mix_dialog_setter.launch_job
       expect(job_done).to have_attributes(:ems_ref => "1", :status => "completed")


### PR DESCRIPTION
New attributes include start_time, finish_time, verbosity, hosts, and configuration_script_base_id

https://www.pivotaltracker.com/story/show/140529219