### PR TITLE
Adding nodes and cluster_attributes to datawarehouse manager

### DIFF
--- a/app/models/datawarehouse_node.rb
+++ b/app/models/datawarehouse_node.rb
@@ -1,0 +1,9 @@
+class DatawarehouseNode < ApplicationRecord
+  include CustomAttributeMixin
+
+  belongs_to :ext_management_system, :foreign_key => "ems_id"
+
+  belongs_to :lives_on, :polymorphic => true
+
+  acts_as_miq_taggable
+end

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -283,6 +283,22 @@ module EmsRefresh::SaveInventory
     save_inventory_multi(os.processes, hashes, :use_association, [:pid])
   end
 
+  def save_custom_attribute_attribute_inventory(entity, attribute_name, hashes, target = nil)
+    return if hashes.nil?
+
+    entity.send(attribute_name).reset
+    deletes = if target.kind_of?(ExtManagementSystem)
+                :use_association
+              else
+                []
+              end
+
+    save_inventory_multi(entity.send(attribute_name),
+                         hashes, deletes, [:section, :name])
+    store_ids_for_new_records(entity.send(attribute_name),
+                              hashes, [:section, :name])
+  end
+
   def save_custom_attributes_inventory(parent, hashes, mode = :refresh)
     return if hashes.nil?
 

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -400,22 +400,6 @@ module EmsRefresh::SaveInventoryContainer
     save_custom_attribute_attribute_inventory(entity, :additional_attributes, hashes, target)
   end
 
-  def save_custom_attribute_attribute_inventory(entity, attribute_name, hashes, target = nil)
-    return if hashes.nil?
-
-    entity.send(attribute_name).reset
-    deletes = if target.kind_of?(ExtManagementSystem)
-                :use_association
-              else
-                []
-              end
-
-    save_inventory_multi(entity.send(attribute_name),
-                         hashes, deletes, [:section, :name])
-    store_ids_for_new_records(entity.send(attribute_name),
-                              hashes, [:section, :name])
-  end
-
   def save_labels_inventory(entity, hashes, target = nil)
     save_custom_attribute_attribute_inventory(entity, :labels, hashes, target)
   end

--- a/app/models/ems_refresh/save_inventory_datawarehouse.rb
+++ b/app/models/ems_refresh/save_inventory_datawarehouse.rb
@@ -2,12 +2,31 @@ module EmsRefresh::SaveInventoryDatawarehouse
   def save_ems_datawarehouse_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    child_keys = []
+    child_keys = [:datawarehouse_nodes, :cluster_attributes]
     # Save and link other subsections
     child_keys.each do |k|
       send("save_#{k}_inventory", ems, hashes[k], target)
     end
 
     ems.save!
+  end
+
+  def save_cluster_attributes_inventory(entity, hashes, target = nil)
+    save_custom_attribute_attribute_inventory(entity, :cluster_attributes, hashes, target)
+  end
+
+  def save_datawarehouse_nodes_inventory(ems, hashes, target = nil)
+    return if hashes.nil?
+
+    ems.datawarehouse_nodes.reset
+    deletes = if target.kind_of?(ExtManagementSystem)
+                :use_association
+              else
+                []
+              end
+
+    save_inventory_multi(ems.datawarehouse_nodes, hashes, deletes, [:ems_ref],
+                         [], [], true)
+    store_ids_for_new_records(ems.datawarehouse_nodes, hashes, :ems_ref)
   end
 end

--- a/app/models/manageiq/providers/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/datawarehouse_manager.rb
@@ -1,5 +1,8 @@
 module ManageIQ::Providers
   class DatawarehouseManager < BaseManager
+    has_many :datawarehouse_nodes, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cluster_attributes, -> { where(:section => "cluster_attributes") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
+
     class << model_name
       def route_key
         "ems_datawarehouse"

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4213,6 +4213,35 @@
       :feature_type: admin
       :identifier: ems_datawarehouse_new
 
+# DatawarehouseNode
+- :name: Nodes
+  :description: Everything under Datawarehouse Node
+  :feature_type: node
+  :identifier: datawarehouse_node
+  :children:
+  - :name: View
+    :description: View Datawarehouse Node
+    :feature_type: node
+    :identifier: datawarehouse_node_view
+    :children:
+    - :name: List
+      :description: Display Lists of Datawarehouse Node
+      :feature_type: view
+      :identifier: datawarehouse_node_show_list
+    - :name: Show
+      :description: Display Individual Datawarehouse Node
+      :feature_type: view
+      :identifier: datawarehouse_node_show
+  - :name: Operate
+    :description: Perform Operations on Datawarehouse Node
+    :feature_type: control
+    :identifier: datawarehouse_node_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Datawarehouse Node
+      :feature_type: control
+      :identifier: datawarehouse_node_tag
+
 # EmsNetwork
 - :name: Network Providers
   :description: Everything under Network Providers

--- a/db/migrate/20170110104626_create_datawarehouse_node.rb
+++ b/db/migrate/20170110104626_create_datawarehouse_node.rb
@@ -1,0 +1,21 @@
+class CreateDatawarehouseNode < ActiveRecord::Migration[5.0]
+  def change
+    create_table :datawarehouse_nodes do |t|
+      t.string     :ems_ref
+      t.string     :name
+
+      t.string     :host
+      t.string     :ip
+      t.string     :port
+
+      t.boolean    :master
+      t.float      :load
+      t.float      :mem
+      t.float      :heap
+      t.float      :disk
+      t.float      :cpu
+
+      t.belongs_to :ems, :type => :bigint
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1044,6 +1044,20 @@ database_backups:
 - name
 - created_at
 - updated_at
+datawarehouse_nodes:
+- id
+- ems_ref
+- name
+- host
+- ip
+- port
+- master
+- load
+- mem
+- heap
+- disk
+- cpu
+- ems_id
 dialog_fields:
 - id
 - name

--- a/product/views/DatawarehouseNode.yaml
+++ b/product/views/DatawarehouseNode.yaml
@@ -1,0 +1,71 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+
+# Report title
+title: Datawarehouse Nodes
+
+# Menu name
+name: DatawarehouseNode
+
+# Main DB table report is based on
+db: DatawarehouseNode
+
+# Columns to fetch from the main table
+cols:
+- name
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+include_for_find:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- ext_management_system.name
+
+# Column titles, in order
+headers:
+- Name
+- Provider
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims: 

--- a/spec/factories/datawarehouse_nodes.rb
+++ b/spec/factories/datawarehouse_nodes.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :datawarehouse_node do
+    after(:create) do |x|
+    end
+  end
+end


### PR DESCRIPTION
Adding nodes and cluster_attributes to the Datawarehouse manager.

The nodes are nodes of the datawarehouse that are part of its cluster.

The `cluster_attribtes` are saved as CustomAttributes and describe various things about the datawarehouse which will probably depend on the underling type of Datawarehouse.


This was split from https://github.com/ManageIQ/manageiq/pull/13320