### PR TITLE
Support operation `clear` on CloudObjectStoreContainer

### DIFF
--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -15,4 +15,5 @@ class CloudObjectStoreContainer < ApplicationRecord
   alias_attribute :name, :key
 
   supports_not :delete, :reason => N_("Delete operation is not supported.")
+  supports_not :cloud_object_store_container_clear
 end

--- a/app/models/cloud_object_store_container/operations.rb
+++ b/app/models/cloud_object_store_container/operations.rb
@@ -8,4 +8,12 @@ module CloudObjectStoreContainer::Operations
   def raw_delete
     raise NotImplementedError, _("must be implemented in subclass")
   end
+
+  def cloud_object_store_container_clear
+    raw_cloud_object_store_container_clear
+  end
+
+  def raw_cloud_object_store_container_clear
+    raise NotImplementedError, _("must be implemented in subclass")
+  end
 end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -65,6 +65,7 @@ module SupportsFeatureMixin
     # FIXME: this is just a internal helper and should be refactored
     :control                    => 'Basic control operations',
     :cloud_tenant_mapping       => 'CloudTenant mapping',
+    :cloud_object_store_container_clear => 'Clear Object Store Container',
     :create                     => 'Creation',
     :backup_create              => 'CloudVolume backup creation',
     :backup_restore             => 'CloudVolume backup restore',

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -616,6 +616,10 @@
       :description: Delete Object Store Containers
       :feature_type: admin
       :identifier: cloud_object_store_container_delete
+    - :name: Clear
+      :description: Clear Object Store Containers
+      :feature_type: admin
+      :identifier: cloud_object_store_container_clear
 
 # CloudObjectStoreObject
 - :name: Cloud Objects

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -25,6 +25,8 @@
   - ontap_storage_volume
   - catalog
   - cloud_network
+  - cloud_object_store_container
+  - cloud_object_store_object
   - control_explorer
   - dashboard
   - datacenter


### PR DESCRIPTION
Operation `clear` removes all CloudObjectStoreObjects from the CloudObjectStoreContainer. Since this kind of operation is not recognized by miq yet, I had to register it in `supports_feature_mixin.rb`.