### PR TITLE
Add EmbeddedAnsible workers to WorkerManagement

### DIFF
--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -24,6 +24,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ProvisioningManager::RefreshWorker
     ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshWorker
@@ -44,6 +45,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
@@ -106,6 +108,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Google::CloudManager::RefreshWorker
     ManageIQ::Providers::Google::NetworkManager::RefreshWorker
     ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ProvisioningManager::RefreshWorker
     ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshWorker
@@ -139,6 +142,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
     ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
     ManageIQ::Providers::Google::CloudManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,6 +115,8 @@
   :capture_vm_created_on_date: false
   :ansible_tower_automation:
     :refresh_interval: 15.minutes
+  :embedded_ansible_automation:
+    :refresh_interval: 15.minutes
   :foreman_configuration:
     :refresh_interval: 15.minutes
   :foreman_provisioning:
@@ -1219,6 +1221,8 @@
         :poll: 1.seconds
       :event_catcher_ansible_tower:
         :poll: 20.seconds
+      :event_catcher_embedded_ansible:
+        :poll: 20.seconds
       :event_catcher_redhat:
         :poll: 15.seconds
       :event_catcher_vmware:
@@ -1333,6 +1337,7 @@
           :queue_timeout: 120.minutes
           :restart_interval: 2.hours
         :ems_refresh_worker_ansible_tower_automation: {}
+        :ems_refresh_worker_embedded_ansible_automation: {}
         :ems_refresh_worker_azure: {}
         :ems_refresh_worker_azure_network: {}
         :ems_refresh_worker_foreman_configuration: {}


### PR DESCRIPTION
`EmbeddedAnsible` workers need to exist in `WorkerManagement::ClassNames` so that workers can be controlled by Worker Management.