### PR TITLE
Update catalog item without config_options

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -427,7 +427,12 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def validate_update_config_info(options)
-    raise _('service_type and prov_type cannot be changed') if options[:service_type] || options[:prov_type]
+    if options[:service_type] && options[:service_type] != service_type
+      raise _('service_type cannot be changed')
+    end
+    if options[:prov_type] && options[:prov_type] != prov_type
+      raise _('prov_type cannot be changed')
+    end
     options[:config_info]
   end
 

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -93,6 +93,7 @@ class ServiceTemplate < ApplicationRecord
 
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
+    return update_attributes!(options) unless config_info
     transaction do
       update_from_options(options)
 

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -66,6 +66,7 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
 
   def validate_update_config_info(options)
     super
+    return unless options.key?(:config_info)
     self.class.validate_config_info(options)
   end
 

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -72,6 +72,7 @@ class ServiceTemplateOrchestration < ServiceTemplate
 
   def validate_update_config_info(options)
     super
+    return unless options.key?(:config_info)
     self.class.validate_config_info(options)
   end
 

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -101,6 +101,13 @@ describe ServiceTemplateAnsibleTower do
 
       expect(updated.configuration_script).to eq(new_configuration_script)
     end
+
+    it 'allows for update without the presence of config_info' do
+      expect do
+        @catalog_item.update_catalog_item(:name => 'new_name')
+      end.to change(@catalog_item, :name)
+      expect(@catalog_item.reload.name).to eq('new_name')
+    end
   end
 
   describe '#config_info' do

--- a/spec/models/service_template_orchestration_spec.rb
+++ b/spec/models/service_template_orchestration_spec.rb
@@ -226,6 +226,13 @@ describe ServiceTemplateOrchestration do
       expect(updated.orchestration_template).to eq(new_template)
       expect(updated.orchestration_manager).to eq(new_manager)
     end
+
+    it 'allows for update without the presence of config_info' do
+      expect do
+        @catalog_item.update_catalog_item(:name => 'new_name')
+      end.to change(@catalog_item, :name)
+      expect(@catalog_item.reload.name).to eq('new_name')
+    end
   end
 
   describe '#config_info' do

--- a/spec/models/service_template_orchestration_spec.rb
+++ b/spec/models/service_template_orchestration_spec.rb
@@ -210,13 +210,6 @@ describe ServiceTemplateOrchestration do
       end.to raise_error(StandardError, 'Must provide both template_id and manager_id or manager and template')
     end
 
-    it 'cannot change service_type or prov_type' do
-      updated_catalog_item_options[:prov_type] = 'new type'
-      expect do
-        @catalog_item.update_catalog_item(updated_catalog_item_options)
-      end.to raise_error(StandardError, 'service_type and prov_type cannot be changed')
-    end
-
     it 'can accept manager and template objects on update' do
       updated_catalog_item_options[:config_info].delete(:manager_id)
       updated_catalog_item_options[:config_info].delete(:manager_id)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -593,10 +593,25 @@ describe ServiceTemplate do
       expect(updated.config_info).to eq(updated_catalog_item_options[:config_info])
     end
 
-    it 'does not allow service_type and prov_type to be changed' do
+    it 'does not allow service_type to be changed' do
       expect do
         @catalog_item.update_catalog_item({:service_type => 'new'}, user)
-      end.to raise_error(StandardError, /service_type and prov_type cannot be changed/)
+      end.to raise_error(StandardError, /service_type cannot be changed/)
+    end
+
+    it 'does not allow prov_type to be changed' do
+      expect do
+        @catalog_item.update_catalog_item({:prov_type => 'new'}, user)
+      end.to raise_error(StandardError, /prov_type cannot be changed/)
+    end
+
+    it 'accepts prov_type and service_type if they are not changed' do
+      expect do
+        @catalog_item.update_catalog_item({:name         => 'new_name',
+                                           :service_type => @catalog_item.service_type,
+                                           :prov_type    => @catalog_item.prov_type}, user)
+      end.to change(@catalog_item, :name)
+      expect(@catalog_item.reload.name).to eq('new_name')
     end
 
     it 'allows for update without the presence of config_info' do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -598,6 +598,13 @@ describe ServiceTemplate do
         @catalog_item.update_catalog_item({:service_type => 'new'}, user)
       end.to raise_error(StandardError, /service_type and prov_type cannot be changed/)
     end
+
+    it 'allows for update without the presence of config_info' do
+      expect do
+        @catalog_item.update_catalog_item(:name => 'new_name')
+      end.to change(@catalog_item, :name)
+      expect(@catalog_item.reload.name).to eq('new_name')
+    end
   end
 
   describe "#provision_request" do


### PR DESCRIPTION
This will update the catalog item without the need for `config_options`. Will update #14068 based off of this.

@miq-bot add_label enhancement, services
@miq-bot assign @bzwei 
cc: @abellotti 