### PR TITLE
[WIP] Adds lib/miq_benchmark to benchmark per PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ env:
   - TEST_SUITE=brakeman
 matrix:
   fast_finish: true
+  include:
+    - rvm: '2.3.1'
+      env: TEST_SUITE=miq_benchmark
+      sudo: required
 addons:
   postgresql: '9.4'
 before_install:

--- a/lib/miq_benchmark/kernel_require_patch.rb
+++ b/lib/miq_benchmark/kernel_require_patch.rb
@@ -1,0 +1,85 @@
+# This is a modified version of the core_ext patches to Kernel::require, originally
+# authored by Richard Schneeman (@schneems):
+#
+#   https://github.com/schneems/derailed_benchmarks/blob/2a736e1/lib/derailed_benchmarks/require_tree.rb
+#
+# No current license exists.
+
+require 'bigdecimal'
+require 'sys/proctable'
+require 'English'
+require_relative 'require_tree'
+
+ENV['CUT_OFF'] ||= "0.3"
+
+# This file contains classes and monkey patches to measure the amount of memory
+# useage requiring an individual file adds.
+
+# Monkey patch kernel to ensure that all `require` calls call the same
+# method
+module Kernel
+  alias original_require require
+  MEMORY_MB_PROC = proc { (Sys::ProcTable.ps($PID).rss / ::BigDecimal.new(1_048_576)).to_f }
+
+  def require(file)
+    Kernel.require(file)
+  end
+
+  # This breaks things, not sure how to fix
+  # def require_relative(file)
+  #   Kernel.require_relative(file)
+  # end
+  class << self
+    attr_writer :require_stack
+    alias original_require require
+    # alias :original_require_relative :require_relative
+
+    def require_stack
+      @require_stack ||= []
+    end
+  end
+
+  # The core extension we use to measure require time of all requires
+  # When a file is required we create a tree node with its file name.
+  # We then push it onto a stack, this is because requiring a file can
+  # require other files before it is finished.
+  #
+  # When a child file is required, a tree node is created and the child file
+  # is pushed onto the parents tree. We then repeat the process as child
+  # files may require additional files.
+  #
+  # When a require returns we remove it from the require stack so we don't
+  # accidentally push additional children nodes to it. We then store the
+  # memory cost of the require in the tree node.
+  def self.measure_memory_impact(file, &block)
+    node   = MiqBenchmark::RequireTree.new(file)
+
+    parent = require_stack.last
+    parent << node
+    require_stack.push(node)
+    begin
+      before = ::Kernel::MEMORY_MB_PROC.call
+      block.call file
+    ensure
+      require_stack.pop # node
+      after = ::Kernel::MEMORY_MB_PROC.call
+    end
+    node.cost = after - before
+  end
+end
+
+# Top level node that will store all require information for the entire app
+TOP_REQUIRE = MiqBenchmark::RequireTree.new("TOP")
+::Kernel.require_stack.push(TOP_REQUIRE)
+
+Kernel.define_singleton_method(:require) do |file|
+  measure_memory_impact(file) { |f| original_require(f) }
+end
+
+# Don't forget to assign a cost to the top level
+# cost_before_requiring_anything = GetProcessMem.new.mb
+cost_before_requiring_anything = ::Kernel::MEMORY_MB_PROC.call
+TOP_REQUIRE.cost = cost_before_requiring_anything
+def TOP_REQUIRE.set_top_require_cost
+  self.cost = ::Kernel::MEMORY_MB_PROC.call - cost
+end

--- a/lib/miq_benchmark/mem_full_load_benchmark.rb
+++ b/lib/miq_benchmark/mem_full_load_benchmark.rb
@@ -1,0 +1,32 @@
+require 'yaml'
+
+require_relative 'kernel_require_patch'
+
+ENV['LOG_LEVEL']              = "FATAL"
+ENV["RAILS_ENV"]              = "production"
+ENV['RACK_ENV']               = ENV["RAILS_ENV"]
+ENV["DISABLE_SPRING"]         = "true"
+ENV['RAILS_USE_MEMORY_STORE'] = "1"
+
+require ::File.expand_path('../../../config/application', __FILE__)
+
+Vmdb::Application.configure do
+  config.instance_variable_set(:@eager_load, true)
+end
+
+# Prevent overriding the @eager_load variable in the `config/environments/production.rb`
+class Rails::Application::Configuration
+  def eager_load=(value)
+  end
+
+  def eager_load_paths=(value)
+  end
+end
+
+Vmdb::Application.initialize!
+
+TOP_REQUIRE.set_top_require_cost
+
+# puts TOP_REQUIRE.flattened_full_hash_output.to_yaml
+TOP_REQUIRE.print_sorted_children
+TOP_REQUIRE.print_summary

--- a/lib/miq_benchmark/mem_full_load_benchmark.rb
+++ b/lib/miq_benchmark/mem_full_load_benchmark.rb
@@ -2,6 +2,7 @@ require 'yaml'
 
 require_relative 'kernel_require_patch'
 
+ENV['CUT_OFF']                = "0.0"
 ENV['LOG_LEVEL']              = "FATAL"
 ENV["RAILS_ENV"]              = "production"
 ENV['RACK_ENV']               = ENV["RAILS_ENV"]
@@ -29,4 +30,5 @@ TOP_REQUIRE.set_top_require_cost
 
 # puts TOP_REQUIRE.flattened_full_hash_output.to_yaml
 TOP_REQUIRE.print_sorted_children
+ENV['CUT_OFF'] = "0.3"
 TOP_REQUIRE.print_summary

--- a/lib/miq_benchmark/require_tree.rb
+++ b/lib/miq_benchmark/require_tree.rb
@@ -1,0 +1,114 @@
+# This is a modified version of the DerailedBenchmarks::RequireTree, originally
+# authored by Richard Schneeman (@schneems):
+#
+#   https://github.com/schneems/derailed_benchmarks/blob/2a736e1/lib/derailed_benchmarks/require_tree.rb
+#
+# No current license exists.
+
+# Tree structure used to store and sort require memory costs
+# RequireTree.new('get_process_mem')
+
+module MiqBenchmark
+  class RequireTree
+    attr_reader   :name
+    attr_accessor :cost
+    attr_accessor :parent
+
+    def self.required_by
+      @required_by ||= {}
+    end
+
+    def initialize(name)
+      @name     = name
+      @children = {}
+    end
+
+    def <<(tree)
+      @children[tree.name.to_s] = tree
+      tree.parent = self
+      (self.class.required_by[tree.name.to_s] ||= []) << name
+    end
+
+    def [](name)
+      @children[name.to_s]
+    end
+
+    # Returns array of child nodes
+    def children
+      @children.values
+    end
+
+    def cost
+      @cost || 0
+    end
+
+    def short_name
+      @short_name ||= name.gsub(/^#{Dir.home}.*\/bundler\/gems\//, '')
+                          .gsub(/^([^\/]+)-[0-9a-f]+\//, '\1/')
+                          .gsub(/^#{defined?(Rails) ? Rails.root : Dir.pwd}\//, '')
+    end
+
+    # Returns sorted array of child nodes from Largest to Smallest
+    def sorted_children
+      children.sort { |c1, c2| c2.cost <=> c1.cost }
+    end
+
+    def to_string
+      str = "#{short_name}: #{cost.round(4)} MiB"
+      if parent && self.class.required_by[name.to_s]
+        names = self.class.required_by[name.to_s].uniq - [parent.name.to_s]
+        if names.any?
+          str << " (Also required by: #{names.first(2).join(", ")}"
+          str << ", and #{names.count - 2} others" if names.count > 3
+          str << ")"
+        end
+      end
+      str
+    end
+
+    def flattened_full_hash_output(data = {})
+      data[name] = cost
+      sorted_children.each do |child|
+        child.flattened_full_hash_output data
+      end
+      data
+    end
+
+    def full_hash_output(data = {})
+      data["name"] = name
+      data["cost"] = cost
+      data["children"] = []
+      sorted_children.each do |child|
+        data["children"] << child.full_hash_output
+      end
+      data
+    end
+
+    # Recursively prints all child nodes
+    def print_sorted_children(level = 0, out = STDOUT)
+      return if cost < ENV['CUT_OFF'].to_f
+      out.puts "  " * level + to_string
+      level += 1
+      sorted_children.each do |child|
+        child.print_sorted_children(level, out)
+      end
+    end
+
+    def print_summary(out = STDOUT)
+      longest_name = sorted_children.map { |c| c.short_name.length }.max
+      longest_cost = sorted_children.map { |c| c.cost.round(4).to_s.length }.max
+
+      out.puts "\n\n\n"
+      out.puts "SUMMARY ( TOTAL COST: #{cost.round(4)} MiB )"
+      out.puts "-" * (longest_name + longest_cost + 7)
+
+      sorted_children.each do |child|
+        next if child.cost < ENV['CUT_OFF'].to_f
+        out.puts [
+          child.short_name.ljust(longest_name),
+          "#{"%.4f" % child.cost} MiB".rjust(longest_cost + 4)
+        ].join(' | ')
+      end
+    end
+  end
+end

--- a/lib/tasks/test_benchmark.rake
+++ b/lib/tasks/test_benchmark.rake
@@ -22,7 +22,51 @@ namespace :test do
     #     https://ruby-doc.org/core-2.4.0/Kernel.html#method-i-exec
     #
     # Allowing us to start fresh with the ruby memory poll.
-    exec "bundle exec ruby #{mem_benchmark_test_file}"
+    # exec "bundle exec ruby #{mem_benchmark_test_file}"
+    exec <<-SCRIPT
+      bundle exec ruby -e 'puts "#{mem_benchmark_test_file}"';
+
+      echo "shell out to ps..."
+      bundle exec ruby -e '
+        require "bigdecimal";
+        puts "Pid: \#{$$}";
+        puts "before: \#{((BigDecimal.new(%x{ps -o rss= -p \#{$$}}) * 1024)/::BigDecimal.new(1_048_576)).to_f}";
+        require "rbvmomi"
+        puts "after:  \#{((BigDecimal.new(%x{ps -o rss= -p \#{$$}}) * 1024)/::BigDecimal.new(1_048_576)).to_f}";';
+      echo;
+
+      echo "Using sys/proctable...";
+      bundle exec ruby -e '
+        require "bigdecimal";
+        require "sys/proctable";
+        puts "Pid: \#{$$}";
+        puts "before: \#{(Sys::ProcTable.ps($$).rss/::BigDecimal.new(1_048_576)).to_f}";
+        require "rbvmomi"
+        puts "after: \#{(Sys::ProcTable.ps($$).rss/::BigDecimal.new(1_048_576)).to_f}";';
+      echo;
+
+      echo "GemProcessMem method..."
+      bundle exec ruby -e '
+        require "bigdecimal";
+        def linux_status_memory;
+          file = Pathname.new("/proc/\#{$$}/status");
+          line = file.each_line.detect {|line| line.start_with? "VmRSS".freeze };
+          return unless line;
+          return unless (_name, value, unit = line.split(nil)).length == 3;
+          {"kb" => 1024, "mb" => 1_048_576, "gb" => 1_073_741_824}[unit.downcase!] * value.to_i;
+        rescue Errno::EACCES, Errno::ENOENT;
+          0;
+        end;
+        puts "Pid: \#{$$}";
+        puts "before: \#{(linux_status_memory/::BigDecimal.new(1_048_576)).to_f;}"
+        require "rbvmomi"
+        puts "after:  \#{(linux_status_memory/::BigDecimal.new(1_048_576)).to_f;}"';
+      echo;
+
+      echo;
+      echo;
+      bundle exec ruby #{mem_benchmark_test_file};
+    SCRIPT
 
     # test scripts
     # exec %Q{bundle exec ruby -e 'puts "#{mem_benchmark_test_file}"'}

--- a/lib/tasks/test_benchmark.rake
+++ b/lib/tasks/test_benchmark.rake
@@ -1,0 +1,31 @@
+namespace :test do
+  namespace :miq_benchmark do
+    task :setup do
+      # Don't know why I am doing this in a seperate process... but I am... and it seems to work
+      exec <<-SCRIPT
+        export RAILS_USE_MEMORY_STORE=1;
+        export DISABLE_DATABASE_ENVIRONMENT_CHECK=1;
+        export RAILS_ENV=production;
+        export ERB_IN_CONFIG=1;
+        bundle exec rake db:create db:environment:set db:migrate > /dev/null;
+      SCRIPT
+    end
+  end
+
+  desc "Task description"
+  task :miq_benchmark do
+    mem_benchmark_test_file = File.expand_path "../../miq_benchmark/mem_full_load_benchmark.rb", __FILE__
+
+    # Running this with exec since we replace the current process with a new
+    # process, even though we keep the same PID.  See:
+    #
+    #     https://ruby-doc.org/core-2.4.0/Kernel.html#method-i-exec
+    #
+    # Allowing us to start fresh with the ruby memory poll.
+    exec "bundle exec ruby #{mem_benchmark_test_file}"
+
+    # test scripts
+    # exec %Q{bundle exec ruby -e 'puts "#{mem_benchmark_test_file}"'}
+    # exec %Q{bundle exec ruby -e 'require "bigdecimal"; require "sys/proctable"; puts $$; puts (Sys::ProcTable.ps($$).rss/::BigDecimal.new(1_048_576)).to_f'}
+  end
+end


### PR DESCRIPTION
Purpose
-------
Provide a per PR feedback loop to developers about trends/changes in the overall memory footprint of the application, and other benchmarks.  Currently, there is only a script to analyze memory after eager loading the entire project, but other tests are expected to follow.

**`mem_full_load_benchmark`**

This is heavily borrowing the code from [`derailed_benchmarks` project](https://github.com/schneems/derailed_benchmarks), specifically, the `perf:mem` task from the tool.  This currently doesn't make a request against a booted app, but does `eager_load` the entire application into memory to get a better picture of what is taking up the most amount of memory (if we didn't eager load, we would only see about 120 MiB allocated when booting up the application, v.s. alomst 300 MiB).

To see the report, you can currently run:

```console
$ bundle exec ruby lib/miq_benchmark/mem_full_load_benchmark.rb
```


And you should see some output like this:

```console
$ bundle exec ruby lib/miq_benchmark/mem_full_load_benchmark.rb
TOP: 281.1094 MiB
  config/application: 77.625 MiB
    omniauth-google-oauth2: 13.8086 MiB
      omniauth/google_oauth2: 13.7305 MiB
        omniauth/strategies/google_oauth2: 13.6563 MiB
          omniauth/strategies/oauth2: 9.1367 MiB
            oauth2: 6.3398 MiB
              oauth2/client: 3.8125 MiB
                faraday: 3.5742 MiB (Also required by: manageiq/api/client, faraday_middleware)
                  /Users/nicklamuro/.gem/ruby/2.3.3/gems/faraday-0.9.2/lib/faraday/upload_io: 0.6914 MiB
                  /Users/nicklamuro/.gem/ruby/2.3.3/gems/faraday-0.9.2/lib/faraday/response: 0.4492 MiB
              oauth2/mac_token: 0.5469 MiB
              oauth2/response: 0.5391 MiB
                multi_xml: 0.3633 MiB
            omniauth/strategy: 1.5313 MiB
              hashie/mash: 1.1719 MiB (Also required by: omniauth/auth_hash)
                hashie/hash: 0.4961 MiB
                hashie/array: 0.3867 MiB
            socket: 0.7617 MiB (Also required by: puma, puma/server, and 12 others)
          addressable/uri: 4.3867 MiB (Also required by: addressable, addressable/template)
            addressable/idna: 3.1523 MiB
              addressable/idna/pure: 2.6484 MiB
    active_record/railtie: 12.8789 MiB (Also required by: rails/all)
...

SUMMARY ( TOTAL COST: 281.1094 MiB )
-------------------------------------------------------------------------------------------------------------------------------------
config/application                                                                                                      | 77.6250 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager                                            | 44.5977 MiB
manageiq-providers-azure/app/models/manageiq/providers/azure/regions                                                    | 38.3359 MiB
manageiq-providers-vmware/app/models/manageiq/providers/vmware/cloud_manager                                            | 27.1094 MiB
vmdb_helper                                                                                                             | 11.5391 MiB
manageiq-ui-classic/app/presenters/tree_builder_buttons                                                                 |  3.0312 MiB
manageiq-ui-classic/app/controllers/miq_policy_controller                                                               |  2.9062 MiB
manageiq-ui-classic/app/controllers/alert_controller                                                                    |  2.5508 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/orchestration_service_option_converter     |  2.3906 MiB
action_cable/server/base                                                                                                |  2.0703 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/vm                                         |  1.4453 MiB
manageiq-providers-vmware/app/models/manageiq/providers/vmware/infra_manager/refresher                                  |  1.3789 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/provision                                  |  1.2695 MiB
automation_engine                                                                                                       |  1.1914 MiB
action_dispatch/routing/mapper                                                                                          |  1.1875 MiB
manageiq-ui-classic/app/decorators/manageiq/providers/ansible_tower/automation_manager/configuration_script_decorator   |  1.1641 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/network_manager                                          |  0.9961 MiB
manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner                       |  0.9297 MiB
config/environments/production.rb                                                                                       |  0.9141 MiB
...
```

Implementation Notes
--------------------
Some monkey patching was necessary to make this work:

  * `Kernel::require` - this is taken from `derailed_benchmarks`, so pretty well tested.  Nothing really changed in that file from the source.
  * `Rails::Application::Configuration` - Needed to force eager_loading even though we don't do it in our project in any environment.  This was the best way I could think of doing it based on my limited knowledge of the Rails setup process and without modifying the configuration directly.  This is done in the `lib/miq_benchmark/mem_full_load_benchmark.rb` file.

Currently, the code added in this PR lives in `lib/miq_benchmark` and should only be loaded when the miq_benchmark code is loaded (or rather, at least it wasn't loaded when I ran this in a console locally).  This might be off living in the `tools/` dir, or possibly a new top level directory entirely that is not packaged when the appliance is built... not sure...

Also, you might ask:

> "Hey Nick, why didn't you just use `derailed_benchmarks`?"

That gem directly depends on about 5-6 performance focused gems, and while I think they are all solid, they are not something I felt necessary to be in our repository.  Also,the functionality that exists from `GetProcessMem` already exists in `sys-proctable`, which already is a dependency of `manageiq`.  Plus, with the hacks necessary to load the app in the fashion we wanted, we probably would have had to write just as much code to use `derailed_benchmarks` normally, so extra effort to do it this way seemed silly.

To put it simply, it is an effort to avoid any new dependencies in the project.


~~A separate Travis job will be added as part of this PR eventually, but there is a bug that needs to be addressed in a separate PR before this could run properly, so that will be implemented later.~~  Done!  See second commit.


Links
-----
* https://www.pivotaltracker.com/story/show/141463609
* https://github.com/schneems/derailed_benchmarks
* https://github.com/ManageIQ/manageiq/pull/14262 (bug fix necessary for this to work)

Steps for Testing/QA
--------------------

Feel free to run:

```console
$ bundle exec ruby lib/miq_benchmark/mem_full_load_benchmark.rb
```

From your own machine and compare the results.  There will probably be a bit of a fudge factor of 10-20 MiB from what I have sampled above, but as long as you are in the ballpark, this is probably good.  Also, if a patch hasn't been added, you might also need to update the `high-voltage` gem to `>= 3.0.0` (this was the "bug" I was referring to earlier).