### PR TITLE
Ensure user name is set even when common LDAP attributes are missing.

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -47,10 +47,12 @@ module Authenticator
       user_attrs, _membership_list = identity
 
       user.userid     = user_attrs[:username]
-      user.name       = user_attrs[:fullname]
       user.first_name = user_attrs[:firstname]
       user.last_name  = user_attrs[:lastname]
       user.email      = user_attrs[:email] unless user_attrs[:email].blank?
+      user.name       = user_attrs[:fullname]
+      user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?
+      user.name       = user.userid if user.name.blank?
     end
 
     private

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -131,11 +131,13 @@ module Authenticator
 
     def update_user_attributes(user, _username, lobj)
       user.userid     = ldap.normalize(ldap.get_attr(lobj, :userprincipalname) || ldap.get_attr(lobj, :dn))
-      user.name       = ldap.get_attr(lobj, :displayname)
       user.first_name = ldap.get_attr(lobj, :givenname)
       user.last_name  = ldap.get_attr(lobj, :sn)
       email           = ldap.get_attr(lobj, :mail)
       user.email      = email unless email.blank?
+      user.name       = ldap.get_attr(lobj, :displayname)
+      user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?
+      user.name       = user.userid if user.name.blank?
     end
 
     REQUIRED_LDAP_USER_PROXY_KEYS = [:basedn, :bind_dn, :bind_pwd, :ldaphost, :ldapport, :mode]

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -295,6 +295,34 @@ describe Authenticator::Httpd do
             expect(MiqTask.status_error?(task.status)).to be_truthy
           end
         end
+
+        context "when fullname is blank" do
+          let(:username) { 'betty' }
+          let(:headers) do
+            super().merge('X-Remote-User-FullName'  => '',
+                          'X-Remote-User-FirstName' => 'Betty',
+                          'X-Remote-User-LastName'  => 'Boop',
+                          'X-Remote-User-Email'     => 'betty@example.com')
+          end
+
+          it "creates a new User with name set to FirstName + LastName" do
+            expect(-> { authenticate }).to change { User.where(:name => 'Betty Boop').count }.from(0).to(1)
+          end
+        end
+
+        context "when fullname, firstname and lastname are blank" do
+          let(:username) { 'sam' }
+          let(:headers) do
+            super().merge('X-Remote-User-FullName'  => '',
+                          'X-Remote-User-FirstName' => '',
+                          'X-Remote-User-LastName'  => '',
+                          'X-Remote-User-Email'     => 'sam@example.com')
+          end
+
+          it "creates a new User with name set to the userid" do
+            expect(-> { authenticate }).to change { User.where(:name => 'sam').count }.from(0).to(1)
+          end
+        end
       end
 
       describe ".user_attrs_from_external_directory" do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -62,6 +62,8 @@ describe Authenticator::Ldap do
       'rootdn' => {:password => 'verysecret'},
       'alice'  => alice_data,
       'bob'    => bob_data,
+      'betty'  => betty_data,
+      'sam'    => sam_data,
     }
   end
   let(:alice_data) do
@@ -83,6 +85,28 @@ describe Authenticator::Ldap do
       :givenname         => 'Bob',
       :sn                => 'Builderson',
       :mail              => 'bob@example.com',
+      :groups            => %w(wibble bubble),
+    }
+  end
+  let(:betty_data) do
+    {
+      :userprincipalname => 'betty',
+      :password          => 'secret',
+      :displayname       => nil,
+      :givenname         => 'Betty',
+      :sn                => 'Builderson',
+      :mail              => 'betty@example.com',
+      :groups            => %w(wibble bubble),
+    }
+  end
+  let(:sam_data) do
+    {
+      :userprincipalname => 'sam',
+      :password          => 'secret',
+      :displayname       => nil,
+      :givenname         => nil,
+      :sn                => nil,
+      :mail              => 'sam@example.com',
       :groups            => %w(wibble bubble),
     }
   end
@@ -460,6 +484,22 @@ describe Authenticator::Ldap do
             task = MiqTask.find(task_id)
             expect(task.status).to eq('Error')
             expect(MiqTask.status_error?(task.status)).to be_truthy
+          end
+        end
+
+        context "when display name is blank" do
+          let(:username) { 'betty' }
+
+          it "creates a new User with name set to givenname + sn" do
+            expect(-> { authenticate }).to change { User.where(:name => 'Betty Builderson').count }.from(0).to(1)
+          end
+        end
+
+        context "when display name, givenname and sn are blank" do
+          let(:username) { 'sam' }
+
+          it "creates a new User with name set to the userid" do
+            expect(-> { authenticate }).to change { User.where(:name => 'sam').count }.from(0).to(1)
           end
         end
       end


### PR DESCRIPTION
**Addresses:**
https://bugzilla.redhat.com/show_bug.cgi?id=1400567

Description of problem:
------------------------

Currently, if an administrator has configured users in LDAP without the common
but not required attribute `displayName`, login to MiQ fails for those users.

This PR adds functionality to set the user name to something other than `displayName`
when it is missing. The user name is used by MiQ to display a header with the name
of the logged in user.

Two attempts to set the user name are made.
The first attempt will try to use the LDAP attributes for first and last name. Which are readable but also optional. Failing that the second attempt will use the userid, which is less attractive
but more foolproof.

Description of solution implementation:
----------------------------------------

This could have been solved by adjusting for an empty user name in the single `app/models/authenticator.rb`. However this resulted in other authentication
mechanisms exercising code that is limited to ldap and httpd authenticators.

The solution presented solves the problem in both the ldap and httpd authenticators.
Because the ldap authenticator code is being EOLed the end result will, in the near
future, have the solution in a single place, the httpd authenticators.

Steps for Testing/QA
---------------------

**Test 1:**
Attempt to log in to MiQ with an LDAP user who's `displayName` attribute has been deleted.

**Test 2:**
Attempt to log in to MiQ with an LDAP user who's `displayName`, `sn` and `givenName`  attributes have been deleted.

These test should be repeated using both the MiQLdap client and External Auth

