### PR TITLE
Prevent a DVPortGroup from overwriting a LAN with the same name in provisioning

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -218,7 +218,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       # TODO: Use Active Record to preload this data?
       MiqPreloader.preload(hosts, :switches => :lans)
       hosts.each do |h|
-        h.lans.each { |l| vlans[l.name] = l.name if @vlan_options[:dvs] || !l.switch.shared? }
+        h.lans.each { |l| vlans[l.name] = l.name unless l.switch.shared? }
       end
       rails_logger('allowed_vlans', 1)
     end


### PR DESCRIPTION
During the provisioning workflow we return the list of allowed_vlans as a hash with the name of the network as the key.

If you have a DVPortGroup and a normal network with the same name they will have only one entry in the `vlans` hash.

Later we change the `vlans` key of a DVS to be `"dvs_#{name}` and delete the old key: https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb#L141-L142

This leads to only one entry in the `vlans` hash and it is the dvportgroup, the standard network is deleted.

This change will set the key of a dvportgroup to have the `dvs_` prefix initially so it will not collide with non dvportgroups and both will be returned.

VC Networks:
![screenshot from 2017-03-13 12-06-48](https://cloud.githubusercontent.com/assets/12851112/23863354/fc8b7aea-07e5-11e7-9a84-f023b7f2e63e.png)

Before:
![screenshot from 2017-03-13 12-08-09](https://cloud.githubusercontent.com/assets/12851112/23863368/00fedbee-07e6-11e7-9592-832c5f867577.png)

After:
![screenshot from 2017-03-13 12-09-17](https://cloud.githubusercontent.com/assets/12851112/23863371/043e1d6a-07e6-11e7-9a9b-7ffe83b3bace.png)


Related: https://github.com/ManageIQ/manageiq-providers-vmware/pull/25

https://bugzilla.redhat.com/show_bug.cgi?id=1430709