### PR TITLE
Adding require_nested for missing ansible objects

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers::ExternalAutomationManager
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
 
+  require_nested :Credential
   require_nested :AmazonCredential
   require_nested :AzureCredential
   require_nested :CloudCredential
@@ -9,6 +10,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   require_nested :NetworkCredential
   require_nested :OpenstackCredential
   require_nested :RackspaceCredential
+  require_nested :ScmCredential
   require_nested :Satellite6Credential
   require_nested :VmwareCredential
 
@@ -17,6 +19,7 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager < ManageIQ::Providers
   require_nested :ConfiguredSystem
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :Inventory
   require_nested :Job
   require_nested :Playbook
   require_nested :Refresher

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
 
+  require_nested :Credential
   require_nested :AmazonCredential
   require_nested :AzureCredential
   require_nested :CloudCredential
@@ -9,6 +10,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :NetworkCredential
   require_nested :OpenstackCredential
   require_nested :RackspaceCredential
+  require_nested :ScmCredential
   require_nested :Satellite6Credential
   require_nested :VmwareCredential
 


### PR DESCRIPTION
Some objects were missing `require_nested` entries in `AnsibleTower` and `EmbeddedAnsible`.

As a follow up PR, looks like we need to replicate `Inventory` over to `EmbeddedAnsible`, too