### PR TITLE
Don't pass empty lists of certificates to the oVirt SDK

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -264,6 +264,12 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
       # Get the timeout from the configuration:
       timeout, = ems_timeouts(:ems_redhat, options[:service])
 
+      # The constructor of the SDK expects a list of certificates, but that list can't be empty, or contain only 'nil'
+      # values, so we need to check the value passed and make a list only if it won't be empty. If it will be empty then
+      # we should just pass 'nil'.
+      ca_certs = options[:ca_certs]
+      ca_certs = [ca_certs] if ca_certs
+
       url = URI::Generic.build(
         :scheme => options[:scheme],
         :host   => options[:server],
@@ -277,7 +283,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
         :password => options[:password],
         :timeout  => timeout,
         :insecure => options[:verify_ssl] == OpenSSL::SSL::VERIFY_NONE,
-        :ca_certs => [options[:ca_certs]],
+        :ca_certs => ca_certs,
         :log      => $rhevm_log,
       )
     end


### PR DESCRIPTION
The oVirt SDK accepts lists of trusted CA certificates. But when an
empty list, or a list containing just 'nil' elements is passed, the
result is that no certificate is trusted, not even the system default
trusted certificate. To avoid that this patch changes the oVirt provider
so that it passes 'nil' instead of empty lists.
