### PR TITLE
Fix for Service Dialog not saving default value <None> for drop down or radio button

### DIFF
--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -4,6 +4,20 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   end
 
   def initial_values
-    [["", "<None>"]]
+    [[nil, "<None>"]]
+  end
+
+  private
+
+  def raw_values
+    @raw_values ||= dynamic ? values_from_automate : static_raw_values
+
+    self.value ||= default_value if @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
+
+    @raw_values
+  end
+
+  def static_raw_values
+    self[:values].to_miq_a
   end
 end

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -11,8 +11,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
-
-    self.value ||= default_value if @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
+    self.value ||= default_value if default_value_included_in_raw_values?
 
     @raw_values
   end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -92,12 +92,18 @@ class DialogFieldSortedItem < DialogField
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
-    unless @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
-      self.default_value = sort_data(@raw_values).first.try(:first)
-    end
+    use_first_value_as_default unless default_value_included_in_raw_values?
     self.value ||= default_value
 
     @raw_values
+  end
+
+  def use_first_value_as_default
+    self.default_value = sort_data(@raw_values).first.try(:first)
+  end
+
+  def default_value_included_in_raw_values?
+    @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
   end
 
   def static_raw_values

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -91,13 +91,18 @@ class DialogFieldSortedItem < DialogField
   end
 
   def raw_values
-    @raw_values ||= dynamic ? values_from_automate : self[:values].to_miq_a
+    @raw_values ||= dynamic ? values_from_automate : static_raw_values
     unless @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
       self.default_value = sort_data(@raw_values).first.try(:first)
     end
     self.value ||= default_value
 
     @raw_values
+  end
+
+  def static_raw_values
+    first_values = required? ? [[nil, "<Choose>"]] : initial_values
+    first_values + self[:values].to_miq_a.reject { |value| value[0].nil? }
   end
 
   def initial_values

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -24,44 +24,44 @@ describe DialogFieldDropDownList do
 
     it "return sorted values array as strings" do
       @df.data_type = "string"
-      @df.values = [["2", "Y"], ["1", "Z"], ["3", "X"]]
-      expect(@df.values).to eq([[nil, "<None>"], ["3", "X"], ["2", "Y"], ["1", "Z"]])
+      @df.values = [%w(2 Y), %w(1 Z), %w(3 X)]
+      expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"], [nil, "<None>"]])
+      expect(@df.values).to eq([%w(1 Z), %w(2 Y), %w(3 X), [nil, "<None>"]])
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], ["1", "Z"], ["2", "Y"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"], [nil, "<None>"]])
+      expect(@df.values).to eq([%w(3 X), %w(2 Y), %w(1 Z), [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
     end
 
     it "return sorted values array as integers" do
       @df.data_type = "integer"
-      @df.values = [["2", "Y"], ["10", "Z"], ["3", "X"]]
+      @df.values = [%w(2 Y), %w(10 Z), %w(3 X)]
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["3", "X"], ["10", "Z"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(3 X), %w(10 Z)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["10", "Z"], ["3", "X"], ["2", "Y"], [nil, "<None>"]])
+      expect(@df.values).to eq([%w(10 Z), %w(3 X), %w(2 Y), [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
     end
 
     context "#initialize_with_values" do
       before(:each) do
-        @df.values = [["3", "X"], ["2", "Y"], ["1", "Z"]]
+        @df.values = [%w(3 X), %w(2 Y), %w(1 Z)]
         @df.load_values_on_init = true
       end
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -25,21 +25,21 @@ describe DialogFieldDropDownList do
     it "return sorted values array as strings" do
       @df.data_type = "string"
       @df.values = [["2", "Y"], ["1", "Z"], ["3", "X"]]
-      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["3", "X"], ["2", "Y"], ["1", "Z"]])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
+      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"], [nil, "<None>"]])
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["1", "Z"], ["2", "Y"], ["3", "X"]])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
+      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"], [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["1", "Z"], ["3", "X"]])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["1", "Z"], ["3", "X"]])
     end
 
     it "return sorted values array as integers" do
@@ -48,15 +48,15 @@ describe DialogFieldDropDownList do
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["3", "X"], ["10", "Z"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["3", "X"], ["10", "Z"]])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["10", "Z"], ["3", "X"], ["2", "Y"]])
+      expect(@df.values).to eq([["10", "Z"], ["3", "X"], ["2", "Y"], [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["10", "Z"], ["3", "X"]])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], ["2", "Y"], ["10", "Z"], ["3", "X"]])
     end
 
     context "#initialize_with_values" do
@@ -65,10 +65,10 @@ describe DialogFieldDropDownList do
         @df.load_values_on_init = true
       end
 
-      it "uses the first as the default value" do
+      it "uses the nil as the default value" do
         @df.default_value = nil
         @df.initialize_with_values({})
-        expect(@df.value).to eq("3")
+        expect(@df.value).to eq(nil)
       end
 
       it "with default value" do
@@ -77,10 +77,10 @@ describe DialogFieldDropDownList do
         expect(@df.value).to eq("1")
       end
 
-      it "uses the first when there is a non-matching default value" do
+      it "uses the nil when there is a non-matching default value" do
         @df.default_value = "4"
         @df.initialize_with_values({})
-        expect(@df.value).to eq("3")
+        expect(@df.value).to eq(nil)
       end
     end
 
@@ -154,7 +154,7 @@ describe DialogFieldDropDownList do
 
           it "returns the values" do
             expect(dialog_field.refresh_json_value("789")).to eq(
-              :refreshed_values => [["789", 101], ["123", 456]],
+              :refreshed_values => [["789", 101], ["123", 456], [nil, "<None>"]],
               :checked_value    => "789",
               :read_only        => true,
               :visible          => true
@@ -256,11 +256,11 @@ describe DialogFieldDropDownList do
 
       context "when the raw values are not already set" do
         before do
-          dialog_field.values = %w(original values)
+          dialog_field.values = [%w(original values)]
         end
 
         it "returns the values" do
-          expect(dialog_field.values).to eq(%w(original values))
+          expect(dialog_field.values).to eq([[nil, "<None>"], %w(original values)])
         end
       end
     end
@@ -301,11 +301,11 @@ describe DialogFieldDropDownList do
       context "when the raw values are already set" do
         before do
           dialog_field.instance_variable_set(:@raw_values, %w(potato potato))
-          dialog_field.values = %w(original values)
+          dialog_field.values = [%w(original values)]
         end
 
         it "returns the raw values" do
-          expect(dialog_field.trigger_automate_value_updates).to eq(%w(original values))
+          expect(dialog_field.trigger_automate_value_updates).to eq([[nil, "<None>"], %w(original values)])
         end
       end
 
@@ -315,12 +315,12 @@ describe DialogFieldDropDownList do
         end
 
         it "returns the values" do
-          expect(dialog_field.trigger_automate_value_updates).to eq([%w(original values)])
+          expect(dialog_field.trigger_automate_value_updates).to eq([[nil, "<None>"], %w(original values)])
         end
 
         it "sets up the default value" do
           dialog_field.trigger_automate_value_updates
-          expect(dialog_field.default_value).to eq("original")
+          expect(dialog_field.default_value).to eq(nil)
         end
       end
 

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -49,7 +49,9 @@ describe DialogFieldRadioButton do
           end
 
           it "sets raw values from values attribute" do
-            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
+              [["", "<None>"], ["testing", 123]]
+            )
           end
         end
       end
@@ -95,7 +97,9 @@ describe DialogFieldRadioButton do
         end
 
         it "gets values from values attribute" do
-          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
+            [["", "<None>"], ["testing", 123]]
+          )
         end
       end
     end

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -50,7 +50,7 @@ describe DialogFieldRadioButton do
 
           it "sets raw values from values attribute" do
             expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
-              [["", "<None>"], ["testing", 123]]
+              [["testing", 123]]
             )
           end
         end
@@ -63,7 +63,7 @@ describe DialogFieldRadioButton do
         end
 
         it "sets raw_values to initial values" do
-          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["", "<None>"]])
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<None>"]])
         end
       end
     end
@@ -98,7 +98,7 @@ describe DialogFieldRadioButton do
 
         it "gets values from values attribute" do
           expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
-            [["", "<None>"], ["testing", 123]]
+            [["testing", 123]]
           )
         end
       end
@@ -161,10 +161,10 @@ describe DialogFieldRadioButton do
     context "when the checked value is not in the list of refreshed values" do
       let(:refreshed_values_from_automate) { [%w(123 123)] }
 
-      it "returns the list of refreshed values and checked (default) value as a hash" do
+      it "returns the list of refreshed values and no checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(
           :refreshed_values => refreshed_values_from_automate,
-          :checked_value    => "123",
+          :checked_value    => nil,
           :read_only        => false,
           :visible          => true
         )

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -1,17 +1,15 @@
 describe DialogFieldSortedItem do
-  let(:df) { FactoryGirl.build(:dialog_field_sorted_item, :label => 'dialog_field', :name => 'dialog_field') }
-
   describe "#initialize_with_values" do
     let(:dialog_field) do
       described_class.new(
         :name                => "potato_name",
-        :default_value       => default_value,
+        :default_value       => "test2",
+        :dynamic             => true,
         :load_values_on_init => load_values_on_init,
         :show_refresh_button => show_refresh_button,
         :values              => [%w(test test), %w(test2 test2)]
       )
     end
-    let(:default_value) { "test2" }
 
     context "when show_refresh_button is true" do
       let(:show_refresh_button) { true }
@@ -40,20 +38,9 @@ describe DialogFieldSortedItem do
         context "when the values from the passed in dialog values do not match either the automate or dialog name" do
           let(:dialog_values) { {"not_potato_name" => "not potato value"} }
 
-          context "when the default value does not exist in the list of options" do
-            let(:default_value) { "default value" }
-
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
-            end
+          it "defaults to nil" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq(nil)
           end
         end
       end
@@ -99,16 +86,9 @@ describe DialogFieldSortedItem do
           context "when the default value does not exist in the list of options" do
             let(:default_value) { "default value" }
 
-            it "uses the default value of the dialog field" do
+            it "defaults to nil" do
               dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
+              expect(dialog_field.value).to eq(nil)
             end
           end
         end
@@ -138,41 +118,120 @@ describe DialogFieldSortedItem do
         context "when the values from the passed in dialog values do not match either the automate or dialog name" do
           let(:dialog_values) { {"not_potato_name" => "not potato value"} }
 
-          context "when the default value does not exist in the list of options" do
-            let(:default_value) { "default value" }
-
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
-            end
+          it "defaults to nil" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq(nil)
           end
         end
       end
     end
   end
 
-  describe "#get_default_value" do
-    it "returns the first value when no default and only a single value is available" do
-      df.values = [%w(value1 text1)]
-      expect(df.get_default_value).to eq("value1")
+  describe "#values" do
+    let(:dialog_field) do
+      described_class.new(
+        :default_value => default_value,
+        :dynamic       => dynamic,
+        :required      => required,
+        :sort_by       => :none,
+        :values        => values
+      )
+    end
+    let(:values) { [%w(test test), %w(abc abc)] }
+    let(:required) { false }
+
+    context "when the field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(values)
+      end
+
+      context "when the default_value is included in the list of returned values" do
+        let(:default_value) { "abc" }
+
+        it "sets the default value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("abc")
+        end
+
+        it "sets the value to the default value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("abc")
+        end
+      end
+
+      context "when the default_value is not included in the list of returned values" do
+        let(:default_value) { "123" }
+
+        it "sets the default value to the first value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("test")
+        end
+
+        it "sets the value to the default value" do
+          dialog_field.values
+          expect(dialog_field.value).to eq("test")
+        end
+      end
     end
 
-    it "returns the first value when no default and multiple values are available" do
-      df.values = [%w(value1 text1), %w(value2 text2)]
-      expect(df.get_default_value).to eq("value1")
+    context "when the field is not dynamic" do
+      let(:dynamic) { false }
+      let(:default_value) { "abc" }
+
+      context "when the field is required" do
+        let(:required) { true }
+
+        it "returns the values with the first option being a nil 'Choose' option" do
+          expect(dialog_field.values).to eq([[nil, "<Choose>"], %w(test test), %w(abc abc)])
+        end
+      end
+
+      context "when the field is not required" do
+        it "returns the values with the first option being a nil 'None' option" do
+          expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
+        end
+      end
+    end
+  end
+
+  describe "#get_default_value" do
+    let(:dialog_field) { described_class.new(:default_value => default_value, :values => values) }
+    let(:values) { [%w(value1 text1), %w(value2 text2)] }
+
+    context "when the default value is set to nil" do
+      let(:default_value) { nil }
+
+      it "returns nil as the default value" do
+        expect(dialog_field.get_default_value).to eq(nil)
+      end
+    end
+
+    context "when the default value exists" do
+      context "when the default value matches with a value in the list" do
+        let(:default_value) { "value2" }
+
+        it "returns the matched value" do
+          expect(dialog_field.get_default_value).to eq("value2")
+        end
+      end
+
+      context "when the default value does not match with a value in the list" do
+        let(:default_value) { "value3" }
+
+        it "returns nil" do
+          expect(dialog_field.get_default_value).to eq(nil)
+        end
+      end
     end
   end
 
   describe "#script_error_values" do
+    let(:dialog_field) { described_class.new }
+
     it "returns the script error values" do
-      expect(df.script_error_values).to eq([[nil, "<Script error>"]])
+      expect(dialog_field.script_error_values).to eq([[nil, "<Script error>"]])
     end
   end
 

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -285,7 +285,7 @@ describe DialogFieldSortedItem do
       it_behaves_like "DialogFieldSortedItem#normalize_automate_values"
 
       it "returns the initial values of the dialog field" do
-        expect(dialog_field.normalize_automate_values(automate_hash)).to eq([["", "<None>"]])
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq([[nil, "<None>"]])
       end
     end
 


### PR DESCRIPTION
This will allow nil to be a default value for static sorted item fields. When the field is required, the user will be able to pick a "<Choose>" options which corresponds to the nil option, and a "<None>" option otherwise.

https://bugzilla.redhat.com/show_bug.cgi?id=1428133

/cc @gmcculloug Please review/test

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, euwe/yes