### PR TITLE
[Euwe] Add missing group trees

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -664,6 +664,7 @@ module OpsController::OpsRbac
   end
 
   def rbac_edit_reset(operation, what, klass)
+    @sb[:active_rbac_group_tab] ||= "rbac_customer_tags"
     key = what.to_sym
     obj = find_checked_items
     obj[0] = params[:id] if obj.blank? && params[:id]
@@ -930,20 +931,22 @@ module OpsController::OpsRbac
 
   def rbac_group_get_details(id)
     @record = @group = MiqGroup.find_by_id(from_cid(id))
-    get_tagdata(@group)
     # Build the belongsto filters hash
     @belongsto = {}
-    @group.get_belongsto_filters.each do |b|            # Go thru the belongsto tags
-      bobj = MiqFilter.belongsto2object(b)            # Convert to an object
-      next unless bobj
-      @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
-    end
     @filters = {}
-    # Build the managed filters hash
-    [@group.get_managed_filters].flatten.each do |f|
-      @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
-    end
+    if @record.present?
+      get_tagdata(@group)
+      @group.get_belongsto_filters.each do |b|            # Go thru the belongsto tags
+        bobj = MiqFilter.belongsto2object(b)            # Convert to an object
+        next unless bobj
+        @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+      end
 
+      # Build the managed filters hash
+      [@group.get_managed_filters].flatten.each do |f|
+        @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
+      end
+    end
     rbac_group_right_tree(@belongsto.keys)
   end
 

--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -35,7 +35,7 @@ class TreeBuilderTags < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(:id_prefix         => 'tags_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :checkboxes        => true,
                   :highlight_changes => true,

--- a/app/views/ops/rbac_group/_hosts_clusters.html.haml
+++ b/app/views/ops/rbac_group/_hosts_clusters.html.haml
@@ -8,6 +8,6 @@
                         :tree_name         => "hac_tree",
                         :bs_tree           => @hac_tree,
                         :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                        :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                         :highlight_changes => true,
                         :checkboxes        => true})

--- a/app/views/ops/rbac_group/_vms_templates.html.haml
+++ b/app/views/ops/rbac_group/_vms_templates.html.haml
@@ -8,6 +8,6 @@
                         :tree_name         => "vat_tree",
                         :bs_tree           => @vat_tree,
                         :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
-                        :check_url         => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                         :highlight_changes => true,
                         :checkboxes        => true})


### PR DESCRIPTION
Euwe version of https://github.com/ManageIQ/manageiq-ui-classic/pull/379

Configuration -> Access Control -> Groups -> Configuration -> Add new group -> try tabs Red Hat Tags, Hosts/Nodes & Clusters/Deployment Roles, VMs &Templates

One tree maybe rendered but others won't.

Before:
<img width="908" alt="screen shot 2017-02-14 at 11 40 27 am" src="https://cloud.githubusercontent.com/assets/9210860/22925817/67b40310-f2aa-11e6-9021-52b2bd5cd419.png">

After:
<img width="880" alt="screen shot 2017-02-14 at 11 36 29 am" src="https://cloud.githubusercontent.com/assets/9210860/22925684/f40e85d4-f2a9-11e6-9d6e-2564b8540054.png">

@miq-bot add_label bug, ui, euwe/yes