### PR TITLE
Add scope for ownership

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1829,6 +1829,10 @@ class VmOrTemplate < ApplicationRecord
      template_tenant_ids, vm_tenant_ids]
   end
 
+  def self.with_ownership
+    includes(:ext_management_system).where(:ext_management_systems => {:tenant_mapping_enabled => [false, nil]})
+  end
+
   def tenant_identity
     user = evm_owner
     user = User.super_admin.tap { |u| u.current_group = miq_group } if user.nil? || !user.miq_group_ids.include?(miq_group_id)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1400671

This is used for check whether images/instances are accessible for ownership change.
When images/instances comes from provider with tenant mapping then ownership change is not allowed.

UI Pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/649

@miq-bot add_label core, enhancement, blocker
@miq-bot assign @gtanzillo 

