### PR TITLE
Fix extend_retires_on method for number of days.

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -50,6 +50,7 @@ module RetirementMixin
   end
 
   def extend_retires_on(days, date = Time.zone.now)
+    raise _("Invalid Date specified: %{date}") % {:date => date} unless date.kind_of?(ActiveSupport::TimeWithZone)
     _log.info "Extending Retirement Date on #{self.class.name} id:<#{self.id}>, name:<#{self.name}> "
     new_retires_date = date.in_time_zone + days.to_i.days
     _log.info "Original Date: #{date} Extend days: #{days} New Retirement Date: #{new_retires_date}"

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -49,9 +49,9 @@ module RetirementMixin
     self.retirement_requester = nil
   end
 
-  def extend_retires_on(days, date = Time.zone.today)
+  def extend_retires_on(days, date = Time.zone.now)
     _log.info "Extending Retirement Date on #{self.class.name} id:<#{self.id}>, name:<#{self.name}> "
-    new_retires_date = date + days.to_i.days
+    new_retires_date = date.in_time_zone + days.to_i.days
     _log.info "Original Date: #{date} Extend days: #{days} New Retirement Date: #{new_retires_date}"
     self.retires_on = new_retires_date
     save

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -51,7 +51,7 @@ module RetirementMixin
 
   def extend_retires_on(days, date = Time.zone.today)
     _log.info "Extending Retirement Date on #{self.class.name} id:<#{self.id}>, name:<#{self.name}> "
-    new_retires_date = date + days.to_i
+    new_retires_date = date + days.to_i.days
     _log.info "Original Date: #{date} Extend days: #{days} New Retirement Date: #{new_retires_date}"
     self.retires_on = new_retires_date
     save

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
@@ -186,8 +186,8 @@ EOF
     end
 
     it "#retires_on - today" do
-      service.update_attributes(:retirement_last_warn => Date.today)
-      service_service.retires_on = Time.zone.today
+      service.update_attributes(:retirement_last_warn => Time.zone.now)
+      service_service.retires_on = Time.zone.now
       service.reload
       expect(service.retirement_last_warn).to be_nil
       expect(service.retirement_due?).to be_truthy
@@ -199,7 +199,7 @@ EOF
         :retirement_last_warn => Time.zone.today,
         :retirement_state     => "retiring"
       )
-      service_service.retires_on = Time.zone.today + 1
+      service_service.retires_on = Time.zone.today + 1.day
       service.reload
 
       expect(service).to have_attributes(
@@ -227,7 +227,7 @@ EOF
           :retirement_last_warn => Time.zone.today,
           :retirement_state     => "retiring"
         )
-        future_retires_on = Time.zone.now + 30
+        future_retires_on = Time.zone.now + 30.days
         service_service.retires_on = future_retires_on
         extend_days = 7
         service_service.extend_retires_on(extend_days, future_retires_on)
@@ -244,7 +244,7 @@ EOF
 
     it "#retirement_warn" do
       expect(service_service.retirement_warn).to be_nil
-      service.retirement_last_warn = Date.today
+      service.retirement_last_warn = Time.zone.today
       service_service.retirement_warn = 60
       service.reload
 

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
@@ -199,7 +199,7 @@ EOF
         :retirement_last_warn => Time.zone.today,
         :retirement_state     => "retiring"
       )
-      service_service.retires_on = Time.zone.today + 1.day
+      service_service.retires_on = Time.zone.now + 1.day
       service.reload
 
       expect(service).to have_attributes(
@@ -224,7 +224,7 @@ EOF
       Timecop.freeze(Time.zone.now) do
         service.update_attributes(
           :retired              => true,
-          :retirement_last_warn => Time.zone.today,
+          :retirement_last_warn => Time.zone.now,
           :retirement_state     => "retiring"
         )
         future_retires_on = Time.zone.now + 30.days
@@ -240,6 +240,11 @@ EOF
           :retires_on           => future_retires_on + extend_days.days
         )
       end
+    end
+
+    it "#extend_retires_on - invalid date" do
+      error_msg = "Invalid Date specified: #{Time.zone.today}"
+      expect { service_service.extend_retires_on(7, Time.zone.today) }.to raise_error(RuntimeError, error_msg)
     end
 
     it "#retirement_warn" do

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_service_spec.rb
@@ -212,22 +212,22 @@ EOF
 
     it "#extend_retires_on - no retirement date set" do
       extend_days = 7
-      Timecop.freeze(Time.zone.today) do
+      Timecop.freeze(Time.zone.now) do
         service_service.extend_retires_on(extend_days)
         service.reload
-        new_retires_on = Time.zone.today + extend_days
+        new_retires_on = Time.zone.now + extend_days.days
         expect(service.retires_on.day).to eq(new_retires_on.day)
       end
     end
 
     it "#extend_retires_on - future retirement date set" do
-      Timecop.freeze(Time.zone.today) do
+      Timecop.freeze(Time.zone.now) do
         service.update_attributes(
           :retired              => true,
           :retirement_last_warn => Time.zone.today,
           :retirement_state     => "retiring"
         )
-        future_retires_on = Time.zone.today + 30
+        future_retires_on = Time.zone.now + 30
         service_service.retires_on = future_retires_on
         extend_days = 7
         service_service.extend_retires_on(extend_days, future_retires_on)
@@ -237,7 +237,7 @@ EOF
           :retirement_last_warn => nil,
           :retired              => false,
           :retirement_state     => nil,
-          :retires_on           => future_retires_on + extend_days
+          :retires_on           => future_retires_on + extend_days.days
         )
       end
     end

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
@@ -149,8 +149,8 @@ module MiqAeServiceVmSpec
     end
 
     it "#retires_on - today" do
-      vm.update_attributes(:retirement_last_warn => Date.today)
-      service_vm.retires_on = Time.zone.today
+      vm.update_attributes(:retirement_last_warn => Time.zone.now)
+      service_vm.retires_on = Time.zone.now
 
       vm.reload
       expect(vm.retirement_last_warn).to be_nil
@@ -160,10 +160,10 @@ module MiqAeServiceVmSpec
     it "#retires_on - tomorrow" do
       vm.update_attributes(
         :retired              => true,
-        :retirement_last_warn => Time.zone.today,
+        :retirement_last_warn => Time.zone.now,
         :retirement_state     => "retiring"
       )
-      service_vm.retires_on = Time.zone.today + 1
+      service_vm.retires_on = Time.zone.now + 1.day
       vm.reload
 
       expect(vm).to have_attributes(
@@ -191,7 +191,7 @@ module MiqAeServiceVmSpec
           :retirement_last_warn => Time.zone.now,
           :retirement_state     => "retiring"
         )
-        future_retires_on = Time.zone.now + 30
+        future_retires_on = Time.zone.now + 30.days
         service_vm.retires_on = future_retires_on
         extend_days = 7
         service_vm.extend_retires_on(extend_days, future_retires_on)
@@ -208,7 +208,7 @@ module MiqAeServiceVmSpec
 
     it "#retirement_warn" do
       expect(service_vm.retirement_warn).to be_nil
-      vm.retirement_last_warn = Date.today
+      vm.retirement_last_warn = Time.zone.now
       service_vm.retirement_warn = 60
 
       vm.reload

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
@@ -206,6 +206,11 @@ module MiqAeServiceVmSpec
       end
     end
 
+    it "#extend_retires_on - invalid date" do
+      error_msg = "Invalid Date specified: #{Time.zone.today}"
+      expect { service_vm.extend_retires_on(7, Time.zone.today) }.to raise_error(RuntimeError, error_msg)
+    end
+
     it "#retirement_warn" do
       expect(service_vm.retirement_warn).to be_nil
       vm.retirement_last_warn = Time.zone.now

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_vm_spec.rb
@@ -175,23 +175,23 @@ module MiqAeServiceVmSpec
     end
 
     it "#extend_retires_on - no retirement date set" do
-      Timecop.freeze(Time.zone.today) do
+      Timecop.freeze(Time.zone.now) do
         extend_days = 7
         service_vm.extend_retires_on(extend_days)
         vm.reload
-        new_retires_on = Time.zone.today + extend_days
+        new_retires_on = Time.zone.now + extend_days.days
         expect(vm.retires_on.day).to eq(new_retires_on.day)
       end
     end
 
     it "#extend_retires_on - future retirement date set" do
-      Timecop.freeze(Time.zone.today) do
+      Timecop.freeze(Time.zone.now) do
         vm.update_attributes(
           :retired              => true,
-          :retirement_last_warn => Time.zone.today,
+          :retirement_last_warn => Time.zone.now,
           :retirement_state     => "retiring"
         )
-        future_retires_on = Time.zone.today + 30
+        future_retires_on = Time.zone.now + 30
         service_vm.retires_on = future_retires_on
         extend_days = 7
         service_vm.extend_retires_on(extend_days, future_retires_on)
@@ -201,7 +201,7 @@ module MiqAeServiceVmSpec
           :retirement_last_warn => nil,
           :retired              => false,
           :retirement_state     => nil,
-          :retires_on           => future_retires_on + extend_days
+          :retires_on           => future_retires_on + extend_days.days
         )
       end
     end


### PR DESCRIPTION
The retires_on field was changed from a :date column to a :datetime
Issue brought to our attention by:
https://github.com/ManageIQ/manageiq-content/pull/62

Prefer to use the model method extend_retires_on in Automate methods.
https://bugzilla.redhat.com/show_bug.cgi?id=1427503
