### PR TITLE
[WIP] Embed Automate Methods into other Automate Methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -8,11 +8,11 @@ module MiqAeEngine
       @num_methods = 0
     end
 
-    def with_server(inputs, body, method_name)
+    def with_server(inputs, bodies, method_name)
       setup if num_methods == 0
       self.num_methods += 1
       svc = MiqAeMethodService::MiqAeService.new(@workspace, inputs)
-      yield build_method_content(body, method_name, svc.object_id)
+      yield build_method_content(bodies, method_name, svc.object_id)
     ensure
       svc.destroy # Reset inputs to empty to avoid storing object references
       self.num_methods -= 1
@@ -67,11 +67,11 @@ module MiqAeEngine
 
     # code building
 
-    def build_method_content(body, method_name, miq_ae_service_token)
+    def build_method_content(bodies, method_name, miq_ae_service_token)
       [
         dynamic_preamble(method_name, miq_ae_service_token),
         RUBY_METHOD_PREAMBLE,
-        body,
+        bodies.flatten,
         RUBY_METHOD_POSTSCRIPT
       ].join("\n")
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -221,7 +221,7 @@ module MiqAeEngine
         cls = ::MiqAeClass.find_by_fqname("#{match_ns}/#{klass}")
         aem = ::MiqAeMethod.find_by_class_id_and_name(cls.id, method_name) if cls
         raise  MiqAeException::MethodNotFound, "Embedded method #{inputs[key]} not found" unless aem
-        $miq_ae_logger.info("Loading embedded method #{ns}/#{klass}/#{method_name}")
+        $miq_ae_logger.info("Loading embedded method #{match_ns}/#{klass}/#{method_name}")
         aem.data
       end
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1418374

With this optional feature we can embed an Automate method into other Automate Methods by specifying them in the input parameter list 

e.g.
embed1 => /Shared/Methods/MyMethod1
embed2 => /Shared/Methods/SomeOtherMethod

Before we launch a method we would collect the input parameters and scan for any parameters that start with **embed** and sort them and load up all the automate methods that they point to and inject them ahead of the method. e.g

We have a Shared Method defined in 

<img width="836" alt="screen shot 2017-03-12 at 10 13 37 pm" src="https://cloud.githubusercontent.com/assets/6452699/23839010/40907530-0771-11e7-88b7-d0091d8f2f4d.png">

Then in another method we can call this method by embedding it via input parameters

<img width="1179" alt="screen shot 2017-03-12 at 10 17 41 pm" src="https://cloud.githubusercontent.com/assets/6452699/23839069/c591e28c-0771-11e7-9b7b-39241e2cf5e2.png">


If the embedded method cannot be found we would raise an exception

If the embedded method exists in other domains we can fetch the correct ones based on the enabled domains and priorities.

Caveats:

If the embedded methods have other embed methods we won't load them up.


 