### PR TITLE
Provide better error message when migrating to the same host

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -47,6 +47,10 @@ module VmOrTemplate::Operations::Relocation
       end
     end
 
+    if host_id == host.id
+      raise _("The VM '#{name}' can not be migrated to the same host it is already running on.")
+    end
+
     host_mor = host.ems_ref_obj
     pool_mor = pool.ems_ref_obj
     run_command_via_parent(:vm_migrate, :host => host_mor, :pool => pool_mor, :priority => priority, :state => state)


### PR DESCRIPTION
In case the VM is migrated to the same host it is already running on, a
misleading error message is shown in the Requests:
"There are no hosts to use. Check that the cluster contains at least one host
in Up state"

Fixed by failing the migration with the better message:
"Error: The VM 'vm name' can not be migrated to the same host it is already
running on."

The host is not filtered out from the "Migrate Virtual Machine" screen since this
screen can be used to migrate more VMs at once and what is a good host for one
VM is not for the other.

* https://bugzilla.redhat.com/show_bug.cgi?id=1418708