### PR TITLE
Include modules instead of reopening classes.

### DIFF
--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,13 +1,14 @@
 require 'resource_feeder/common'
 class RssFeed < ApplicationRecord
   include ResourceFeeder
+  include_concern 'ImportExport'
+
   validates_presence_of     :name
   validates_uniqueness_of   :name
 
   attr_accessor :options
 
   acts_as_miq_taggable
-  include_concern 'ImportExport'
 
   YML_DIR = File.join(File.expand_path(Rails.root), "product", "alerts", "rss")
 

--- a/app/models/rss_feed/import_export.rb
+++ b/app/models/rss_feed/import_export.rb
@@ -1,11 +1,9 @@
-class RssFeed
-  module ImportExport
-    extend ActiveSupport::Concern
+module RssFeed::ImportExport
+  extend ActiveSupport::Concern
 
-    def export_to_array
-      h = attributes
-      ["id", "created_on", "updated_on", "yml_file_mtime"].each { |k| h.delete(k) }
-      [self.class.to_s => h]
-    end
+  def export_to_array
+    h = attributes
+    ["id", "created_on", "updated_on", "yml_file_mtime"].each { |k| h.delete(k) }
+    [self.class.to_s => h]
   end
 end

--- a/spec/factories/rss_feed.rb
+++ b/spec/factories/rss_feed.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :rss_feed do
+    sequence(:name) { |n| "feed_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/models/rss_feed/import_export_spec.rb
+++ b/spec/models/rss_feed/import_export_spec.rb
@@ -1,0 +1,6 @@
+describe RssFeed::ImportExport do
+  it "#export_to_array" do
+    expect(FactoryGirl.create(:rss_feed, :title => "Latest things!!!")
+      .export_to_array.first["RssFeed"]["title"]).to eq("Latest things!!!")
+  end
+end


### PR DESCRIPTION
Related to #14128

We should either use RssFeed.class_eval to reopen the class to force
rails to load the RssFeed model first or the technique in this commit,
which is to just include the module in RssFeed.  Note, this module was
already being included so there was no reason to reopen the class also.

The existing layout of re-opening the RssFeed with different class
definitions:

rss_feed/import_export.rb:
class RssFeed

rss_feed.rb:
class RssFeed < ApplicationRecord

can cause `TypeError: superclass mismatch for class RssFeed` if
the import_export.rb is loaded first.