### PR TITLE
[Api] Improve error handling on destroy action

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -183,9 +183,9 @@ module Api
 
       def delete_resource_action(klass, type, id)
         api_log_info("Deleting #{type} id #{id}")
-        resource_search(id, type, klass)
+        resource = resource_search(id, type, klass)
         result = begin
-                   klass.destroy(id)
+                   resource.destroy!
                    action_result(true, "#{type} id: #{id} deleting")
                  rescue => err
                    action_result(false, err.to_s)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -98,8 +98,6 @@ module Api
         klass = collection_class(type)
         id ||= @req.c_id
         raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
-        api_log_info("Deleting #{type} id #{id}")
-        resource_search(id, type, klass)
         delete_resource_action(klass, type, id)
       end
 
@@ -184,6 +182,8 @@ module Api
       end
 
       def delete_resource_action(klass, type, id)
+        api_log_info("Deleting #{type} id #{id}")
+        resource_search(id, type, klass)
         result = begin
                    klass.destroy(id)
                    action_result(true, "#{type} id: #{id} deleting")

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -188,7 +188,7 @@ module Api
                    resource.destroy!
                    action_result(true, "#{type} id: #{id} deleting")
                  rescue => err
-                   action_result(false, err.to_s)
+                   action_result(false, "#{err} - #{resource.errors.full_messages.join(', ')}")
                  end
         add_href_to_result(result, type, id)
         log_result(result)


### PR DESCRIPTION
Minor improvements of the generic resource_delete action
 * get RBAC check closer to the actual action
 * avoid extra select
 * publish errors from validations/callbacks to user

@miq-bot add_label api, enhancement, euwe/yes
@miq-bot assign @abellotti 