### PR TITLE
always pass valid date format

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
@@ -30,9 +30,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
   private
 
   def filter
+    timestamp = @last_activity ? Time.zone.parse(@last_activity.timestamp) : 1.minute.ago
     {
       :order_by      => 'timestamp',
-      :timestamp__gt => @last_activity ? @last_activity.timestamp : 1.minute.ago.to_s(:db)
+      :timestamp__gt => timestamp.to_s(:db)
     }
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/event_catcher/stream.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatche
   private
 
   def filter
-    timestamp = @last_activity ? Time.zone.parse(@last_activity.timestamp) : 1.minute.ago
+    timestamp = @last_activity ? Time.zone.parse(@last_activity.timestamp.to_s) : 1.minute.ago
     {
       :order_by      => 'timestamp',
       :timestamp__gt => timestamp.to_s(:db)

--- a/spec/support/ansible_shared/automation_manager/event_catcher/stream.rb
+++ b/spec/support/ansible_shared/automation_manager/event_catcher/stream.rb
@@ -66,4 +66,19 @@ shared_examples_for "ansible event_catcher stream" do |cassette_file|
       end
     end
   end
+
+  context ".filter" do
+    it "converts timestamp to correct timeformat" do
+      # It must be in YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ]
+      timestamps = {
+        '2016-01-01 01:00:00'                  => '2016-01-01 01:00:00',
+        '2017-03-10 19%3A31%3A26'              => '2017-03-10 00:00:00',
+        Time.zone.parse('1975-12-31 01:01:01') => '1975-12-31 01:01:01',
+      }
+      timestamps.each do |input, converted|
+        subject.instance_variable_set(:@last_activity, OpenStruct.new(:timestamp => input))
+        expect(subject.send(:filter)[:timestamp__gt]).to eq(converted)
+      end
+    end
+  end
 end


### PR DESCRIPTION
It could be, for whatever reason, that the filter timestamp is in an invalid format (see issue)

This makes sure, we parse the date and always convert it to the valid format of `to_s(:db)`

fixes https://github.com/ManageIQ/manageiq/issues/14279

@miq-bot assign @mkanoor 
@miq-bot add_labels bug, providers/ansible_tower