### PR TITLE
Add openstack excon settings

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -43,8 +43,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         :ssl_ca_path    => ::Settings.ssl.ssl_ca_path,
         :ssl_cert_store => OpenSSL::X509::Store.new
       }
-      extra_options[:domain_id] = keystone_v3_domain_id
-      extra_options[:region]    = provider_region if provider_region.present?
+      extra_options[:domain_id]         = keystone_v3_domain_id
+      extra_options[:region]            = provider_region if provider_region.present?
+      extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
+      extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,6 +96,10 @@
     :keep_drift_states: 6.months
     :purge_window_size: 10000
 :ems:
+  :ems_openstack:
+    :excon:
+      :omit_default_port: true
+      :read_timeout: 60
   :ems_redhat:
     :resolve_ip_addresses: true
     :service:


### PR DESCRIPTION
adds read_timeout and omit_default_port excon settings for use with OpenStack providers

https://bugzilla.redhat.com/show_bug.cgi?id=1413912
https://bugzilla.redhat.com/show_bug.cgi?id=1417273