### PR TITLE
Support Rails 5.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem "ovirt_metrics",                  "~>1.4.0",       :require => false
 gem "pg-pglogical",                   "~>1.1.0",       :require => false
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.0.1"
+gem "rails",                          "~>5.0.2"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"


### PR DESCRIPTION
Checking out our compatibility with the newest patch release. This can/should be included in Euwe (but not 5.1.x, currently in beta, even when its released)

Includes a bunch of minor improvements:
https://github.com/rails/rails/compare/v5.0.1...v5.0.2