### PR TITLE
Move the previously refactored provider mixin into the shared directory

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
-  include ManageIQ::Providers::AnsibleTower::ProviderMixin
+  include ManageIQ::Providers::AnsibleTower::Shared::Provider
 
   has_one :automation_manager,
           :foreign_key => "provider_id",

--- a/app/models/manageiq/providers/ansible_tower/shared/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/provider.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::AnsibleTower::ProviderMixin
+module ManageIQ::Providers::AnsibleTower::Shared::Provider
   extend ActiveSupport::Concern
 
   def self.included(klass)

--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
-  include ManageIQ::Providers::AnsibleTower::ProviderMixin
+  include ManageIQ::Providers::AnsibleTower::Shared::Provider
 
   has_one :automation_manager,
           :foreign_key => "provider_id",


### PR DESCRIPTION
This was previously moved out into a mixin in #13733, but probably belongs with the other things in the shared namespace that was created in #14074