### PR TITLE
Drop not used 'jobs.code' column

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -50,7 +50,6 @@ class Job < ApplicationRecord
     self.context ||= {}
     self.options ||= {}
     self.status   = "ok"
-    self.code     = 0
     self.message  = "process initiated"
   end
 
@@ -105,10 +104,9 @@ class Job < ApplicationRecord
     end
   end
 
-  def set_status(message, status = "ok", code = 0)
+  def set_status(message, status = "ok")
     self.message = message
     self.status  = status
-    self.code    = code
 
     save
   end
@@ -139,13 +137,13 @@ class Job < ApplicationRecord
   def process_error(*args)
     message, status = args
     _log.error message.to_s
-    set_status(message, status, 1)
+    set_status(message, status)
   end
 
   def process_abort(*args)
     message, status = args
     _log.error "job aborting, #{message}"
-    set_status(message, status, 1)
+    set_status(message, status)
     signal(:finish, message, status)
   end
 

--- a/db/migrate/20170303213837_remove_field_code_from_jobs.rb
+++ b/db/migrate/20170303213837_remove_field_code_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveFieldCodeFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :code, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1558,7 +1558,6 @@ jobs:
 - state
 - status
 - message
-- code
 - name
 - userid
 - created_on


### PR DESCRIPTION
 I can not find where ```jobs.code``` used. Also, it looks like information in ```jobs.code``` is redundant (with possible values 1 for error or aborting job, and 0 for all other cases).


@miq-bot add-label core , technical debt

\cc @Fryguy 