### PR TITLE
Move the call to reload ntp settings to the server only

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -13,6 +13,7 @@ module MiqServer::ConfigurationManagement
   def set_config(config)
     config = config.config if config.respond_to?(:config)
     add_settings_for_resource(config)
+    ntp_reload_queue
   end
 
   def reload_settings

--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -32,10 +32,6 @@ module VMDB
         Vmdb::Loggers.apply_config(data)
       end
 
-      def ntp(_data)
-        MiqServer.my_server.ntp_reload_queue unless MiqServer.my_server.nil? rescue nil
-      end
-
       def session(data)
         Session.timeout data.timeout
         Session.interval data.interval


### PR DESCRIPTION
Previously, when the ntp settings were changed every worker would enqueue a message for the server to reload the settings when they went through the Config::Activator.

Multiple calls to restart chronyd within a matter of seconds causes systemd to back off and fail the unit causing chronyd not to run until the appliance is rebooted or it is started manually.

This change makes the server reload the ntp settings every time its config is changed, but removes the call to reload from the activator which removes all the calls generated when the workers refresh their settings. This results in just one call to reload the settings when the config is changed rather than tens.