### PR TITLE
Set the raw power state when starting Openstack instance

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Power
       when "SHELVED", "SHELVED_OFFLOADED" then connection.unshelve_server(ems_ref)
       end
     end
+    self.update_attributes!(:raw_power_state => "ACTIVE")
   end
 
   def raw_stop

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -226,4 +226,18 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       vm.resize_revert
     end
   end
+
+  describe "#raw_start" do
+    it "sets the raw power state to 'ACTIVE'" do
+      vm = FactoryGirl.create(:vm_openstack,
+                              :ext_management_system => ems,
+                              :cloud_tenant          => tenant,
+                              :raw_power_state       => "SHUTOFF")
+      expect(handle).to receive(:start_server)
+
+      vm.raw_start
+
+      expect(vm.raw_power_state).to eq("ACTIVE")
+    end
+  end
 end


### PR DESCRIPTION
Changes #raw_start to be like the other power state operations which
set the #raw_power_state at the end of the operation.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1290003

@miq-bot add-label providers, bug
@miq-bot assign @agrare 