### PR TITLE
Fixed bug in migrating message attribute from jobs table  to miq_task

### DIFF
--- a/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
+++ b/db/migrate/20170120164058_create_task_for_each_job_and_transfer_attributes.rb
@@ -13,7 +13,7 @@ class CreateTaskForEachJobAndTransferAttributes < ActiveRecord::Migration[5.0]
       Job.find_each do |job|
         job.create_miq_task(:status        => job.status.try(:capitalize),
                             :name          => job.name,
-                            :message       => job.message,
+                            :message       => job.message.try(:truncate, 255),
                             :state         => job.state.try(:capitalize),
                             :userid        => job.userid,
                             :miq_server_id => job.miq_server_id,

--- a/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
+++ b/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
@@ -15,6 +15,14 @@ describe CreateTaskForEachJobAndTransferAttributes do
       expect(MiqTask.find_by(:name => "Hello Test Job").status).to eq "Some test status"
       expect(MiqTask.find_by(:name => "Hello Test Job2").state).to eq "Some state"
     end
+
+    it "truncates message from jobs.message to 255 characters before assigning it to tasks.message" do
+      jobs_stub.create!(:name => "Hello Test Job", :message => "a" * 999)
+
+      migrate
+
+      expect(MiqTask.find_by(:name => "Hello Test Job").message.length).to be 255
+    end
   end
 
   migration_context :down do


### PR DESCRIPTION
Data from db column type ```TEXT``` should be truncated to 255 characters before assigning to  ```VARCHAR(255)``` column

Issue: https://github.com/ManageIQ/manageiq/issues/14089

@miq_bot add-label bug, core

\cc @isimluk @Fryguy 
Does it make sense to change data type of ```miq_tasks.message``` to ```TEXT``` to accommodate long messages (like stack trace, which is currently could be present in ```jobs.message```) ?
