### PR TITLE
Add SupportsFeatureMixin to CloudNetwork

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -1,5 +1,6 @@
 class CloudNetwork < ApplicationRecord
   include NewWithTypeStiMixin
+  include SupportsFeatureMixin
 
   acts_as_miq_taggable
 


### PR DESCRIPTION
This is needed to allow non-OpenStack providers to filter out certain
buttons in the UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1403152