### PR TITLE
A constant detailing the SmartState roles

### DIFF
--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -3,6 +3,8 @@ require 'yaml'
 module MiqServer::ServerSmartProxy
   extend ActiveSupport::Concern
 
+  SMART_ROLES = %w(smartproxy smartstate).freeze
+
   included do
     serialize :capabilities
   end


### PR DESCRIPTION
I was looking for the smart state roles in a constant or other consumable state and couldn't find one so I want to add this.
It will be useful for https://github.com/ManageIQ/manageiq-ui-classic/pull/273