### PR TITLE
Do not truncate(255) message attribute in miq_tasks table

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -262,7 +262,7 @@ class Job < ApplicationRecord
     {:status        => status.try(:capitalize),
      :state         => state.try(:capitalize),
      :name          => name,
-     :message       => message.try(:truncate, 255),
+     :message       => message,
      :userid        => userid,
      :miq_server_id => miq_server_id,
      :context_data  => context,

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -59,7 +59,7 @@ class MiqTask < ApplicationRecord
   def update_status(state, status, message)
     status = STATUS_ERROR if status == STATUS_EXPIRED
     _log.info("Task: [#{id}] [#{state}] [#{status}] [#{message}]")
-    attributes = {:state => state, :status => status, :message => message.truncate(255)}
+    attributes = {:state => state, :status => status, :message => message}
     attributes[:started_on] = Time.now.utc if state == STATE_ACTIVE && started_on.nil?
     update_attributes!(attributes)
   end
@@ -71,7 +71,7 @@ class MiqTask < ApplicationRecord
 
   def update_message(message)
     _log.info("Task: [#{id}] [#{message}]")
-    update_attributes!(:message => message.truncate(255))
+    update_attributes!(:message => message)
   end
 
   def update_context(context)
@@ -79,7 +79,7 @@ class MiqTask < ApplicationRecord
   end
 
   def message=(message)
-    super(message.truncate(255))
+    super(message)
   end
 
   def self.info(taskid, message, pct_complete)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -311,7 +311,7 @@ describe Job do
           :status        => @job.status.try(:capitalize),
           :state         => @job.state.try(:capitalize),
           :name          => @job.name,
-          :message       => @job.message.try(:truncate, 255),
+          :message       => @job.message,
           :userid        => @job.userid,
           :miq_server_id => @job.miq_server_id,
           :context_data  => @job.context,

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -32,17 +32,6 @@ describe MiqTask do
       expect(@miq_task.message).to eq(message)
     end
 
-    it "should trim long message to 255" do
-      message = ("So there I was sitting in a rabbit's suit" * 100).freeze
-      @miq_task.message = message
-      expect(@miq_task.message.length).to eq(255)
-      expect(@miq_task.message[252, 3]).to eq("...")
-
-      @miq_task.update_attributes(:message => message)
-      expect(@miq_task.message.length).to eq(255)
-      expect(@miq_task.message[252, 3]).to eq("...")
-    end
-
     it "should update context upon request" do
       context = {:a => 1, :b => 2}
       @miq_task.update_context(context)


### PR DESCRIPTION
After linking ```jobs``` and ```miq_tasks``` tables, message attribute from ```jobs``` table propagated to ```miq_tasks.message``` (PR: https://github.com/ManageIQ/manageiq/pull/13452).  
We do not need to truncate message since data type of ```miq_tasks.message``` is ```text``` (PR: https://github.com/ManageIQ/manageiq/pull/14100)

this PR depends on https://github.com/ManageIQ/manageiq/pull/14100

@miq-bot add-label bug, core

\cc @Fryguy 