### PR TITLE
[DARGA] Fill guest_os correctly

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -166,6 +166,10 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
     uid      = image.image_id
     location = image.image_location
     guest_os = (image.platform == "windows") ? "windows" : "linux"
+    if guest_os == "linux"
+      guest_os = OperatingSystem.normalize_os_name(location)
+      guest_os = "linux" if guest_os == "unknown"
+    end
 
     name     = get_from_tags(image, :name)
     name ||= image.name


### PR DESCRIPTION
Fill guest_os correctly, inferring it from Image location

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1404752

Conflicted cherry-pick of:
https://github.com/ManageIQ/manageiq-providers-amazon/pull/84/

The commit for old refresh was applied without conflicts, the
commit for a new refresh is not relevant for Darga.