### PR TITLE
Introduce CountField with changing inheritance in MiqExpression

### DIFF
--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -1,0 +1,18 @@
+class MiqExpression::CountField < MiqExpression::Target
+  REGEX = /
+(?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
+\.(?<associations>[a-z_\.]+)
+/x
+
+  def self.parse(field)
+    count_field = super(field)
+    is_plural = suppress(Exception) { count_field.plural? }
+    return unless is_plural
+
+    count_field
+  end
+
+  def initialize(model, associations)
+    super(model, associations, nil)
+  end
+end

--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -5,7 +5,9 @@ class MiqExpression::CountField < MiqExpression::Target
 /x
 
   def self.parse(field)
-    count_field = super(field)
+    parsed_params = parse_params(field) || return
+    count_field = new(parsed_params[:model_name], parsed_params[:associations])
+
     is_plural = suppress(Exception) { count_field.plural? }
     return unless is_plural
 

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,4 +1,4 @@
-class MiqExpression::Field
+class MiqExpression::Field < MiqExpression::Target
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 (?!.*\b(managed|user_tag)\b)
@@ -6,26 +6,13 @@ class MiqExpression::Field
 -(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x
 
-  ParseError = Class.new(StandardError)
-
   def self.parse(field)
     match = FIELD_REGEX.match(field) or return
     model = match[:model_name].safe_constantize or return
     new(model, match[:associations].to_s.split("."), match[:column])
   end
 
-  def self.parse!(field)
-    parse(field) or raise ParseError, field
-  end
-
-  attr_reader :model, :associations, :column
   delegate :eq, :not_eq, :lteq, :gteq, :lt, :gt, :between, :to => :arel_attribute
-
-  def initialize(model, associations, column)
-    @model = model
-    @associations = associations
-    @column = column
-  end
 
   def date?
     column_type == :date

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -1,16 +1,10 @@
 class MiqExpression::Field < MiqExpression::Target
-  FIELD_REGEX = /
+  REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 (?!.*\b(managed|user_tag)\b)
 \.?(?<associations>[a-z_\.]+)?
 -(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x
-
-  def self.parse(field)
-    match = FIELD_REGEX.match(field) or return
-    model = match[:model_name].safe_constantize or return
-    new(model, match[:associations].to_s.split("."), match[:column])
-  end
 
   delegate :eq, :not_eq, :lteq, :gteq, :lt, :gt, :between, :to => :arel_attribute
 
@@ -20,7 +14,7 @@ class MiqExpression::Field < MiqExpression::Target
 
   def self.is_field?(field)
     return false unless field.kind_of?(String)
-    match = FIELD_REGEX.match(field)
+    match = REGEX.match(field)
     return false unless match
     model = match[:model_name].safe_constantize
     return false unless model

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -8,6 +8,11 @@ class MiqExpression::Field < MiqExpression::Target
 
   delegate :eq, :not_eq, :lteq, :gteq, :lt, :gt, :between, :to => :arel_attribute
 
+  def self.parse(field)
+    parsed_params = parse_params(field) || return
+    new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column])
+  end
+
   def self.is_field?(field)
     return false unless field.kind_of?(String)
     match = REGEX.match(field)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -21,31 +21,8 @@ class MiqExpression::Field < MiqExpression::Target
     !custom_attribute_column? && target.attribute_supported_by_sql?(column)
   end
 
-  def plural?
-    return false if reflections.empty?
-    [:has_many, :has_and_belongs_to_many].include?(reflections.last.macro)
-  end
-
   def custom_attribute_column?
     column.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
-  end
-
-  def reflections
-    klass = model
-    associations.collect do |association|
-      klass.reflection_with_virtual(association).tap do |reflection|
-        raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
-        klass = reflection.klass
-      end
-    end
-  end
-
-  def target
-    if associations.none?
-      model
-    else
-      reflections.last.klass
-    end
   end
 
   def matches(other)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -8,10 +8,6 @@ class MiqExpression::Field < MiqExpression::Target
 
   delegate :eq, :not_eq, :lteq, :gteq, :lt, :gt, :between, :to => :arel_attribute
 
-  def date?
-    column_type == :date
-  end
-
   def self.is_field?(field)
     return false unless field.kind_of?(String)
     match = REGEX.match(field)
@@ -19,18 +15,6 @@ class MiqExpression::Field < MiqExpression::Target
     model = match[:model_name].safe_constantize
     return false unless model
     !!(model < ApplicationRecord)
-  end
-
-  def datetime?
-    column_type == :datetime
-  end
-
-  def string?
-    column_type == :string
-  end
-
-  def numeric?
-    [:fixnum, :integer, :float].include?(column_type)
   end
 
   def attribute_supported_by_sql?

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -11,6 +11,12 @@ class MiqExpression::Tag < MiqExpression::Target
 
   attr_reader :namespace
 
+  def self.parse(field)
+    parsed_params = parse_params(field) || return
+    managed = parsed_params[:namespace] == self::MANAGED_NAMESPACE
+    new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column], managed)
+  end
+
   def initialize(model, associations, column, managed = true)
     super(model, associations, column)
     @namespace = "/#{managed ? MANAGED_NAMESPACE : USER_NAMESPACE}/#{column}"

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,4 +1,4 @@
-class MiqExpression::Tag < MiqExpression::Field
+class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
 (?<model_name>([[:alnum:]]*(::)?)+)
 \.(?<associations>([a-z_]+\.)*)

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,5 +1,5 @@
 class MiqExpression::Tag < MiqExpression::Field
-  TAG_REGEX = /
+  REGEX = /
 (?<model_name>([[:alnum:]]*(::)?)+)
 \.(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
@@ -10,14 +10,6 @@ class MiqExpression::Tag < MiqExpression::Field
   USER_NAMESPACE         = 'user'.freeze
 
   attr_reader :namespace
-
-  def self.parse(field)
-    match = TAG_REGEX.match(field) || return
-
-    associations = match[:associations].split(".")
-    model = match[:model_name].classify.safe_constantize
-    new(model, associations, match[:column], match[:namespace] == MANAGED_NAMESPACE)
-  end
 
   def initialize(model, associations, column, managed = true)
     super(model, associations, column)

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -1,0 +1,7 @@
+class MiqExpression::Target
+  def initialize(model, associations, column)
+    @model = model
+    @associations = associations
+    @column = column
+  end
+end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -5,6 +5,14 @@ class MiqExpression::Target
     parse(field) || raise(ParseError, field)
   end
 
+  def self.parse(field)
+    match = self::REGEX.match(field) || return
+    model = match[:model_name].classify.safe_constantize || return
+    args = [model, match[:associations].to_s.split("."), match[:column]]
+    args.push(match[:namespace] == self::MANAGED_NAMESPACE) if match.names.include?('namespace')
+    new(*args)
+  end
+
   attr_reader :model, :associations, :column
 
   def initialize(model, associations, column)

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -1,4 +1,12 @@
 class MiqExpression::Target
+  ParseError = Class.new(StandardError)
+
+  def self.parse!(field)
+    parse(field) || raise(ParseError, field)
+  end
+
+  attr_reader :model, :associations, :column
+
   def initialize(model, associations, column)
     @model = model
     @associations = associations

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -8,7 +8,8 @@ class MiqExpression::Target
   def self.parse(field)
     match = self::REGEX.match(field) || return
     model = match[:model_name].classify.safe_constantize || return
-    args = [model, match[:associations].to_s.split("."), match[:column]]
+    args = [model, match[:associations].to_s.split(".")]
+    args.push(match[:column]) if match.names.include?('column')
     args.push(match[:namespace] == self::MANAGED_NAMESPACE) if match.names.include?('namespace')
     new(*args)
   end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -5,13 +5,17 @@ class MiqExpression::Target
     parse(field) || raise(ParseError, field)
   end
 
-  def self.parse(field)
+  # example .parse('Host.vms-host_name')
+  # returns hash:
+  # {:model_name => Host<ApplicationRecord> , :associations => ['vms']<Array>, :column_name => 'host_name' <String>}
+  def self.parse_params(field)
     match = self::REGEX.match(field) || return
-    model = match[:model_name].classify.safe_constantize || return
-    args = [model, match[:associations].to_s.split(".")]
-    args.push(match[:column]) if match.names.include?('column')
-    args.push(match[:namespace] == self::MANAGED_NAMESPACE) if match.names.include?('namespace')
-    new(*args)
+    # convert matches to hash to format
+    # {:model_name => 'User', :associations => ...}
+    parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
+    parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize || return
+    parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
+    parsed_params
   end
 
   attr_reader :model, :associations, :column

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -36,4 +36,27 @@ class MiqExpression::Target
   def numeric?
     [:fixnum, :integer, :float].include?(column_type)
   end
+
+  def plural?
+    return false if reflections.empty?
+    [:has_many, :has_and_belongs_to_many].include?(reflections.last.macro)
+  end
+
+  def reflections
+    klass = model
+    associations.collect do |association|
+      klass.reflection_with_virtual(association).tap do |reflection|
+        raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
+        klass = reflection.klass
+      end
+    end
+  end
+
+  def target
+    if associations.none?
+      model
+    else
+      reflections.last.klass
+    end
+  end
 end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -20,4 +20,20 @@ class MiqExpression::Target
     @associations = associations
     @column = column
   end
+
+  def date?
+    column_type == :date
+  end
+
+  def datetime?
+    column_type == :datetime
+  end
+
+  def string?
+    column_type == :string
+  end
+
+  def numeric?
+    [:fixnum, :integer, :float].include?(column_type)
+  end
 end

--- a/spec/lib/miq_expression/count_field_spec.rb
+++ b/spec/lib/miq_expression/count_field_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe MiqExpression::CountField do
+  describe '.parse' do
+    it 'parses field model.has_many_associations with valid format' do
+      count_field = 'Vm.disks'
+      expect(described_class.parse(count_field)).to have_attributes(:model        => Vm,
+                                                                    :associations => ['disks'])
+    end
+
+    it 'doesn\'t parse field model.belongs_to_associations with invalid format' do
+      count_field = 'Vm.host'
+      expect(described_class.parse(count_field)).to be_nil
+    end
+
+    it 'doesn\'t parse field with format of MiqExpression::Field::REGEX' do
+      count_field = 'Vm.host-name'
+      expect(described_class.parse(count_field)).to be_nil
+    end
+
+    it 'doesn\'t parse field with format of  MiqExpression::Tag::REGEX' do
+      count_field = 'Vm.managed-service_level'
+      expect(described_class.parse(count_field)).to be_nil
+    end
+
+    it 'doesn\'t parse field with invalid format' do
+      count_field = 'sdfsdf.host'
+      expect(described_class.parse(count_field)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- Added Target class as parent of Tag, Field and CountField
- Introduced CountField with format:
`Model.association.some_has_many_association ..`
So field is basically representing only has_many association in field

Marking as wip some specs are missing 
but I would like to have your review before it.

@miq-bot add_label wip 

cc @kbrock  @imtayadeway 

@miq-bot assign @gtanzillo 

This PR is blocking https://github.com/ManageIQ/manageiq/pull/13692

