### PR TITLE
Support operation `create` on CloudObjectStoreContainer

### DIFF
--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -9,6 +9,7 @@ module ManageIQ::Providers
     supports_not :smartstate_analysis
     supports_not :block_storage
     supports_not :object_storage
+    supports_not :cloud_object_store_container_create
 
     belongs_to :parent_manager,
                :foreign_key => :parent_ems_id,

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -65,7 +65,8 @@ module SupportsFeatureMixin
     # FIXME: this is just a internal helper and should be refactored
     :control                    => 'Basic control operations',
     :cloud_tenant_mapping       => 'CloudTenant mapping',
-    :cloud_object_store_container_clear => 'Clear Object Store Container',
+    :cloud_object_store_container_create => 'Create Object Store Container',
+    :cloud_object_store_container_clear  => 'Clear Object Store Container',
     :create                     => 'Creation',
     :backup_create              => 'CloudVolume backup creation',
     :backup_restore             => 'CloudVolume backup restore',

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -612,6 +612,10 @@
     :feature_type: admin
     :identifier: cloud_object_store_container_admin
     :children:
+    - :name: Create
+      :description: Create Cloud Object Store Container
+      :feature_type: admin
+      :identifier: cloud_object_store_container_new
     - :name: Delete
       :description: Delete Object Store Containers
       :feature_type: admin


### PR DESCRIPTION
Support operation `create` on CloudObjectStoreContainer. Implementation for Amazon S3 depends on this.

@miq-bot add_label enhancement
@miq-bot assign @durandom
