### PR TITLE
Enterprise rate parent for containers chargeback

### DIFF
--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -42,7 +42,7 @@ module Metric::ChargebackHelper
     when VmOrTemplate.name
       (resource_parents + [MiqEnterprise.my_enterprise]).compact
     when ContainerProject.name
-      [parent_ems].compact
+      [parent_ems, MiqEnterprise.my_enterprise].compact
     when Container.name
       [parent_ems]
     end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -181,4 +181,31 @@ describe ChargebackContainerProject do
       expect(subject.fixed_compute_metric).to eq(@metric_size / 2)
     end
   end
+
+  context "gets rate from enterprise" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
+    let(:miq_enterprise) { FactoryGirl.create(:miq_enterprise) }
+
+    before do
+      add_metric_rollups_for(@project, month_beginning...month_end, 24.hours, metric_rollup_params)
+
+      metric_rollup_params[:cpu_usage_rate_average] = 0.0
+      metric_rollup_params[:derived_memory_used] = 0.0
+
+      add_metric_rollups_for(@project, (month_beginning + 12.hours)...month_end, 24.hours, metric_rollup_params, nil)
+
+      @metric_size = @project.metric_rollups.size
+
+      temp = {:cb_rate => chargeback_rate, :object => miq_enterprise}
+      ChargebackRate.set_assignments(:compute, [temp])
+    end
+
+    subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
+
+    it "fixed_compute" do
+      # .to be_within(0.01) is used since theres a float error here
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
+      expect(subject.fixed_compute_metric).to eq(@metric_size / 2)
+    end
+  end
 end


### PR DESCRIPTION
Adding enterprise as a rate parent in `ChargebackContainerProject`. This means rates that are assigned to enterprise would act the same as rates assigned to Containers Providers for this particular chargeback type.
Im hesitant to add the same for `ChargebackContainerImage`. that would need more of a discussion on why and how rates should be inherited for that use case.
@simon3z

cc @blomquisg @gtanzillo  