### PR TITLE
Make db_ping.rb easier to run

### DIFF
--- a/tools/db_ping.rb
+++ b/tools/db_ping.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 total = 0
 5.times do
   ping = EvmDatabase.ping


### PR DESCRIPTION
Support users running this as an executable, a ruby script, or through
rails runner:

`./tools/db_ping.rb`
`ruby tools/db_ping.rb`
`bin/rails r tools/db_ping.rb`

* Add executable permission
* Add shebang for ruby
* Load rails automatically

[skip ci]