### PR TITLE
Sort files to require for coverage reports

### DIFF
--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/kernel/reporting'
 
 # Require all ruby files for accuracte test coverage reports
 %w(app lib).each do |path|
-  Dir.glob(Rails.root.join(path, "**", "*.rb")) do |file|
+  Dir.glob(Rails.root.join(path, "**", "*.rb")).sort.each do |file|
     next if file.include?("/bin/") || file.include?("/spec/") || file.include?("/lib/generators/provider/templates/")
     begin
       silence_warnings { require file }


### PR DESCRIPTION
`Dir.glob` don't guarantee the order of the files it returns
For example we have model in
[`app/model/rss_feed.rb` ](https://github.com/ManageIQ/manageiq/blob/master/app/models/rss_feed.rb#L1) and his extension in
[`app/model/rss_feed/import_export.rb` ](https://github.com/ManageIQ/manageiq/blob/master/app/models/rss_feed/import_export.rb#L1)- there is class
defined without inheriting from ApplicationRecord
so when class from `import_export.rb` is loaded first
is it loaded as `RssFeed < Object` and when
after this is `app/model/rss_feed.rb` loaded
it is causing error(this warning is suppressed by
silence_warnings in coverage_helper):

`TypeError: superclass mismatch for class RssFeed`

and then `RssFeed < ApplicationRecord` is not loaded

Sorting `Dir.glob` guarantee order so that
files will be first then subdirectories,..
() because `'.'.ord < '/'.ord`
(sort is also used in eager_load!
https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L475)

this sporadic failure can be seen  here: https://travis-ci.org/ManageIQ/manageiq/jobs/206552109
(there are some my debug messages)

This PR is blocking https://github.com/ManageIQ/manageiq/pull/14041

thanks @isimluk for help!

cc @kbrock  @jrafanie 
@miq-bot assign @gtanzillo 

@miq-bot add_label bug/sporadic test failure, test

