### PR TITLE
[EUWE] SCVMM - Enable VM reset functionality

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -2,7 +2,6 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   include_concern 'ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared'
 
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
-  supports     :reset
 
   POWER_STATES = {
     "Running"  => "on",
@@ -32,5 +31,9 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
 
   def validate_publish
     validate_unsupported("Publish VM")
+  end
+
+  def validate_reset
+    validate_vm_control_powered_on
   end
 end


### PR DESCRIPTION
Euwe backport of https://github.com/ManageIQ/manageiq/pull/14123
The `:reset` feature was added by https://github.com/ManageIQ/manageiq/pull/11625 and is `euwe/no` so we have to do this the old-fashioned way