### PR TITLE
Remove not used VmOrTemplate#miq_proxies and MiqServer#miq_proxy

### DIFF
--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -154,10 +154,6 @@ module MiqServer::ServerSmartProxy
     errArray.each { |e| $log.error "Error Trace: [#{e}]" }
   end
 
-  def miq_proxy
-    self
-  end
-
   def forceVmScan
     true
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -939,7 +939,7 @@ class VmOrTemplate < ApplicationRecord
   def log_proxies(proxy_list = [], all_proxy_list = nil, message = nil, job = nil)
     log_method = proxy_list.empty? ? :warn : :debug
     all_proxy_list ||= storage2proxies
-    proxies = all_proxy_list.collect { |a| "[#{log_proxies_format_instance(a.miq_proxy)}]" }
+    proxies = all_proxy_list.collect { |a| "[#{log_proxies_format_instance(a)}]" }
     job_guid = job.nil? ? "" : job.guid
     proxies_text = proxies.empty? ? "[none]" : proxies.join(" -- ")
     method_name = caller[0][/`([^']*)'/, 1]

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1007,14 +1007,6 @@ class VmOrTemplate < ApplicationRecord
     storage2proxies.any?
   end
 
-  def miq_proxies
-    miqproxies = storage2proxies.collect(&:miq_proxy).compact
-
-    # The UI does not handle getting back non-MiqProxy objects back from this call.
-    # Remove MiqServer elements until we can support different class types.
-    miqproxies.delete_if { |p| p.class == MiqServer }
-  end
-
   # Cache the servers because the JobProxyDispatch calls this for each Vm scan job in a loop
   cache_with_timeout(:miq_servers_for_scan, 30.seconds) do
     MiqServer.where(:status => "started").includes([:zone, :server_roles]).to_a

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -101,8 +101,7 @@ class VmScan < Job
          vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
         return unless create_snapshot(vm)
       elsif vm.require_snapshot_for_scan?
-        host  = Object.const_get(agent_class).find(agent_id)
-        proxy = host.respond_to?("miq_proxy") ? host.miq_proxy : nil
+        proxy = MiqServer.find(agent_id)
 
         # Check if the broker is available
         if MiqServer.use_broker_for_embedded_proxy? && !MiqVimBrokerWorker.available?


### PR DESCRIPTION
 Removed not used methods ```VmOrTemplate#miq_proxies``` and  ```MiqServer#miq_proxy```


