### PR TITLE
Namespace the mappable object types, add Amazon VM and Image types.

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -13,14 +13,20 @@ class ContainerLabelTagMapping < ApplicationRecord
   # All involved tags must also have a Classification.
 
   AUTOTAG_PREFIX = "kubernetes".freeze
-  MAPPABLE_ENTITIES = [nil,
-                       "ContainerProject",
-                       "ContainerRoute",
-                       "ContainerNode",
-                       "ContainerReplicator",
-                       "ContainerService",
-                       "ContainerGroup",
-                       "ContainerBuild"].freeze
+
+  MAPPABLE_ENTITIES = [
+    nil,
+    "Amazon::Vm",
+    "Amazon::Image",
+    "Kubernetes::ContainerProject",
+    "Kubernetes::ContainerRoute",
+    "Kubernetes::ContainerNode",
+    "Kubernetes::ContainerReplicator",
+    "Kubernetes::ContainerService",
+    "Kubernetes::ContainerGroup",
+    "Kubernetes::ContainerBuild"
+  ].freeze
+
   belongs_to :tag
 
   # Pass the data this returns to map_* methods.


### PR DESCRIPTION
This adds Amazon images and vm's as a mappable type to the ContainerLabelTagMapping model. Furthermore, I've scoped the names by provider type.

This serves two purposes. First, it modifies the drop down menu, and lets the user know exactly which type of resource that they're mapping:

<img width="755" alt="screen shot 2017-03-13 at 8 52 41 am" src="https://cloud.githubusercontent.com/assets/78529/23859807/8c294018-07ca-11e7-8d18-627ead34f8d0.png">

Second, rather than use the hard coded AUTOTAG_PREFIX constant, the prefix will be parsed from the name. This will require a minor modification on the UI side. The net result will be that you will see entries in this form inside the `tags` table:
```
/managed/kubernetes:container_node:container_stuff
/managed/amazon:vm:test_label
/managed/kubernetes::label_for_all
/managed/amazon:image:aws_image_label
 ```

The UI modification is here: https://github.com/ManageIQ/manageiq-ui-classic/pull/666