### PR TITLE
Create a CustomAttribute for VmOrTemplate labels.

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -39,7 +39,7 @@ module EmsRefresh::SaveInventory
                     []
                   end
 
-    child_keys = [:operating_system, :hardware, :custom_attributes, :snapshots, :advanced_settings]
+    child_keys = [:operating_system, :hardware, :custom_attributes, :snapshots, :advanced_settings, :labels]
     extra_infra_keys = [:host, :ems_cluster, :storage, :storages, :storage_profile, :raw_power_state, :parent_vm]
     extra_cloud_keys = [
       :flavor,

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -128,6 +128,7 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :direct_services, :through => :service_resources, :source => :service
   belongs_to                :tenant
   has_many                  :connected_shares, -> { where(:resource_type => "VmOrTemplate") }, :foreign_key => :resource_id, :class_name => "Share"
+  has_many                  :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
 
   acts_as_miq_taggable
 


### PR DESCRIPTION
AWS labels (or potentially any provider's labels ) are gathered and stored as Custom Attributes in the database. They will be displayed in the Summary pages of the UI in the **Labels** table

This PR takes care of the model changes for this feature. Currently, only AWS VMs and images support tags.

The ```save_labels_inventory``` and ```save_custom_attribute_attribute_inventory``` methods should be moved out of the ```save_inventory_containers``` class and into a generic class but since the dev freeze is 2 weeks away this will have to be done in a separate PR 

Pivotal story: https://www.pivotaltracker.com/story/show/139414085


