### PR TITLE
pass hash of event out of ansible event stream

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/runner.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
     event_monitor_handle.start
     event_monitor_running
     event_monitor_handle.poll do |event|
-      _log.debug { "#{log_prefix} Received event #{event.id}" }
+      _log.debug { "#{log_prefix} Received event #{event['id']}" }
       @queue.enq event
     end
   ensure
@@ -15,7 +15,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
   end
 
   def queue_event(event)
-    _log.info "#{log_prefix} Caught event [#{event.id}]"
+    _log.info "#{log_prefix} Caught event [#{event['id']}]"
     event_hash = provider_module::AutomationManager::EventParser.event_to_hash(event, @cfg[:ems_id])
     EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
   end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
           loop do
             ansible.api.activity_stream.all(filter).each do |activity|
               throw :stop_polling if @stop_polling
-              yield activity
+              yield activity.to_h
               @last_activity = activity
             end
             sleep @poll_sleep

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_parser.rb
@@ -1,10 +1,10 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventParser
   def event_to_hash(event, ems_id)
     {
-      :event_type => "#{event.object1}_#{event.operation}",
+      :event_type => "#{event['object1']}_#{event['operation']}",
       :source     => "#{self.source}",
-      :timestamp  => event.timestamp,
-      :full_data  => event.to_h,
+      :timestamp  => event['timestamp'],
+      :full_data  => event,
       :ems_id     => ems_id
     }
   end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream_spec.rb
@@ -1,0 +1,69 @@
+describe ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher::Stream do
+  let(:tower_url) { ENV['TOWER_URL'] || "https://dev-ansible-tower3.example.com/api/v1/" }
+  let(:auth_userid) { ENV['TOWER_USER'] || 'testuser' }
+  let(:auth_password) { ENV['TOWER_PASSWORD'] || 'secret' }
+
+  let(:auth)                    { FactoryGirl.create(:authentication, :userid => auth_userid, :password => auth_password) }
+  let(:automation_manager)      { provider.automation_manager }
+  let(:provider) do
+    FactoryGirl.create(:provider_ansible_tower,
+                       :url        => tower_url,
+                       :verify_ssl => false,).tap { |provider| provider.authentications << auth }
+  end
+
+  subject do
+    described_class.new(automation_manager)
+  end
+
+  context "#poll" do
+    it "yields valid events" do
+      subject.instance_variable_set(:@last_activity, OpenStruct.new(:timestamp => '2016-01-01 01:00:00'))
+      subject.instance_variable_set(:@poll_sleep, 0)
+      expected_event = {
+        "id"                 => 1,
+        "type"               => "activity_stream",
+        "url"                => "/api/v1/activity_stream/1/",
+        "related"            => {
+          "user" => [
+            "/api/v1/users/1/"
+          ]
+        },
+        "summary_fields"     => {
+          "user" => [
+            {
+              "username"   => "admin",
+              "first_name" => "",
+              "last_name"  => "",
+              "id"         => 1
+            }
+          ]
+        },
+        "timestamp"          => "2016-08-02T17:56:37.212874Z",
+        "operation"          => "create",
+        "changes"            => {
+          "username"     => "admin",
+          "first_name"   => "",
+          "last_name"    => "",
+          "is_active"    => true,
+          "id"           => 1,
+          "is_superuser" => true,
+          "is_staff"     => true,
+          "password"     => "hidden",
+          "email"        => "admin@example.com",
+          "date_joined"  => "2016-08-02 17:56:37.162225+00:00"
+        },
+        "object1"            => "user",
+        "object2"            => "",
+        "object_association" => ""
+      }
+
+      VCR.use_cassette(described_class.name.underscore.to_s) do
+        subject.poll do |event|
+          polled_event = event
+          expect(polled_event.to_h).to eq(expected_event)
+          subject.stop
+        end
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream?order_by=timestamp&timestamp__gt=2016-01-01%2001:00:00
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Mon, 13 Mar 2017 16:14:55 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=timestamp&timestamp__gt=2016-01-01+01%3A00%3A00
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 13 Mar 2017 15:14:45 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=timestamp&timestamp__gt=2016-01-01%2001:00:00
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 13 Mar 2017 16:14:56 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.689s
+      Content-Length:
+      - '15180'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count":3275,"next":"/api/v1/activity_stream/?order_by=timestamp&page=2&timestamp__gt=2016-01-01+01%3A00%3A00","previous":null,"results":[{"id":1,"type":"activity_stream","url":"/api/v1/activity_stream/1/","related":{"user":["/api/v1/users/1/"]},"summary_fields":{"user":[{"username":"admin","first_name":"","last_name":"","id":1}]},"timestamp":"2016-08-02T17:56:37.212874Z","operation":"create","changes":{"username":"admin","first_name":"","last_name":"","is_active":true,"id":1,"is_superuser":true,"is_staff":true,"password":"hidden","email":"admin@example.com","date_joined":"2016-08-02
+        17:56:37.162225+00:00"},"object1":"user","object2":"","object_association":""},{"id":2,"type":"activity_stream","url":"/api/v1/activity_stream/2/","related":{"unified_job_template":"/api/v1/system_job_templates/1/","schedule":["/api/v1/schedules/1/"]},"summary_fields":{"schedule":[{"next_run":"2017-03-19T17:56:13Z","description":"Automatically
+        Generated Schedule","id":1,"name":"Cleanup Job Schedule"}],"system_job_template":{"id":1,"name":"Cleanup
+        Job Details"}},"timestamp":"2016-08-02T17:56:53.298836Z","operation":"update","changes":{"next_run":[null,"2016-08-07
+        17:56:13+00:00"],"dtstart":[null,"2016-08-07 17:56:13+00:00"],"modified":["2016-08-02
+        17:56:13.334787+00:00","2016-08-02 17:56:53.294137+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":3,"type":"activity_stream","url":"/api/v1/activity_stream/3/","related":{"unified_job_template":"/api/v1/system_job_templates/2/","schedule":["/api/v1/schedules/2/"]},"summary_fields":{"schedule":[{"next_run":"2017-03-14T17:56:13Z","description":"Automatically
+        Generated Schedule","id":2,"name":"Cleanup Activity Schedule"}],"system_job_template":{"id":2,"name":"Cleanup
+        Activity Stream"}},"timestamp":"2016-08-02T17:56:53.469192Z","operation":"update","changes":{"next_run":[null,"2016-08-09
+        17:56:13+00:00"],"dtstart":[null,"2016-08-02 17:56:13+00:00"],"modified":["2016-08-02
+        17:56:13.334787+00:00","2016-08-02 17:56:53.461383+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":4,"type":"activity_stream","url":"/api/v1/activity_stream/4/","related":{"unified_job_template":"/api/v1/system_job_templates/3/","schedule":["/api/v1/schedules/3/"]},"summary_fields":{"schedule":[{"next_run":"2017-04-01T17:56:13Z","description":"Automatically
+        Generated Schedule","id":3,"name":"Cleanup Fact Schedule"}],"system_job_template":{"id":3,"name":"Cleanup
+        Fact Details"}},"timestamp":"2016-08-02T17:56:53.534456Z","operation":"update","changes":{"next_run":[null,"2016-09-01
+        17:56:13+00:00"],"dtstart":[null,"2016-09-01 17:56:13+00:00"],"modified":["2016-08-02
+        17:56:13.334787+00:00","2016-08-02 17:56:53.530012+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":5,"type":"activity_stream","url":"/api/v1/activity_stream/5/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.864976Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"organization","object2":"role","object1_pk":1,"action":"associate"},"object1":"organization","object2":"role","object_association":"parents"},{"id":6,"type":"activity_stream","url":"/api/v1/activity_stream/6/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.886688Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"organization","object2":"role","object1_pk":1,"action":"associate"},"object1":"organization","object2":"role","object_association":"parents"},{"id":7,"type":"activity_stream","url":"/api/v1/activity_stream/7/","related":{"organization":["/api/v1/organizations/1/"]},"summary_fields":{"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.908036Z","operation":"create","changes":{"description":"","id":1,"name":"Default"},"object1":"organization","object2":"","object_association":""},{"id":8,"type":"activity_stream","url":"/api/v1/activity_stream/8/","related":{"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}]},"timestamp":"2016-08-02T17:57:02.933880Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"project","object2":"role","object1_pk":4,"action":"associate"},"object1":"project","object2":"role","object_association":"parents"},{"id":9,"type":"activity_stream","url":"/api/v1/activity_stream/9/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.942946Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":5,"object1":"project","object2":"organization","object1_pk":4,"action":"associate"},"object1":"project","object2":"organization","object_association":"parents"},{"id":10,"type":"activity_stream","url":"/api/v1/activity_stream/10/","related":{},"summary_fields":{},"timestamp":"2016-08-02T17:57:02.993553Z","operation":"create","changes":{"credential":null,"scm_branch":"","name":"Demo
+        Project","scm_update_cache_timeout":0,"scm_clean":false,"scm_url":"https://github.com/ansible/ansible-tower-samples","scm_delete_on_update":false,"local_path":"","scm_type":"git","scm_update_on_launch":true,"organization":"Default","id":4,"description":""},"object1":"project","object2":"","object_association":""},{"id":11,"type":"activity_stream","url":"/api/v1/activity_stream/11/","related":{"project":["/api/v1/projects/4/"]},"summary_fields":{"project":[{"status":"successful","description":"A
+        great demo","id":4,"name":"Demo Project"}]},"timestamp":"2016-08-02T17:57:03.007623Z","operation":"update","changes":{"local_path":["","_4__demo_project"]},"object1":"project","object2":"","object_association":""},{"id":12,"type":"activity_stream","url":"/api/v1/activity_stream/12/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}]},"timestamp":"2016-08-02T17:57:03.037615Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"credential","object2":"role","object1_pk":1,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":13,"type":"activity_stream","url":"/api/v1/activity_stream/13/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}]},"timestamp":"2016-08-02T17:57:03.057364Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":12,"object1":"credential","object2":"credential","object1_pk":1,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":14,"type":"activity_stream","url":"/api/v1/activity_stream/14/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}]},"timestamp":"2016-08-02T17:57:03.066061Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":14,"object1":"credential","object2":"credential","object1_pk":1,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":15,"type":"activity_stream","url":"/api/v1/activity_stream/15/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}]},"timestamp":"2016-08-02T17:57:03.073107Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"credential","object2":"role","object1_pk":1,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":16,"type":"activity_stream","url":"/api/v1/activity_stream/16/","related":{"credential":["/api/v1/credentials/1/"]},"summary_fields":{"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}]},"timestamp":"2016-08-02T17:57:03.103350Z","operation":"create","changes":{"authorize":false,"domain":"","vault_password":"hidden","become_username":"","id":1,"become_method":"","secret":"hidden","ssh_key_unlock":"hidden","authorize_password":"hidden","username":"admin","description":"","host":"","become_password":"hidden","password":"hidden","tenant":"","subscription":"","kind":"ssh","name":"Demo
+        Credential","security_token":"hidden","project":"","client":"","ssh_key_data":"hidden","organization":null},"object1":"credential","object2":"","object_association":""},{"id":17,"type":"activity_stream","url":"/api/v1/activity_stream/17/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/12/"],"user":["/api/v1/users/1/"]},"summary_fields":{"role":[{"id":12,"role_field":"admin_role"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
+        Credential"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}]},"timestamp":"2016-08-02T17:57:03.126094Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"credential","object2":"user","object1_pk":1,"action":"associate"},"object1":"credential","object2":"user","object_association":"role"},{"id":18,"type":"activity_stream","url":"/api/v1/activity_stream/18/","related":{"inventory":["/api/v1/inventories/1/"]},"summary_fields":{"inventory":[{"has_active_failures":false,"has_inventory_sources":false,"description":"","inventory_sources_with_failures":0,"groups_with_active_failures":0,"hosts_with_active_failures":0,"total_hosts":2,"total_inventory_sources":0,"total_groups":0,"id":1,"name":"Demo
+        Inventory"}]},"timestamp":"2016-08-02T17:57:03.201638Z","operation":"create","changes":{"organization":"Default","variables":"","description":"","id":1,"name":"Demo
+        Inventory"},"object1":"inventory","object2":"","object_association":""},{"id":19,"type":"activity_stream","url":"/api/v1/activity_stream/19/","related":{"host":["/api/v1/hosts/1/"]},"summary_fields":{"host":[{"description":"","has_inventory_sources":false,"id":1,"has_active_failures":false,"name":"localhost"}]},"timestamp":"2016-08-02T17:57:03.239272Z","operation":"create","changes":{"name":"localhost","variables":"ansible_connection:
+        local","enabled":true,"instance_id":"","inventory":"Demo Inventory-1","id":1,"description":""},"object1":"host","object2":"","object_association":""},{"id":20,"type":"activity_stream","url":"/api/v1/activity_stream/20/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/5/"]},"summary_fields":{"role":[{"id":5,"role_field":"admin_role"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:03.290739Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":5,"object1":"job_template","object2":"organization","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":21,"type":"activity_stream","url":"/api/v1/activity_stream/21/","related":{"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}]},"timestamp":"2016-08-02T17:57:03.347125Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":20,"object1":"job_template","object2":"job_template","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":22,"type":"activity_stream","url":"/api/v1/activity_stream/22/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:03.362262Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":6,"object1":"job_template","object2":"organization","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":23,"type":"activity_stream","url":"/api/v1/activity_stream/23/","related":{"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}]},"timestamp":"2016-08-02T17:57:03.380020Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":22,"object1":"job_template","object2":"job_template","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":24,"type":"activity_stream","url":"/api/v1/activity_stream/24/","related":{"job_template":["/api/v1/job_templates/5/"]},"summary_fields":{"job_template":[{"description":"","id":5,"name":"Demo
+        Job Template"}]},"timestamp":"2016-08-02T17:57:03.424469Z","operation":"create","changes":{"network_credential":null,"ask_tags_on_launch":false,"job_type":"run","skip_tags":"","playbook":"hello_world.yml","id":5,"survey_enabled":false,"force_handlers":false,"job_tags":"","ask_inventory_on_launch":false,"inventory":"Demo
+        Inventory-1","forks":0,"cloud_credential":null,"become_enabled":false,"credential":"Demo
+        Credential-1","description":"","ask_variables_on_launch":false,"ask_job_type_on_launch":false,"start_at_task":"","ask_limit_on_launch":false,"host_config_key":"","name":"Demo
+        Job Template","ask_credential_on_launch":false,"extra_vars":"","verbosity":0,"allow_simultaneous":false,"project":"Demo
+        Project-4","limit":""},"object1":"job_template","object2":"","object_association":""},{"id":25,"type":"activity_stream","url":"/api/v1/activity_stream/25/","related":{"unified_job_template":"/api/v1/system_job_templates/3/","schedule":["/api/v1/schedules/3/"]},"summary_fields":{"schedule":[{"next_run":"2017-04-01T17:56:13Z","description":"Automatically
+        Generated Schedule","id":3,"name":"Cleanup Fact Schedule"}],"system_job_template":{"id":3,"name":"Cleanup
+        Fact Details"}},"timestamp":"2016-08-02T17:57:12.865342Z","operation":"update","changes":{"modified":["2016-08-02
+        17:56:53.530012+00:00","2016-08-02 17:57:12.860263+00:00"]},"object1":"schedule","object2":"","object_association":""}]}'
+    http_version: 
+  recorded_at: Mon, 13 Mar 2017 15:14:46 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
passing just plain old hashes around is less error prone for future
use. E.g. if an event does not have a object1 property it will not
crash the parser.

it also makes it easier to test other parts (e.g. the event parser)

added specs for the event stream


@miq-bot assign @lfu 
@miq-bot add_labels refactoring, tests, providers/ansible_tower