### PR TITLE
Drop not used 'jobs.archive' column

### DIFF
--- a/db/migrate/20170303192951_remove_field_archive_form_jobs.rb
+++ b/db/migrate/20170303192951_remove_field_archive_form_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveFieldArchiveFormJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :archive, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1577,7 +1577,6 @@ jobs:
 - miq_server_id
 - zone
 - agent_name
-- archive
 - options
 - context
 - miq_task_id


### PR DESCRIPTION
I can not find where ```jobs.archive``` column used.  Dropping it will make future merging of ```Job``` and ```MiqTask``` models simpler. 

@miq-bot add-label core, technical debt

@Fryguy 