### PR TITLE
boot skips all seeding with env variable

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -44,16 +44,18 @@ class EvmDatabase
   end
 
   def self.seed_primordial
-    if ENV['SKIP_PRIMORDIAL_SEED'] && MiqDatabase.count > 0
-      puts "** Primordial seedings is skipped."
-      puts "** Unset SKIP_PRIMORDIAL_SEED to re-enable"
+    if ENV['SKIP_SEEDING'] && MiqDatabase.count > 0
+      puts "** seedings is skipped on startup."
+      puts "** Unset SKIP_SEEDING to re-enable"
     else
       seed(PRIMORDIAL_CLASSES)
     end
   end
 
   def self.seed_last
-    seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
+    if ENV['SKIP_SEEDING'] && MiqDatabase.count > 0
+      seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
+    end
   end
 
   def self.seed(classes = nil, exclude_list = [])


### PR DESCRIPTION
This is a follow-up to https://github.com/ManageIQ/manageiq/pull/6672

We need to reboot `rails s` dozens of times a day as we run performance tests, often in production mode.

On appliance startup, the environment variable ~~`SKIP_PRIMORDIAL_SEED`~~`SKIP_SEEDING` is consulted when booting the appliance to skip seeding the database.

Using a docker db, local `rails s` takes 18s. Using this flag takes it down to 9s (50% savings).

For evm server, it was only skipping the first half of the seeding. This PR skips the second half of seeding

/cc @jrafanie @Fryguy @chrisarcand same actors as last round.