### PR TITLE
Return result of destroy action to user, not nil

### DIFF
--- a/app/controllers/api/orchestration_templates_controller.rb
+++ b/app/controllers/api/orchestration_templates_controller.rb
@@ -3,8 +3,9 @@ module Api
     def delete_resource(type, id, data = {})
       klass    = collection_class(type)
       resource = resource_search(id, type, klass)
-      super
+      result = super
       resource.raw_destroy if resource.kind_of?(OrchestrationTemplateVnfd)
+      result
     end
 
     def copy_resource(type, id, data = {})

--- a/spec/requests/api/orchestration_template_spec.rb
+++ b/spec/requests/api/orchestration_template_spec.rb
@@ -112,6 +112,18 @@ RSpec.describe 'Orchestration Template API' do
       expect(OrchestrationTemplate.exists?(cfn.id)).to be_falsey
     end
 
+    it 'runs callback before_destroy on the model' do
+      api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
+
+      cfn = FactoryGirl.create(:orchestration_template_vnfd_with_content)
+      api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
+      expect_any_instance_of(OrchestrationTemplateVnfd).to receive(:raw_destroy).with(no_args) # callback on the model
+      run_delete(orchestration_templates_url(cfn.id))
+
+      expect(response).to have_http_status(:no_content)
+      expect(OrchestrationTemplate.exists?(cfn.id)).to be_falsey
+    end
+
     it 'supports multiple orchestration_template delete' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :delete)
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1414881

The cause of the bug was, that delete_resource action must return action-result-hash and this was returning nil.

@miq-bot add_label bug, euwe/yes, api
@miq-bot assign @abellotti 