### PR TITLE
[EUWE] MiddlwareTopology - fix wrong assets/svg/... image path

### DIFF
--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -10,7 +10,7 @@
         %svg.kube-topology
           %g.MiddlewareServer{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
-            %image{:height => "20", :width => "20", :x => "-10", :y => "-10", "xlink:href" => image_path('/assets/svg/vendor-wildfly.svg')}
+            %image{:height => "20", :width => "20", :x => "-10", :y => "-10", "xlink:href" => image_path('svg/vendor-wildfly.svg')}
         %label
           = _("Servers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDeployment"}


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/219

(cherry-picked from ManageIQ/manageiq-ui-classic@b5f047ce1f11ced8afe3fe7ad3e2849696f5f237)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1428838
EUWE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1428904

@miq-bot assign simaishi
@miq-bot add_label ui, bug