### PR TITLE
Added missing second level menu keys for Storage menu

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -3,6 +3,7 @@
 - :automate
 - :ansible
 - :at
+- :bst
 - :clo
 - :cnt
 - :compute
@@ -13,6 +14,7 @@
 - :dwh
 - :net
 - :opt
+- :ost
 - :set
 - :sto
 - :svc


### PR DESCRIPTION
These sections were added in https://github.com/ManageIQ/manageiq-ui-classic/commit/66797bac889512c7f9192ab772c6556f1c991f09

https://bugzilla.redhat.com/show_bug.cgi?id=1428447

@dclarizio please review.