### PR TITLE
SCVMM - Enable VM reset functionality

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
 
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
   supports_not :publish
+  supports     :reset
 
   POWER_STATES = {
     "Running"  => "on",


### PR DESCRIPTION
Although the SCVMM VM reset method is in place and working correctly, ```supports :reset``` was missing, this resulted in the the "Power/reset" menu item being excluded from the VM summary page.

https://bugzilla.redhat.com/show_bug.cgi?id=1392608