### PR TITLE
Add Picture to Orchestration Template

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -7,6 +7,7 @@ class OrchestrationTemplate < ApplicationRecord
   acts_as_miq_taggable
 
   has_many :stacks, :class_name => "OrchestrationStack"
+  has_one :picture, :dependent => :destroy, :as => :resource, :autosave => true
 
   default_value_for :draft, false
   default_value_for :orderable, true


### PR DESCRIPTION
SUI needs to be able to store/retrieve an image for an OrchestrationTemplate

cc: @chalettu 
@miq-bot add_label enhancement
@miq-bot assign @Fryguy 

* [Pivotal ticket](https://www.pivotaltracker.com/story/show/141134301)