### PR TITLE
Switched version to the latest version of gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "activerecord-session_store",     "~>1.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.2.1",       :require => false
-gem "ansible_tower_client",           "~>0.7.0",       :require => false
+gem "ansible_tower_client",           "~>0.8.0",       :require => false
 gem "aws-sdk",                        "~>2",           :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"


### PR DESCRIPTION
The latest version of ansible_tower_client has better error handling.

Links
-----

* https://github.com/ansible/ansible_tower_client_ruby/pull/76


