### PR TITLE
Report includes cols

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -108,19 +108,9 @@ module MiqReport::Generator
           result[:tags] = {}
         else
           assoc_reflection = klass.reflect_on_association(k)
-          assoc_klass = assoc_reflection.nil? ? nil : (assoc_reflection.options[:polymorphic] ? k : assoc_reflection.klass)
+          assoc_klass = (assoc_reflection.options[:polymorphic] ? k : assoc_reflection.klass) if assoc_reflection
 
-          if v.nil? || v["include"].blank?
-            result[k] = {}
-          elsif assoc_klass
-            result[k] = include_as_hash(v["include"], assoc_klass, nil)
-          end
-
-          if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]
-            v["columns"].each do |c|
-              result[k][c.to_sym] = {} if assoc_klass.virtual_attribute?(c) && !assoc_klass.attribute_supported_by_sql?(c)
-            end
-          end
+          result[k] = include_as_hash(v && v["include"], assoc_klass, v && v["columns"])
         end
       end
     elsif includes.kind_of?(Array)

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -94,9 +94,9 @@ module MiqReport::Generator
   end
 
   def include_as_hash(includes = include, klass = nil)
+    result = {}
     if klass.nil?
       klass = db_class
-      result = {}
       if cols && klass.respond_to?(:virtual_attribute?)
         cols.each do |c|
           result[c.to_sym] = {} if klass.virtual_attribute?(c) && !klass.attribute_supported_by_sql?(c)
@@ -105,7 +105,6 @@ module MiqReport::Generator
     end
 
     if includes.kind_of?(Hash)
-      result ||= {}
       includes.each do |k, v|
         k = k.to_sym
         if k == :managed
@@ -128,7 +127,6 @@ module MiqReport::Generator
         end
       end
     elsif includes.kind_of?(Array)
-      result ||= {}
       includes.each { |i| result[i.to_sym] = {} }
     end
 

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -93,14 +93,11 @@ module MiqReport::Generator
     end
   end
 
-  def include_as_hash(includes = include, klass = nil)
+  def include_as_hash(includes = include, klass = db_class, klass_cols = cols)
     result = {}
-    if klass.nil?
-      klass = db_class
-      if cols && klass.respond_to?(:virtual_attribute?)
-        cols.each do |c|
-          result[c.to_sym] = {} if klass.virtual_attribute?(c) && !klass.attribute_supported_by_sql?(c)
-        end
+    if klass_cols && klass && klass.respond_to?(:virtual_attribute?)
+      klass_cols.each do |c|
+        result[c.to_sym] = {} if klass.virtual_attribute?(c) && !klass.attribute_supported_by_sql?(c)
       end
     end
 
@@ -116,7 +113,7 @@ module MiqReport::Generator
           if v.nil? || v["include"].blank?
             result[k] = {}
           elsif assoc_klass
-            result[k] = include_as_hash(v["include"], assoc_klass)
+            result[k] = include_as_hash(v["include"], assoc_klass, nil)
           end
 
           if assoc_klass && assoc_klass.respond_to?(:virtual_attribute?) && v["columns"]


### PR DESCRIPTION
### High Level
Dedup `include_as_hash` logic for determining columns.

`MiqReport#include_as_hash` takes the `include` value from a `report.yaml` file and generates the `includes()` value.

The new code works on each layer of the `include` hash more consistently. (Which deletion of duplicate code tends to do.)

### Details

Making `columns` into a variable allows us to trim down the `if` block up front. It also allows us to set `klass` and `columns` with a default parameter.

The duplicate code in the iterator of the `includes` nicely falls out and is handled by the block up front.

I did do this as 3 commits...

### Why?

I want to generate the `includes` in a more straightforward manner. That way we can do a better job generating it and hopefully include fewer tables. (Right now we are including these tables even for intermediary results. Which is bring back many more records and making our `count(*)` less efficient by using both `inner joins` and `distinct`.