### PR TITLE
ansible include event stream module

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher::Stream
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatcher::Stream
+
   class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
   end
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/event_catcher/stream.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher::Stream
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatcher::Stream
+
   class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
   end
 


### PR DESCRIPTION
Looks like including this shared module was missed during refactoring

@miq-bot assign @blomquisg 
@miq-bot add_label providers/ansible_tower, bug