### PR TITLE
Ems event groups - allow provider settings (deeper_merge edition)

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -25,7 +25,16 @@ class EmsEvent < EventStream
   end
 
   def self.event_groups
-    ::Settings.event_handling.event_groups.to_hash
+    core_event_groups = ::Settings.event_handling.event_groups.to_hash
+    Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
+      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
+      next unless provider_event_groups
+      DeepMerge.deep_merge!(
+        provider_event_groups.to_hash, event_groups,
+        :preserve_unmergeables => false,
+        :overwrite_arrays      => false
+      )
+    end
   end
 
   def self.bottleneck_event_groups

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -198,4 +198,39 @@ describe EmsEvent do
       end
     end
   end
+
+  context '.event_groups' do
+    let(:provider_event) { 'SomeSpecialProviderEvent' }
+
+    it 'returns a list of groups' do
+      event_group_names = [
+        :addition, :application, :configuration, :console, :deletion, :general, :import_export, :migration, :network,
+        :power, :snapshot, :status, :storage
+      ]
+      expect(described_class.event_groups.keys).to match_array(event_group_names)
+      expect(described_class.event_groups[:addition]).to include(:name => 'Creation/Addition')
+      expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
+      expect(described_class.event_groups[:addition][:critical]).not_to include(provider_event)
+    end
+
+    it 'returns the provider event if configured' do
+      stub_settings_merge(
+        :ems => {
+          :some_provider => {
+            :event_handling => {
+              :event_groups => {
+                :addition => {
+                  :critical => [provider_event]
+                }
+              }
+            }
+          }
+        }
+      )
+      allow(Vmdb::Plugins.instance).to receive(:registered_provider_plugin_names).and_return([:some_provider])
+
+      expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
+      expect(described_class.event_groups[:addition][:critical]).to include(provider_event)
+    end
+  end
 end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -4,6 +4,11 @@ def stub_settings(hash)
   allow(Vmdb::Settings).to receive(:for_resource) { settings }
 end
 
+def stub_settings_merge(hash)
+  hash = Settings.to_hash.deep_merge(hash)
+  stub_settings(hash)
+end
+
 def stub_template_settings(hash)
   settings = Config::Options.new.merge!(hash)
   allow(Vmdb::Settings).to receive(:template_settings) { settings }


### PR DESCRIPTION
### Allow provider plugins to participate in setting up `EmsEvent.event_groups`

In order to provide settings for `event_handling.event_groups` every provider had to include its event names into `settings.yml` - which grew massively to beyond recognition.

To split these into `settings.yml` in the provider repos I have to hook into the `event_groups` method (see [1] for reasons).
This patch iterates over all registered provider plugins and looks for the same `event_handling.event_groups` structure under the provider name key.

Eg.
```yaml
:ems:
  :ems_amazon:
     :event_handling:
        :event_groups:
          :addition:
            :critical:
            - AWS_EC2_Instance_CREATE
            - AWS_EC2_Instance_UPDATE
            - AWS_EC2_Instance_DELETE
          :power:
            :critical:
            - AWS_EC2_Instance_running
            - AWS_EC2_Instance_shutting-down
            - AWS_EC2_Instance_stopped
```

Then it merges the hash and more important merges the arrays of events.

Follows the suggestion in [1] 

[1] https://github.com/ManageIQ/manageiq-providers-amazon/pull/138

### This is the same as https://github.com/ManageIQ/manageiq/pull/13942 - just with `DeepMerge.deep_merge!`