### PR TITLE
Report Widget

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -121,6 +121,36 @@ class Hardware < ApplicationRecord
       t[:disk_capacity]) * -100 + 100)
   end)
 
+  def provisioned_storage
+    if has_attribute?("provisioned_storage")
+      self["provisioned_storage"]
+    else
+      allocated_disk_storage.to_i + ram_size_in_bytes
+    end
+  end
+
+  # added casts because we were overflowing integers
+  # resulting sql:
+  # (
+  #   (COALESCE(
+  #     ((SELECT SUM("disks"."size")
+  #       FROM "disks"
+  #       WHERE "hardwares"."id" = "disks"."hardware_id")),
+  #     0
+  #   )) + (COALESCE(
+  #     (CAST("hardwares"."memory_mb" AS bigint)),
+  #     0
+  #   )) * 1048576
+  # )
+  virtual_attribute :provisioned_storage, :integer, :arel => (lambda do |t|
+    t.grouping(
+      t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [arel_attribute(:allocated_disk_storage), 0])) +
+      t.grouping(Arel::Nodes::NamedFunction.new(
+                   'COALESCE', [t.grouping(Arel::Nodes::NamedFunction.new('CAST', [t[:memory_mb].as("bigint")])), 0]
+      )) * 1.megabyte
+    )
+  end)
+
   def connect_lans(lans)
     return if lans.blank?
     nics.each do |n|

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -97,7 +97,11 @@ module MiqReport::Generator
     if klass.nil?
       klass = db_class
       result = {}
-      cols.each { |c| result[c.to_sym] = {} if klass.virtual_attribute?(c) } if cols
+      if cols && klass.respond_to?(:virtual_attribute?)
+        cols.each do |c|
+          result[c.to_sym] = {} if klass.virtual_attribute?(c) && !klass.attribute_supported_by_sql?(c)
+        end
+      end
     end
 
     if includes.kind_of?(Hash)
@@ -118,7 +122,7 @@ module MiqReport::Generator
 
           if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]
             v["columns"].each do |c|
-              result[k][c.to_sym] = {} if assoc_klass.virtual_attribute?(c)
+              result[k][c.to_sym] = {} if assoc_klass.virtual_attribute?(c) && !assoc_klass.attribute_supported_by_sql?(c)
             end
           end
         end
@@ -283,6 +287,7 @@ module MiqReport::Generator
       # TODO: add once only_cols is fixed
       # targets = targets.select(only_cols)
       where_clause = MiqExpression.merge_where_clauses(self.where_clause, options[:where_clause])
+      ## add in virtual attributes that can be calculated from sql
       va_sql_cols = cols.select do |col|
         db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
       end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1538,12 +1538,8 @@ class VmOrTemplate < ApplicationRecord
   # Hardware Disks/Memory storage methods
   #
 
-  virtual_delegate :allocated_disk_storage, :used_disk_storage,
+  virtual_delegate :allocated_disk_storage, :used_disk_storage, :provisioned_storage,
                    :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}
-
-  def provisioned_storage
-    allocated_disk_storage.to_i + ram_size_in_bytes
-  end
 
   def used_storage
     used_disk_storage.to_i + ram_size_in_bytes


### PR DESCRIPTION
### High level

Widgets are reports that are pre-run for users.
They are updated every hour and run in the user's group context and timezone.
In summary, each report is run many times (# groups x # timezones x # times per day).
So any performance issue will be felt.

A customer complained that three reports were taking too long to run.

### Before

- While we do embed virtual attributes directly into SQL where possible ( https://github.com/ManageIQ/manageiq/pull/13101 ) we are still bringing back the tables for these columns.
- Top Storage Consumers report uses a non-SQL-friendly attribute `Vm#provisioned_storage`. This forces a download of the `hardwares` and `disks` tables.

### After

- Tables for SQL-friendly virtual attributes are no longer downloaded. This is done by removing them from the `includes` list.
- `Vm#provisioned_storage` is now SQL-friendly so we can take advantage of the above `includes` optimization.

### numbers

|        ms |    bytes |  objects |queries | query (ms) |     rows |`comments`
|       ---:|      ---:|      ---:|  ---:|      ---:|      ---:| ---
|   6,119.8 | 103,342,161* |  7,534,105 |1,194 |  1,497.9 |    6,768 |before
|  4,958.1 | 121,689,623* |  5,639,577 |  1,190 | 1,197.1 |    1,148 |after
|19.0%|n/a|25%|0.3%|20.1%|83%|diff

\* Memory usage does not reflect 7,169,463 freed objects.
\* Memory usage does not reflect 2,051,300 freed objects.
GC cleaned up too many objects to truly reflect the memory improvement

related to:
- https://github.com/ManageIQ/manageiq/pull/14224
- https://bugzilla.redhat.com/show_bug.cgi?id=1251259

---
reproduction details

```ruby
profile_methods("MiqWidget::ContentGenerator#generate_content", "MiqWidget#generate_one_content_for_group", "MiqWidget#generate_one_content_for_user")
opts = ["MiqGroup", "EMS_OPS_BU", nil, ["Pacific Time (US & Canada)", "UTC"]] # w.group_options.last
w = MiqWidget.find_by(description: 'report_top_storage_consumers')
w.reload ; bookend("master", gc: true) { w.send(:content_generator).generate(w, *opts) }
```

|        ms |    bytes |  objects |queries | query (ms) |     rows |`comments`
|       ---:|      ---:|      ---:|  ---:|      ---:|      ---:| ---
|  11,311.3 | 120,445,839* | 16,006,917 |1,194 |  2,529.8 |    6,768 |`master-1`
|   6,180.1 |   7,873,235* |  7,534,025 |1,194 |  1,418.4 |    6,768 |`master-1`
|   6,195.6 | 104,498,675* |  7,516,979 |1,194 |  1,528.1 |    6,768 |`master-1`
|   6,119.8 | 103,342,161* |  7,534,105 |1,194 |  1,497.9 |    6,768 |`master-1`

\* Memory usage does not reflect 7,169,463 freed objects.
\* Memory usage does not reflect 3,134,060 freed objects.
\* Memory usage does not reflect 3,117,013 freed objects.
\* Memory usage does not reflect 3,134,141 freed objects.

|       ms |        bytes |    objects |queries |query(ms)|     rows |`comments`
|      ---:|          ---:|        ---:|    ---:|     ---:|      ---:| ---
|  8,915.0 |  44,824,308* | 12,650,749 |  1,190 | 2,322.9 |    1,148 |`widget-1`
|  4,912.0 | 124,986,592* |  5,598,635 |  1,190 | 1,230.9 |    1,148 |`widget-1`
|  5,074.4 |   9,322,759* |  5,426,925 |  1,190 | 1,381.1 |    1,148 |`widget-1`
|  4,958.1 | 121,689,623* |  5,639,577 |  1,190 | 1,197.1 |    1,148 |`widget-1`

\* Memory usage does not reflect 5,280,780 freed objects.
\* Memory usage does not reflect 2,010,357 freed objects.
\* Memory usage does not reflect 1,838,645 freed objects.
\* Memory usage does not reflect 2,051,300 freed objects.
