### PR TITLE
Fix a typo in word

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -105,7 +105,7 @@ module SupportsFeatureMixin
     :resize                     => 'Resizing',
     :retire                     => 'Retirement',
     :revert_to_snapshot         => 'Revert Snapshot Operation',
-    :smartstate_analysis        => 'Smartstate Analaysis',
+    :smartstate_analysis        => 'Smartstate Analysis',
     :snapshot_create            => 'Create Snapshot',
     :snapshots                  => 'Snapshots',
     :shutdown_guest             => 'Shutdown Guest Operation',


### PR DESCRIPTION
Fixed a small typo: 'Analaysis' => 'Analysis'