### PR TITLE
Enable operations on CloudObjectStoreObject

### DIFF
--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -5,7 +5,16 @@ class CloudObjectStoreObject < ApplicationRecord
 
   acts_as_miq_taggable
 
+  include ProviderObjectMixin
+  include NewWithTypeStiMixin
+  include ProcessTasksMixin
+  include SupportsFeatureMixin
+
+  include_concern 'Operations'
+
   alias_attribute :name, :key
+
+  supports_not :delete, :reason => N_("Delete operation is not supported.")
 
   def disconnect_inv
     # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a

--- a/app/models/cloud_object_store_object/operations.rb
+++ b/app/models/cloud_object_store_object/operations.rb
@@ -1,0 +1,11 @@
+module CloudObjectStoreObject::Operations
+  extend ActiveSupport::Concern
+
+  def delete_cloud_object_store_object
+    raw_delete
+  end
+
+  def raw_delete
+    raise NotImplementedError, _("must be implemented in subclass")
+  end
+end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -634,6 +634,15 @@
       :description: Edit Tags of Objects
       :feature_type: control
       :identifier: cloud_object_store_object_tag
+  - :name: Modify
+    :description: Modify Object Store Object
+    :feature_type: admin
+    :identifier: cloud_object_store_object_admin
+    :children:
+    - :name: Delete
+      :description: Delete Object Store Object
+      :feature_type: admin
+      :identifier: cloud_object_store_object_delete
 
 # CloudTenant
 - :name: Cloud Tenants

--- a/db/migrate/20170223135511_add_name_to_cloud_object_store_object.rb
+++ b/db/migrate/20170223135511_add_name_to_cloud_object_store_object.rb
@@ -1,0 +1,5 @@
+class AddNameToCloudObjectStoreObject < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_object_store_objects, :name, :string
+  end
+end

--- a/db/migrate/20170223135521_add_type_to_cloud_object_store_object.rb
+++ b/db/migrate/20170223135521_add_type_to_cloud_object_store_object.rb
@@ -1,0 +1,6 @@
+class AddTypeToCloudObjectStoreObject < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_object_store_objects, :type, :string
+    add_index :cloud_object_store_objects, :type
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -324,6 +324,8 @@ cloud_object_store_objects:
 - ems_id
 - cloud_tenant_id
 - cloud_object_store_container_id
+- name
+- type
 cloud_resource_quotas:
 - id
 - ems_ref


### PR DESCRIPTION
This commit brings support for operations on CloudObjectStoreObject. For now, only delete operation is supported. The two new columns `type` and `name` have to be there to enable appropriate async task processing.
