### PR TITLE
Fix no arg client creation

### DIFF
--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -38,7 +38,8 @@ module ManageIQ::Providers
     end
 
     # Hawkular Client
-    def self.raw_connect(hostname, port, token, type = :alerts)
+    def self.raw_connect(hostname, port, token, type)
+      type ||= :alerts
       klass = case type
               when :metrics
                 ::Hawkular::Metrics::Client


### PR DESCRIPTION
A recent change in client creation did not take into account the verify_credentials flow, 
where `connect({})` is called which then passes `options[:type]` which is nil to raw connect.

Extracted from #12773 to isolate Travis failures, see https://github.com/ManageIQ/manageiq/pull/12773#issuecomment-284378468

