### PR TITLE
[EUWE] Backport for Fix for Service Dialog not saving default value <None> for drop down or radio button

### DIFF
--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -1,11 +1,6 @@
 module ApplicationHelper::Dialogs
-  def dialog_dropdown_select_values(field, selected_value, category_tags = nil)
+  def dialog_dropdown_select_values(field, _selected_value, category_tags = nil)
     values = []
-    if !field.required
-      values.push(["<None>", nil])
-    elsif selected_value.blank?
-      values.push(["<Choose>", nil])
-    end
     if field.type.include?("DropDown")
       values += field.values.collect(&:reverse)
     elsif field.type.include?("TagControl")

--- a/app/helpers/application_helper/dialogs.rb
+++ b/app/helpers/application_helper/dialogs.rb
@@ -110,6 +110,19 @@ module ApplicationHelper::Dialogs
     add_options_unless_read_only({}, tag_options, field)
   end
 
+  def default_value_form_options(field_type, field_values, field_default_value)
+    no_default_value = [["<#{_('None')}>", nil]]
+    if field_values.empty?
+      values = no_default_value
+    else
+      values = field_values.collect(&:reverse)
+      values = no_default_value + values if field_type == "DialogFieldRadioButton"
+    end
+
+    selected = field_default_value || nil
+    options_for_select(values, selected)
+  end
+
   def build_auto_refreshable_field_indicies(workflow)
     auto_refreshable_field_indicies = []
 

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -4,6 +4,19 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   end
 
   def initial_values
-    [["", "<None>"]]
+    [[nil, "<None>"]]
+  end
+
+  private
+
+  def raw_values
+    @raw_values ||= dynamic ? values_from_automate : static_raw_values
+    self.value ||= default_value if default_value_included_in_raw_values?
+
+    @raw_values
+  end
+
+  def static_raw_values
+    self[:values].to_miq_a
   end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -91,13 +91,24 @@ class DialogFieldSortedItem < DialogField
   end
 
   def raw_values
-    @raw_values ||= dynamic ? values_from_automate : self[:values].to_miq_a
-    unless @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
-      self.default_value = sort_data(@raw_values).first.try(:first)
-    end
+    @raw_values ||= dynamic ? values_from_automate : static_raw_values
+    use_first_value_as_default unless default_value_included_in_raw_values?
     self.value ||= default_value
 
     @raw_values
+  end
+
+  def use_first_value_as_default
+    self.default_value = sort_data(@raw_values).first.try(:first)
+  end
+
+  def default_value_included_in_raw_values?
+    @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
+  end
+
+  def static_raw_values
+    first_values = required? ? [[nil, "<Choose>"]] : initial_values
+    first_values + self[:values].to_miq_a.reject { |value| value[0].nil? }
   end
 
   def initial_values

--- a/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_non_dynamic_options.html.haml
@@ -114,12 +114,9 @@
     %label.col-md-2.control-label
       = _('Default Value')
     .col-md-8
-      - none = [["<#{_('None')}>", nil]]
-      - values = @edit[:field_values].empty? ? none : none + @edit[:field_values].collect(&:reverse)
-      - selected = @edit[:field_default_value] || nil
       = select_tag("field_default_value",
-                    options_for_select(values, selected),
-                    :class    => "selectpicker")
+                   default_value_form_options(@edit[:field_typ], @edit[:field_values], @edit[:field_default_value]),
+                   :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent("field_default_value", "#{url}")
   .form-group

--- a/app/views/miq_ae_customization/_dialog_sample.html.haml
+++ b/app/views/miq_ae_customization/_dialog_sample.html.haml
@@ -86,22 +86,15 @@
                                     options_for_select(val.collect(&:reverse), field.default_value))
                                 - else
                                   = select_tag('field.id',
-                                              options_for_select([["<#{_('Choose')}>", nil]] + val.collect(&:reverse),
-                                                                  field.default_value))
+                                              options_for_select(val.collect(&:reverse), field.default_value))
 
                               - else
                                 -# NOT REQUIRED
                                 = select_tag('field.id',
-                                              options_for_select([["#{_('None')}", nil]] + val.collect(&:reverse),
-                                                                  field.default_value))
+                                              options_for_select(val.collect(&:reverse), field.default_value))
 
                             - else
                               - val.each_with_index do |rb, i|
-                                - unless field.required || i != 0
-                                  %input{:type => "radio", :disabled => true, :checked => field.default_value.nil?,
-                                    :id => "None", :value => "nil", :name => "None"}
-                                  &nbsp; None &nbsp;
-
                                 %input{:type => "radio", :disabled => true, :checked => (field.default_value == rb[0]),
                                   :id => rb[0], :value => rb[1], :name => rb[0]}
                                 &nbsp;

--- a/app/views/miq_ae_customization/_field_values.html.haml
+++ b/app/views/miq_ae_customization/_field_values.html.haml
@@ -17,7 +17,8 @@
         - else
           = render :partial => "field_value_entry", :locals => {:entry => "new", :edit => false}
         - @edit[:field_values].each_with_index do |e, i|
-          - if !entry.nil? && entry != "new" && entry.to_i == i
-            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
-          - else
-            = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}
+          - unless e[0].nil?
+            - if !entry.nil? && entry != "new" && entry.to_i == i
+              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => true}
+            - else
+              = render :partial => "field_value_entry", :locals => {:entry => e, :idx => i, :edit => false}

--- a/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_radio_button.html.haml
@@ -1,9 +1,7 @@
 - if edit
   - if field.values.length > 1
     %span{:id => "dynamic-radio-#{field.id}"}
-      - values = field.values
-      - values = [['', "<#{_('None')}>"]] + values if !field.required && !field.dynamic
-      - values.each do |rb|
+      - field.values.each do |rb|
 
         %input{radio_options(field, url, rb[0], wf.value(field.name))}
         %label.dynamic-radio-label= rb[1]

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -506,4 +506,104 @@ describe ApplicationHelper::Dialogs do
       expect(helper.auto_refresh_listening_options(options, true)).to eq(:trigger => true)
     end
   end
+
+  describe "#default_value_form_options" do
+    let(:subject) { helper.default_value_form_options(field_type, field_values, field_default_value) }
+
+    context "when the field values are empty" do
+      let(:field_values) { [] }
+
+      context "when the field type is a DialogFieldDropDownList" do
+        let(:field_type) { "DialogFieldDropDownList" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "some default" }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+      end
+
+      context "when the field type is a DialogFieldRadioButton" do
+        let(:field_type) { "DialogFieldRadioButton" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "some default" }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expect(subject).to eq("<option value=\"\">&lt;None&gt;</option>")
+          end
+        end
+      end
+    end
+
+    context "when the field values are not empty" do
+      let(:field_values) { [%w(123 456)] }
+
+      context "when the field type is a DialogFieldDropDownList" do
+        let(:field_type) { "DialogFieldDropDownList" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "123" }
+
+          it "selects the default value and does not add any" do
+            expect(subject).to eq("<option selected=\"selected\" value=\"123\">456</option>")
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "does not explicitly select anything" do
+            expect(subject).to eq("<option value=\"123\">456</option>")
+          end
+        end
+      end
+
+      context "when the field type is a DialogFieldRadioButton" do
+        let(:field_type) { "DialogFieldRadioButton" }
+
+        context "when the field default value is set" do
+          let(:field_default_value) { "123" }
+
+          it "adds the ability to select no default value but selects the default" do
+            expected_html = <<-HTML
+<option value=\"\">&lt;None&gt;</option>
+<option selected=\"selected\" value=\"123\">456</option>
+            HTML
+            expect(subject).to eq(expected_html.chomp)
+          end
+        end
+
+        context "when the field default value is not set" do
+          let(:field_default_value) { nil }
+
+          it "adds the ability to select no default value" do
+            expected_html = <<-HTML
+<option value=\"\">&lt;None&gt;</option>
+<option value=\"123\">456</option>
+            HTML
+            expect(subject).to eq(expected_html.chomp)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper/dialogs_spec.rb
+++ b/spec/helpers/application_helper/dialogs_spec.rb
@@ -10,25 +10,23 @@ describe ApplicationHelper::Dialogs do
   let(:trigger_auto_refresh) { nil }
 
   describe "#dialog_dropdown_select_values" do
-    before do
-      val_array = [["cat", "Cat"], ["dog", "Dog"]]
-      @val_array_reversed = val_array.collect(&:reverse)
-      @field = DialogFieldDropDownList.new(:values => val_array)
+    let(:dialog_field) { instance_double("DialogFieldDropDownList", :values => values, :type => type) }
+    let(:values) { [%w(cat Cat), %w(dog Dog)] }
+
+    context "when the field type includes drop down" do
+      let(:type) { "BananaDropDown" }
+
+      it "returns the values collected and reversed" do
+        expect(helper.dialog_dropdown_select_values(dialog_field, nil)).to eq(values.collect(&:reverse))
+      end
     end
 
-    it "not required" do
-      @field.required = false
-      expect(helper.dialog_dropdown_select_values(@field, nil)).to eq([["<None>", nil]] + @val_array_reversed)
-    end
+    context "when the field type includes tag control" do
+      let(:type) { "BananaTagControl" }
 
-    it "required, nil selected" do
-      @field.required = true
-      expect(helper.dialog_dropdown_select_values(@field, nil)).to eq([["<Choose>", nil]] + @val_array_reversed)
-    end
-
-    it "required, non-nil selected" do
-      @field.required = true
-      expect(helper.dialog_dropdown_select_values(@field, "cat")).to eq(@val_array_reversed)
+      it "returns the values with the passed in category tags" do
+        expect(helper.dialog_dropdown_select_values(dialog_field, nil, %w(category tags))).to eq(%w(category tags))
+      end
     end
   end
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -132,7 +132,7 @@ describe DialogFieldDropDownList do
 
       it "returns the values" do
         expect(dialog_field.refresh_json_value("789")).to eq(
-          :refreshed_values => [["789", 101], ["123", 456]],
+          :refreshed_values => [["789", 101], ["123", 456], [nil, "<None>"]],
           :checked_value    => "789",
           :read_only        => true,
           :visible          => true

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -24,51 +24,51 @@ describe DialogFieldDropDownList do
 
     it "return sorted values array as strings" do
       @df.data_type = "string"
-      @df.values = [["2", "Y"], ["1", "Z"], ["3", "X"]]
-      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
+      @df.values = [%w(2 Y), %w(1 Z), %w(3 X)]
+      expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
+      expect(@df.values).to eq([%w(1 Z), %w(2 Y), %w(3 X), [nil, "<None>"]])
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["1", "Z"], ["2", "Y"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["3", "X"], ["2", "Y"], ["1", "Z"]])
+      expect(@df.values).to eq([%w(3 X), %w(2 Y), %w(1 Z), [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["2", "Y"], ["1", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
     end
 
     it "return sorted values array as integers" do
       @df.data_type = "integer"
-      @df.values = [["2", "Y"], ["10", "Z"], ["3", "X"]]
+      @df.values = [%w(2 Y), %w(10 Z), %w(3 X)]
 
       @df.sort_by = :value
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["3", "X"], ["10", "Z"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(3 X), %w(10 Z)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["10", "Z"], ["3", "X"], ["2", "Y"]])
+      expect(@df.values).to eq([%w(10 Z), %w(3 X), %w(2 Y), [nil, "<None>"]])
 
       @df.sort_by = :none
       @df.sort_order = :ascending
-      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
       @df.sort_order = :descending
-      expect(@df.values).to eq([["2", "Y"], ["10", "Z"], ["3", "X"]])
+      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
     end
 
     context "#initialize_with_values" do
       before(:each) do
-        @df.values = [["3", "X"], ["2", "Y"], ["1", "Z"]]
+        @df.values = [%w(3 X), %w(2 Y), %w(1 Z)]
         @df.load_values_on_init = true
       end
 
-      it "uses the first as the default value" do
+      it "uses the nil as the default value" do
         @df.default_value = nil
         @df.initialize_with_values({})
-        expect(@df.value).to eq("3")
+        expect(@df.value).to eq(nil)
       end
 
       it "with default value" do
@@ -77,10 +77,10 @@ describe DialogFieldDropDownList do
         expect(@df.value).to eq("1")
       end
 
-      it "uses the first when there is a non-matching default value" do
+      it "uses the nil when there is a non-matching default value" do
         @df.default_value = "4"
         @df.initialize_with_values({})
-        expect(@df.value).to eq("3")
+        expect(@df.value).to eq(nil)
       end
     end
 
@@ -183,11 +183,11 @@ describe DialogFieldDropDownList do
 
       context "when the raw values are not already set" do
         before do
-          dialog_field.values = %w(original values)
+          dialog_field.values = [%w(original values)]
         end
 
         it "returns the values" do
-          expect(dialog_field.values).to eq(%w(original values))
+          expect(dialog_field.values).to eq([[nil, "<None>"], %w(original values)])
         end
       end
     end
@@ -228,11 +228,11 @@ describe DialogFieldDropDownList do
       context "when the raw values are already set" do
         before do
           dialog_field.instance_variable_set(:@raw_values, %w(potato potato))
-          dialog_field.values = %w(original values)
+          dialog_field.values = [%w(original values)]
         end
 
         it "returns the raw values" do
-          expect(dialog_field.trigger_automate_value_updates).to eq(%w(original values))
+          expect(dialog_field.trigger_automate_value_updates).to eq([[nil, "<None>"], %w(original values)])
         end
       end
 
@@ -242,12 +242,12 @@ describe DialogFieldDropDownList do
         end
 
         it "returns the values" do
-          expect(dialog_field.trigger_automate_value_updates).to eq([%w(original values)])
+          expect(dialog_field.trigger_automate_value_updates).to eq([[nil, "<None>"], %w(original values)])
         end
 
         it "sets up the default value" do
           dialog_field.trigger_automate_value_updates
-          expect(dialog_field.default_value).to eq("original")
+          expect(dialog_field.default_value).to eq(nil)
         end
       end
 

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -49,7 +49,9 @@ describe DialogFieldRadioButton do
           end
 
           it "sets raw values from values attribute" do
-            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
+              [["testing", 123]]
+            )
           end
         end
       end
@@ -61,7 +63,7 @@ describe DialogFieldRadioButton do
         end
 
         it "sets raw_values to initial values" do
-          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["", "<None>"]])
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([[nil, "<None>"]])
         end
       end
     end
@@ -95,7 +97,9 @@ describe DialogFieldRadioButton do
         end
 
         it "gets values from values attribute" do
-          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["testing", 123]])
+          expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(
+            [["testing", 123]]
+          )
         end
       end
     end
@@ -157,10 +161,10 @@ describe DialogFieldRadioButton do
     context "when the checked value is not in the list of refreshed values" do
       let(:refreshed_values_from_automate) { [%w(123 123)] }
 
-      it "returns the list of refreshed values and checked (default) value as a hash" do
+      it "returns the list of refreshed values and no checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(
           :refreshed_values => refreshed_values_from_automate,
-          :checked_value    => "123",
+          :checked_value    => nil,
           :read_only        => false,
           :visible          => true
         )

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -1,17 +1,15 @@
 describe DialogFieldSortedItem do
-  let(:df) { FactoryGirl.build(:dialog_field_sorted_item, :label => 'dialog_field', :name => 'dialog_field') }
-
   describe "#initialize_with_values" do
     let(:dialog_field) do
       described_class.new(
         :name                => "potato_name",
-        :default_value       => default_value,
+        :default_value       => "test2",
+        :dynamic             => true,
         :load_values_on_init => load_values_on_init,
         :show_refresh_button => show_refresh_button,
         :values              => [%w(test test), %w(test2 test2)]
       )
     end
-    let(:default_value) { "test2" }
 
     context "when show_refresh_button is true" do
       let(:show_refresh_button) { true }
@@ -40,20 +38,9 @@ describe DialogFieldSortedItem do
         context "when the values from the passed in dialog values do not match either the automate or dialog name" do
           let(:dialog_values) { {"not_potato_name" => "not potato value"} }
 
-          context "when the default value does not exist in the list of options" do
-            let(:default_value) { "default value" }
-
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
-            end
+          it "defaults to nil" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq(nil)
           end
         end
       end
@@ -99,16 +86,9 @@ describe DialogFieldSortedItem do
           context "when the default value does not exist in the list of options" do
             let(:default_value) { "default value" }
 
-            it "uses the default value of the dialog field" do
+            it "defaults to nil" do
               dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
+              expect(dialog_field.value).to eq(nil)
             end
           end
         end
@@ -138,41 +118,120 @@ describe DialogFieldSortedItem do
         context "when the values from the passed in dialog values do not match either the automate or dialog name" do
           let(:dialog_values) { {"not_potato_name" => "not potato value"} }
 
-          context "when the default value does not exist in the list of options" do
-            let(:default_value) { "default value" }
-
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test")
-            end
-          end
-
-          context "when the default value does exist in the list of options" do
-            it "uses the default value of the dialog field" do
-              dialog_field.initialize_with_values(dialog_values)
-              expect(dialog_field.value).to eq("test2")
-            end
+          it "defaults to nil" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq(nil)
           end
         end
       end
     end
   end
 
-  describe "#get_default_value" do
-    it "returns the first value when no default and only a single value is available" do
-      df.values = [%w(value1 text1)]
-      expect(df.get_default_value).to eq("value1")
+  describe "#values" do
+    let(:dialog_field) do
+      described_class.new(
+        :default_value => default_value,
+        :dynamic       => dynamic,
+        :required      => required,
+        :sort_by       => :none,
+        :values        => values
+      )
+    end
+    let(:values) { [%w(test test), %w(abc abc)] }
+    let(:required) { false }
+
+    context "when the field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(values)
+      end
+
+      context "when the default_value is included in the list of returned values" do
+        let(:default_value) { "abc" }
+
+        it "sets the default value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("abc")
+        end
+
+        it "sets the value to the default value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("abc")
+        end
+      end
+
+      context "when the default_value is not included in the list of returned values" do
+        let(:default_value) { "123" }
+
+        it "sets the default value to the first value" do
+          dialog_field.values
+          expect(dialog_field.default_value).to eq("test")
+        end
+
+        it "sets the value to the default value" do
+          dialog_field.values
+          expect(dialog_field.value).to eq("test")
+        end
+      end
     end
 
-    it "returns the first value when no default and multiple values are available" do
-      df.values = [%w(value1 text1), %w(value2 text2)]
-      expect(df.get_default_value).to eq("value1")
+    context "when the field is not dynamic" do
+      let(:dynamic) { false }
+      let(:default_value) { "abc" }
+
+      context "when the field is required" do
+        let(:required) { true }
+
+        it "returns the values with the first option being a nil 'Choose' option" do
+          expect(dialog_field.values).to eq([[nil, "<Choose>"], %w(test test), %w(abc abc)])
+        end
+      end
+
+      context "when the field is not required" do
+        it "returns the values with the first option being a nil 'None' option" do
+          expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
+        end
+      end
+    end
+  end
+
+  describe "#get_default_value" do
+    let(:dialog_field) { described_class.new(:default_value => default_value, :values => values) }
+    let(:values) { [%w(value1 text1), %w(value2 text2)] }
+
+    context "when the default value is set to nil" do
+      let(:default_value) { nil }
+
+      it "returns nil as the default value" do
+        expect(dialog_field.get_default_value).to eq(nil)
+      end
+    end
+
+    context "when the default value exists" do
+      context "when the default value matches with a value in the list" do
+        let(:default_value) { "value2" }
+
+        it "returns the matched value" do
+          expect(dialog_field.get_default_value).to eq("value2")
+        end
+      end
+
+      context "when the default value does not match with a value in the list" do
+        let(:default_value) { "value3" }
+
+        it "returns nil" do
+          expect(dialog_field.get_default_value).to eq(nil)
+        end
+      end
     end
   end
 
   describe "#script_error_values" do
+    let(:dialog_field) { described_class.new }
+
     it "returns the script error values" do
-      expect(df.script_error_values).to eq([[nil, "<Script error>"]])
+      expect(dialog_field.script_error_values).to eq([[nil, "<Script error>"]])
     end
   end
 
@@ -226,7 +285,7 @@ describe DialogFieldSortedItem do
       it_behaves_like "DialogFieldSortedItem#normalize_automate_values"
 
       it "returns the initial values of the dialog field" do
-        expect(dialog_field.normalize_automate_values(automate_hash)).to eq([["", "<None>"]])
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq([[nil, "<None>"]])
       end
     end
 

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -73,8 +73,8 @@ describe AnsibleTowerJobTemplateDialogService do
     assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
     assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
     assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
-    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
-    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), %w(opt1 opt1), %w(opt3 opt3)])
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [[nil, "<Choose>"], %w(Apple Apple), %w(Banana Banana), %w(Peach Peach)])
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "opt1",  :values => [%w(222 222), [nil, "<Choose>"], %w(opt1 opt1), %w(opt3 opt3)])
     assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
   end
 

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -76,7 +76,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
     assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
     assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
-    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [%w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
+    assert_field(fields[2], DialogFieldDropDownList, :name => "stack_onfailure", :values => [[nil, "<Choose>"], %w(DO_NOTHING Do\ nothing), %w(ROLLBACK Rollback)])
     assert_field(fields[3], DialogFieldTextBox,      :name => "stack_timeout",   :data_type => 'integer')
   end
 
@@ -95,7 +95,8 @@ describe OrchestrationTemplateDialogService do
     assert_field(fields[2], DialogFieldDropDownList, :name => "resource_group",     :dynamic => true)
     assert_field(fields[3], DialogFieldTextBox,      :name => "new_resource_group", :validator_rule => '^[A-Za-z][A-Za-z0-9\-_]*$')
 
-    mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
+    mode_values = [[nil,           "<Choose>"],
+                   ["Complete",    "Complete (Delete other resources in the group)"],
                    ["Incremental", "Incremental (Default)"]]
     assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
     expect(fields[4].default_value).to eq("Incremental")
@@ -145,7 +146,7 @@ describe OrchestrationTemplateDialogService do
     expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox,      :name => "param_flavor",     :default_value => "m1.small")
-    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [%w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
+    assert_field(fields[1], DialogFieldDropDownList, :name => "param_image_id",   :default_value => "F18-x86_64-cfntools", :values => [[nil, "<Choose>"], %w(F18-i386-cfntools F18-i386-cfntools), %w(F18-x86_64-cfntools F18-x86_64-cfntools)])
     assert_field(fields[2], DialogFieldTextBox,      :name => "param_cartridges", :default_value => "cron,diy,haproxy,mysql,nodejs,perl,php,postgresql,python,ruby")
   end
 


### PR DESCRIPTION
This backport includes the code from https://github.com/ManageIQ/manageiq/pull/14240 and the UI side from https://github.com/ManageIQ/manageiq-ui-classic/pull/633.

Conflicts on main repo side were minor, but I had to manually patch the UI side as there was a change in one of the files that didn't allow `git apply` or `git am` to even try to process the whole file.

@gmcculloug Not sure what other labels should be added here, if any. Also assigning you but if someone else should be then please change it :smile:

/cc @simaishi 

@miq-bot assign @gmcculloug 
@miq-bot add_label bug