### PR TITLE
[DARGA] Don't wait for refresh if stack no longer exists

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -14,7 +14,14 @@ end
 def refresh_may_have_completed?(service)
   stack = service.orchestration_stack
   refreshed_stack = $evm.vmdb(:orchestration_stack).find_by(:name => stack.name, :ems_ref => stack.ems_ref)
-  refreshed_stack && refreshed_stack.status != 'CREATE_IN_PROGRESS'
+  if refreshed_stack
+    refreshed_stack.status != 'CREATE_IN_PROGRESS'
+  elsif $evm.get_state_var('deploy_result') == 'error' && service.orchestration_stack_status[0] == 'check_status_failed'
+    # stack failed and has been removed from the provider, no need to wait for refresh complete
+    true
+  else
+    false
+  end
 end
 
 def check_deployed(service)

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -55,6 +55,18 @@ describe "Orchestration check_provisioned Method Validation" do
     expect(ws_with_refresh_started.root['ae_result']).to eq("retry")
   end
 
+  context "stack on longer exists" do
+    let(:deploy_result) { 'error' }
+
+    it "does not need to wait for refresh completion" do
+      allow_any_instance_of(ServiceOrchestration)
+        .to receive(:orchestration_stack_status) { ['check_status_failed', 'stack does not exist'] }
+      allow_any_instance_of(ServiceOrchestration)
+        .to receive(:orchestration_stack) { FactoryGirl.build(:orchestration_stack_amazon) }
+      expect(ws_with_refresh_started.root['ae_result']).to eq(deploy_result)
+    end
+  end
+
   it "completes check_provisioned step when refresh is done" do
     allow_any_instance_of(ServiceOrchestration)
       .to receive(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon, :status => "success") }


### PR DESCRIPTION
Ported from https://github.com/ManageIQ/manageiq-content/pull/29

https://bugzilla.redhat.com/show_bug.cgi?id=1421156

@miq-bot assign @simaishi 
@miq-bot add_label orchestration
@miq-bot add_label bug
@miq-bot add_label automate