### PR TITLE
Fetch the allowed WebSocket origin from the XFH header when possible

### DIFF
--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -99,6 +99,7 @@ class WebsocketServer
   # Primitive same-origin policy checking in production
   def same_origin_as_host?(env)
     proto = Rack::Request.new(env).ssl? ? 'https' : 'http'
-    Rails.env.development? || env['HTTP_ORIGIN'] == "#{proto}://#{env['HTTP_HOST']}"
+    host = env['HTTP_X_FORWARDED_HOST'] ? env['HTTP_X_FORWARDED_HOST'].split(/,\s*/).first : env['HTTP_HOST']
+    Rails.env.development? || env['HTTP_ORIGIN'] == "#{proto}://#{host}"
   end
 end


### PR DESCRIPTION
This will allow to use WebSocket (notifications, remote consoles) connections to be processed properly when using ~~an additional proxy~~ a chain of proxies between the client and the appliance.

For testing and more info see the relevant PR in the UI repo: https://github.com/ManageIQ/manageiq-ui-classic/pull/583