### PR TITLE
Enhance service edit to accept attribute references 

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -12,6 +12,11 @@ module Api
       service
     end
 
+    def edit_resource(type, id, data)
+      attributes = build_service_attributes(data)
+      super(type, id, attributes)
+    end
+
     def reconfigure_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 


### PR DESCRIPTION
closes #13664

Allows for all `id` and `href` references for all the same attributes that it does in create.

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 