### PR TITLE
Remove admin role for tenant admin

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -61,7 +61,7 @@ module Rbac
     # value:
     #   array - disallowed roles for the user's role
     DISALLOWED_ROLES_FOR_USER_ROLE = {
-      'EvmRole-tenant_administrator' => %w(EvmRole-super_administrator)
+      'EvmRole-tenant_administrator' => %w(EvmRole-super_administrator EvmRole-administrator)
     }.freeze
 
     # key: descendant::klass

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -341,6 +341,10 @@ describe Rbac::Filterer do
           FactoryGirl.create(:miq_user_role, :name => MiqUserRole::SUPER_ADMIN_ROLE_NAME)
         end
 
+        let!(:administrator_user_role) do
+          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::ADMIN_ROLE_NAME)
+        end
+
         let(:group) do
           FactoryGirl.create(:miq_group, :tenant => default_tenant, :miq_user_role => tenant_administrator_user_role)
         end
@@ -348,12 +352,12 @@ describe Rbac::Filterer do
         let!(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
 
         it 'can see all roles expect to EvmRole-super_administrator' do
-          expect(MiqUserRole.count).to eq(2)
+          expect(MiqUserRole.count).to eq(3)
           get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role])
         end
 
         it 'can see all groups expect to group with role EvmRole-super_administrator' do
-          expect(MiqUserRole.count).to eq(2)
+          expect(MiqUserRole.count).to eq(3)
           get_rbac_results_for_and_expect_objects(MiqGroup, [group])
         end
       end


### PR DESCRIPTION
Follow up: https://github.com/ManageIQ/manageiq/pull/13689

https://bugzilla.redhat.com/show_bug.cgi?id=1426619

User with tenant-admin role cannot user administator-role(cannot see or assign it to any group).
Other roles have lower permissions.

@miq-bot add_label rbac, core, enhancement, euwe/yes

@miq-bot assign @gtanzillo 
