### PR TITLE
add configuration_script reference to service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -44,6 +44,7 @@ class Service < ApplicationRecord
   virtual_has_one    :provision_dialog
   virtual_has_one    :user
   virtual_has_one    :chargeback_report
+  virtual_has_one    :configuration_script
 
   before_validation :set_tenant_from_group
 


### PR DESCRIPTION
`configuration_script` needs to be exposed to be accessed via the API for displaying `ServiceAnsibleTower` in the Service UI as so:
```
GET http://localhost:3000/api/services/10000000000477?attributes=configuration_script
```

cc: @AllenBW 
@miq-bot add_label enhancement, services
@miq-bot assign @Fryguy 