### PR TITLE
Run #authentication_check after the embedded ansible service starts

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -72,6 +72,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     admin_auth = MiqDatabase.first.ansible_admin_authentication
 
     provider.update_authentication(:default => {:userid => admin_auth.userid, :password => admin_auth.password})
+    provider.authentication_check
   end
 
   # Base class methods we override since we don't have a separate process.  We might want to make these opt-in features in the base class that this subclass can choose to opt-out.


### PR DESCRIPTION
This will kick the workers if they failed to authenticate on a restart. After this change, enabling the role should give us refresh and event workers for the embedded ansible provider.