### PR TITLE
Port the saving of provider Tags as custom attributes

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -31,8 +31,8 @@ module ManageIQ::Providers
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_networks,                :through     => :network_manager
     has_many :security_groups,               :through     => :network_manager
-
-    has_one  :source_tenant, :as => :source, :class_name => 'Tenant'
+    has_one  :source_tenant, :as => :source, :class_name  => 'Tenant'
+    has_many :vm_and_template_labels,        :through     => :vms_and_templates, :source => :labels
 
     validates_presence_of :zone
 


### PR DESCRIPTION
This PR ports https://github.com/ManageIQ/manageiq/pull/14202 to the new refresh Inventory code.
https://github.com/ManageIQ/manageiq-providers-amazon/pull/162 is dependent on this.


https://www.pivotaltracker.com/story/show/139414085