### PR TITLE
[EUWE] Add jquery ~2.1.4 to bower's resolutions section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -58,6 +58,7 @@
   "resolutions": {
     "patternfly-bootstrap-treeview": "~2.1.1",
     "moment": ">=2.10.5",
-    "d3": "~3.5.0"
+    "d3": "~3.5.0",
+    "jquery": "~2.1.4"
   }
 }


### PR DESCRIPTION
.. meant to prevent jquery 3 from becoming a valid choice on dependency conflict.

Should prevent failures such as https://travis-ci.org/ManageIQ/manageiq/jobs/207470021#L725.

@miq-bot assign simaishi