### PR TITLE
Set timeout for inventory refresh calls

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -98,6 +98,8 @@
 :ems:
   :ems_redhat:
     :resolve_ip_addresses: true
+    :inventory:
+      :read_timeout: 1.hour
     :service:
       :read_timeout: 1.hour
   :ems_kubernetes:


### PR DESCRIPTION
The settings.yml contains timeout only for RHV service calls. However
when services are invoked as part of the refresh process, no timeout
is provided for these calls, letting the Net::HTTP 60 seconds default
timeout to be the affective timeout.

The 60 seconds default timeout is too short, therefore the default
timeout for inventory service calls to RHV is set to 1 hour.

http://bugzilla.redhat.com/1430722
