### PR TITLE
Extracted debug_trace to setting from being hardcoded.

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -18,8 +18,7 @@ module EmsRefresh
   extend EmsRefresh::VcUpdates
 
   def self.debug_trace
-    # TODO: Replace with configuration option
-    false
+    Settings.ems_refresh[:debug_trace]
   end
 
   # If true, Refreshers will raise any exceptions encountered, instead

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -2,7 +2,6 @@ module ManageIQ
   module Providers
     class BaseManager::Refresher
       include Vmdb::Logging
-      DEBUG_TRACE = false
 
       attr_accessor :ems_by_ems_id, :targets_by_ems_id
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,6 +112,7 @@
     :keep_events: 6.months
     :purge_window_size: 1000
 :ems_refresh:
+  :debug_trace: false
   :capture_vm_created_on_date: false
   :ansible_tower_automation:
     :refresh_interval: 15.minutes


### PR DESCRIPTION
Fixes BZ RFE https://bugzilla.redhat.com/show_bug.cgi?id=1223120

Extracts debug_trace to become a user defined setting under `ems_refresh`.

Questions: Where should the specs for this live?
* EmsRefresh
* VMDB::Settings

Also removed `DEBUG_TRACE` in https://github.com/ManageIQ/manageiq/blob/2f069b74bdebdb8f2bdcd38d3aac75a72ef521bd/app/models/manageiq/providers/base_manager/refresher.rb#L5 is this related to the method in `ems_refresh` is it being used?