### PR TITLE
[WIP] Add support for provider tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ unless dependencies.detect { |d| d.name == "manageiq-content" }
   gem "manageiq-content", :git => "https://github.com/ManageIQ/manageiq-content", :branch => "master"
 end
 unless dependencies.detect { |d| d.name == "manageiq-providers-amazon" }
-  gem "manageiq-providers-amazon", :git => "https://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+  #gem "manageiq-providers-amazon", :git => "https://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+  gem "manageiq-providers-amazon", :path => "/Users/dberger/Dev/manageiq-providers-amazon-djberg96"
 end
 unless dependencies.detect { |d| d.name == "manageiq-providers-azure" }
   gem "manageiq-providers-azure", :git => "https://github.com/ManageIQ/manageiq-providers-azure", :branch => "master"

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -16,6 +16,7 @@ class CloudSubnet < ApplicationRecord
   has_many :network_ports, :through => :cloud_subnet_network_ports, :dependent => :destroy
   has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
   has_many :cloud_subnets, :foreign_key => :parent_cloud_subnet_id
+  has_many :provider_tags, :foreign_key => :resource_id, :primary_key => :ems_ref
 
   has_one :public_network, :through => :network_router, :source => :cloud_network
 

--- a/app/models/manageiq/providers/tag_manager.rb
+++ b/app/models/manageiq/providers/tag_manager.rb
@@ -1,6 +1,0 @@
-module ManageIQ::Providers
-  class TagManager < BaseManager
-    include SupportsFeatureMixin
-    has_many :resources, :foreign_key => :ems_uid, :dependent => :destroy
-  end
-end

--- a/app/models/manageiq/providers/tag_manager.rb
+++ b/app/models/manageiq/providers/tag_manager.rb
@@ -1,0 +1,6 @@
+module ManageIQ::Providers
+  class TagManager < BaseManager
+    include SupportsFeatureMixin
+    has_many :resources, :foreign_key => :ems_uid, :dependent => :destroy
+  end
+end

--- a/app/models/provider_tag.rb
+++ b/app/models/provider_tag.rb
@@ -1,0 +1,6 @@
+class ProviderTag < ApplicationRecord
+  validates_presence_of :key
+  validates_presence_of :resource_id
+  validates_presence_of :type
+  validates_uniqueness_of :key, :scope => [:value, :resource_id]
+end

--- a/app/models/provider_tag.rb
+++ b/app/models/provider_tag.rb
@@ -14,4 +14,13 @@ class ProviderTag < ApplicationRecord
   validates :resource_id, :presence => true
   validates :type, :presence => true
   validates :key, :uniqueness => { :scope => [:value, :resource_id] }
+
+  before_save :set_tag_type
+
+  # If the :type field isn't already set then use a stringified version
+  # of the current class name to set the type for STI purposes.
+  #
+  def set_tag_type
+    type = self.class.to_s if type.blank?
+  end
 end

--- a/app/models/provider_tag.rb
+++ b/app/models/provider_tag.rb
@@ -1,3 +1,14 @@
+# The ProviderTag model serves as the class for tags (key/value pairs) that
+# exist on remote (e.g. Azure, Amazon) resources. We then store and manage
+# them locally.
+#
+# When establishing a relationship from a model, it should look like this:
+#
+#   has_many :provider_tags, :foreign_key => :resource_id, :primary_key => :some_unique_key
+#
+# Where 'some_unique_key' is ems_ref, guid, or whatever stringy key uniquely
+# identifies that resource.
+#
 class ProviderTag < ApplicationRecord
   validates :key, :presence => true
   validates :resource_id, :presence => true

--- a/app/models/provider_tag.rb
+++ b/app/models/provider_tag.rb
@@ -1,6 +1,6 @@
 class ProviderTag < ApplicationRecord
-  validates_presence_of :key
-  validates_presence_of :resource_id
-  validates_presence_of :type
-  validates_uniqueness_of :key, :scope => [:value, :resource_id]
+  validates :key, :presence => true
+  validates :resource_id, :presence => true
+  validates :type, :presence => true
+  validates :key, :uniqueness => { :scope => [:value, :resource_id] }
 end

--- a/app/models/provider_tags/cloud_subnet_tag.rb
+++ b/app/models/provider_tags/cloud_subnet_tag.rb
@@ -1,0 +1,3 @@
+class CloudSubnetTag < ProviderTag
+  belongs_to :cloud_subnet, :foreign_key => :resource_id, :primary_key => :ems_ref
+end

--- a/app/models/provider_tags/vm_or_template_tag.rb
+++ b/app/models/provider_tags/vm_or_template_tag.rb
@@ -1,0 +1,3 @@
+class VmOrTemplateTag < ProviderTag
+  belongs_to :vm_or_templates, :foreign_key => :guid
+end

--- a/app/models/provider_tags/vm_or_template_tag.rb
+++ b/app/models/provider_tags/vm_or_template_tag.rb
@@ -1,3 +1,3 @@
 class VmOrTemplateTag < ProviderTag
-  belongs_to :vm_or_templates, :foreign_key => :guid
+  belongs_to :vm_or_template, :foreign_key => :resource_id, :primary_key => :guid
 end

--- a/app/models/provider_tags/vm_or_template_tag.rb
+++ b/app/models/provider_tags/vm_or_template_tag.rb
@@ -1,5 +1,5 @@
 class VmOrTemplateTag < ProviderTag
-  belongs_to :vm_or_template, :foreign_key => :resource_id, :primary_key => :guid
+  belongs_to :vm_or_template, :foreign_key => :resource_id, :primary_key => :ems_ref
 
   # TODO: Can we automatically use the VmTag subclass from here if the :type
   # column is a Vm instead of a Template?

--- a/app/models/provider_tags/vm_or_template_tag.rb
+++ b/app/models/provider_tags/vm_or_template_tag.rb
@@ -1,3 +1,6 @@
 class VmOrTemplateTag < ProviderTag
   belongs_to :vm_or_template, :foreign_key => :resource_id, :primary_key => :guid
+
+  # TODO: Can we automatically use the VmTag subclass from here if the :type
+  # column is a Vm instead of a Template?
 end

--- a/app/models/provider_tags/vm_tag.rb
+++ b/app/models/provider_tags/vm_tag.rb
@@ -1,3 +1,3 @@
 class VmTag < VmOrTemplateTag
-  belongs_to :vm, :foreign_key => :resource_id, :primary_key => :guid
+  belongs_to :vm, :foreign_key => :resource_id, :primary_key => :ems_ref
 end

--- a/app/models/provider_tags/vm_tag.rb
+++ b/app/models/provider_tags/vm_tag.rb
@@ -1,0 +1,3 @@
+class VmTag < VmOrTemplateTag
+  belongs_to :vm, :foreign_key => :resource_id, :primary_key => :guid
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -78,7 +78,7 @@ class VmOrTemplate < ApplicationRecord
 
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
-  has_many                  :provider_tags, :foreign_key => :resource_id, :primary_key => :guid
+  has_many                  :provider_tags, :foreign_key => :resource_id, :primary_key => :ems_ref
 
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -78,7 +78,7 @@ class VmOrTemplate < ApplicationRecord
 
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
-  has_many                  :provider_tags, :as => :resource
+  has_many                  :provider_tags, :foreign_key => :resource_id, :primary_key => :guid
 
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -78,6 +78,7 @@ class VmOrTemplate < ApplicationRecord
 
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
+  has_many                  :provider_tags, :as => :resource
 
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,6 +74,7 @@ module Vmdb
     config.autoload_paths += config.eager_load_paths
     config.autoload_paths << Rails.root.join("app", "models", "aliases")
     config.autoload_paths << Rails.root.join("app", "models", "mixins")
+    config.autoload_paths << Rails.root.join("app", "models", "provider_tags")
     config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models")
     config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models", "mixins")
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins")

--- a/db/migrate/20170301192129_create_provider_tags_table.rb
+++ b/db/migrate/20170301192129_create_provider_tags_table.rb
@@ -5,6 +5,8 @@ class CreateProviderTagsTable < ActiveRecord::Migration[5.0]
       t.string :value, :comment => "The value within a key/value pair."
       t.string :resource_id, :null => false, :comment => "Reference to the field used as primary key of the resource."
       t.string :type, :null => false, :comment => "The model name of the resource type."
+      t.string :label, :comment => "Optional symbolic label for the key/value pair."
+      t.integer :classification_id, :comment => "Optional reference to a Classification."
       t.timestamps
     end
   end

--- a/db/migrate/20170301192129_create_provider_tags_table.rb
+++ b/db/migrate/20170301192129_create_provider_tags_table.rb
@@ -1,0 +1,11 @@
+class CreateProviderTagsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :provider_tags do |t|
+      t.string :key, :null => false, :comment => "The key in a key/value pair."
+      t.string :value, :comment => "The value within a key/value pair."
+      t.string :resource_id, :null => false, :comment => "Reference to the field used as primary key of the resource."
+      t.string :type, :null => false, :comment => "The model name of the resource type."
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This PR takes a fresh approach to modeling key/value pairs (tags) from the provider side to our local side. It creates a single table that stores all tags for all resources using STI. It is then up to each class to define the relationship with provider tags (if any).

It does NOT re-use the existing tags tables and models because the current architecture was just not designed for key/value pairs. Instead, it was designed for labels and policy. Not only is effectively split across 3 tables, each of the models for those tables have restrictions that make re-use extremely unpleasant for our purposes.

While initially targeted at AWS, this is a general solution that any provider that supports simple key/value tagging on its resources should be able to use. So, currently you can do this:

```
# Create two tags. For a cloud subnet, the key is the ems_ref
CloudSubnetTag.create!(:key => "foo", :value => "bar", :resource_id => "abc-123", :type => "CloudSubnetTag")
CloudSubnetTag.create!(:key => "foo", :value => "baz", :resource_id => "abc-123", :type => "CloudSubnetTag")

tag1 = CloudSubnetTag.first
tag2 = CloudSubnetTag.last

tag1.cloud_subnet # => Returns cloud_subnet object

sub = CloudSubnet.find_by_ems_ref("abc-123")
sub.provider_tags # => Returns array of two tags
```

Each key/value/resource_id combo is unique.

