### PR TITLE
Always pass the URL path to the oVirt SDK

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -29,6 +29,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     connect_options = {
       :server     => options[:ip] || address,
       :port       => options[:port] || self.port,
+      :path       => path,
       :username   => options[:user] || authentication_userid(options[:auth_type]),
       :password   => options[:pass] || authentication_password(options[:auth_type]),
       :service    => options[:service] || "Service",


### PR DESCRIPTION
Currently the 'path' component of the URL is not always explicitly
passed to the constructor of the oVirt SDK connection, it is only passed
if explicitly provided by the caller. This patch changes the oVirt
provider so that the path is always passed, taking it from the endpoint
table if not explicitly provided by the caller.
