### PR TITLE
Add ae service model for S3 CloudObjectStoreContainer

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-s3-cloud_object_store_container.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-amazon-storage_manager-s3-cloud_object_store_container.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Amazon_StorageManager_S3_CloudObjectStoreContainer < MiqAeServiceCloudObjectStoreContainer
+  end
+end


### PR DESCRIPTION
Travis is failing since this ae service model is missing.

@miq-bot add_label bug
@miq-bot assign @gmcculloug