### PR TITLE
Speed up widget generation

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -120,7 +120,11 @@ module Metric::Helper
   end
 
   def self.remove_duplicate_timestamps(recs)
-    return recs if recs.empty? || !recs.all? { |r| r.kind_of?(Metric) || r.kind_of?(MetricRollup) }
+    if recs.respond_to?(:klass) # active record relation
+      return recs unless recs.klass.kind_of?(Metric) || recs.klass.kind_of?(MetricRollup)
+    elsif recs.empty? || !recs.all? { |r| r.kind_of?(Metric) || r.kind_of?(MetricRollup) }
+      return recs 
+    end
 
     recs = recs.sort_by { |r| r.resource_type + r.resource_id.to_s + r.timestamp.iso8601 }
 


### PR DESCRIPTION
Reporting is bringing back all rows to check for data types.
For widgets, this was bringing back unnecessary data.

The change detects if the input is a query, and uses `ActiveRecord::Relation#klass` instead of fetching all rows and comparing them.

https://bugzilla.redhat.com/show_bug.cgi?id=1251259



|       ms |   bytes | objects |queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  5,962.8 | 51,785,052* | 6,412,174 |1,196 | 1,570.6 |    6,768 |`before.4`
|    260.9 |   6,975,857 |    84,669 |   56 |   105.8 |       16 |`after.4`
|    95.6% |        >87% |       99% |  95% |   93.3% |     99.8% | diff


EOM

---
The verbose numbers section.
If you note, the numbers below were used up top


```ruby
w = MiqWidget.find_by(name: 'report_top_storage_consumers') ; opts = w.group_options.last
bookend("generate", gc: true) { w.send(:content_generator).generate(w, *opts) }
```

|       ms |   bytes | objects |queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  8,048.9 | 117,580,084* | 9,798,996 |1,196 | 2,507.0 |    6,768 |`before.1`
|  5,948.2 | 96,799,316* | 6,407,554 |1,196 | 1,463.2 |    6,768 |`before.2`
|  5,994.2 | 51,616,590* | 6,412,285 |1,196 | 1,491.9 |    6,768 |`before.3`
|  5,962.8 | 51,785,052* | 6,412,174 |1,196 | 1,570.6 |    6,768 |`before.4`
|  1,314.7 | 46,933,349* | 1,091,083 |   56 |   169.7 |       16 |`after.1`
|    249.0 | 6,975,855 |  84,669 |   56 |    96.5 |       16 |`after.2`
|    265.0 | 6,975,856 |  84,669 |   56 |   101.7 |       16 |`after.3`
|    260.9 | 6,975,857 |  84,669 |   56 |   105.8 |       16 |`after.4`

\* Memory usage does not reflect 3,599,936 freed objects - before.1
\* Memory usage does not reflect 2,200,252 freed objects - before.2
\* Memory usage does not reflect 2,204,985 freed objects - before.3
\* Memory usage does not reflect 2,204,873 freed objects - before.4
\* Memory usage does not reflect 9,060 freed objects - after.1
