### PR TITLE
Add the location LED state to the physical_servers table

### DIFF
--- a/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
+++ b/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
@@ -1,0 +1,5 @@
+class AddLocLedStateToPhysicalServers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :physical_servers, :locLedState, :string
+  end
+end

--- a/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
+++ b/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
@@ -1,5 +1,5 @@
 class AddLocLedStateToPhysicalServers < ActiveRecord::Migration[5.0]
   def change
-    add_column :physical_servers, :locLedState, :string
+    add_column :physical_servers, :loc_led_state, :string
   end
 end

--- a/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
+++ b/db/migrate/20170309150930_add_loc_led_state_to_physical_servers.rb
@@ -1,5 +1,5 @@
 class AddLocLedStateToPhysicalServers < ActiveRecord::Migration[5.0]
   def change
-    add_column :physical_servers, :loc_led_state, :string
+    add_column :physical_servers, :location_led_state, :string
   end
 end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6153,8 +6153,8 @@ physical_servers:
 - model
 - serial_number
 - field_replaceable_unit
-- raw_power_state
 - loc_led_state
+- raw_power_state
 pictures:
 - id
 - resource_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6154,7 +6154,7 @@ physical_servers:
 - serial_number
 - field_replaceable_unit
 - raw_power_state
-- locLedState
+- loc_led_state
 pictures:
 - id
 - resource_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6153,7 +6153,7 @@ physical_servers:
 - model
 - serial_number
 - field_replaceable_unit
-- loc_led_state
+- location_led_state
 - raw_power_state
 pictures:
 - id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6154,6 +6154,7 @@ physical_servers:
 - serial_number
 - field_replaceable_unit
 - raw_power_state
+- locLedState
 pictures:
 - id
 - resource_id


### PR DESCRIPTION
Added the location LED state to the physical_servers table so that the state can be displayed on a future server summary page.