### PR TITLE
Support tenant parameter in hawkular client creation

### DIFF
--- a/app/models/manageiq/providers/hawkular/common/event_catcher/runner_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/common/event_catcher/runner_mixin.rb
@@ -1,0 +1,50 @@
+module ManageIQ::Providers::Hawkular::Common::EventCatcher::RunnerMixin
+  extend ActiveSupport::Concern
+
+  def log_handle
+    self.class.log_handle
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.try(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      new_events = events.select { |e| whitelist?(e) }
+      log_handle.debug("#{log_prefix} Discarding events #{events - new_events}") if new_events.length < events.length
+      if new_events.any?
+        log_handle.debug "#{log_prefix} Queueing events #{new_events}"
+        @queue.enq new_events
+      end
+      # invoke the configured sleep before the next event fetch
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def event_monitor_handle
+    @event_monitor_handle ||= self.class.event_monitor_class.new(@ems)
+  end
+
+  def process_event(event)
+    log_handle.debug "Processing Event #{event}"
+    event_hash = event_to_hash(event, @cfg[:ems_id])
+
+    if blacklist?(event_hash[:event_type])
+      log_handle.debug "#{log_prefix} Filtering blacklisted event [#{event}]"
+    else
+      log_handle.debug "#{log_prefix} Adding ems event [#{event_hash}]"
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
@@ -1,0 +1,30 @@
+module ManageIQ::Providers::Hawkular::Common::EventCatcher::StreamMixin
+  extend ActiveSupport::Concern
+
+  def start
+    @collecting_events = true
+  end
+
+  def stop
+    @collecting_events = false
+  end
+
+  def each_batch
+    while @collecting_events
+      yield fetch
+    end
+  end
+
+  def fetch
+    new_alerts = []
+    alert_tenants.each do |tenant|
+      log_handle.debug "Fetching tenant [#{tenant}] events using criteria [#{hawkular_alert_criteria}]"
+      new_alerts.concat(@ems.alerts_client(:tenant => tenant).list_alerts(hawkular_alert_criteria))
+    end
+    post_fetch(new_alerts)
+    new_alerts
+  rescue => err
+    log_handle.error "Error capturing alerts #{err}"
+    []
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -38,7 +38,8 @@ module ManageIQ::Providers
     end
 
     # Hawkular Client
-    def self.raw_connect(hostname, port, token, type = :alerts)
+    def self.raw_connect(hostname, port, token, type)
+      type ||= :alerts
       klass = case type
               when :metrics
                 ::Hawkular::Metrics::Client

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -38,39 +38,42 @@ module ManageIQ::Providers
     end
 
     # Hawkular Client
-    def self.raw_connect(hostname, port, token, type)
-      type ||= :alerts
-      klass = case type
+    def self.raw_connect(options)
+      options[:type] ||= :alerts
+      options[:tenant] ||= '_system'
+      klass = case options[:type]
               when :metrics
                 ::Hawkular::Metrics::Client
               when :alerts
                 ::Hawkular::Alerts::AlertsClient
               else
-                raise ArgumentError, "Client not found for #{type}"
+                raise ArgumentError, "Client not found for #{options[:type]}"
               end
       klass.new(
-        URI::HTTPS.build(:host => hostname, :port => port.to_i).to_s,
-        { :token => token },
-        { :tenant => '_system', :verify_ssl => verify_ssl_mode }
+        URI::HTTPS.build(:host => options[:hostname], :port => options[:port].to_i).to_s,
+        { :token => options[:token] },
+        { :tenant => options[:tenant], :verify_ssl => verify_ssl_mode }
       )
     end
 
     def connect(options = {})
       @clients ||= {}
-      @clients[options[:type]] ||= self.class.raw_connect(
-        hostname,
-        port,
-        authentication_token('default'),
-        options[:type]
+      memo_options = options.slice(:type, :tenant)
+      @clients[memo_options.freeze] ||= self.class.raw_connect(
+        memo_options.merge(
+          :hostname => hostname,
+          :port     => port,
+          :token    => authentication_token('default'),
+        )
       )
     end
 
-    def alerts_client
-      connect(:type => :alerts)
+    def alerts_client(options = {})
+      connect(options.merge(:type => :alerts))
     end
 
-    def metrics_client
-      connect(:type => :metrics)
+    def metrics_client(options = {})
+      connect(options.merge(:type => :metrics))
     end
 
     def supports_port?


### PR DESCRIPTION
Currently the system creates all hawkular clients with the '_system' tenant. For Datawarehouse event collection we will need to collect events/alerts from additional tenants.

Extracted from #12773 to isolate Travis failures, see #12773 (comment)