### PR TITLE
Create initial tower objects when we start the worker

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -1,5 +1,6 @@
 class EmbeddedAnsibleWorker < MiqWorker
   require_nested :Runner
+  include_concern 'ObjectManagement'
 
   self.required_roles = ['embedded_ansible']
 

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -1,0 +1,56 @@
+module EmbeddedAnsibleWorker::ObjectManagement
+  extend ActiveSupport::Concern
+
+  def ensure_initial_objects(provider, connection)
+    ensure_organization(provider, connection)
+    ensure_credential(provider, connection)
+    ensure_inventory(provider, connection)
+    ensure_host(provider, connection)
+  end
+
+  def remove_demo_data(connection)
+    connection.api.credentials.all(:name => "Demo Credential").each(&:destroy!)
+    connection.api.inventories.all(:name => "Demo Inventory").each(&:destroy!)
+    connection.api.job_templates.all(:name => "Demo Job Template").each(&:destroy!)
+    connection.api.projects.all(:name => "Demo Project").each(&:destroy!)
+    connection.api.organizations.all(:name => "Default").each(&:destroy!)
+  end
+
+  def ensure_organization(provider, connection)
+    return if provider.default_organization
+
+    provider.default_organization = connection.api.organizations.create!(
+      :name        => I18n.t("product.name"),
+      :description => "#{I18n.t("product.name")} Default Organization"
+    ).id
+  end
+
+  def ensure_credential(provider, connection)
+    return if provider.default_credential
+
+    provider.default_credential = connection.api.credentials.create!(
+      :name         => "#{I18n.t("product.name")} Default Credential",
+      :kind         => "ssh",
+      :organization => provider.default_organization
+    ).id
+  end
+
+  def ensure_inventory(provider, connection)
+    return if provider.default_inventory
+
+    provider.default_inventory = connection.api.inventories.create!(
+      :name         => "#{I18n.t("product.name")} Default Inventory",
+      :organization => provider.default_organization
+    ).id
+  end
+
+  def ensure_host(provider, connection)
+    return if provider.default_host
+
+    provider.default_host = connection.api.hosts.create!(
+      :name      => "localhost",
+      :inventory => provider.default_inventory,
+      :variables => {'ansible_connection' => "local"}.to_yaml
+    ).id
+  end
+end

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -49,6 +49,10 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
     provider.save!
 
+    api_connection = EmbeddedAnsible.api_connection
+    worker.remove_demo_data(api_connection)
+    worker.ensure_initial_objects(provider, api_connection)
+
     admin_auth = MiqDatabase.first.ansible_admin_authentication
 
     provider.update_authentication(:default => {:userid => admin_auth.userid, :password => admin_auth.password})

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -64,6 +64,15 @@ class EmbeddedAnsible
     AwesomeSpawn.run!("source /etc/sysconfig/ansible-tower; echo $TOWER_SERVICES").output.split
   end
 
+  def self.api_connection
+    admin_auth = miq_database.ansible_admin_authentication
+    AnsibleTowerClient::Connection.new(
+      :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => HTTP_PORT).to_s,
+      :username => admin_auth.userid,
+      :password => admin_auth.password
+    )
+  end
+
   def self.run_setup_script(exclude_tags)
     json_extra_vars = {
       :minimum_var_space => 0,
@@ -171,14 +180,4 @@ class EmbeddedAnsible
     ActiveRecord::Base.connection
   end
   private_class_method :database_connection
-
-  def self.api_connection
-    admin_auth = miq_database.ansible_admin_authentication
-    AnsibleTowerClient::Connection.new(
-      :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => HTTP_PORT).to_s,
-      :username => admin_auth.userid,
-      :password => admin_auth.password
-    )
-  end
-  private_class_method :api_connection
 end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -12,6 +12,7 @@ class EmbeddedAnsible
   START_EXCLUDE_TAGS          = "packages,migrations,firewall".freeze
   HTTP_PORT                   = 54_321
   HTTPS_PORT                  = 54_322
+  WAIT_FOR_ANSIBLE_SLEEP      = 1.second
 
   def self.available?
     path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
@@ -50,6 +51,15 @@ class EmbeddedAnsible
   def self.start
     configure_secret_key
     run_setup_script(START_EXCLUDE_TAGS)
+
+    5.times do
+      return if alive?
+
+      _log.info("Waiting for EmbeddedAnsible to respond")
+      sleep WAIT_FOR_ANSIBLE_SLEEP
+    end
+
+    raise "EmbeddedAnsible service is not responding after setup"
   end
 
   def self.stop

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -64,6 +64,25 @@ describe EmbeddedAnsibleWorker::Runner do
         expect(provider.default_endpoint.url).to eq("https://boringserver/ansibleapi/v1")
       end
     end
+
+    context "#setup_ansible" do
+      it "configures EmbeddedAnsible if it is not configured" do
+        expect(EmbeddedAnsible).to receive(:start)
+
+        expect(EmbeddedAnsible).to receive(:configured?).and_return(false)
+        expect(EmbeddedAnsible).to receive(:configure)
+
+        runner.setup_ansible
+      end
+
+      it "doesn't call configure if EmbeddedAnsible is already configured" do
+        expect(EmbeddedAnsible).to receive(:start)
+
+        expect(EmbeddedAnsible).to receive(:configured?).and_return(true)
+        expect(EmbeddedAnsible).not_to receive(:configure)
+
+        runner.setup_ansible
+      end
+    end
   end
 end
-

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -1,0 +1,138 @@
+describe EmbeddedAnsibleWorker do
+  subject { FactoryGirl.create(:embedded_ansible_worker) }
+
+  context "ObjectManagement concern" do
+    let(:provider)       { FactoryGirl.create(:provider_embedded_ansible) }
+    let(:api_connection) { double("AnsibleAPIConnection", :api => tower_api) }
+    let(:tower_api) do
+      methods = {
+        :organizations => org_collection,
+        :credentials   => cred_collection,
+        :inventories   => inv_collection,
+        :hosts         => host_collection,
+        :job_templates => job_templ_collection,
+        :projects      => proj_collection
+
+      }
+      double("TowerAPI", methods)
+    end
+
+    let(:org_collection)       { double("AnsibleOrgCollection", :all => [org_resource]) }
+    let(:cred_collection)      { double("AnsibleCredCollection", :all => [cred_resource]) }
+    let(:inv_collection)       { double("AnsibleInvCollection", :all => [inv_resource]) }
+    let(:host_collection)      { double("AnsibleHostCollection", :all => [host_resource]) }
+    let(:job_templ_collection) { double("AnsibleJobTemplCollection", :all => [job_templ_resource]) }
+    let(:proj_collection)      { double("AnsibleProjCollection", :all => [proj_resource]) }
+
+    let(:org_resource)         { double("AnsibleOrgResource", :id => 12) }
+    let(:cred_resource)        { double("AnsibleCredResource", :id => 13) }
+    let(:inv_resource)         { double("AnsibleInvResource", :id => 14) }
+    let(:host_resource)        { double("AnsibleHostResource", :id => 15) }
+    let(:job_templ_resource)   { double("AnsibleJobTemplResource", :id => 16) }
+    let(:proj_resource)        { double("AnsibleProjResource", :id => 17) }
+
+    describe "#ensure_initial_objects" do
+      it "creates the expected objects" do
+        expect(org_collection).to receive(:create!).and_return(org_resource)
+        expect(cred_collection).to receive(:create!).and_return(cred_resource)
+        expect(inv_collection).to receive(:create!).and_return(inv_resource)
+        expect(host_collection).to receive(:create!).and_return(host_resource)
+
+        subject.ensure_initial_objects(provider, api_connection)
+      end
+    end
+
+    describe "#remove_demo_data" do
+      it "removes the existing data" do
+        expect(org_resource).to receive(:destroy!)
+        expect(cred_resource).to receive(:destroy!)
+        expect(inv_resource).to receive(:destroy!)
+        expect(job_templ_resource).to receive(:destroy!)
+        expect(proj_resource).to receive(:destroy!)
+
+        subject.remove_demo_data(api_connection)
+      end
+    end
+
+    describe "#ensure_organization" do
+      it "sets the provider default organization" do
+        expect(org_collection).to receive(:create!).with(
+          :name        => "ManageIQ",
+          :description => "ManageIQ Default Organization"
+        ).and_return(org_resource)
+
+        subject.ensure_organization(provider, api_connection)
+        expect(provider.default_organization).to eq(12)
+      end
+
+      it "doesn't recreate the organization if one is already set" do
+        provider.default_organization = 1
+        expect(org_collection).not_to receive(:create!)
+
+        subject.ensure_organization(provider, api_connection)
+      end
+    end
+
+    describe "#ensure_credential" do
+      it "sets the provider default credential" do
+        provider.default_organization = 123
+        expect(cred_collection).to receive(:create!).with(
+          :name         => "ManageIQ Default Credential",
+          :kind         => "ssh",
+          :organization => 123
+        ).and_return(cred_resource)
+
+        subject.ensure_credential(provider, api_connection)
+        expect(provider.default_credential).to eq(13)
+      end
+
+      it "doesn't recreate the credential if one is already set" do
+        provider.default_credential = 2
+        expect(cred_collection).not_to receive(:create!)
+
+        subject.ensure_credential(provider, api_connection)
+      end
+    end
+
+    describe "#ensure_inventory" do
+      it "sets the provider default inventory" do
+        provider.default_organization = 123
+        expect(inv_collection).to receive(:create!).with(
+          :name         => "ManageIQ Default Inventory",
+          :organization => 123
+        ).and_return(inv_resource)
+
+        subject.ensure_inventory(provider, api_connection)
+        expect(provider.default_inventory).to eq(14)
+      end
+
+      it "doesn't recreate the inventory if one is already set" do
+        provider.default_inventory = 3
+        expect(inv_collection).not_to receive(:create!)
+
+        subject.ensure_inventory(provider, api_connection)
+      end
+    end
+
+    describe "#ensure_host" do
+      it "sets the provider default host" do
+        provider.default_inventory = 234
+        expect(host_collection).to receive(:create!).with(
+          :name      => "localhost",
+          :inventory => 234,
+          :variables => "---\nansible_connection: local\n"
+        ).and_return(host_resource)
+
+        subject.ensure_host(provider, api_connection)
+        expect(provider.default_host).to eq(15)
+      end
+
+      it "doesn't recreate the host if one is already set" do
+        provider.default_host = 1
+        expect(host_collection).not_to receive(:create!)
+
+        subject.ensure_host(provider, api_connection)
+      end
+    end
+  end
+end


### PR DESCRIPTION
These objects will be used for dynamically creating things like job templates during playbook runs from automate.

Requires https://github.com/ManageIQ/manageiq/pull/14377 for storing the ansible side ids with the provider.

https://www.pivotaltracker.com/story/show/140098929