### PR TITLE
Add relationship between PersistentVolumes and Pods

### DIFF
--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -3,7 +3,7 @@ class PersistentVolume < ContainerVolume
   include NewWithTypeStiMixin
   serialize :capacity, Hash
   delegate :name, :to => :parent, :prefix => true
-  has_many :container_volumes, :through => :persistent_volume_claim
+  has_many :container_volumes, -> { where(:type => 'ContainerVolume') }, :through => :persistent_volume_claim
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
   alias_attribute :container_groups, :parents
 end

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -3,4 +3,7 @@ class PersistentVolume < ContainerVolume
   include NewWithTypeStiMixin
   serialize :capacity, Hash
   delegate :name, :to => :parent, :prefix => true
+  has_many :container_volumes, :through => :persistent_volume_claim
+  has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
+  alias_attribute :container_groups, :parents
 end

--- a/spec/factories/persistent_volume_claim.rb
+++ b/spec/factories/persistent_volume_claim.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :persistent_volume_claim do
+    sequence(:name) { |n| "persistent_volume_claim_#{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/models/persistent_volume.rb
+++ b/spec/models/persistent_volume.rb
@@ -1,0 +1,43 @@
+describe PersistentVolume do
+  it "has container volumes and pods" do
+    pvc = FactoryGirl.create(
+      :persistent_volume_claim,
+      :name => "test_claim"
+    )
+
+    group = FactoryGirl.create(
+      :container_group,
+      :name => "group",
+    )
+
+    ems = FactoryGirl.create(
+      :ems_kubernetes,
+      :id   => group.id,
+      :name => "ems"
+    )
+
+    FactoryGirl.create(
+      :container_volume,
+      :name                    => "container_volume",
+      :type                    => 'ContainerVolume',
+      :parent                  => group,
+      :persistent_volume_claim => pvc
+    )
+
+    persistent_volume = FactoryGirl.create(
+      :persistent_volume,
+      :name                    => "persistent_volume",
+      :parent                  => ems,
+      :persistent_volume_claim => pvc
+    )
+
+    assert_pv_relationships(persistent_volume)
+  end
+
+  def assert_pv_relationships(persistent_volume)
+    expect(persistent_volume.container_volumes.first.name).to eq("container_volume")
+    expect(persistent_volume.container_volumes.count).to eq(1)
+    expect(persistent_volume.container_groups.first.name).to eq("group")
+    expect(persistent_volume.container_groups.count).to eq(1)
+  end
+end


### PR DESCRIPTION
Currently we do not show the user which Pods are using a given Persistent Volume.
In this PR we work towards supplying that information to the user.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1402329

cc: @zakiva @simon3z 