### PR TITLE
MiqServers with IPv6 (only)

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -1,3 +1,5 @@
+require 'resolv'
+
 class MiqServer < ApplicationRecord
   include_concern 'WorkerManagement'
   include_concern 'ServerMonitor'

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -189,7 +189,7 @@ class MiqServer < ApplicationRecord
 
     ipaddr, hostname, mac_address = get_network_information
 
-    if ipaddr =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+    if ipaddr =~ Regexp.union(Resolv::IPv4::Regex, Resolv::IPv6::Regex).freeze
       server_hash[:ipaddress] = config_hash[:host] = ipaddr
     end
 

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -48,7 +48,7 @@ module MiqServer::EnvironmentManagement
         if MiqEnvironment::Command.is_appliance?
           eth0 = LinuxAdmin::NetworkInterface.new("eth0")
 
-          ipaddr      = eth0.address
+          ipaddr      = eth0.address || eth0.address6
           hostname    = LinuxAdmin::Hosts.new.hostname
           mac_address = eth0.mac_address
         else


### PR DESCRIPTION
Let's grab IPv6 of MiqServer during the server start-up, otherwise ipv6 only machine has no ipaddress.

Note: MiqServer.ipaddress is a varchar(255).

## Before
![before](https://cloud.githubusercontent.com/assets/6666052/23553350/a8332348-0020-11e7-9a78-0ffd457f0fc5.jpg)

## After
![after](https://cloud.githubusercontent.com/assets/6666052/23553359/b191e078-0020-11e7-9b92-b1bbf86f19ac.jpg)

