### PR TITLE
Save newly created dialog_id in options

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -44,8 +44,9 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
           next unless dialog_name
 
           job_template = enhanced_config.fetch_path(action, :configuration_template)
-          enhanced_config[action][:dialog] =
-            Dialog::AnsiblePlaybookServiceDialog.create_dialog(dialog_name, job_template)
+          new_dialog = Dialog::AnsiblePlaybookServiceDialog.create_dialog(dialog_name, job_template)
+          enhanced_config[action][:dialog] = new_dialog
+          service_template.options[:config_info][action][:dialog_id] = new_dialog.id
         end
         service_template.create_resource_actions(enhanced_config)
       end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -142,6 +142,9 @@ describe ServiceTemplateAnsiblePlaybook do
         :fqname                 => described_class.default_provisioning_entry_point('atomic'),
         :configuration_template => job_template
       )
+
+      saved_options = catalog_item_options_two[:config_info].deep_merge(:provision => {:dialog_id => service_template.dialogs.first.id})
+      expect(service_template.options[:config_info]).to include(saved_options)
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140972071

The dialog_id allows the UI to show the newly created dialog in the list of existing ones.