### PR TITLE
Target and target collection abstractions

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -324,4 +324,8 @@ class EmsEvent < EventStream
   def ems_refresh_target
     ext_management_system
   end
+
+  def manager_refresh_targets
+    ext_management_system.class::EventTargetParser.new(self).parse
+  end
 end

--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -2,6 +2,14 @@ class EmsEvent
   module Automate
     extend ActiveSupport::Concern
 
+    def graph_refresh(sync: false)
+      refresh_targets = manager_refresh_targets
+
+      return if refresh_targets.empty?
+
+      EmsRefresh.queue_refresh(refresh_targets, nil, sync)
+    end
+
     def refresh(*targets, sync)
       targets = targets.flatten
       return if targets.blank?

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -135,7 +135,7 @@ module EmsRefresh
       ids.uniq!
 
       recs = if target_class <= ManagerRefresh::Target
-               ids.map { |x| ManagerRefresh::Target.new(x) }
+               ids.map { |x| ManagerRefresh::Target.load(x) }
              else
                active_record_recs = target_class.where(:id => ids)
                active_record_recs = active_record_recs.includes(:ext_management_system) unless target_class <= ExtManagementSystem

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -39,7 +39,7 @@ module EmsRefresh
 
   def self.queue_refresh(target, id = nil, opts = {})
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
-    targets = get_ar_objects(target, id)
+    targets = get_target_objects(target, id)
 
     # Group the target refs by zone and role
     targets_by_ems = targets.each_with_object(Hash.new { |h, k| h[k] = [] }) do |t, h|
@@ -82,7 +82,7 @@ module EmsRefresh
     EmsRefresh.init_console if defined?(Rails::Console)
 
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
-    targets = get_ar_objects(target, id)
+    targets = get_target_objects(target, id)
 
     # Split the targets into refresher groups
     groups = targets.group_by do |t|
@@ -109,10 +109,10 @@ module EmsRefresh
       return
     end
 
-    ems.refresher.refresh(get_ar_objects(target))
+    ems.refresher.refresh(get_target_objects(target))
   end
 
-  def self.get_ar_objects(target, single_id = nil)
+  def self.get_target_objects(target, single_id = nil)
     # Handle targets passed as a single class/id pair, an array of class/id pairs, an array of references
     target = [[target, single_id]] unless single_id.nil?
     return [target] unless target.kind_of?(Array)

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -134,8 +134,7 @@ module EmsRefresh
     targets_by_type.each_with_object([]) do |(target_class, ids), target_objects|
       ids.uniq!
 
-      recs = case target_class
-             when ManagerRefresh::Target
+      recs = if target_class <= ManagerRefresh::Target
                ids.map { |x| ManagerRefresh::Target.new(x) }
              else
                active_record_recs = target_class.where(:id => ids)

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -21,8 +21,14 @@ module ManagerRefresh
       @options     = options
     end
 
+    # A Rails recommended interface for deserializing an object
     def self.load(*args)
-      self.new(*args)
+      new(*args)
+    end
+
+    # A Rails recommended interface for serializing an object
+    def self.dump(obj)
+      obj.dump
     end
 
     # Returns a serialized ManagerRefresh::Target object. This can be used to initialize a new object, then the object

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -44,7 +44,7 @@ module ManagerRefresh
     end
 
     alias id dump
-    alias name association
+    alias name manager_ref
 
     # @return [ManageIQ::Providers::BaseManager] The Manager owning the Target
     def manager
@@ -59,7 +59,7 @@ module ManagerRefresh
     # Loads ManagerRefresh::Target ApplicationRecord representation from our DB, this requires that ManagerRefresh::Target
     # has been refreshed, otherwise the AR object can be missing.
     # @return [ApplicationRecord] A ManagerRefresh::Target loaded from the database as AR object
-    def load
+    def load_from_db
       manager.public_send(association).find_by(manager_ref)
     end
   end

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -21,9 +21,13 @@ module ManagerRefresh
       @options     = options
     end
 
+    def self.load(*args)
+      self.new(*args)
+    end
+
     # Returns a serialized ManagerRefresh::Target object. This can be used to initialize a new object, then the object
     # target acts the same as the object ManagerRefresh::Target.new(target.serialize)
-    def serialize
+    def dump
       {
         :manager_id  => manager_id,
         :association => association,
@@ -33,7 +37,7 @@ module ManagerRefresh
       }
     end
 
-    alias id serialize
+    alias id dump
     alias name association
 
     # @return [ManageIQ::Providers::BaseManager] The Manager owning the Target

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -1,0 +1,56 @@
+module ManagerRefresh
+  class Target
+    attr_reader :association, :manager_ref, :event_id, :options
+
+    # @param association [Symbol] An existing association on Manager, that lists objects represented by a Target, naming
+    #                             should be the same of association of a counterpart InventoryCollection object
+    # @param manager_ref [Hash] A Hash that can be used to find_by on a given association and returning a unique object.
+    #                           The keys should be the same as the keys of the counterpart InventoryObject
+    # @param manager [ManageIQ::Providers::BaseManager] The Manager owning the Target
+    # @param manager_id [Integer] A primary key of the Manager owning the Target
+    # @param event_id [Integer] A primary key of the EmsEvent associated with the Target
+    # @param options [Hash] A free form options hash
+    def initialize(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, options: {})
+      raise "Provide either :manager or :manager_id argument" if manager.nil? && manager_id.nil?
+
+      @manager     = manager
+      @manager_id  = manager_id
+      @association = association
+      @manager_ref = manager_ref
+      @event_id    = event_id
+      @options     = options
+    end
+
+    # Returns a serialized ManagerRefresh::Target object. This can be used to initialize a new object, then the object
+    # target acts the same as the object ManagerRefresh::Target.new(target.serialize)
+    def serialize
+      {
+        :manager_id  => manager_id,
+        :association => association,
+        :manager_ref => manager_ref,
+        :event_id    => event_id,
+        :options     => options
+      }
+    end
+
+    alias id serialize
+    alias name association
+
+    # @return [ManageIQ::Providers::BaseManager] The Manager owning the Target
+    def manager
+      @manager || ManageIQ::Providers::BaseManager.find(@manager_id)
+    end
+
+    # @return [Integer] A primary key of the Manager owning the Target
+    def manager_id
+      @manager_id || manager.try(:id)
+    end
+
+    # Loads ManagerRefresh::Target ApplicationRecord representation from our DB, this requires that ManagerRefresh::Target
+    # has been refreshed, otherwise the AR object can be missing.
+    # @return [ApplicationRecord] A ManagerRefresh::Target loaded from the database as AR object
+    def load
+      manager.public_send(association).find_by(manager_ref)
+    end
+  end
+end

--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -59,7 +59,7 @@ module ManagerRefresh
     def manager_refs_by_association
       @manager_refs_by_association ||= targets.select { |x| x.kind_of?(ManagerRefresh::Target) }.each_with_object({}) do |x, obj|
         if obj[x.association].blank?
-          obj[x.association] = x.manager_ref.each_with_object({}) { |(key, value), hash| hash[key] = Set.new([value])}
+          obj[x.association] = x.manager_ref.each_with_object({}) { |(key, value), hash| hash[key] = Set.new([value]) }
         else
           obj[x.association].each do |key, value|
             value << x.manager_ref[key]

--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -1,0 +1,76 @@
+module ManagerRefresh
+  class TargetCollection
+    attr_reader :targets
+
+    delegate :<<, :to => :targets
+
+    # @param manager [ManageIQ::Providers::BaseManager] The Manager owning the TargetCollection
+    # @param event [EmsEvent] AnEmsEvent associated with the TargetCollection
+    # @param targets [Array] An Array of ManagerRefresh::Target objects or ApplicationRecord objects
+    def initialize(manager: nil, manager_id: nil, event: nil, targets: [])
+      @manager    = manager
+      @manager_id = manager_id
+      @event      = event
+      @targets    = targets
+    end
+
+    # @param association [Symbol] An existing association on Manager, that lists objects represented by a Target, naming
+    #                             should be the same of association of a counterpart InventoryCollection object
+    # @param manager_ref [Hash] A Hash that can be used to find_by on a given association and returning a unique object.
+    #                           The keys should be the same as the keys of the counterpart InventoryObject
+    # @param manager [ManageIQ::Providers::BaseManager] The Manager owning the Target
+    # @param manager_id [Integer] A primary key of the Manager owning the Target
+    # @param event_id [Integer] A primary key of the EmsEvent associated with the Target
+    # @param options [Hash] A free form options hash
+    def add_target!(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, options: {})
+      self << ManagerRefresh::Target.new(:association => association,
+                                         :manager_ref => manager_ref,
+                                         :manager     => manager || @manager,
+                                         :manager_id  => manager_id || @manager_id || @manager.try(:id),
+                                         :event_id    => event_id || @event.try(:id),
+                                         :options     => options)
+    end
+
+    # @return [String] A String containing a name of each target in the TargetCollection
+    def name
+      "Collection of targets with name: #{targets.collect(&:name)}"
+    end
+
+    # @return [String] A String containing an id of each target in the TargetCollection
+    def id
+      "Collection of targets with id: #{targets.collect(&:id)}"
+    end
+
+    # Returns targets in a format:
+    # {
+    #   :vms => {:ems_ref => Set.new(["vm_ref_1", "vm_ref2"])}
+    #   :network_ports => {:ems_ref => Set.new(["network_port_1", "network_port2"])
+    # }
+    #
+    # Then we can quickly access all objects affected by:
+    #   NetworkPort.where(target_collection.manager_refs_by_association[:network_ports].to_a) =>
+    #     return AR objects with ems_refs ["network_port_1", "network_port2"]
+    # And we can get a list of ids for the API query by:
+    #   target_collection.manager_refs_by_association[:network_ports][:ems_ref].to_a =>
+    #     ["network_port_1", "network_port2"]
+    #
+    # Only targets of a type ManagerRefresh::Target are processed, any other targets present should be converted to
+    # ManagerRefresh::Target, e.g. in the Inventory::Collector code.
+    def manager_refs_by_association
+      @manager_refs_by_association ||= targets.select { |x| x.kind_of?(ManagerRefresh::Target) }.each_with_object({}) do |x, obj|
+        if obj[x.association].blank?
+          obj[x.association] = x.manager_ref.each_with_object({}) { |(key, value), hash| hash[key] = Set.new([value])}
+        else
+          obj[x.association].each do |key, value|
+            value << x.manager_ref[key]
+          end
+        end
+      end
+    end
+
+    # Resets the cached @manager_refs_by_association to enforce reload when calling :manager_refs_by_association method
+    def manager_refs_by_association_reset
+      @manager_refs_by_association = nil
+    end
+  end
+end

--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -22,7 +22,7 @@ module ManagerRefresh
     # @param manager_id [Integer] A primary key of the Manager owning the Target
     # @param event_id [Integer] A primary key of the EmsEvent associated with the Target
     # @param options [Hash] A free form options hash
-    def add_target!(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, options: {})
+    def add_target(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, options: {})
       self << ManagerRefresh::Target.new(:association => association,
                                          :manager_ref => manager_ref,
                                          :manager     => manager || @manager,

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -105,6 +105,14 @@ module MiqAeEngine
       ["host", "storage"].each { |k| obj[k] = result[k] } unless result.empty?
     end
 
+    def self.miq_refresh(obj, _inputs)
+      event_object_from_workspace(obj).graph_refresh(:sync => false)
+    end
+
+    def self.miq_refresh_sync(obj, _inputs)
+      event_object_from_workspace(obj).graph_refresh(:sync => true)
+    end
+
     def self.miq_event_action_refresh(obj, inputs)
       event_object_from_workspace(obj).refresh(inputs['target'], false)
     end

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -91,7 +91,7 @@ describe EmsRefresh do
     expect(q_all[0].role).to eq("ems_inventory")
   end
 
-  context ".get_ar_objects" do
+  context ".get_target_objects" do
     it "array of class/ids pairs" do
       ems1 = FactoryGirl.create(:ems_vmware,     :name => "ems_vmware1")
       ems2 = FactoryGirl.create(:ems_redhat, :name => "ems_redhat1")
@@ -100,7 +100,7 @@ describe EmsRefresh do
         [ems2.class, ems2.id]
       ]
 
-      expect(described_class.get_ar_objects(pairs)).to match_array([ems1, ems2])
+      expect(described_class.get_target_objects(pairs)).to match_array([ems1, ems2])
     end
   end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -93,7 +93,7 @@ describe EmsRefresh do
 
   context ".get_target_objects" do
     it "array of class/ids pairs" do
-      ems1 = FactoryGirl.create(:ems_vmware,     :name => "ems_vmware1")
+      ems1 = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
       ems2 = FactoryGirl.create(:ems_redhat, :name => "ems_redhat1")
       pairs = [
         [ems1.class, ems1.id],
@@ -101,6 +101,32 @@ describe EmsRefresh do
       ]
 
       expect(described_class.get_target_objects(pairs)).to match_array([ems1, ems2])
+    end
+
+    it "array of class/hash pairs for ManagerRefresh::Target objects" do
+      ems1 = FactoryGirl.create(:ems_vmware, :name => "ems_vmware1")
+      ems2 = FactoryGirl.create(:ems_redhat, :name => "ems_redhat1")
+
+      target1     = ManagerRefresh::Target.load(:manager_id  => ems1.id,
+                                                :association => :vms,
+                                                :manager_ref => {:ems_ref => "vm1"})
+      target2     = ManagerRefresh::Target.load(:manager_id  => ems2.id,
+                                                :association => :network_ports,
+                                                :manager_ref => {:ems_ref => "network_port_1"})
+      target3     = ManagerRefresh::Target.new(:manager_id  => ems1.id,
+                                               :association => :vms,
+                                               :manager_ref => {:ems_ref => "vm2"})
+      target1_dup = ManagerRefresh::Target.load(:manager_id  => ems1.id,
+                                                :association => :vms,
+                                                :manager_ref => {:ems_ref => "vm1"})
+      pairs = [
+        [target1.class, target1.id],
+        [target2.class, target2.id],
+        [target3.class, target3.id],
+        [target1_dup.class, target1_dup.id],
+      ]
+
+      expect(described_class.get_target_objects(pairs).map(&:dump)).to match_array([target1, target2, target3].map(&:dump))
     end
   end
 

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -29,14 +29,12 @@ describe ManagerRefresh::TargetCollection do
 
       expect(target_collection.targets.first).to(
         have_attributes(
-          {
-            :manager     => @ems,
-            :manager_id  => @ems.id,
-            :event_id    => nil,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          }
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :event_id    => nil,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
       )
     end
@@ -52,14 +50,12 @@ describe ManagerRefresh::TargetCollection do
 
       expect(target_collection.targets.first).to(
         have_attributes(
-          {
-            :manager     => @ems,
-            :manager_id  => @ems.id,
-            :event_id    => @ems_event.id,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          }
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :event_id    => @ems_event.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
       )
     end
@@ -75,14 +71,12 @@ describe ManagerRefresh::TargetCollection do
 
       expect(target_collection.targets.first).to(
         have_attributes(
-          {
-            :manager     => @ems,
-            :manager_id  => @ems.id,
-            :event_id    => @ems_event.id,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          }
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :event_id    => @ems_event.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
       )
     end

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -1,0 +1,264 @@
+describe ManagerRefresh::TargetCollection do
+  before(:each) do
+    @zone      = FactoryGirl.create(:zone)
+    @ems       = FactoryGirl.create(:ems_cloud, :zone => @zone)
+    @ems_event = FactoryGirl.create(:ems_event)
+
+    @vm_1 = FactoryGirl.create(
+      :vm_cloud,
+      :ext_management_system => @ems,
+      :ems_ref               => "vm_1"
+    )
+
+    @vm_2 = FactoryGirl.create(
+      :vm_cloud,
+      :ext_management_system => @ems,
+      :ems_ref               => "vm_2"
+    )
+  end
+
+  context ".add_target" do
+    it "intializes correct ManagerRefresh::Target object" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager => @ems)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.targets.first).to(
+        have_attributes(
+          {
+            :manager     => @ems,
+            :manager_id  => @ems.id,
+            :event_id    => nil,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+          }
+        )
+      )
+    end
+
+    it "intializes correct ManagerRefresh::Target object with manager_id" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.targets.first).to(
+        have_attributes(
+          {
+            :manager     => @ems,
+            :manager_id  => @ems.id,
+            :event_id    => @ems_event.id,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+          }
+        )
+      )
+    end
+
+    it "intializes correct ManagerRefresh::Target object with event" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager => @ems, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.targets.first).to(
+        have_attributes(
+          {
+            :manager     => @ems,
+            :manager_id  => @ems.id,
+            :event_id    => @ems_event.id,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+          }
+        )
+      )
+    end
+
+    it "raises exception when manager not provided in any form" do
+      data = {
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      }
+
+      target_collection = ManagerRefresh::TargetCollection.new
+
+      expect { target_collection.add_target(data) }.to raise_error("Provide either :manager or :manager_id argument")
+    end
+  end
+
+  context ".name" do
+    it "prints names of all targets" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_2.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.name).to eq "Collection of targets with name: [{:ems_ref=>\"vm_1\"}, {:ems_ref=>\"vm_2\"}]"
+    end
+  end
+
+  context ".id" do
+    it "prints ids of all targets" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_2.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.id).to include ":ems_ref=>\"vm_1\""
+      expect(target_collection.id).to include ":ems_ref=>\"vm_2\""
+    end
+  end
+
+  context ".manager_refs_by_association" do
+    it "returns all manager refs grouped by association" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_2.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :network_ports,
+        :manager_ref => {:ems_ref => "network_port_1"},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.manager_refs_by_association[:vms][:ems_ref].to_a).to(
+        match_array(["vm_1", "vm_2"])
+      )
+      expect(target_collection.manager_refs_by_association[:network_ports][:ems_ref].to_a).to(
+        match_array(["network_port_1"])
+      )
+    end
+
+    it "handles duplicates" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      # Adding a duplicate Vm
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      # Checking the duplicate is there
+      expect(target_collection.targets.map(&:dump)).to(
+        match_array(
+          [
+            {
+              :manager_id  => @ems.id,
+              :event_id    => @ems_event.id,
+              :association => :vms,
+              :manager_ref => {:ems_ref => @vm_1.ems_ref},
+              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+            }, {
+              :manager_id  => @ems.id,
+              :event_id    => @ems_event.id,
+              :association => :vms,
+              :manager_ref => {:ems_ref => @vm_1.ems_ref},
+              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+            }
+          ]
+        )
+      )
+
+      # Checking the manager_refs_by_association handle duplicate
+      expect(target_collection.manager_refs_by_association[:vms][:ems_ref].to_a).to(
+        match_array(["vm_1"])
+      )
+    end
+
+    it "caches the result until manager_refs_by_association_reset is called" do
+      target_collection = ManagerRefresh::TargetCollection.new(:manager_id => @ems.id, :event => @ems_event)
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_2.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      target_collection.add_target(
+        :association => :network_ports,
+        :manager_ref => {:ems_ref => "network_port_1"},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_collection.manager_refs_by_association[:vms][:ems_ref].to_a).to(
+        match_array(["vm_1", "vm_2"])
+      )
+      expect(target_collection.manager_refs_by_association[:network_ports][:ems_ref].to_a).to(
+        match_array(["network_port_1"])
+      )
+
+      # Adding new target
+      target_collection.add_target(
+        :association => :network_ports,
+        :manager_ref => {:ems_ref => "network_port_2"},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      # check that manager_refs_by_association returns cached result
+      expect(target_collection.manager_refs_by_association[:network_ports][:ems_ref].to_a).to(
+        match_array(["network_port_1"])
+      )
+
+      # Clear the cache and check new target is present
+      target_collection.manager_refs_by_association_reset
+      expect(target_collection.manager_refs_by_association[:network_ports][:ems_ref].to_a).to(
+        match_array(["network_port_1", "network_port_2"])
+      )
+    end
+  end
+end

--- a/spec/models/manager_refresh/target_spec.rb
+++ b/spec/models/manager_refresh/target_spec.rb
@@ -27,13 +27,11 @@ describe ManagerRefresh::Target do
 
       expect(target_1).to(
         have_attributes(
-          {
-            :manager     => @ems,
-            :manager_id  => @ems.id,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          }
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
       )
     end
@@ -48,13 +46,11 @@ describe ManagerRefresh::Target do
 
       expect(target_1).to(
         have_attributes(
-          {
-            :manager     => @ems,
-            :manager_id  => @ems.id,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          }
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
       )
     end
@@ -80,13 +76,11 @@ describe ManagerRefresh::Target do
 
         expect(target_1.dump).to(
           eq(
-            {
-              :manager_id  => @ems.id,
-              :event_id    => nil,
-              :association => :vms,
-              :manager_ref => {:ems_ref => @vm_1.ems_ref},
-              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-            }
+            :manager_id  => @ems.id,
+            :event_id    => nil,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
           )
         )
       end
@@ -101,13 +95,11 @@ describe ManagerRefresh::Target do
 
         expect(target_1.dump).to(
           eq(
-            {
-              :manager_id  => @ems.id,
-              :event_id    => nil,
-              :association => :vms,
-              :manager_ref => {:ems_ref => @vm_1.ems_ref},
-              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-            }
+            :manager_id  => @ems.id,
+            :event_id    => nil,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
           )
         )
       end

--- a/spec/models/manager_refresh/target_spec.rb
+++ b/spec/models/manager_refresh/target_spec.rb
@@ -1,0 +1,166 @@
+describe ManagerRefresh::Target do
+  before(:each) do
+    @zone = FactoryGirl.create(:zone)
+    @ems  = FactoryGirl.create(:ems_cloud, :zone => @zone)
+
+    @vm_1 = FactoryGirl.create(
+      :vm_cloud,
+      :ext_management_system => @ems,
+      :ems_ref               => "vm_1"
+    )
+
+    @vm_2 = FactoryGirl.create(
+      :vm_cloud,
+      :ext_management_system => @ems,
+      :ems_ref               => "vm_2"
+    )
+  end
+
+  context ".load" do
+    it "intializes correct ManagerRefresh::Target.object with a :manager_id" do
+      target_1 = ManagerRefresh::Target.load(
+        :manager_id  => @ems.id,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1).to(
+        have_attributes(
+          {
+            :manager     => @ems,
+            :manager_id  => @ems.id,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+          }
+        )
+      )
+    end
+
+    it "intializes correct ManagerRefresh::Target.object with a :manager " do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1).to(
+        have_attributes(
+          {
+            :manager     => @ems,
+            :manager_id  => @ems.id,
+            :association => :vms,
+            :manager_ref => {:ems_ref => @vm_1.ems_ref},
+            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+          }
+        )
+      )
+    end
+
+    it "raises exception when manager not provided in any form" do
+      data = {
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      }
+
+      expect { ManagerRefresh::Target.load(data) }.to raise_error("Provide either :manager or :manager_id argument")
+    end
+
+    context ".dump" do
+      it "intializes correct ManagerRefresh::Target.object with a :manager_id" do
+        target_1 = ManagerRefresh::Target.load(
+          :manager_id  => @ems.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.dump).to(
+          eq(
+            {
+              :manager_id  => @ems.id,
+              :event_id    => nil,
+              :association => :vms,
+              :manager_ref => {:ems_ref => @vm_1.ems_ref},
+              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+            }
+          )
+        )
+      end
+
+      it "intializes correct ManagerRefresh::Target.object with a :manager " do
+        target_1 = ManagerRefresh::Target.load(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.dump).to(
+          eq(
+            {
+              :manager_id  => @ems.id,
+              :event_id    => nil,
+              :association => :vms,
+              :manager_ref => {:ems_ref => @vm_1.ems_ref},
+              :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+            }
+          )
+        )
+      end
+
+      it "class method .dump returns the same as an instance method .dump " do
+        target_1 = ManagerRefresh::Target.load(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.dump).to eq ManagerRefresh::Target.dump(target_1)
+      end
+    end
+
+    context ".load_from_db" do
+      it "loads ManagerRefresh::Target from the db" do
+        target_1 = ManagerRefresh::Target.load(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.load_from_db).to eq @vm_1
+      end
+    end
+
+    context ".id" do
+      it "checks that .id is an alias for .dump" do
+        target_1 = ManagerRefresh::Target.load(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.dump).to eq target_1.id
+      end
+    end
+
+    context ".name" do
+      it "checks that .name is an alias for .association" do
+        target_1 = ManagerRefresh::Target.load(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.name).to eq target_1.manager_ref
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bringing new a ManagerRefresh::Target object, that allowed to be queue for the refresh. And adding ManagerRefresh::TargetCollection, to easily process related targets as well as helpers that allow to call the refresh from automate statemachine,