### PR TITLE
Update oVirt SDK to 4.1.z

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "novnc-rails",                    "~>0.2"
 gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
-gem "ovirt-engine-sdk",               "~>4.0.10",      :require => false # Required by the oVirt provider
+gem "ovirt-engine-sdk",               "~>4.1.4",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.4.1",       :require => false
 gem "pg-pglogical",                   "~>1.1.0",       :require => false
 gem "puma",                           "~>3.3.0"


### PR DESCRIPTION
Currently ManageIQ uses version 4.0.z of the oVirt SDK. This works
correctly with version 4.0 of oVirt, but can't use some of the new
capabilities included in version 4.1. This patch changes the Gemfile to
require version 4.1 of the SDK, which is backwards compatible with 4.0
and supports the new features introduced in 4.1.