### PR TITLE
Require EmbeddedAnsible playbook to create playbook service

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -74,7 +74,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   def self.create_job_template(name, description, info, auth_user)
     tower, params = build_parameter_list(name, description, info)
 
-    task_id = ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
+    task_id = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
     task = MiqTask.wait_for_taskid(task_id)
     raise task.message unless task.status == "Ok"
     task.task_results
@@ -82,7 +82,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   private_class_method :create_job_template
 
   def self.build_parameter_list(name, description, info)
-    playbook = ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook.find(info[:playbook_id])
+    playbook = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(info[:playbook_id])
     tower = playbook.manager
     params = {
       :name                     => name,

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -14,4 +14,8 @@ FactoryGirl.define do
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
           :parent => :configuration_script
+
+  factory :embedded_playbook,
+          :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook",
+          :parent => :configuration_script_payload
 end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -3,7 +3,6 @@ describe ServiceTemplateAnsiblePlaybook do
   let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
   let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 10) }
 
-  let(:config_script) { FactoryGirl.create(:configuration_script) }
   let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
 
   let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
@@ -13,11 +12,10 @@ describe ServiceTemplateAnsiblePlaybook do
   end
 
   let(:playbook) do
-    FactoryGirl.create(:configuration_script_payload,
+    FactoryGirl.create(:embedded_playbook,
                        :configuration_script_source => script_source,
                        :manager                     => ems,
-                       :inventory_root_group        => inventory_root_group,
-                       :type                        => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook')
+                       :inventory_root_group        => inventory_root_group)
   end
 
   let(:job_template) do
@@ -74,7 +72,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
     it '#create_job_template' do
       expect(described_class).to receive(:build_parameter_list).and_return([ems, {}])
-      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript)
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
         .to receive(:create_in_provider_queue).once.with(ems.id, {}, 'system')
       expect(MiqTask).to receive(:wait_for_taskid).with(any_args).once.and_return(
         instance_double('MiqTask', :task_results => {}, :status => 'Ok')
@@ -89,7 +87,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
     it 'create_job_template exception' do
       expect(described_class).to receive(:build_parameter_list).and_return([ems, {}])
-      expect(ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript)
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
         .to receive(:create_in_provider_queue).once.with(ems.id, {}, 'system')
       expect(MiqTask).to receive(:wait_for_taskid).with(any_args).once.and_raise(Exception, 'bad job template')
 


### PR DESCRIPTION
Before we assume the playbook to create a playbook catalog item is of type `ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook`. Now we need to switch to `ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook`

We can argue whether it is better to write `playbook = ConfigurationScriptBase.find(info[:playbook_id])` which will work for both Embedded and external playbook. I think right now limiting to Embedded only can help to reject unqualified ConfigurationScript. We can further enhance when the time comes to support external tower.