### PR TITLE
Opt-in to EventedFileUpdateChecker if listen gem installed

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,15 @@ Vmdb::Application.configure do
   config.cache_classes = false
   config.eager_load = false
 
+  # Guard's 'listen' gem is measurably faster than filesystem polling
+  # but some people have a bad time with it.  Opt in if you already
+  # installed it (e.g. in Gemfile.dev.rb).
+  begin
+    require 'listen'
+    config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  rescue LoadError
+  end
+
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 


### PR DESCRIPTION
In dev mode Rails by defaults globs and stats source & asset files to check for modifications *every single request*.
For us that's >3000 files, making things ~2x slower than they could be!
(developement mode, without compiling assets)
E.g. login page, a pretty much static page, loads ~250 assets, takes ~20s to reload, becomes a lightning-fast :man_facepalming: <10s  with this PR :cherries: :racehorse:

- Investigation details in https://gist.github.com/cben/ca7a0d75734216816b39afdec5865224
- Skipping filesystem polling for static assets has been tried but rejected in https://github.com/rails/rails/pull/23518 (possible with custom middleware).
- I have a PoC monkey patch rate-limiting the polling to 100ms and that's enough to get near-optimal performance.  I plan to make a rails PR proposing this as a 10%/90% option.
- **Rails 5 supports a no-polling mode using Guard's `listen` gem which uses inotify/fsevents etc.**
  - People have reported problems with this mode, especially on Mac: https://github.com/rails/rails/issues/26158
  - [listen's README](https://github.com/guard/listen) sounds like it's tricky to install, especially on travis.

~~This PR activates the shiny no-polling mode.  I added `listen` gem to development group, won't be there in tests nor production (which don't reload code anyway, right?).~~
Some docs suggest merely having `listen` gem is enough but I also had to add the development.rb config line.  Docs: http://edgeguides.rubyonrails.org/configuring.html#rails-general-configuration (search file_watcher), http://edgeguides.rubyonrails.org/configuring.html#evented-file-system-monitor

I don't know if it's robust enough but the gain seems worth making it the default.  What say you?

CHANGED: **This PR activates the shiny no-polling mode only for people that have `listen` gem installed.**  Makes it easy to opt-in by adding `gem 'listen'` to `Gemfile.dev.rb`.

@miq-bot add-label developer, gem changes, ui, performance
