### PR TITLE
make all managers inherit from BaseManager

### DIFF
--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::AutomationManager < ::ExtManagementSystem
+class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
   require_nested :Authentication
   require_nested :ConfigurationScript
   require_nested :ConfigurationScriptPayload

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::ConfigurationManager < ::ExtManagementSystem
+class ManageIQ::Providers::ConfigurationManager < ManageIQ::Providers::BaseManager
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"

--- a/app/models/manageiq/providers/provisioning_manager.rb
+++ b/app/models/manageiq/providers/provisioning_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::ProvisioningManager < ::ExtManagementSystem
+class ManageIQ::Providers::ProvisioningManager < ManageIQ::Providers::BaseManager
   has_many :operating_system_flavors, :dependent => :destroy
   has_many :customization_scripts,    :dependent => :destroy
   has_many :customization_script_ptables

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AutomationManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_AutomationManager < MiqAeServiceManageIQ_Providers_BaseManager
     expose :provider,               :association => true
     expose :configuration_profiles, :association => true
     expose :configured_systems,     :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-configuration_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_ConfigurationManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_ConfigurationManager < MiqAeServiceManageIQ_Providers_BaseManager
     expose :provider,               :association => true
     expose :configuration_profiles, :association => true
     expose :configured_systems,     :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-provisioning_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-provisioning_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_ProvisioningManager < MiqAeServiceExtManagementSystem
+  class MiqAeServiceManageIQ_Providers_ProvisioningManager < MiqAeServiceManageIQ_Providers_BaseManager
     expose :provider,                 :association => true
     expose :operating_system_flavors, :association => true
     expose :customization_scripts,    :association => true


### PR DESCRIPTION
This makes all Managers inherit from `BaseManager`, which makes things more consistent.
