### PR TITLE
Small extentions to queued manager refresh

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -222,6 +222,10 @@ class EmsEvent < EventStream
     (vm_or_template || ext_management_system).tenant_identity
   end
 
+  def manager_refresh_targets
+    ext_management_system.class::EventTargetParser.new(self).parse
+  end
+
   private
 
   def self.create_event(event)
@@ -323,9 +327,5 @@ class EmsEvent < EventStream
 
   def ems_refresh_target
     ext_management_system
-  end
-
-  def manager_refresh_targets
-    ext_management_system.class::EventTargetParser.new(self).parse
   end
 end

--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -7,7 +7,7 @@ class EmsEvent
 
       return if refresh_targets.empty?
 
-      EmsRefresh.queue_refresh(refresh_targets, nil, sync)
+      EmsRefresh.queue_refresh(refresh_targets, nil, :create_task => sync)
     end
 
     def refresh(*targets, sync)

--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -2,7 +2,7 @@ class EmsEvent
   module Automate
     extend ActiveSupport::Concern
 
-    def graph_refresh(sync: false)
+    def manager_refresh(sync: false)
       refresh_targets = manager_refresh_targets
 
       return if refresh_targets.empty?

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -106,11 +106,11 @@ module MiqAeEngine
     end
 
     def self.miq_refresh(obj, _inputs)
-      event_object_from_workspace(obj).graph_refresh(:sync => false)
+      event_object_from_workspace(obj).manager_refresh(:sync => false)
     end
 
     def self.miq_refresh_sync(obj, _inputs)
-      event_object_from_workspace(obj).graph_refresh(:sync => true)
+      event_object_from_workspace(obj).manager_refresh(:sync => true)
     end
 
     def self.miq_event_action_refresh(obj, inputs)

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -10,6 +10,17 @@ describe EmsRefresh do
       queue_refresh_and_assert_queue_item(target, [target])
     end
 
+    it "with ManagerRefresh::Target" do
+      target = ManagerRefresh::Target.load(
+        :manager_id  => @ems.id,
+        :association => :vms,
+        :manager_ref => {:ems_ref => "vm_1"},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      queue_refresh_and_assert_queue_item(target, [target])
+    end
+
     it "with Host" do
       target = FactoryGirl.create(:host_vmware, :ext_management_system => @ems)
       queue_refresh_and_assert_queue_item(target, [target])


### PR DESCRIPTION
Changed queue_refresh interface. Renaming graph_refresh to manager_refresh. Method manager_refresh_targets must be public. And testing we can queue ManagerRefresh::Target to a refresh queue. 