### PR TITLE
Refactor refresh new target to use save_ems_inventory

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -27,9 +27,9 @@ class EmsEvent
       ems = ext_management_system
       if ems.supports_refresh_new_target?
         ep_class = ems.class::EventParser
-        target_hash = ep_class.parse_new_target(full_data, message, ems, event_type)
+        target_hash, target_class, target_find = ep_class.parse_new_target(full_data, message, ems, event_type)
 
-        EmsRefresh.queue_refresh_new_target(target_hash, ems)
+        EmsRefresh.queue_refresh_new_target(ems, target_hash, target_class, target_find)
       else
         EmsRefresh.queue_refresh(ems)
       end

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -101,7 +101,7 @@ module EmsRefresh
   def self.refresh_new_target(ems_id, target_hash, target_class, target_find)
     ems = ExtManagementSystem.find(ems_id)
 
-    save_ems_inventory(ems, target_hash, nil, :refresh_new_target)
+    save_ems_inventory_no_disconnect(ems, target_hash)
 
     target = target_class.find_by(target_find)
     if target.nil?

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -63,14 +63,14 @@ module EmsRefresh
     return task_ids if opts[:create_task]
   end
 
-  def self.queue_refresh_new_target(target_hash, ems)
+  def self.queue_refresh_new_target(ems, target_hash, target_class, target_find)
     MiqQueue.put(
       :queue_name  => MiqEmsRefreshWorker.queue_name_for_ems(ems),
       :class_name  => name,
       :method_name => 'refresh_new_target',
       :role        => "ems_inventory",
       :zone        => ems.my_zone,
-      :args        => [target_hash, ems.id],
+      :args        => [ems.id, target_hash, target_class, target_find],
       :msg_timeout => queue_timeout,
       :task_id     => nil
     )
@@ -98,10 +98,12 @@ module EmsRefresh
     end
   end
 
-  def self.refresh_new_target(target_hash, ems_id)
+  def self.refresh_new_target(ems_id, target_hash, target_class, target_find)
     ems = ExtManagementSystem.find(ems_id)
 
-    target = save_new_target(ems, target_hash)
+    save_new_target(target_hash)
+
+    target = target_class.find_by(target_find)
     if target.nil?
       _log.warn "Unknown target for event data: #{target_hash}."
       return

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -101,7 +101,7 @@ module EmsRefresh
   def self.refresh_new_target(ems_id, target_hash, target_class, target_find)
     ems = ExtManagementSystem.find(ems_id)
 
-    save_new_target(target_hash)
+    save_ems_inventory(ems, target_hash, nil, :refresh_new_target)
 
     target = target_class.find_by(target_find)
     if target.nil?

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -100,6 +100,7 @@ module EmsRefresh
 
   def self.refresh_new_target(ems_id, target_hash, target_class, target_find)
     ems = ExtManagementSystem.find(ems_id)
+    target_class = target_class.constantize if target_class.kind_of? String
 
     save_ems_inventory_no_disconnect(ems, target_hash)
 
@@ -110,6 +111,8 @@ module EmsRefresh
     end
 
     ems.refresher.refresh(get_target_objects(target))
+
+    target
   end
 
   def self.get_target_objects(target, single_id = nil)

--- a/app/models/ems_refresh/metadata_relats.rb
+++ b/app/models/ems_refresh/metadata_relats.rb
@@ -5,9 +5,10 @@ module EmsRefresh::MetadataRelats
   # TODO: Replace with more efficient lookup methods using new relationships
 
   def vmdb_relats(target, relats = nil)
-    _log.info "Getting VMDB relationships for #{target.class} [#{target.name}] id: [#{target.id}]..."
-
     relats ||= default_relats_hash
+    return relats if target.nil?
+
+    _log.info "Getting VMDB relationships for #{target.class} [#{target.name}] id: [#{target.id}]..."
     if target.kind_of?(ExtManagementSystem)
       vmdb_relats_ems(target, relats)
     else

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -1,5 +1,5 @@
 module EmsRefresh::SaveInventory
-  def save_ems_inventory(ems, hashes, target = nil, mode = :refresh)
+  def save_ems_inventory(ems, hashes, target = nil, disconnect = true)
     if hashes.kind_of?(Array)
       ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
       return
@@ -7,7 +7,7 @@ module EmsRefresh::SaveInventory
 
     case ems
     when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target)
-    when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target, mode)
+    when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target, disconnect)
     when EmsPhysicalInfra                                   then save_ems_physical_infra_inventory(ems, hashes, target)
     when ManageIQ::Providers::AutomationManager             then save_automation_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ConfigurationManager          then save_configuration_manager_inventory(ems, hashes, target)
@@ -18,13 +18,17 @@ module EmsRefresh::SaveInventory
     end
   end
 
+  def save_ems_inventory_no_disconnect(ems, hashes, target = nil)
+    save_ems_inventory(ems, hashes, target, false)
+  end
+
   #
   # Shared between Cloud and Infra
   #
 
-  def save_vms_inventory(ems, hashes, target = nil, mode = :refresh)
+  def save_vms_inventory(ems, hashes, target = nil, disconnect = true)
     return if hashes.nil?
-    target = ems if target.nil? && mode == :refresh
+    target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if target.kind_of?(ExtManagementSystem) || target.kind_of?(Host)

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -24,7 +24,7 @@ module EmsRefresh::SaveInventory
 
   def save_vms_inventory(ems, hashes, target = nil, mode = :refresh)
     return if hashes.nil?
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if target.kind_of?(ExtManagementSystem) || target.kind_of?(Host)

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -6,7 +6,7 @@ module EmsRefresh::SaveInventory
     end
 
     case ems
-    when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target)
+    when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target, disconnect)
     when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target, disconnect)
     when EmsPhysicalInfra                                   then save_ems_physical_infra_inventory(ems, hashes, target)
     when ManageIQ::Providers::AutomationManager             then save_automation_manager_inventory(ems, hashes, target)

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -1,5 +1,5 @@
 module EmsRefresh::SaveInventory
-  def save_ems_inventory(ems, hashes, target = nil)
+  def save_ems_inventory(ems, hashes, target = nil, mode = :refresh)
     if hashes.kind_of?(Array)
       ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
       return
@@ -7,7 +7,7 @@ module EmsRefresh::SaveInventory
 
     case ems
     when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target)
-    when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target)
+    when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target, mode)
     when EmsPhysicalInfra                                   then save_ems_physical_infra_inventory(ems, hashes, target)
     when ManageIQ::Providers::AutomationManager             then save_automation_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ConfigurationManager          then save_configuration_manager_inventory(ems, hashes, target)
@@ -22,7 +22,7 @@ module EmsRefresh::SaveInventory
   # Shared between Cloud and Infra
   #
 
-  def save_vms_inventory(ems, hashes, target = nil)
+  def save_vms_inventory(ems, hashes, target = nil, mode = :refresh)
     return if hashes.nil?
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -352,35 +352,6 @@ module EmsRefresh::SaveInventory
     save_inventory_multi(os.event_logs, hashes, :use_association, [:uid])
   end
 
-  def save_new_target(ems, target_hash)
-    if target_hash[:vm]
-      vm_hash = target_hash[:vm]
-      existing_vm = VmOrTemplate.find_by(:ems_ref => vm_hash[:ems_ref], :ems_id => target_hash[:ems_id])
-      unless existing_vm.nil?
-        return existing_vm
-      end
-
-      old_cluster = get_cluster(ems, target_hash[:cluster], target_hash[:resource_pools], target_hash[:folders])
-
-      vm_hash[:ems_cluster_id] = old_cluster[:id]
-
-      new_vm = ems.vms_and_templates.create!(vm_hash)
-
-      dc = old_cluster.parent_datacenter
-      vm_folder = dc.children.select { |folder| folder.name == "vm" }[0]
-      vm_folder.add_vm(new_vm)
-      vm_folder.save!
-
-      resource_pool = old_cluster.children.first
-      resource_pool.add_vm(new_vm)
-      resource_pool.save!
-
-      new_vm
-    elsif target_hash[:folder]
-      ems.ems_folders.create!(target_hash[:folder])
-    end
-  end
-
   #
   # Storage managers can support many different types of storages. We thus rely
   # on the supports feature of the manager to choose which parts of the

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -29,13 +29,13 @@
 #
 
 module EmsRefresh::SaveInventoryCloud
-  def save_ems_cloud_inventory(ems, hashes, target = nil)
+  def save_ems_cloud_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
     if hashes.blank?
-      target.disconnect_inv
+      target.disconnect_inv if disconnect
       return
     end
 
@@ -66,7 +66,7 @@ module EmsRefresh::SaveInventoryCloud
     ]
 
     # Save and link other subsections
-    save_child_inventory(ems, hashes, child_keys, target)
+    save_child_inventory(ems, hashes, child_keys, target, disconnect)
 
     link_volumes_to_base_snapshots(hashes[:cloud_volumes]) if hashes.key?(:cloud_volumes)
     link_parents_to_cloud_tenant(hashes[:cloud_tenants]) if hashes.key?(:cloud_tenants)
@@ -79,7 +79,7 @@ module EmsRefresh::SaveInventoryCloud
     ems
   end
 
-  def save_flavors_inventory(ems, hashes, target = nil)
+  def save_flavors_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.flavors.reset
@@ -97,7 +97,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.flavors, hashes, :ems_ref)
   end
 
-  def save_availability_zones_inventory(ems, hashes, target = nil)
+  def save_availability_zones_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.availability_zones.reset
@@ -111,7 +111,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
   end
 
-  def save_host_aggregates_inventory(ems, hashes, target = nil)
+  def save_host_aggregates_inventory(ems, hashes, target = nil, disconnect = true)
     target ||= ems
 
     ems.host_aggregates.reset
@@ -126,7 +126,7 @@ module EmsRefresh::SaveInventoryCloud
     # FIXME: what about hosts?
   end
 
-  def save_cloud_tenants_inventory(ems, hashes, target = nil)
+  def save_cloud_tenants_inventory(ems, hashes, target = nil, disconnect = true)
     target ||= ems
 
     ems.cloud_tenants.reset
@@ -140,7 +140,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_tenants, hashes, :ems_ref)
   end
 
-  def save_cloud_resource_quotas_inventory(ems, hashes, target = nil)
+  def save_cloud_resource_quotas_inventory(ems, hashes, target = nil, disconnect = true)
     target ||= ems
 
     ems.cloud_resource_quotas.reset
@@ -158,7 +158,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_resource_quotas, hashes, [:ems_ref, :name])
   end
 
-  def save_key_pairs_inventory(ems, hashes, target = nil)
+  def save_key_pairs_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.key_pairs.reset
@@ -172,7 +172,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.key_pairs, hashes, :name)
   end
 
-  def save_cloud_volumes_inventory(ems, hashes, target = nil)
+  def save_cloud_volumes_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_volumes.reset
@@ -193,7 +193,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_volumes, hashes, :ems_ref)
   end
 
-  def save_cloud_volume_backups_inventory(ems, hashes, target = nil)
+  def save_cloud_volume_backups_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_volume_backups.reset
@@ -214,7 +214,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_volume_backups, hashes, :ems_ref)
   end
 
-  def save_cloud_volume_snapshots_inventory(ems, hashes, target = nil)
+  def save_cloud_volume_snapshots_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots.reset
@@ -261,7 +261,7 @@ module EmsRefresh::SaveInventoryCloud
     end
   end
 
-  def save_cloud_object_store_containers_inventory(ems, hashes, target = nil)
+  def save_cloud_object_store_containers_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_object_store_containers.reset
@@ -280,7 +280,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_object_store_containers, hashes, :ems_ref)
   end
 
-  def save_cloud_object_store_objects_inventory(ems, hashes, target = nil)
+  def save_cloud_object_store_objects_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_object_store_objects.reset
@@ -300,7 +300,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.cloud_object_store_objects, hashes, :ems_ref)
   end
 
-  def save_resource_groups_inventory(ems, hashes, target = nil)
+  def save_resource_groups_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.resource_groups.reset
@@ -314,7 +314,7 @@ module EmsRefresh::SaveInventoryCloud
     store_ids_for_new_records(ems.resource_groups, hashes, :ems_ref)
   end
 
-  def save_cloud_services_inventory(ems, hashes, target = nil)
+  def save_cloud_services_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil?
 
     ems.cloud_services.reset

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -83,11 +83,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.flavors.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:cloud_tenant_ids] = (h.delete(:cloud_tenants) || []).compact.map { |x| x[:id] }.uniq
@@ -101,11 +97,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.availability_zones.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.availability_zones, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
@@ -115,11 +107,7 @@ module EmsRefresh::SaveInventoryCloud
     target ||= ems
 
     ems.host_aggregates.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.host_aggregates, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.host_aggregates, hashes, :ems_ref)
@@ -130,11 +118,7 @@ module EmsRefresh::SaveInventoryCloud
     target ||= ems
 
     ems.cloud_tenants.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.cloud_tenants, hashes, deletes, [:ems_ref], nil, [:parent_id])
     store_ids_for_new_records(ems.cloud_tenants, hashes, :ems_ref)
@@ -144,11 +128,7 @@ module EmsRefresh::SaveInventoryCloud
     target ||= ems
 
     ems.cloud_resource_quotas.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:cloud_tenant_id] = h.fetch_path(:cloud_tenant, :id)
@@ -162,11 +142,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.key_pairs.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.key_pairs, hashes, deletes, [:name])
     store_ids_for_new_records(ems.key_pairs, hashes, :name)
@@ -176,11 +152,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_volumes.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:ems_id]               = ems.id
@@ -197,11 +169,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_volume_backups.reset
-    deletes = if target == ems
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:ems_id]          = ems.id
@@ -218,11 +186,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_volume_snapshots.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:ems_id]          = ems.id
@@ -265,11 +229,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_object_store_containers.reset
-    deletes = if target == ems
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:ems_id]          = ems.id
@@ -284,11 +244,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_object_store_objects.reset
-    deletes = if target == ems
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
       h[:ems_id]                          = ems.id
@@ -304,11 +260,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.resource_groups.reset
-    deletes = if (target == ems)
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.resource_groups, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.resource_groups, hashes, :ems_ref)
@@ -318,11 +270,7 @@ module EmsRefresh::SaveInventoryCloud
     target = ems if target.nil?
 
     ems.cloud_services.reset
-    deletes = if target == ems
-                :use_association
-              else
-                []
-              end
+    deletes = determine_deletes_using_association(ems, target, disconnect)
 
     save_inventory_multi(ems.cloud_services, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.cloud_services, hashes, :ems_ref)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -177,4 +177,12 @@ module EmsRefresh::SaveInventoryHelper
 
     top_level && (target == true || target.nil? || parent == target) ? :use_association : []
   end
+
+  def determine_deletes_using_association(ems, target, disconnect = true)
+    if disconnect && target == ems
+      :use_association
+    else
+      []
+    end
+  end
 end

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -177,22 +177,4 @@ module EmsRefresh::SaveInventoryHelper
 
     top_level && (target == true || target.nil? || parent == target) ? :use_association : []
   end
-
-  def get_cluster(ems, cluster_hash, rp_hash, dc_hash)
-    cluster = EmsCluster.find_by(:ems_ref => cluster_hash[:ems_ref], :ems_id => ems.id)
-    if cluster.nil?
-      rp = ems.resource_pools.create!(rp_hash)
-
-      cluster = ems.clusters.create!(cluster_hash)
-
-      cluster.add_resource_pool(rp)
-      cluster.save!
-
-      dc = Datacenter.find_by(:ems_ref => dc_hash[:ems_ref], :ems_id => ems.id)
-      dc.add_cluster(cluster)
-      dc.save!
-    end
-
-    cluster
-  end
 end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -34,8 +34,8 @@
 #
 
 module EmsRefresh::SaveInventoryInfra
-  def save_ems_infra_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_ems_infra_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
@@ -66,7 +66,7 @@ module EmsRefresh::SaveInventoryInfra
     ]
 
     # Save and link other subsections
-    save_child_inventory(ems, hashes, child_keys, target, mode)
+    save_child_inventory(ems, hashes, child_keys, target, disconnect)
 
     link_floating_ips_to_network_ports(hashes[:floating_ips]) if hashes.key?(:floating_ips)
     link_cloud_subnets_to_network_routers(hashes[:cloud_subnets]) if hashes.key?(:cloud_subnets)
@@ -83,8 +83,8 @@ module EmsRefresh::SaveInventoryInfra
     ems
   end
 
-  def save_storages_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_storages_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Query for all of the storages ahead of time
@@ -113,8 +113,8 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_hosts_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_hosts_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if (target == ems)
@@ -219,8 +219,8 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_host_storages_inventory(host, hashes, target = nil, mode = :refresh)
-    target = host if target.nil? && mode == :refresh
+  def save_host_storages_inventory(host, hashes, target = nil, disconnect = true)
+    target = host if target.nil? && disconnect
 
     # Update the associated ids
     hashes.each do |h|
@@ -239,8 +239,8 @@ module EmsRefresh::SaveInventoryInfra
     save_inventory_multi(host.host_storages, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
   end
 
-  def save_folders_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_folders_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
 
     ems.ems_folders.reset
     deletes = if (target == ems)
@@ -254,8 +254,8 @@ module EmsRefresh::SaveInventoryInfra
   end
   alias_method :save_ems_folders_inventory, :save_folders_inventory
 
-  def save_clusters_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_clusters_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
 
     ems.ems_clusters.reset
     deletes = if (target == ems)
@@ -269,8 +269,8 @@ module EmsRefresh::SaveInventoryInfra
   end
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
-  def save_resource_pools_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_resource_pools_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
 
     ems.resource_pools.reset
     deletes = if (target == ems)
@@ -285,8 +285,8 @@ module EmsRefresh::SaveInventoryInfra
     store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
-  def save_storage_profiles_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil? && mode == :refresh
+  def save_storage_profiles_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil? && disconnect
 
     ems.storage_profiles.reset
     deletes =
@@ -312,7 +312,7 @@ module EmsRefresh::SaveInventoryInfra
                          [], [:storage_profile_id, :storage_id])
   end
 
-  def save_customization_specs_inventory(ems, hashes, _target = nil, _mode = :refresh)
+  def save_customization_specs_inventory(ems, hashes, _target = nil, _disconnect = true)
     save_inventory_multi(ems.customization_specs, hashes, :use_association, [:name])
   end
 

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -35,12 +35,12 @@
 
 module EmsRefresh::SaveInventoryInfra
   def save_ems_infra_inventory(ems, hashes, target = nil, disconnect = true)
-    target = ems if target.nil? && disconnect
+    target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
     if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank? && hashes[:folders].blank?)
-      target.disconnect_inv
+      target.disconnect_inv if disconnect
       return
     end
 
@@ -83,8 +83,8 @@ module EmsRefresh::SaveInventoryInfra
     ems
   end
 
-  def save_storages_inventory(ems, hashes, target = nil, disconnect = true)
-    target = ems if target.nil? && disconnect
+  def save_storages_inventory(ems, hashes, target = nil, _disconnect = true)
+    target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Query for all of the storages ahead of time

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -34,7 +34,7 @@
 #
 
 module EmsRefresh::SaveInventoryInfra
-  def save_ems_infra_inventory(ems, hashes, target = nil)
+  def save_ems_infra_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -66,7 +66,7 @@ module EmsRefresh::SaveInventoryInfra
     ]
 
     # Save and link other subsections
-    save_child_inventory(ems, hashes, child_keys, target)
+    save_child_inventory(ems, hashes, child_keys, target, mode)
 
     link_floating_ips_to_network_ports(hashes[:floating_ips]) if hashes.key?(:floating_ips)
     link_cloud_subnets_to_network_routers(hashes[:cloud_subnets]) if hashes.key?(:cloud_subnets)
@@ -83,7 +83,7 @@ module EmsRefresh::SaveInventoryInfra
     ems
   end
 
-  def save_storages_inventory(ems, hashes, target = nil)
+  def save_storages_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -113,7 +113,7 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_hosts_inventory(ems, hashes, target = nil)
+  def save_hosts_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
@@ -219,7 +219,7 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
-  def save_host_storages_inventory(host, hashes, target = nil)
+  def save_host_storages_inventory(host, hashes, target = nil, mode = :refresh)
     target = host if target.nil?
 
     # Update the associated ids
@@ -239,7 +239,7 @@ module EmsRefresh::SaveInventoryInfra
     save_inventory_multi(host.host_storages, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
   end
 
-  def save_folders_inventory(ems, hashes, target = nil)
+  def save_folders_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
 
     ems.ems_folders.reset
@@ -254,7 +254,7 @@ module EmsRefresh::SaveInventoryInfra
   end
   alias_method :save_ems_folders_inventory, :save_folders_inventory
 
-  def save_clusters_inventory(ems, hashes, target = nil)
+  def save_clusters_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
 
     ems.ems_clusters.reset
@@ -269,7 +269,7 @@ module EmsRefresh::SaveInventoryInfra
   end
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
-  def save_resource_pools_inventory(ems, hashes, target = nil)
+  def save_resource_pools_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
 
     ems.resource_pools.reset
@@ -285,7 +285,7 @@ module EmsRefresh::SaveInventoryInfra
     store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
-  def save_storage_profiles_inventory(ems, hashes, target = nil)
+  def save_storage_profiles_inventory(ems, hashes, target = nil, mode = :refresh)
     target = ems if target.nil?
 
     ems.storage_profiles.reset
@@ -312,7 +312,7 @@ module EmsRefresh::SaveInventoryInfra
                          [], [:storage_profile_id, :storage_id])
   end
 
-  def save_customization_specs_inventory(ems, hashes, _target = nil)
+  def save_customization_specs_inventory(ems, hashes, _target = nil, _mode = :refresh)
     save_inventory_multi(ems.customization_specs, hashes, :use_association, [:name])
   end
 

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -35,7 +35,7 @@
 
 module EmsRefresh::SaveInventoryInfra
   def save_ems_infra_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
@@ -84,7 +84,7 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_storages_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Query for all of the storages ahead of time
@@ -114,7 +114,7 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_hosts_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     disconnects = if (target == ems)
@@ -220,7 +220,7 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_host_storages_inventory(host, hashes, target = nil, mode = :refresh)
-    target = host if target.nil?
+    target = host if target.nil? && mode == :refresh
 
     # Update the associated ids
     hashes.each do |h|
@@ -240,7 +240,7 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_folders_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
 
     ems.ems_folders.reset
     deletes = if (target == ems)
@@ -255,7 +255,7 @@ module EmsRefresh::SaveInventoryInfra
   alias_method :save_ems_folders_inventory, :save_folders_inventory
 
   def save_clusters_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
 
     ems.ems_clusters.reset
     deletes = if (target == ems)
@@ -270,7 +270,7 @@ module EmsRefresh::SaveInventoryInfra
   alias_method :save_ems_clusters_inventory, :save_clusters_inventory
 
   def save_resource_pools_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
 
     ems.resource_pools.reset
     deletes = if (target == ems)
@@ -286,7 +286,7 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_storage_profiles_inventory(ems, hashes, target = nil, mode = :refresh)
-    target = ems if target.nil?
+    target = ems if target.nil? && mode == :refresh
 
     ems.storage_profiles.reset
     deletes =

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -8,7 +8,7 @@
 
 module EmsRefresh
   module SaveInventoryOrchestrationStacks
-    def save_orchestration_templates_inventory(_ems, hashes, _target = nil, _mode = :refresh)
+    def save_orchestration_templates_inventory(_ems, hashes, _target = nil, _disconnect = true)
       # cloud_stack_template does not belong to an ems;
       # only to create new if necessary, but not to update existing template
       templates = OrchestrationTemplate.find_or_create_by_contents(hashes)
@@ -28,8 +28,8 @@ module EmsRefresh
       store_ids_for_new_records(ems.orchestration_templates, hashes, :ems_ref)
     end
 
-    def save_orchestration_stacks_inventory(ems, hashes, target = nil, mode = :refresh)
-      target = ems if target.nil? && mode == :refresh
+    def save_orchestration_stacks_inventory(ems, hashes, target = nil, disconnect = true)
+      target = ems if target.nil? && disconnect
 
       deletes = target == ems ? :use_association : []
 

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -29,7 +29,7 @@ module EmsRefresh
     end
 
     def save_orchestration_stacks_inventory(ems, hashes, target = nil, mode = :refresh)
-      target = ems if target.nil?
+      target = ems if target.nil? && mode == :refresh
 
       deletes = target == ems ? :use_association : []
 

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -15,7 +15,7 @@ module EmsRefresh
       hashes.zip(templates).each { |hash, template| hash[:id] = template.id }
     end
 
-    def save_orchestration_templates_catalog_inventory(ems, hashes, target = nil)
+    def save_orchestration_templates_catalog_inventory(ems, hashes, target = nil, disconnect = true)
       target = ems if target.nil?
 
       deletes = target == ems ? :use_association : []

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -18,7 +18,7 @@ module EmsRefresh
     def save_orchestration_templates_catalog_inventory(ems, hashes, target = nil, disconnect = true)
       target = ems if target.nil?
 
-      deletes = target == ems ? :use_association : []
+      deletes = determine_deletes_using_association(ems, target, disconnect)
 
       save_inventory_multi(ems.orchestration_templates,
                            hashes,
@@ -29,9 +29,9 @@ module EmsRefresh
     end
 
     def save_orchestration_stacks_inventory(ems, hashes, target = nil, disconnect = true)
-      target = ems if target.nil? && disconnect
+      target = ems if target.nil?
 
-      deletes = target == ems ? :use_association : []
+      deletes = determine_deletes_using_association(ems, target, disconnect)
 
       hashes.each do |h|
         h[:orchestration_template_id] = h.fetch_path(:orchestration_template, :id)

--- a/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
+++ b/app/models/ems_refresh/save_inventory_orchestration_stacks.rb
@@ -8,7 +8,7 @@
 
 module EmsRefresh
   module SaveInventoryOrchestrationStacks
-    def save_orchestration_templates_inventory(_ems, hashes, _target = nil)
+    def save_orchestration_templates_inventory(_ems, hashes, _target = nil, _mode = :refresh)
       # cloud_stack_template does not belong to an ems;
       # only to create new if necessary, but not to update existing template
       templates = OrchestrationTemplate.find_or_create_by_contents(hashes)
@@ -28,7 +28,7 @@ module EmsRefresh
       store_ids_for_new_records(ems.orchestration_templates, hashes, :ems_ref)
     end
 
-    def save_orchestration_stacks_inventory(ems, hashes, target = nil)
+    def save_orchestration_stacks_inventory(ems, hashes, target = nil, mode = :refresh)
       target = ems if target.nil?
 
       deletes = target == ems ? :use_association : []

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -162,7 +162,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   }.freeze
 
   def on_create_event(ems_id, event)
-    target_hash, target_class, target_find = ManageIQ::Providers::Vmware::InfraManager::EventParser.obj_update_to_hash(event)
+    target_hash, target_class, target_find = ManageIQ::Providers::Vmware::InfraManager::EventParser.parse_new_target(event)
     if target_hash.nil?
       _log.debug("Ignoring refresh for EMS id: [#{ems_id}] on event [#{event[:objType]}-create]")
     else

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -162,12 +162,12 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   }.freeze
 
   def on_create_event(ems_id, event)
-    target_hash = ManageIQ::Providers::Vmware::InfraManager::EventParser.obj_update_to_hash(event)
+    target_hash, target_class, target_find = ManageIQ::Providers::Vmware::InfraManager::EventParser.obj_update_to_hash(event)
     if target_hash.nil?
       _log.debug("Ignoring refresh for EMS id: [#{ems_id}] on event [#{event[:objType]}-create]")
     else
       ems = ExtManagementSystem.find(ems_id)
-      EmsRefresh.queue_refresh_new_target(target_hash, ems)
+      EmsRefresh.queue_refresh_new_target(ems, target_hash, target_class, target_find)
     end
   end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -247,6 +247,28 @@ describe EmsRefresh do
         described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
       end
     end
+
+    context 'targeting an archived vm' do
+      let(:vm) { FactoryGirl.create(:vm_with_ref, :ems_id => nil) }
+
+      it 'adopts the existing vm' do
+        vm_hash = {
+          :ems_ref => vm.ems_ref,
+          :uid_ems => vm.uid_ems,
+          :type    => vm.class.name
+        }
+        target_hash  = {:vms => [vm_hash]}
+        target_klass = vm_hash[:type].constantize
+        target_find  = {:uid_ems => vm_hash[:uid_ems]}
+
+        expect(ems.refresher).to receive(:refresh)
+
+        described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
+
+        vm.reload
+        expect(vm.ext_management_system).to eq(ems)
+      end
+    end
   end
 
   context '.queue_merge' do

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -200,6 +200,31 @@ describe EmsRefresh do
 
         expect(ems.refresher).to receive(:refresh)
         described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
+
+        new_vm = target_klass.find_by(target_find)
+        expect(new_vm).to have_attributes(vm_hash)
+      end
+
+      context 'on an existing host' do
+        let(:host) { FactoryGirl.create(:host_with_ref, :ext_management_system => ems) }
+
+        it 'links the new vm to the existing host' do
+          target_hash = {
+            :hosts => [{:ems_ref => host.ems_ref}]
+          }
+
+          vm_hash[:host] = target_hash[:hosts].first
+          target_hash[:vms] = [vm_hash]
+
+          target_find  = {:uid_ems => vm_hash[:uid_ems]}
+          target_klass = vm_hash[:type].constantize
+
+          expect(ems.refresher).to receive(:refresh)
+          described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
+
+          new_vm = target_klass.find_by(target_find)
+          expect(new_vm.host).to eq(host)
+        end
       end
     end
   end

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -178,6 +178,32 @@ describe EmsRefresh do
     end
   end
 
+  context '.refresh_new_target' do
+    let(:ems) { FactoryGirl.create(:ems_vmware) }
+
+    context 'targeting a new vm' do
+      let(:vm_hash) do
+        {
+          :type        => ManageIQ::Providers::InfraManager::Vm.name,
+          :ems_ref     => 'vm-123',
+          :ems_ref_obj => 'vm-123',
+          :uid_ems     => 'vm-123',
+          :name        => 'new-vm',
+          :vendor      => 'unknown'
+        }
+      end
+
+      it 'creates the new record' do
+        target_hash  = {:vms => [vm_hash]}
+        target_klass = vm_hash[:type].constantize
+        target_find  = {:uid_ems => vm_hash[:uid_ems]}
+
+        expect(ems.refresher).to receive(:refresh)
+        described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
+      end
+    end
+  end
+
   context '.queue_merge' do
     let(:ems) { FactoryGirl.create(:ems_vmware, :name => "ems_vmware1") }
     let(:vm)  { FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems) }

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -227,6 +227,26 @@ describe EmsRefresh do
         end
       end
     end
+
+    context 'targeting an existing vm' do
+      let(:vm) { FactoryGirl.create(:vm_with_ref, :ext_management_system => ems) }
+
+      it "doesn't try to create a new record" do
+        vm_hash = {
+          :ems_ref => vm.ems_ref,
+          :uid_ems => vm.uid_ems,
+          :type    => vm.class.name
+        }
+        target_hash  = {:vms => [vm_hash]}
+        target_klass = vm_hash[:type].constantize
+        target_find  = {:uid_ems => vm_hash[:uid_ems]}
+
+        expect(ems.vms_and_templates.klass).not_to receive(:new)
+        expect(ems.refresher).to receive(:refresh)
+
+        described_class.refresh_new_target(ems.id, target_hash, target_klass, target_find)
+      end
+    end
   end
 
   context '.queue_merge' do

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -250,20 +250,24 @@ describe MiqVimBrokerWorker::Runner do
         end
 
         it "will handle create events properly" do
+          mor       = "group-v123"
+          klass     = "EmsFolder"
+          find_opts = {:uid_ems => mor}
+
           event = {
             :server   => @ems.address,
             :username => @ems.authentication_userid,
             :objType  => "Folder",
             :op       => "create",
-            :mor      => "group-v123"
+            :mor      => mor
           }
 
           expected_folder_hash = {
             :folder => {
-              :type        => "EmsFolder",
-              :ems_ref     => "group-v123",
-              :ems_ref_obj => "group-v123",
-              :uid_ems     => "group-v123"
+              :type        => klass,
+              :ems_ref     => mor,
+              :ems_ref_obj => mor,
+              :uid_ems     => mor
             }
           }
 
@@ -274,7 +278,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh_new_target")
-          expect(q.args).to eq([expected_folder_hash, @ems.id])
+          expect(q.args).to eq([@ems.id, expected_folder_hash, klass, find_opts])
         end
 
         it "will ignore updates to unknown properties" do


### PR DESCRIPTION
By adding the ability for `save_ems_inventory` to work with a nil target we can delete the specialized `save_new_target` method which only worked for RHEV VMs and replace it with the general `save_ems_inventory` method.

Now any links that the caller wants to be made can be made, and any linked inventory that doesn't exist will be created just like a normal save_inventory would, so we can get rid of the specific calls to find or create linked inventory here https://github.com/ManageIQ/manageiq/blob/c9e9ae107ecc16d13517f019c5616e33a268c1f7/app/models/ems_refresh/save_inventory_helper.rb#L157-L164

- [ ] Update RHV `parse_new_event` (https://github.com/ManageIQ/manageiq-providers-ovirt/pull/13)

- [x] Update VMware `obj_update_to_hash` https://github.com/ManageIQ/manageiq-providers-vmware/pull/55