### PR TITLE
add vms via dsl in ansible automation manager

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
@@ -9,14 +9,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::Automati
     has_automation_manager_configuration_script_payloads :model_class => ManageIQ::Providers::Inflector.provider_module(self)::AutomationManager::Playbook
     has_automation_manager_configured_systems
     has_automation_manager_inventory_root_groups
-  end
-
-  def initialize_inventory_collections
-    collections[:vms] = ::ManagerRefresh::InventoryCollection.new(
-      :model_class => Vm,
-      :arel        => Vm,
-      :strategy    => :local_db_find_references,
-      :manager_ref => [:uid_ems]
-    )
+    has_vms :arel => Vm, :strategy => :local_db_find_references
   end
 end

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -52,5 +52,13 @@ module ManagerRefresh::Inventory::Core
         :inventory_object_attributes => %i(name),
       }.merge(options))
     end
+
+    def has_vms(options = {})
+      has_inventory({
+        :model_class                 => ::Vm,
+        :manager_ref                 => [:uid_ems],
+        :inventory_object_attributes => %i(),
+      }.merge(options))
+    end
   end
 end

--- a/app/models/manager_refresh/inventory/persister.rb
+++ b/app/models/manager_refresh/inventory/persister.rb
@@ -14,11 +14,16 @@ class ManagerRefresh::Inventory::Persister
 
   # creates method on class that lazy initializes an InventoryCollection
   def self.has_inventory(options)
-    name = options[:association]
+    name = options[:association] || options[:model_class].name.pluralize.underscore
+
     define_method(name) do
       collections[name] ||= begin
         collection_options = options.dup
-        collection_options[:parent] ||= manager
+
+        unless collection_options[:strategy] == :local_db_find_references
+          collection_options[:parent] ||= manager
+        end
+
         if collection_options[:builder_params]
           collection_options[:builder_params] = collection_options[:builder_params].transform_values do |value|
             if value.respond_to? :call
@@ -67,7 +72,7 @@ class ManagerRefresh::Inventory::Persister
   protected
 
   def initialize_inventory_collections
-    raise NotImplementedError, _("must be implemented in a subclass")
+    # can be implemented in a subclass
   end
 
   # Adds 1 ManagerRefresh::InventoryCollection under a target.collections using :association key as index


### PR DESCRIPTION
### api for defining inventory collections

Follow up for https://github.com/ManageIQ/manageiq/pull/14022 

* if no `:association` is given, we use the name of the class, so `Vm` becomes `:vms`

@miq-bot add_labels refactoring, providers/ansible_tower
@miq-bot assign @kbrock 

@Ladas please review