### PR TITLE
Disable SSL verification for embedded Ansible.

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -65,6 +65,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     provider.name = "Embedded Ansible"
     provider.zone = server.zone
     provider.url  = URI::HTTPS.build(:host => server.hostname || server.ipaddress, :path => "/ansibleapi/v1").to_s
+    provider.verify_ssl = 0
 
     provider.save!
 


### PR DESCRIPTION
Turn off SSL verification for embedded Ansible.

Unable to verify credentials for embedded Ansible without `verify_ssl = 0`