### PR TITLE
Remove duplicate include in Host model

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -10,7 +10,6 @@ class Host < ApplicationRecord
   include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include TenantIdentityMixin
-  include SupportsFeatureMixin
 
   VENDOR_TYPES = {
     # DB            Displayed


### PR DESCRIPTION
Unless we need to include `SupportsFeatureMixin` twice for extra potency, I figure we can delete the second one 😄 
