### PR TITLE
Set 'https' as the default protocol when using oVirt SDK

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -27,6 +27,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
 
     # Prepare the options to call the method that creates the actual connection:
     connect_options = {
+      :scheme     => options[:scheme] || 'https',
       :server     => options[:ip] || address,
       :port       => options[:port] || self.port,
       :username   => options[:user] || authentication_userid(options[:auth_type]),


### PR DESCRIPTION
This patch changes the oVirt provider so that it uses 'https' by default
as the protocol when using the oVirt SDK to talk to the oVirt engine.