### PR TITLE
ApplicationRecord - temporarily add .decorate and self.decorate

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,4 +9,8 @@ class ApplicationRecord < ActiveRecord::Base
   include ToModelHash
 
   extend ArTableLock
+
+  # FIXME: UI code - decorator support
+  extend MiqDecorator::Klass
+  include MiqDecorator::Instance
 end


### PR DESCRIPTION
This is UI code that should live in the UI, but that requires a few more steps first.

In the mean time, we either have to keep patching ApplicationRecord and deal with the autoloader, **or** just add it to ApplicationRecord directly :).

This is a follow up to ManageIQ/manageiq-ui-classic#237 (which solved this by an initializer, which doesn't work with rails' autoloading in development mode).

---

Please merge together with https://github.com/ManageIQ/manageiq-ui-classic/pull/506 (either will break without the other).

@miq-bot add_label technical debt, ui, euwe/no