### PR TITLE
Add group_by_success to API

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -104,7 +104,7 @@ module Api
         else
           resources << json_body_resource
         end
-        update_multiple_collections(is_subcollection, target, type, resources)
+        update_multiple_collections(is_subcollection, target, type, resources, @req.group_by_success)
       end
 
       def json_body_resource
@@ -121,7 +121,7 @@ module Api
         end
       end
 
-      def update_multiple_collections(is_subcollection, target, type, resources)
+      def update_multiple_collections(is_subcollection, target, type, resources, group_by_success)
         action = @req.action
 
         processed = 0
@@ -140,7 +140,16 @@ module Api
           update_one_collection(is_subcollection, target, type, rid, r)
         end.flatten
         raise BadRequestError, "No #{type} resources were specified for the #{action} action" if processed == 0
+        results = group_by_success(results) if group_by_success
         {"results" => results}
+      end
+
+      def group_by_success(results)
+        success, failure = results.partition { |result| result[:success] }
+        {
+          :successes => success,
+          :failures  => failure
+        }
       end
     end
   end

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -112,6 +112,10 @@ module Api
                        end
         end
 
+        def group_by_success
+          json_body['group_by_success'] == 'true'
+        end
+
         private
 
         def expand_requested


### PR DESCRIPTION
While the API sorts bulk actions, it has come up a couple of times that the result passed back from the bulk actions is difficult to work with (ie, not being able to simply grab all of the failures). 

This *proposed* solution accepts
```
"group_by_success": "true"
```
in the body of the request. If this is passed in, the returned result will then be in the following format:

```
{
  "results": {
   "successes": [{"success": true, "id": 1 }, {"success": true, "id": 3}],
   "failures": [{"success": false, "id": 3}]
  }
}
```

open for discussion about the best way to handle this and format the new response.
cc: @AllenBW @imtayadeway @abellotti 

@miq-bot add_label enhancement, api