### PR TITLE
Allow regex for MiqExpression::Field which contains numbers in associations

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -2,7 +2,7 @@ class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 (?!.*\b(managed|user_tag)\b)
-\.?(?<associations>[a-z_\.]+)?
+\.?(?<associations>[a-z][0-9a-z_\.]+)?
 -(?<column>[a-z]+(_[[:alnum:]]+)*)
 /x
 

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe MiqExpression::Field do
       tag = "Vm.hosts.user_tag-name"
       expect(described_class.parse(tag)).to be_nil
     end
+
+    it 'parses field with numbers in association' do
+      field = 'Vm.win32_services-dependencies'
+      expect(described_class.parse(field)).to have_attributes(:model        => Vm,
+                                                              :associations => %w(win32_services),
+                                                              :column       => 'dependencies')
+    end
   end
 
   describe "#parse!" do


### PR DESCRIPTION
example of field: `Vm.win32_services-dependencies`

steps to reproduce a bug:

1. create new report based on `VM and Instance`
2. add field `Vm.win32_services-dependencies`
3. got to tab field 
4. Add condition with field
5. Try to add column `Vm.win32_services-dependencies` to expression 
and then it throws error:

```
[----] F, [2017-03-08T15:37:11.295501 #1604:3fd43e42e33c] FATAL -- : Error caught: [NoMethodError] undefined method `plural?' for nil:NilClass
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/filter/expression.rb:172:in `update_from_expression_editor'
/Users/liborpichler/manageiq/manageiq-ui-classic/app/controllers/application_controller/filter.rb:132:in `exp_changed'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.2/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.2/lib/abstract_controller/base.rb:188:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.2/lib/action_controller/metal/rendering.rb:30:in `process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.2/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:126:in `call'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:455:in `call'
/usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.2/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
```

@miq-bot assign @gtanzillo 
@miq-bot add_label bug, core


cc @kbrock @imtayadeway 

