### PR TITLE
Updates the high_voltage gem to ~>3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false
 gem "hamlit",                         "~>2.7.0"
 gem "hashie",                         "~>3.4.6",       :require => false
-gem "high_voltage",                   "~>2.4.0"
+gem "high_voltage",                   "~>3.0.0"
 gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API


### PR DESCRIPTION
Purpose
-------
Fixes issue when loading any controllers that make use of `high_voltage`.

As part of changes in 3.0.0 for `high_voltage`:

https://github.com/thoughtbot/high_voltage/blob/cbab60f8b9d82d26a50af630241b7dfb7676fae2/NEWS.md

`high_voltage` was updated to properly support 3.0.0.  Currently, we are well past Rails 5.0, and when something that actually uses `high_voltage` is loaded, it fails to load properly because the underlying API in Rails has changed and the 2.4.0 version is incompatable (it seems).

Ran into this while working on https://github.com/ManageIQ/manageiq/pull/14261 .


Links
-----
* https://github.com/thoughtbot/high_voltage/blob/cbab60f8b9d82d26a50af630241b7dfb7676fae2/NEWS.md


Steps for Testing/QA
--------------------
Update the `config/environments/development.rb` to include the line:

```ruby
config.eager_load = true
```

Then try booting a server with `bin/rails s`.  On master this should fail with an error for `HighVoltage`.  After this patch, that is no longer the case.


**NOTE**:
If https://github.com/ManageIQ/manageiq-providers-amazon/pull/173 is not merged yet, add the following to your `Gemfile.dev.rb`:

```ruby
override_gem 'manageiq-providers-amazon',
             :github => "NickLaMuro/manageiq-providers-amazon",
             :branch => "remove_required_nested_Runner_for_invalid_models"
```

Run `bin/bundle update`, and try again.  Remove that addition after you are finished with QA as you will fall behind with updates from the `manageiq-providers-amazon` locally if you don't.