### PR TITLE
Move embedded ansible worker thread up to start_runner

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -14,7 +14,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     update_embedded_ansible_provider
   rescue => err
     _log.log_backtrace(err)
-    do_exit
+    do_exit(err.message, 1)
   end
 
   def do_work_loop
@@ -25,7 +25,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     end
   rescue => err
     _log.log_backtrace(err)
-    do_exit
+    do_exit(err.message, 1)
   end
 
   def setup_ansible

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -9,20 +9,20 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     self
   end
 
+  def do_before_work_loop
+    setup_ansible
+    update_embedded_ansible_provider
+  rescue => err
+    _log.log_backtrace(err)
+    do_exit
+  end
+
   def do_work_loop
     _log.info("entering ansible monitor loop")
     loop do
       do_work
       send(poll_method)
     end
-  rescue => err
-    _log.log_backtrace(err)
-    do_exit
-  end
-
-  def do_before_work_loop
-    setup_ansible
-    update_embedded_ansible_provider
   rescue => err
     _log.log_backtrace(err)
     do_exit

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -45,10 +45,8 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     end
   end
 
-  def do_exit(*args)
+  def before_exit(*_)
     EmbeddedAnsible.disable
-  ensure
-    super
   end
 
   def update_embedded_ansible_provider

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -2,29 +2,30 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   self.wait_for_worker_monitor = false
 
   def prepare
-    # Override prepare so we don't get set as started
+    ObjectSpace.garbage_collect
+    # Overriding prepare so we can set started when we're ready
+    do_before_work_loop
+    started_worker_record
     self
   end
 
-  # This thread runs forever until a stop request is received, which with send us to do_exit to exit our thread
   def do_work_loop
-    Thread.new do
-      begin
-        setup_ansible
-        started_worker_record
-
-        update_embedded_ansible_provider
-
-        _log.info("entering ansible monitor loop")
-        loop do
-          do_work
-          send(poll_method)
-        end
-      rescue => err
-        _log.log_backtrace(err)
-        do_exit
-      end
+    _log.info("entering ansible monitor loop")
+    loop do
+      do_work
+      send(poll_method)
     end
+  rescue => err
+    _log.log_backtrace(err)
+    do_exit
+  end
+
+  def do_before_work_loop
+    setup_ansible
+    update_embedded_ansible_provider
+  rescue => err
+    _log.log_backtrace(err)
+    do_exit
   end
 
   def setup_ansible
@@ -44,16 +45,10 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     end
   end
 
-  # Because we're running in a thread on the Server
-  # we need to intercept SystemExit and exit our thread,
-  # not the main server thread!
   def do_exit(*args)
     # ensure this doesn't fail or that we can still get to the super call
     EmbeddedAnsible.disable
     super
-  rescue SystemExit
-    _log.info("#{log_prefix} SystemExit received, exiting monitoring Thread")
-    Thread.exit
   end
 
   def update_embedded_ansible_provider

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -17,15 +17,6 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     do_exit(err.message, 1)
   end
 
-  def setup_ansible
-    _log.info("calling EmbeddedAnsible.configure")
-    EmbeddedAnsible.configure unless EmbeddedAnsible.configured?
-
-    _log.info("calling EmbeddedAnsible.start")
-    EmbeddedAnsible.start
-    _log.info("calling EmbeddedAnsible.start finished")
-  end
-
   def heartbeat
     super if EmbeddedAnsible.alive?
   end
@@ -36,6 +27,15 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
   def before_exit(*_)
     EmbeddedAnsible.disable
+  end
+
+  def setup_ansible
+    _log.info("calling EmbeddedAnsible.configure")
+    EmbeddedAnsible.configure unless EmbeddedAnsible.configured?
+
+    _log.info("calling EmbeddedAnsible.start")
+    EmbeddedAnsible.start
+    _log.info("calling EmbeddedAnsible.start finished")
   end
 
   def update_embedded_ansible_provider

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -46,8 +46,8 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def do_exit(*args)
-    # ensure this doesn't fail or that we can still get to the super call
     EmbeddedAnsible.disable
+  ensure
     super
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1204,6 +1204,7 @@
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
     :embedded_ansible_worker:
+      :starting_timeout: 20.minutes
       :poll: 10.seconds
       :memory_threshold: 0.megabytes
     :ems_refresh_core_worker:

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -13,6 +13,13 @@ describe EmbeddedAnsibleWorker::Runner do
       described_class.new(:guid => worker_guid)
     }
 
+    it "#do_before_work_loop exits on exceptions" do
+      expect(runner).to receive(:setup_ansible)
+      expect(runner).to receive(:update_embedded_ansible_provider).and_raise(StandardError)
+      expect(runner).to receive(:do_exit)
+      runner.do_before_work_loop
+    end
+
     context "#update_embedded_ansible_provider" do
       before do
         EvmSpecHelper.local_guid_miq_server_zone


### PR DESCRIPTION
This is a followup to feedback in #14053 and was implemented with @carbonin's and @Fryguy 's extensive help:

* move the thread creation and knowledge to `start_runner`, the same place `miq_worker.rb` uses `fork`
* with thread knowledge out of the runner, we can remove our simplified `do_work_loop` and just use the base class's version
* remove `do_exit` overriding by using the long forgotten `before_exit` hook (at least forgotten by me)
* simplify `do_work` by overriding `heartbeat` to only call `super` if it's alive