### PR TITLE
Add orchestration_stacks to ServiceAnsiblePlaybook

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -37,6 +37,7 @@ class Service < ApplicationRecord
   virtual_has_many   :vms
   virtual_has_many   :all_vms
   virtual_has_many   :power_states, :uses => :all_vms
+  virtual_has_many   :orchestration_stacks
   virtual_total      :v_total_vms, :vms
 
   virtual_has_one    :custom_actions
@@ -222,6 +223,10 @@ class Service < ApplicationRecord
 
   def atomic?
     service_template ? service_template.atomic? : children.empty?
+  end
+
+  def orchestration_stacks
+    service_resources.where(:resource_type => 'OrchestrationStack').collect(&:resource)
   end
 
   def map_composite_power_states(action)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -681,6 +681,17 @@ describe Service do
     end
   end
 
+  describe '#orchestration_stacks' do
+    let(:service) { FactoryGirl.create(:service) }
+    let(:tower_job) { FactoryGirl.create(:embedded_ansible_job) }
+
+    before { service.add_resource!(tower_job, :name => ResourceAction::PROVISION) }
+
+    it 'returns the orchestration stacks' do
+      expect(service.orchestration_stacks).to eq([tower_job])
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)


### PR DESCRIPTION
The SUI needs to be able to access the jobs on a `ServiceAnsiblePlaybook`. This returns them as an array: 

```
[
  #<ManageIQ::Providers::AnsibleTower::AutomationManager::Job:0x007fe6608789c8
   id: 371,
   name: "miq-playbook-demo_provision_hd2g8j13",
   type: "ManageIQ::Providers::AnsibleTower::AutomationManager::Job",
   description: nil,
   status: "successful",
   ems_ref: "114",
   ancestry: nil,
   ems_id: 10,
   orchestration_template_id: 516,
   created_at: Tue, 14 Feb 2017 19:20:42 UTC +00:00,
   updated_at: Fri, 24 Feb 2017 16:45:02 UTC +00:00,
   retired: nil,
   retires_on: nil,
   retirement_warn: nil,
   retirement_last_warn: nil,
   retirement_state: nil,
   retirement_requester: nil,
   status_reason: nil,
   cloud_tenant_id: nil,
   resource_group: nil,
   start_time: Tue, 14 Feb 2017 20:20:55 UTC +00:00,
   finish_time: Tue, 14 Feb 2017 20:20:58 UTC +00:00,
   configuration_script_base_id: 488,
   verbosity: 0,
   hosts: ["localhost"]>
]
```

cc: @AllenBW 
thoughts @bzwei ?
@miq-bot add_label enhancement, services 
