### PR TITLE
Extend container service model

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
@@ -2,7 +2,5 @@ module MiqAeMethodService
   class MiqAeServiceContainerTemplate < MiqAeServiceModelBase
     expose :container_template_parameters, :association => true
     expose :ext_management_system,         :association => true
-    expose :is_tagged_with?
-    expose :tags
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerTemplate < MiqAeServiceModelBase
+    expose :container_template_parameters, :association => true
+    expose :ext_management_system,         :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_template_parameter.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_template_parameter.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerTemplateParameter < MiqAeServiceModelBase
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openshift_enterprise-container_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openshift_enterprise-container_manager.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_OpenshiftEnterprise_ContainerManager < MiqAeServiceManageIQ_Providers_ContainerManager
     expose :container_image_registries, :association => true
+    expose :container_projects,         :association => true
   end
 end

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
@@ -1,7 +1,5 @@
 module MiqAeServiceContainerSpec
   describe MiqAeMethodService::MiqAeServiceContainerTemplate do
-module MiqAeServiceContainerSpec
-  describe MiqAeMethodService::MiqAeServiceContainerTemplate do
     it "#ext_management_system" do
       expect(described_class.instance_methods).to include(:ext_management_system)
     end

--- a/spec/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
+++ b/spec/lib/miq_automation_engine/service_models/miq_ae_service_container_template.rb
@@ -1,0 +1,13 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerTemplate do
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerTemplate do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_template_parameters" do
+      expect(described_class.instance_methods).to include(:container_template_parameters)
+    end
+  end
+end


### PR DESCRIPTION
Add useful container service model associations for use in Automate:

- openshift_enterprise-container_manager (projects)
- container_template (container_template_parameters and ext_management_system)