### PR TITLE
Let CloudObjectStoreContainer remember provider region

### DIFF
--- a/db/migrate/20170308145556_add_provider_region_to_cloud_object_store_container.rb
+++ b/db/migrate/20170308145556_add_provider_region_to_cloud_object_store_container.rb
@@ -1,0 +1,5 @@
+class AddProviderRegionToCloudObjectStoreContainer < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_object_store_containers, :provider_region, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -315,6 +315,7 @@ cloud_object_store_containers:
 - cloud_tenant_id
 - name
 - type
+- provider_region
 cloud_object_store_objects:
 - id
 - ems_ref


### PR DESCRIPTION
With AWS, for example, we need to connect to bucket's region if we are to modify bucket. But we are not able to know what region does bucket belong to unless we store it during inventory collect.

With this commit we therefore introduce column `provider_region` for model CloudObjectStoreContainer where refresh parser drops bucket region. This PR only adds *empty* column since it's not possible to guess tell bucket region without connecting to S3. IMO this should not be a problem since first refresh will then fill correct values in.

@miq-bot add_label enhancement,sql migration
@miq-bot assign @Fryguy

This is the amazon PR that cannot work without the new column:
*https://github.com/ManageIQ/manageiq-providers-amazon/pull/169

/cc @bronaghs 