### PR TITLE
Prefix Ansible event type with event target's object type.

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/event_parser.rb
@@ -1,10 +1,6 @@
 module ManageIQ::Providers::AnsibleTower::AutomationManager::EventParser
   extend ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventParser
 
-  def self.event_type
-    "ansible_tower"
-  end
-
   def self.source
     "ANSIBLE_TOWER"
   end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
@@ -1,9 +1,8 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventParser
   def event_to_hash(event, ems_id)
     {
-      :event_type => "#{self.event_type}_#{event.operation}",
+      :event_type => "#{event.object1}_#{event.operation}",
       :source     => "#{self.source}",
-      :message    => event.changes.to_s,
       :timestamp  => event.timestamp,
       :full_data  => event.to_h,
       :ems_id     => ems_id

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/event_parser.rb
@@ -1,10 +1,6 @@
 module ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventParser
   extend ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventParser
 
-  def self.event_type
-    "embedded_ansible"
-  end
-
   def self.source
     "EMBEDDED_ANSIBLE"
   end


### PR DESCRIPTION
The event source tells us if the Ansible is external or embedded. So no need to repeat the info in event type.
Also no need to repeat event.changes in message to reduce the event object's size.

Ansible has create/delete/update/associate events for users, projects, jobs, job templates etc. 
Add event target's object type into event type to distinguish these events.
Following are some examples for the create events.

| Event Target | before | after |
| ---                 | ---       | ---    |
| credential     | ansible_tower_create | credential_create
| group            | ansible_tower_create | group_create 
| host              | ansible_tower_create | host_create 
| inventory      | ansible_tower_create | inventory_create
| job                | ansible_tower_create | job_create 
| job_template | ansible_tower_create | job_template_create
| label   | ansible_tower_create | label_create
| organization | ansible_tower_create | organization_create
| project | ansible_tower_create | project_create
| user | ansible_tower_create | user_create

cc @durandom @blomquisg @gmcculloug 