### PR TITLE
Miq Alert Status model changes for resolved alerts

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,9 +1,6 @@
-require 'ancestry'
-
 class MiqAlertStatus < ApplicationRecord
   SEVERITY_LEVELS = %w(error warning info).freeze
 
-  has_ancestry
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
   belongs_to :ext_management_system

--- a/db/migrate/20170309111313_add_resolved_to_alerts.rb
+++ b/db/migrate/20170309111313_add_resolved_to_alerts.rb
@@ -1,0 +1,5 @@
+class AddResolvedToAlerts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :resolved, :boolean
+  end
+end

--- a/db/migrate/20170309125642_add_alert_ems_ref.rb
+++ b/db/migrate/20170309125642_add_alert_ems_ref.rb
@@ -1,0 +1,6 @@
+class AddAlertEmsRef < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :event_ems_ref, :string
+    add_index :miq_alert_statuses, :event_ems_ref
+  end
+end

--- a/db/migrate/20170313160354_remove_ancestry_from_alerts.rb
+++ b/db/migrate/20170313160354_remove_ancestry_from_alerts.rb
@@ -1,0 +1,6 @@
+class RemoveAncestryFromAlerts < ActiveRecord::Migration[5.0]
+  def change
+    remove_index  :miq_alert_statuses, :ancestry
+    remove_column :miq_alert_statuses, :ancestry, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4863,6 +4863,7 @@ miq_alert_statuses:
 - ems_id
 - description
 - resolved
+- event_ems_ref
 miq_alerts:
 - id
 - guid

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4862,6 +4862,7 @@ miq_alert_statuses:
 - acknowledged
 - ems_id
 - description
+- resolved
 miq_alerts:
 - id
 - guid

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4858,7 +4858,6 @@ miq_alert_statuses:
 - result
 - url
 - severity
-- ancestry
 - acknowledged
 - ems_id
 - description


### PR DESCRIPTION
- ancestry was added in https://github.com/ManageIQ/manageiq/pull/13233 to model resolved alerts
the intention was to link an open alert with a resolved one and figure out using ancestry which alerts to show in the screen (only opening ones, the have no resolving mas). It became apparent it would be more straight forward to represent that using one MAS with a new field(see next commit) and that would also make retrival more performant (save an N+1 issue).
- resolved means the problem represented by the alerts has gone away
- ems_ref is a reference in the provider to the event that created the alert and allows to find the opening alert when the resolving one comes into the system