### PR TITLE
[EUWE] Backport PR 13101 to EUWE

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -28,6 +28,7 @@ class Hardware < ApplicationRecord
   virtual_column :mac_addresses, :type => :string_set, :uses => :nics
   virtual_aggregate :used_disk_storage,      :disks, :sum, :used_disk_storage
   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+  virtual_attribute :ram_size_in_bytes, :integer, :arel => ->(t) { t.grouping(t[:memory_mb] * 1.megabyte) }
 
   def ipaddresses
     @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq
@@ -39,6 +40,10 @@ class Hardware < ApplicationRecord
 
   def mac_addresses
     @mac_addresses ||= nics.collect(&:address).compact.uniq
+  end
+
+  def ram_size_in_bytes
+    memory_mb * 1.megabyte
   end
 
   @@dh = {"type" => "device_name", "devicetype" => "device_type", "id" => "location", "present" => "present",

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -43,7 +43,7 @@ class Hardware < ApplicationRecord
   end
 
   def ram_size_in_bytes
-    memory_mb * 1.megabyte
+    memory_mb.to_i * 1.megabyte
   end
 
   @@dh = {"type" => "device_name", "devicetype" => "device_type", "id" => "location", "present" => "present",

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -149,7 +149,9 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
   virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
   virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_storage_by_state]
-  virtual_column :mem_cpu,                              :type => :integer,    :uses => :hardware
+  virtual_delegate :ram_size_in_bytes,                  :to => :hardware, :allow_nil => true, :default => 0
+  virtual_delegate :mem_cpu,                            :to => "hardware.memory_mb", :allow_nil => true, :default => 0
+  virtual_delegate :ram_size,                           :to => "hardware.memory_mb", :allow_nil => true, :default => 0
   virtual_column :ipaddresses,                          :type => :string_set, :uses => {:hardware => :ipaddresses}
   virtual_column :hostnames,                            :type => :string_set, :uses => {:hardware => :hostnames}
   virtual_column :mac_addresses,                        :type => :string_set, :uses => {:hardware => :mac_addresses}
@@ -1540,12 +1542,12 @@ class VmOrTemplate < ApplicationRecord
     allocated_disk_storage.to_i + ram_size_in_bytes
   end
 
-  def used_storage(include_ram = true, check_state = false)
-    used_disk_storage.to_i + (include_ram ? ram_size_in_bytes(check_state) : 0)
+  def used_storage
+    used_disk_storage.to_i + ram_size_in_bytes
   end
 
-  def used_storage_by_state(include_ram = true)
-    used_storage(include_ram, true)
+  def used_storage_by_state
+    used_disk_storage.to_i + ram_size_in_bytes_by_state
   end
 
   def uncommitted_storage
@@ -1556,23 +1558,13 @@ class VmOrTemplate < ApplicationRecord
     hardware.nil? ? false : hardware.disks.any? { |d| d.disk_type == 'thin' }
   end
 
-  def ram_size(check_state = false)
-    hardware.nil? || (check_state && state != 'on') ? 0 : hardware.memory_mb
-  end
-
   def ram_size_by_state
-    ram_size(true)
-  end
-
-  def ram_size_in_bytes(check_state = false)
-    ram_size(check_state).to_i * 1.megabyte
+    state == 'on' ? ram_size : 0
   end
 
   def ram_size_in_bytes_by_state
-    ram_size_in_bytes(true)
+    ram_size_by_state * 1.megabyte
   end
-
-  alias_method :mem_cpu, :ram_size
 
   def num_cpu
     hardware.nil? ? 0 : hardware.cpu_sockets

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -31,11 +31,39 @@ module VmOrTemplate::RightSizing
 
     virtual_column :max_cpu_usage_rate_average_max_over_time_period,     :type => :float
     virtual_column :max_mem_usage_absolute_average_max_over_time_period, :type => :float
-    virtual_column :cpu_usagemhz_rate_average_max_over_time_period,      :type => :float
-    virtual_column :derived_memory_used_max_over_time_period,            :type => :float
+
+    virtual_attribute :cpu_usagemhz_rate_average_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:cpu_usagemhz_rate_average)
+    virtual_attribute :derived_memory_used_max_over_time_period,
+                      :float, :arel => metric_rollup_vattr_arel(:derived_memory_used)
   end
 
   module ClassMethods
+    def metric_rollup_vattr_arel(col)
+      lambda do |t|
+        metric_rollup_table = MetricRollup.arel_table
+        select_clause = metric_rollup_table[col].maximum
+
+        now       = Time.now.utc
+        timestamp = (now - 30.days).utc..now
+        tp_ids    = TimeProfile.default_time_profile(nil)
+                               .profile_for_each_region
+                               .pluck(:id)
+
+        where_clause =
+          metric_rollup_table[:time_profile_id].in(tp_ids)
+            .and(metric_rollup_table[:capture_interval_name].eq("daily"))
+            .and(metric_rollup_table[:timestamp].between(timestamp))
+            .and(metric_rollup_table[:resource_type].eq("VmOrTemplate"))
+            .and(metric_rollup_table[:resource_id].eq(t[:id]))
+
+        t.grouping(
+          metric_rollup_table.project(select_clause)
+                             .where(where_clause)
+        )
+      end
+    end
+
     def cpu_recommendation_minimum
       ::Settings.recommendations.cpu_minimum
     end
@@ -135,13 +163,29 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:cpu_usagemhz_rate_average).compact.max
+    if has_attribute?("cpu_usagemhz_rate_average_max_over_time_period")
+      self["cpu_usagemhz_rate_average_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:cpu_usagemhz_rate_average)
+    end
   end
 
   def derived_memory_used_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
-    perfs.collect(&:derived_memory_used).compact.max
+    if has_attribute?("derived_memory_used_max_over_time_period")
+      self["derived_memory_used_max_over_time_period"]
+    else
+      opts = {
+        :end_date => Time.now.utc,
+        :days     => Metric::LongTermAverages::AVG_DAYS
+      }
+      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
+                            .maximum(:derived_memory_used)
+    end
   end
 
   private

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -36,14 +36,12 @@ module VmOrTemplate::RightSizing
   end
 
   module ClassMethods
-    DEFAULT_CPU_RECOMMENDATION_MINIMUM = 1
     def cpu_recommendation_minimum
-      VMDB::Config.new("vmdb").config.fetch_path(:recommendations, :cpu_minimum) || DEFAULT_CPU_RECOMMENDATION_MINIMUM
+      ::Settings.recommendations.cpu_minimum
     end
 
-    DEFAULT_MEM_RECOMMENDATION_MINIMUM = 32.megabytes
     def mem_recommendation_minimum
-      min = (VMDB::Config.new("vmdb").config.fetch_path(:recommendations, :mem_minimum) || DEFAULT_MEM_RECOMMENDATION_MINIMUM).to_i_with_method
+      min = ::Settings.recommendations.mem_minimum.to_i_with_method
       min / 1.megabyte
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1028,6 +1028,9 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+:recommendations:
+  :cpu_minimum: 1
+  :mem_minimum: 32.megabytes
 :reporting:
   :format_by_class:
     :Fixnum:

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -39,9 +39,14 @@ module VirtualArel
       end
     end
 
+    # supported by sql if
+    # - it is an attribute alias
+    # - it is an attribute that is non virtual
+    # - it is an attribute that is virtual and has arel defined
     def attribute_supported_by_sql?(name)
       load_schema
-      !virtual_attribute?(name) || !!_virtual_arel[name.to_s]
+      attribute_alias?(name) ||
+        (has_attribute?(name) && (!virtual_attribute?(name) || !!_virtual_arel[name.to_s]))
     end
     private
 

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -617,10 +617,11 @@ module ActiveRecord
       def select(*fields)
         return super if block_given? || fields.empty?
         # support virtual attributes by adding an alias to the sql phrase for the column
+        # it does not add an as() if the column already has an as
         # this code is based upon _select()
         fields.flatten!
         fields.map! do |field|
-          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
             arel.as(field.to_s)
           else
             field

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -760,6 +760,14 @@ module ActiveRecord
 
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
+        # work around 1 until https://github.com/rails/rails/pull/25304 gets merged
+        # This allows attribute_name to be a virtual_attribute
+        if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
+          attribute_name = arel
+        end
+        # end work around 1
+
+        # allow calculate to work when including a virtual attribute
         real = without_virtual_includes
         return super if real.equal?(self)
 

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -608,6 +608,23 @@ module ActiveRecord
         recs
       end
 
+      # From ActiveRecord::QueryMethods
+      def select(*fields)
+        return super if block_given? || fields.empty?
+        # support virtual attributes by adding an alias to the sql phrase for the column
+        # this code is based upon _select()
+        fields.flatten!
+        fields.map! do |field|
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+            arel.as(field.to_s)
+          else
+            field
+          end
+        end
+        # end support virtual attributes
+        super
+      end
+
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
         real = without_virtual_includes

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -45,7 +45,7 @@ module VirtualArel
     # - it is an attribute that is virtual and has arel defined
     def attribute_supported_by_sql?(name)
       load_schema
-      attribute_alias?(name) ||
+      try(:attribute_alias?, name) ||
         (has_attribute?(name) && (!virtual_attribute?(name) || !!_virtual_arel[name.to_s]))
     end
     private

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -589,6 +589,94 @@ module ActiveRecord
         end
       }
     end
+
+    # FIXME: Hopefully we can get this into Rails core so this is no longer
+    # required in our codebase, but the rule that are broken here are mostly
+    # due to the style of the Rails codebase conflicting with our own.
+    # Ignoring them to avoid noise in RuboCop, but allow us to keep the same
+    # syntax from the original codebase.
+    #
+    # rubocop:disable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+    # rubocop:disable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    class JoinDependency
+      def instantiate(result_set, aliases)
+        primary_key = aliases.column_alias(join_root, join_root.primary_key)
+
+        seen = Hash.new { |i, object_id|
+          i[object_id] = Hash.new { |j, child_class|
+            j[child_class] = {}
+          }
+        }
+
+        model_cache = Hash.new { |h,klass| h[klass] = {} }
+        parents = model_cache[join_root]
+        column_aliases = aliases.column_aliases join_root
+
+        # New Code
+        #
+        # This monkey patches the ActiveRecord::Associations::JoinDependency to
+        # include columns into the main record that might have been added
+        # through a `select` clause.
+        #
+        # This can be seen with the following:
+        #
+        #   Vm.select(Vm.arel_table[Arel.star]).select(:some_vm_virtual_col)
+        #     .includes(:tags => {}).references(:tags => {})
+        #
+        # Which will produce a SQL SELECT statement kind of like this:
+        #
+        #   SELECT "vms".*,
+        #          (<virtual_attribute_arel>) AS some_vm_virtual_col,
+        #          "vms"."id"      AS t0_r0
+        #          "vms"."vendor"  AS t0_r1
+        #          "vms"."format"  AS t0_r1
+        #          "vms"."version" AS t0_r1
+        #          ...
+        #          "tags"."id"     AS t1_r0
+        #          "tags"."name"   AS t1_r1
+        #
+        # This is because rails is trying to reduce the number of queries
+        # needed to fetch all of the records in the include, so it grabs the
+        # columns for both of the tables together to do it.  Unfortuantely (or
+        # fortunately... depending on how you look at it), it does not remove
+        # any `.select` columns from the query that is run in the process, so
+        # that is brought along for the ride, but never used when this method
+        # instanciates the objects.
+        #
+        # The "New Code" here simply also instanciates any extra rows that
+        # might have been included in the select (virtual_columns) as well and
+        # brought back with the result set.
+        unless result_set.empty?
+          join_dep_keys         = aliases.columns.map(&:right)
+          join_root_aliases     = column_aliases.map(&:first)
+          additional_attributes = result_set.first.keys
+                                            .reject { |k| join_dep_keys.include?(k) }
+                                            .reject { |k| join_root_aliases.include?(k) }
+                                            .map    { |k| [k, k] }
+          column_aliases += additional_attributes
+        end
+        # End of New Code
+
+        message_bus = ActiveSupport::Notifications.instrumenter
+
+        payload = {
+          record_count: result_set.length,
+          class_name: join_root.base_klass.name
+        }
+
+        message_bus.instrument('instantiation.active_record', payload) do
+          result_set.each { |row_hash|
+            parent_key = primary_key ? row_hash[primary_key] : row_hash
+            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases)
+            construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
+          }
+        end
+
+        parents.values
+      end
+      # rubocop:enable Style/BlockDelimiters, Style/SpaceAfterComma, Style/HashSyntax
+      # rubocop:enable Style/AlignHash, Metrics/AbcSize, Metrics/MethodLength
+    end
   end
 
   class Relation

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -740,6 +740,23 @@ describe VirtualFields do
         expect(tc.parent_col1).to eq("def")
       end
     end
+
+    describe "#sum" do
+      it "supports virtual attributes" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)) })
+          def col2
+            col1
+          end
+        end
+
+        TestClass.create(:id => 1, :col1 => nil)
+        TestClass.create(:id => 2, :col1 => 20)
+        TestClass.create(:id => 3, :col1 => 30)
+
+        expect(TestClass.sum(:col2)).to eq(50)
+      end
+    end
   end
 
   describe "#follow_associations" do

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -554,7 +554,7 @@ describe VirtualFields do
         it "delegates to child (sql)" do
           TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
           TestClass.create(:id => 2, :ref2 => child)
-          tcs = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("child_col1")).to_a
+          tcs = TestClass.all.select(:id, :col1, :child_col1).to_a
           expect { expect(tcs.map(&:child_col1)).to match_array([nil, 2]) }.to match_query_limit_of(0)
         end
 
@@ -562,7 +562,7 @@ describe VirtualFields do
         # just want to make sure it changed due to intentional changes
         it "uses table alias for subquery" do
           TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
-          sql = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("x")).to_sql
+          sql = TestClass.all.select(:id, :col1, :child_col1).to_sql
           expect(sql).to match(/"test_classes_[^"]*"."col1"/i)
         end
       end
@@ -637,6 +637,27 @@ describe VirtualFields do
         TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
+      end
+    end
+
+    describe "#select" do
+      it "supports virtual attributes" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)) })
+          def col2
+            if has_attribute?("col2")
+              col2
+            else
+              # typically we'd return col1
+              # but we're testing that virtual columns are working
+              # col1
+              raise "NOPE"
+            end
+          end
+        end
+
+        TestClass.create(:id => 2, :col1 => 20)
+        expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
     end
 

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -501,6 +501,12 @@ describe VirtualFields do
       it "does not support bogus columns" do
         expect(TestClass.attribute_supported_by_sql?(:bogus_junk)).to be_falsey
       end
+
+      it "supports on an aaar class" do
+        c = Class.new(ActsAsArModel)
+
+        expect(c.attribute_supported_by_sql?(:col)).to eq(false)
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -497,6 +497,10 @@ describe VirtualFields do
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
+
+      it "does not support bogus columns" do
+        expect(TestClass.attribute_supported_by_sql?(:bogus_junk)).to be_falsey
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -682,6 +682,17 @@ describe VirtualFields do
         TestClass.create(:id => 2, :col1 => 20)
         expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
+
+      it "supports #includes with #references" do
+        vm           = FactoryGirl.create :vm_vmware
+        table        = Vm.arel_table
+        dash         = Arel::Nodes::SqlLiteral.new("'-'")
+        name_dash_id = Arel::Nodes::NamedFunction.new("CONCAT", [table[:name], dash, table[:id]])
+                                                 .as("name_dash_id")
+        result       = Vm.select(name_dash_id).includes(:tags => {}).references(:tags => {})
+
+        expect(result.first.attributes["name_dash_id"]).to eq("#{vm.name}-#{vm.id}")
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -663,6 +663,25 @@ describe VirtualFields do
         TestClass.create(:id => 2, :col1 => 20)
         expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
+
+      it "supports virtual attributes with as" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)).as("col2") })
+          def col2
+            if has_attribute?("col2")
+              col2
+            else
+              # typically we'd return col1
+              # but we're testing that virtual columns are working
+              # col1
+              raise "NOPE"
+            end
+          end
+        end
+
+        TestClass.create(:id => 2, :col1 => 20)
+        expect(TestClass.select(:col2).first[:col2]).to eq(20)
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -74,6 +74,12 @@ describe Rbac::Filterer do
         expect(results).to match_array [owned_vm]
       end
 
+      it "with :extra_cols finds Service" do
+        FactoryGirl.create :service, :evm_owner => owner_user
+        results = described_class.search(:class => "Service", :extra_cols => [:owned_by_current_user]).first
+        expect(results.first.attributes["owned_by_current_user"]).to be false
+      end
+
       it "leaving tenant doesnt find Vm" do
         owner_user.update_attributes(:miq_groups => [other_user.current_group])
         User.with_user(owner_user) do

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -179,4 +179,24 @@ describe Hardware do
       end
     end
   end
+
+  describe ".ram_size_in_bytes" do
+    it "handles nil" do
+      hardware = FactoryGirl.build(:hardware)
+
+      expect(hardware.ram_size_in_bytes).to eq(0)
+    end
+
+    it "works in ruby" do
+      hardware = FactoryGirl.build(:hardware, :memory_mb => 5)
+
+      expect(hardware.ram_size_in_bytes).to eq(5.megabytes)
+    end
+
+    it "works in sql" do
+      hardware = FactoryGirl.create(:hardware, :memory_mb => 5)
+
+      expect(virtual_column_sql_value(Hardware, "ram_size_in_bytes")).to eq(5.megabytes)
+    end
+  end
 end

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -44,7 +44,7 @@ describe VirtualTotalMixin do
     end
 
     it "is not defined in sql" do
-      expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(true)
+      expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(false)
     end
 
     def model_with_children(count)

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -6,7 +6,7 @@ describe VirtualTotalMixin do
       ems2 = model_with_children(2)
       ems1 = model_with_children(1)
 
-      expect(base_model.order(base_model.arel_attribute(:total_vms)).pluck(:id))
+      expect(base_model.order(:total_vms).pluck(:id))
         .to eq([ems0, ems1, ems2].map(&:id))
     end
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -620,6 +620,47 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".ram_size", ".mem_cpu" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 10) }
+
+    it "supports null hardware" do
+      vm = FactoryGirl.create(:vm_vmware)
+      expect(vm.ram_size).to eq(0)
+      expect(vm.mem_cpu).to eq(0)
+    end
+
+    it "calculates in ruby" do
+      expect(vm.ram_size).to eq(10)
+      expect(vm.mem_cpu).to eq(10)
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "ram_size")).to eq(10)
+      expect(virtual_column_sql_value(VmOrTemplate, "mem_cpu")).to eq(10)
+    end
+  end
+
+  describe ".ram_size_in_bytes" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 10) }
+
+    it "supports null hardware" do
+      vm = FactoryGirl.create(:vm_vmware)
+      expect(vm.ram_size_in_bytes).to eq(0)
+    end
+
+    it "calculates in ruby" do
+      expect(vm.ram_size_in_bytes).to eq(10.megabytes)
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "ram_size_in_bytes")).to eq(10.megabytes)
+    end
+  end
+
   describe ".host_name" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -661,6 +661,78 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".cpu_usagemhz_rate_average_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 10.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :cpu_usagemhz_rate_average => 100.0,
+                         :time_profile_id           => tp_id,
+                         :resource_id               => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.cpu_usagemhz_rate_average_max_over_time_period).to eq(100.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "cpu_usagemhz_rate_average_max_over_time_period"
+        )
+      ).to eq(100.0)
+    end
+  end
+
+  describe ".derived_memory_used_max_over_time_period (virtual_attribute)" do
+    let(:vm) { FactoryGirl.create :vm_vmware }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      tp_id = TimeProfile.seed.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :time_profile_id => tp_id,
+                         :resource_id     => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 10.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+      FactoryGirl.create :metric_rollup_vm_daily,
+                         :with_data,
+                         :derived_memory_used => 1000.0,
+                         :time_profile_id     => tp_id,
+                         :resource_id         => vm.id
+    end
+
+    it "calculates in ruby" do
+      expect(vm.derived_memory_used_max_over_time_period).to eq(1000.0)
+    end
+
+    it "calculates in the database" do
+      expect(
+        virtual_column_sql_value(
+          VmOrTemplate,
+          "derived_memory_used_max_over_time_period"
+        )
+      ).to eq(1000.0)
+    end
+  end
+
   describe ".host_name" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }


### PR DESCRIPTION
Backports the following PRs to [resolve conflicts](https://github.com/ManageIQ/manageiq/pull/13101#issuecomment-283749939) in the following files when backporting https://github.com/ManageIQ/manageiq/pull/13101 :

* `app/models/vm_or_template/right_sizing.rb`
  - https://github.com/ManageIQ/manageiq/pull/12751 - _Use Settings in VmOrTemplate::RightSizing_
* `spec/lib/extensions/ar_virtual_spec.rb`
  - https://github.com/ManageIQ/manageiq/pull/11631 **\*** - _Support virtual attributes for select_
  - https://github.com/ManageIQ/manageiq/pull/12438 - _Update ar_virtual#suppored_by_sql for bogus cols_
  - https://github.com/ManageIQ/manageiq/pull/13283 - _allow virtual_attribute to have a sql alias_
* `spec/models/vm_or_template_spec.rb`
  - https://github.com/ManageIQ/manageiq/pull/12938 - _Delegate vm ram_size to hardware_
  - https://github.com/ManageIQ/manageiq/pull/13125 - _Fix ram_size_in_bytes for hardware#memory_mb = nil_

Note:  The PR with the `*` is necessary for some of the performance improvements of 13101 to work.


Also, the following have been included in this PR as they relate to other fixes above:

* https://github.com/ManageIQ/manageiq/pull/11630 - _support virtual attributes for aggregation_
* https://github.com/ManageIQ/manageiq/pull/13206 - _Support AAArModel for attribute_supported_by_sql_

What needs to be reviewed...
----------------------------

All of the PRs have been backported mainly because they allow 13101 to be cleanly, but most have little impact on the actual code and just fix conflicts in the files, while most are relatively low risk in my opinion (a opinion which should be heavily vetted).

* https://github.com/ManageIQ/manageiq/pull/12751 while isn't necessary, is also adding a significant performance boost to the same code that is being fixed in #13101 (also a performance improvement).  That said, it was deemed that "Settings PRs" should not be added `euwe` unless necessary, so determining if this is a necessary circumstance should be vetted here.
* https://github.com/ManageIQ/manageiq/pull/11631 allows `virtual_attributes` to be used in the `.select` clause, and PR #13101 uses them extensively with the `apply_select` scope.  This PR won't function without #11631 in place.
* https://github.com/ManageIQ/manageiq/pull/12438 is one of the more "risky-ier" PRs to backport, mostly just reduces when a attribute can be found via SQL.  Worst case scenario (as far as I can tell) code will drop down to ruby filtering instead of SQL when going through things like RBac.
* https://github.com/ManageIQ/manageiq/pull/13283 is a minor change that only really adds more backwords compatability to older `virtual_attributes` that had `as` in the `arel`.
* https://github.com/ManageIQ/manageiq/pull/12938 and https://github.com/ManageIQ/manageiq/pull/13125 prove that some vetting of bugs has already been done, and the code in the PRs (`virtual_delegates` specifically) already exist in the `euwe` branch, so this seems relatively safe to backport.


Everyone CC'd on this PR has had some hand in deciding that the above PRs (not including 13101 of course) were not meant to be in EUWE, and I hope you will be able to help determine if that still is the case for each one or if we should reconsider thoses decisions.  It is also possible to just fix the conflicts and move on, so if necessary, this PR can be updated to use only some of the above PRs if that is deemed necessary.


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1422647
* https://github.com/ManageIQ/manageiq/pull/13101 - **ORIGINAL PR**:  _Allow cpu_usagemhz_rate_average_max_over_time_period and derived_memory_used_max_over_time_period to be used in reports as SQL_
* https://github.com/ManageIQ/manageiq/pull/12751 - _Use Settings in VmOrTemplate::RightSizing_
* https://github.com/ManageIQ/manageiq/pull/11631 - _Support virtual attributes for select_
* https://github.com/ManageIQ/manageiq/pull/12438 - _Update ar_virtual#suppored_by_sql for bogus cols_
* https://github.com/ManageIQ/manageiq/pull/13283 - _allow virtual_attribute to have a sql alias_
* https://github.com/ManageIQ/manageiq/pull/12938 - _Delegate vm ram_size to hardware_
* https://github.com/ManageIQ/manageiq/pull/13125 - _Fix ram_size_in_bytes for hardware#memory_mb = nil_
* https://github.com/ManageIQ/manageiq/pull/11630 - _support virtual attributes for aggregation_
* https://github.com/ManageIQ/manageiq/pull/13206 - _Support AAArModel for attribute_supported_by_sql_

cc/ @dmetzger57 @simaishi @chessbyte @kbrock @Fryguy @gtanzillo @himdel