### PR TITLE
Proper parent initialization

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
@@ -9,6 +9,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::Automati
     has_automation_manager_configuration_script_payloads :model_class => ManageIQ::Providers::Inflector.provider_module(self)::AutomationManager::Playbook
     has_automation_manager_configured_systems
     has_automation_manager_inventory_root_groups
-    has_vms :arel => Vm, :strategy => :local_db_find_references
+    has_vms :parent => nil, :arel => Vm, :strategy => :local_db_find_references
   end
 end

--- a/app/models/manager_refresh/inventory/persister.rb
+++ b/app/models/manager_refresh/inventory/persister.rb
@@ -20,9 +20,7 @@ class ManagerRefresh::Inventory::Persister
       collections[name] ||= begin
         collection_options = options.dup
 
-        unless collection_options[:strategy] == :local_db_find_references
-          collection_options[:parent] ||= manager
-        end
+        collection_options[:parent] = manager unless collection_options.key?(:parent)
 
         if collection_options[:builder_params]
           collection_options[:builder_params] = collection_options[:builder_params].transform_values do |value|


### PR DESCRIPTION
Set :parent to manager only if not sent in options and explicitly pass :parent => nil, because it has a priority over :arel in the DB strategies.

So e.g. for AWS, when we use a DB strategy, it's enough to use parent and association, since the related Vm can only be in the scope of manager.vms. But for Ansible, the crosslink can be to any VM, therefore we use a generic arel to get to the right Vm.

The priority for DB strategy starting with higher priority is: :custom_db_finder, :parent & :association, :arel. So the first defined is used for fetching data from the DB.