### PR TITLE
Invert remote_proxy? attribute to block_raw_action?

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -389,12 +389,13 @@ module ManageIQ::Providers
       uid = vnfd.id
 
       new_result = {
-        :type        => "OrchestrationTemplateVnfd",
-        :ems_ref     => uid,
-        :name        => vnfd.name.blank? ? uid : vnfd.name,
-        :description => vnfd.description,
-        :content     => vnfd.vnf_attributes["vnfd"],
-        :orderable   => true
+        :type             => "OrchestrationTemplateVnfd",
+        :ems_ref          => uid,
+        :name             => vnfd.name.blank? ? uid : vnfd.name,
+        :description      => vnfd.description,
+        :content          => vnfd.vnf_attributes["vnfd"],
+        :orderable        => true,
+        :block_raw_action => true,
       }
       return uid, new_result
     end

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -19,8 +19,6 @@ class OrchestrationTemplate < ApplicationRecord
 
   before_destroy :check_not_in_use
 
-  attr_accessor :remote_proxy
-  alias remote_proxy? remote_proxy
   attr_accessor :block_raw_action
   alias block_raw_action? block_raw_action
 

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -21,6 +21,8 @@ class OrchestrationTemplate < ApplicationRecord
 
   attr_accessor :remote_proxy
   alias remote_proxy? remote_proxy
+  attr_accessor :block_raw_action
+  alias block_raw_action? block_raw_action
 
   # Try to create the template if the name is not found in table
   def self.seed

--- a/app/models/orchestration_template_vnfd.rb
+++ b/app/models/orchestration_template_vnfd.rb
@@ -1,9 +1,9 @@
 class OrchestrationTemplateVnfd < OrchestrationTemplate
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
 
-  before_create :raw_create, :if => :remote_proxy?
-  before_update :raw_update, :if => :remote_proxy?
-  before_destroy :raw_destroy, :if => :remote_proxy?
+  before_create :raw_create,   :unless => :block_raw_action?
+  before_update :raw_update,   :unless => :block_raw_action?
+  before_destroy :raw_destroy, :unless => :block_raw_action?
 
   def raw_create
     vnfd_data = {:attributes    => {:vnfd => content},

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template_vnfd.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_template_vnfd.rb
@@ -4,7 +4,6 @@ module MiqAeMethodService
 
     def self.create(options = {})
       attributes = options.symbolize_keys.slice(*CREATE_ATTRIBUTES)
-      attributes[:remote_proxy] = true
 
       ar_method { MiqAeServiceOrchestrationTemplateVnfd.wrap_results(OrchestrationTemplateVnfd.create!(attributes)) }
     end

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:name)        { |n| "template name #{seq_padded_for_sorting(n)}" }
     sequence(:content)     { |n| "any template text #{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "some description #{seq_padded_for_sorting(n)}" }
+    block_raw_action       true
   end
 
   factory :orchestration_template_cfn, :parent => :orchestration_template, :class => "OrchestrationTemplateCfn" do

--- a/spec/requests/api/orchestration_template_spec.rb
+++ b/spec/requests/api/orchestration_template_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'Orchestration Template API' do
     it 'supports single VNFd orchestration_template creation' do
       api_basic_authorize collection_action_identifier(:orchestration_templates, :create)
 
+      expect_any_instance_of(OrchestrationTemplateVnfd).to receive(:raw_create)
+
       expect do
         run_post(orchestration_templates_url, request_body_vnfd)
       end.to change(OrchestrationTemplateVnfd, :count).by(1)


### PR DESCRIPTION
Merge together with UI: https://github.com/ManageIQ/manageiq-ui-classic/pull/650

Introduce `block_raw_action?` flag and fill it during provider refresh

OrchestrationTemplateVnfd links to real template in openstack. When a user creates/deletes a template we want to keep equivalent in openstack in sync. That's why there is a callback on save of OrchestrationTemplateVnfd.

However, this has exception when we refresh from provider, in that case we must block raw operations.

When we invert, we have less places to maintain to set the flag value.

