### PR TITLE
[EUWE] Resolve oVirt IP addresses (backport of ManageIQ/manageiq#13767)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,6 +93,7 @@
     :purge_window_size: 10000
 :ems:
   :ems_redhat:
+    :resolve_ip_addresses: true
     :service:
       :read_timeout: 1.hour
   :ems_kubernetes:

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -1,9 +1,12 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
+  let(:ip_address) { '192.168.252.231' }
+
   before(:each) do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.252.231", :ipaddress => "192.168.252.231", :port => 8443)
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address, :port => 8443)
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
     allow(@ems).to receive(:supported_api_versions).and_return([3])
+    allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -1,9 +1,12 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
+  let(:ip_address) { '192.168.252.230' }
+
   before(:each) do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.252.230", :ipaddress => "192.168.252.230", :port => 443)
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address, :port => 443)
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
     allow(@ems).to receive(:supported_api_versions).and_return([3])
+    allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
@@ -1,8 +1,10 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   context 'targeted refresh of a Vm' do
+    let(:ip_address) { '192.168.1.31' }
+
     before(:each) do
       _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.31", :ipaddress => "192.168.1.31",
+      @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address,
                                 :port => 8443)
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
 
@@ -13,6 +15,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
                                     :name    => "Default")
 
       allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     end
 
     it "should refresh a vm" do
@@ -70,12 +73,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   context 'targeted refresh after vm migration' do
+    let(:ip_address) { '10.35.161.51' }
+
     before(:each) do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems = FactoryGirl.create(:ems_redhat, :zone => zone,
-                                :hostname => "10.35.161.51", :ipaddress => "10.35.161.51", :port => 443)
+                                :hostname => ip_address, :ipaddress => ip_address, :port => 443)
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "password"})
       allow(@ems).to receive(:supported_api_versions).and_return([3])
+      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     end
 
     it 'should save the vms new host' do

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -1,4 +1,6 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Vm do
+  let(:ip_address) { '192.168.1.31' }
+
   context "#is_available?" do
     let(:ems)  { FactoryGirl.create(:ems_redhat) }
     let(:host) { FactoryGirl.create(:host_redhat, :ext_management_system => ems) }
@@ -116,10 +118,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
   describe "#disconnect_storage" do
     before(:each) do
       _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-      ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.31",
-                               :ipaddress => "192.168.1.31", :port => 8443)
+      ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address,
+                               :ipaddress => ip_address, :port => 8443)
       ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
       allow(ems).to receive(:supported_api_versions).and_return([3, 4])
+      allow(ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
 
       @storage = FactoryGirl.create(:storage, :ems_ref => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0")
       disk = FactoryGirl.create(:disk, :storage => @storage, :filename => "da123bb9-095a-4933-95f2-8032dfa332e1")


### PR DESCRIPTION
This is a back-port of ManageIQ/manageiq#13767.

Since version 4 oVirt rejects connections that use directly the IP
address instead of the host name. This is a side effect of the new SSO
authentication mechanism. That means that when a oVirt provider is added
using an IP address it will not work. Users don't do this frequently,
but the system does it automatically when the provider is added using
the discovery mechanism, as this mechanism uses IP addresses only. To
avoid this issue this patch changes the provider so that when it
receives an IP address it tries to convert it to the corresponding fully
qualified host name.

There may be situations where the user really wants to use an IP
address, and not the host name. For those cases this patch also
introduces a new `resolve_ip_addresses` setting that can be used to
disable resolving. This setting will be stored in the
`config/settings.yml` file, and its default value will be 'true':

```
:ems:
  :ems_redhat:
    :resolve_ip_addresses: true
```

https://bugzilla.redhat.com/1417757