### PR TITLE
Fix format of fields in specs

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1445,7 +1445,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkall" do
       actual = described_class.new(
         "FIND" => {"search"   => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkall" => {">" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkall" => {">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=all><value ref=vm, type=string>/virtual/hardware/cpu_sockets</value> > \"2\"</check></find>"
       expect(actual).to eq(expected)
@@ -1454,7 +1454,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkany" do
       actual = described_class.new(
         "FIND" => {"search"   => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkany" => {">" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkany" => {">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=any><value ref=vm, type=string>/virtual/hardware/cpu_sockets</value> > \"2\"</check></find>"
       expect(actual).to eq(expected)
@@ -1463,7 +1463,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and =" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {"=" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {"=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> == 2</check></find>"
       expect(actual).to eq(expected)
@@ -1472,7 +1472,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and !=" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {"!=" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {"!=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> != 2</check></find>"
       expect(actual).to eq(expected)
@@ -1481,7 +1481,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and <" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {"<" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {"<" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> < 2</check></find>"
       expect(actual).to eq(expected)
@@ -1490,7 +1490,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and >" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {">" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> > 2</check></find>"
       expect(actual).to eq(expected)
@@ -1499,7 +1499,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and <=" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {"<=" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {"<=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> <= 2</check></find>"
       expect(actual).to eq(expected)
@@ -1508,7 +1508,7 @@ describe MiqExpression do
     it "generates the ruby for a FIND expression with checkcount and >=" do
       actual = described_class.new(
         "FIND" => {"search"     => {"=" => {"field" => "Vm-name", "value" => "foo"}},
-                   "checkcount" => {">=" => {"field" => "Vm.hardware.cpu_sockets", "value" => "2"}}}
+                   "checkcount" => {">=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
       expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=count><count> >= 2</check></find>"
       expect(actual).to eq(expected)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1447,7 +1447,7 @@ describe MiqExpression do
         "FIND" => {"search"   => {"=" => {"field" => "Vm-name", "value" => "foo"}},
                    "checkall" => {">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
-      expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=all><value ref=vm, type=string>/virtual/hardware/cpu_sockets</value> > \"2\"</check></find>"
+      expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=all><value ref=vm, type=integer>/virtual/hardware/cpu_sockets</value> > 2</check></find>"
       expect(actual).to eq(expected)
     end
 
@@ -1456,7 +1456,7 @@ describe MiqExpression do
         "FIND" => {"search"   => {"=" => {"field" => "Vm-name", "value" => "foo"}},
                    "checkany" => {">" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}}}
       ).to_ruby
-      expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=any><value ref=vm, type=string>/virtual/hardware/cpu_sockets</value> > \"2\"</check></find>"
+      expected = "<find><search><value ref=vm, type=string>/virtual/name</value> == \"foo\"</search><check mode=any><value ref=vm, type=integer>/virtual/hardware/cpu_sockets</value> > 2</check></find>"
       expect(actual).to eq(expected)
     end
 


### PR DESCRIPTION
- Fix format of field to valid regex in MiqExpression:Field 
- output from `.to_ruby` now can determine type correctly because before field was not parsed and `:string` [type was set as default here
](https://github.com/ManageIQ/manageiq/blob/master/lib/miq_expression.rb#L968)


cc @kbrock @imtayadeway 
@miq-bot add_label bug, test

@miq-bot assign @gtanzillo 

this PR is blocking https://github.com/ManageIQ/manageiq/pull/13692