### PR TITLE
Increase the number of pooled connections for UI

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1425,7 +1425,7 @@
       :stats_update_period: 10.minutes
       :status_update_period: 5.minutes
     :ui_worker:
-      :connection_pool_size: 8
+      :connection_pool_size: 12
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
     :vim_broker_worker:


### PR DESCRIPTION
Bugzilla Ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1420431

When starting a background job using threading on Puma, ActiveRecord
dedicates a connection from the pool to it. If this is done repeatedly,
say, by adding many datasources to a middleware server, all the
connections in the pool are allocated, making the next request not have
any connection available, making the whole server go down.

By increasing the pool size for the UI, we manage to make this case
happen less often (as of now it happens even on normal usage), while
making the application faster in general (even when the connection is
released during the 5s for the timeout, the server has to wait until it
is available, making the whole application slower and queueing
requests).

There are some ways to avoid this case happening (like using a different
connection pool for those threads), but they need to be managed on a
case by case basis and the added complexity is not worth it. A more
sensible solution would be to utilize a real background worker like
Sidekiq, DelayedJob or Resque, but they come with additional
dependencies.

Steps for Testing/QA
----------------------------

Add new Datasource.
Chose MariaDB from select.
Type a DS and JNDI names.
For driver page, from second tab chose "mariadb" pre-uploaded driver.
Finish Creation.
Repeat three or four times.
Without the fix, in a few seconds MIQ should be down, with it, it should not.

