### PR TITLE
Fix fetch methods in services controller 

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -109,19 +109,19 @@ module Api
     end
 
     def fetch_ext_management_system(data)
-      orchestration_manager_id = parse_id(data, :orchestration_manager)
+      orchestration_manager_id = parse_id(data, :providers)
       raise BadRequestError, 'Missing ExtManagementSystem identifier id' if orchestration_manager_id.nil?
       resource_search(orchestration_manager_id, :ext_management_systems, ExtManagementSystem)
     end
 
     def fetch_service(data)
-      service_id = parse_id(data, :service)
+      service_id = parse_id(data, :services)
       raise BadRequestError, 'Missing Service identifier id' if service_id.nil?
       resource_search(service_id, :services, Service)
     end
 
     def fetch_orchestration_template(data)
-      orchestration_template_id = parse_id(data, :orchestration_template)
+      orchestration_template_id = parse_id(data, :orchestration_templates)
       raise BadRequestError, 'Missing OrchestrationTemplate identifier id' if orchestration_template_id.nil?
       resource_search(orchestration_template_id, :orchestration_templates, OrchestrationTemplate)
     end


### PR DESCRIPTION
When looking into #13664, I noticed that there were no tests for referencing objects via `id` or `href` on services create, and that it wasn't working as expected. Parsing by `id` worked but `href` parsing did not work because it was not specifying the correct collection:
* `:service` needed to be `:services`
* `:orchestration_template` needed to be `:orchestration_templates`
* `:orchestration_manager` needed to be `:providers` 

This fixes the above issues and also adds in appropriate tests.

@miq-bot add_label bug, api, test
@miq-bot assign @abellotti 

(this is also my 💯 manageiq PR! 🎉 ) 