### PR TITLE
Add missing fields to Middleware views

### DIFF
--- a/product/views/MiddlewareDatasource.yaml
+++ b/product/views/MiddlewareDatasource.yaml
@@ -33,6 +33,12 @@ headers:
 - Server
 - Host Name
 
+include:
+  middleware_server:
+    columns:
+      - name
+      - hostname
+
 # Condition(s) string for the SQL query
 conditions:
 

--- a/product/views/MiddlewareDeployment.yaml
+++ b/product/views/MiddlewareDeployment.yaml
@@ -36,6 +36,12 @@ headers:
 - Server
 - Host Name
 
+include:
+  middleware_server:
+    columns:
+      - name
+      - hostname
+
 # Condition(s) string for the SQL query
 conditions:
 

--- a/product/views/MiddlewareDomain.yaml
+++ b/product/views/MiddlewareDomain.yaml
@@ -34,6 +34,11 @@ headers:
 - Feed
 - Provider
 
+include:
+  ext_management_system:
+    columns:
+      - name
+
 # Condition(s) string for the SQL query
 conditions:
 

--- a/product/views/MiddlewareMessaging.yaml
+++ b/product/views/MiddlewareMessaging.yaml
@@ -34,6 +34,11 @@ headers:
 - Messaging Type
 - Server
 
+include:
+  middleware_server:
+    columns:
+      - name
+
 # Condition(s) string for the SQL query
 conditions:
 

--- a/product/views/MiddlewareServer.yaml
+++ b/product/views/MiddlewareServer.yaml
@@ -23,7 +23,12 @@ cols:
 - product
 - name
 - hostname
+- ext_management_system.name
 
+include:
+  ext_management_system:
+    columns:
+      - name
 
 # Order of columns (from all tables)
 col_order:


### PR DESCRIPTION
Bugzilla Ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1422584

The fields were not being shown because the associations were not being
loaded. This fixes this, effectively adding data to those columns:

Middleware Servers:
  - Provider

Middleware Domains:
  - Server

Middleware Deployments:
  - Server
  - Hostname

Middleware Datasources:
  - Server
  - Hostname

Middleware Messagings:
  - Server