### PR TITLE
Fix for Service requests show none with "refresh" buttons instead of selected values 

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -94,6 +94,12 @@ class Dialog < ApplicationRecord
     dialog_field_hash.each { |_key, field| field.update_values(values) }
   end
 
+  def init_fields_with_values_for_request(values)
+    dialog_field_hash.each do |_key, field|
+      field.value = values[field.automate_key_name] || values[field.name]
+    end
+  end
+
   def field(name)
     dialog_field_hash[name.to_s]
   end

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -95,7 +95,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     dialog = resource_action.dialog unless resource_action.nil?
     unless dialog.nil?
       dialog.target_resource = @target
-      if options[:request_view]
+      if options[:display_view_only]
         dialog.init_fields_with_values_for_request(values)
       else
         dialog.init_fields_with_values(values)

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -10,7 +10,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     @requester       = requester
     @target          = options[:target]
     @initiator       = options[:initiator]
-    @dialog          = load_dialog(resource_action, values)
+    @dialog          = load_dialog(resource_action, values, options)
 
     @settings[:resource_action_id] = resource_action.id unless resource_action.nil?
     @settings[:dialog_id]          = @dialog.id         unless @dialog.nil?
@@ -86,7 +86,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     }
   end
 
-  def load_dialog(resource_action, values)
+  def load_dialog(resource_action, values, options)
     if resource_action.nil?
       resource_action = load_resource_action(values)
       @settings[:resource_action_id] = resource_action.id unless resource_action.nil?
@@ -95,7 +95,11 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     dialog = resource_action.dialog unless resource_action.nil?
     unless dialog.nil?
       dialog.target_resource = @target
-      dialog.init_fields_with_values(values)
+      if options[:request_view]
+        dialog.init_fields_with_values_for_request(values)
+      else
+        dialog.init_fields_with_values(values)
+      end
     end
     dialog
   end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -435,4 +435,27 @@ describe Dialog do
       expect(ResourceAction.count).to eq(num_actions * 2)
     end
   end
+
+  describe "#init_fields_with_values_for_request" do
+    let(:dialog) { described_class.new(:dialog_tabs => [dialog_tab]) }
+    let(:dialog_tab) { DialogTab.new(:dialog_groups => [dialog_group]) }
+    let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1]) }
+    let(:dialog_field1) { DialogField.new(:value => "123", :name => "field1") }
+
+    context "when the values use the automate key name" do
+      it "initializes the fields with the given values" do
+        values = {"dialog_field1" => "field 1 new value"}
+        dialog.init_fields_with_values_for_request(values)
+        expect(dialog_field1.value).to eq("field 1 new value")
+      end
+    end
+
+    context "when the values use the regular name" do
+      it "initializes the fields with the given values" do
+        values = {"field1" => "field 1 new value"}
+        dialog.init_fields_with_values_for_request(values)
+        expect(dialog_field1.value).to eq("field 1 new value")
+      end
+    end
+  end
 end

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -121,7 +121,7 @@ describe ResourceActionWorkflow do
     let(:resource_action) { instance_double("ResourceAction", :id => 123, :dialog => dialog) }
     let(:dialog) { instance_double("Dialog", :id => 321) }
     let(:values) { "the values" }
-    let(:options) { {:request_view => request_view} }
+    let(:options) { {:display_view_only => display_view_only} }
 
     before do
       allow(ResourceAction).to receive(:find).and_return(resource_action)
@@ -130,8 +130,8 @@ describe ResourceActionWorkflow do
       allow(dialog).to receive(:target_resource=)
     end
 
-    context "when the options set request_view to true" do
-      let(:request_view) { true }
+    context "when the options set display_view_only to true" do
+      let(:display_view_only) { true }
 
       it "calls init_fields_with_values_for_request" do
         expect(dialog).to receive(:init_fields_with_values_for_request).with(values)
@@ -139,8 +139,8 @@ describe ResourceActionWorkflow do
       end
     end
 
-    context "when the options set request_view to false" do
-      let(:request_view) { false }
+    context "when the options set display_view_only to false" do
+      let(:display_view_only) { false }
 
       it "calls init_fields_with_values" do
         expect(dialog).to receive(:init_fields_with_values).with(values)

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -116,4 +116,36 @@ describe ResourceActionWorkflow do
       end
     end
   end
+
+  describe "#initialize #load_dialog" do
+    let(:resource_action) { instance_double("ResourceAction", :id => 123, :dialog => dialog) }
+    let(:dialog) { instance_double("Dialog", :id => 321) }
+    let(:values) { "the values" }
+    let(:options) { {:request_view => request_view} }
+
+    before do
+      allow(ResourceAction).to receive(:find).and_return(resource_action)
+      allow(dialog).to receive(:init_fields_with_values).with(values)
+      allow(dialog).to receive(:init_fields_with_values_for_request).with(values)
+      allow(dialog).to receive(:target_resource=)
+    end
+
+    context "when the options set request_view to true" do
+      let(:request_view) { true }
+
+      it "calls init_fields_with_values_for_request" do
+        expect(dialog).to receive(:init_fields_with_values_for_request).with(values)
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+    end
+
+    context "when the options set request_view to false" do
+      let(:request_view) { false }
+
+      it "calls init_fields_with_values" do
+        expect(dialog).to receive(:init_fields_with_values).with(values)
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, the flow of how dialog information is displayed is going through the `ResourceActionWorkflow`, even for dialogs that have been submitted (which do not need to actually run through the dialog code again since they've already done that, of course). This change adds an option for a `:request_view`, which forces use of the values that are passed in. I'm open to changing the name of that option, maybe to something like `:force_given_values` or something similar to that if there is a better description.

This will need to be combined with [this PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/614) in the classic UI to fix this specific BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=1428171

@miq-bot assign @gmcculloug 
@miq-bot add_label euwe/yes, bug