### PR TITLE
Retrieve resolved alerts from hawkular

### DIFF
--- a/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
@@ -16,15 +16,21 @@ module ManageIQ::Providers::Hawkular::Common::EventCatcher::StreamMixin
   end
 
   def fetch
-    new_alerts = []
-    alert_tenants.each do |tenant|
-      log_handle.debug "Fetching tenant [#{tenant}] events using criteria [#{hawkular_alert_criteria}]"
-      new_alerts.concat(@ems.alerts_client(:tenant => tenant).list_alerts(hawkular_alert_criteria))
-    end
+    new_alerts = fetch_criteria(open_alert_criteria)
+    new_alerts.concat(fetch_criteria(resolved_alert_criteria)) if method(:resolved_alert_criteria)
     post_fetch(new_alerts)
     new_alerts
   rescue => err
     log_handle.error "Error capturing alerts #{err}"
     []
+  end
+
+  def fetch_criteria(criteria)
+    new_alerts = []
+    alert_tenants.each do |tenant|
+      log_handle.debug "Fetching tenant [#{tenant}] alerts using criteria [#{criteria}]"
+      new_alerts.concat(@ems.alerts_client(:tenant => tenant).list_alerts(criteria))
+    end
+    new_alerts
   end
 end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
@@ -45,12 +45,15 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Runner 
     event = event.dup
     event.severity = map_severity(event.severity) # gets into event.full_data
     event.url = event.tags[TAG_URL]
+    event.ems_ref = event.id
+    event.resolved = event.status == "RESOLVED"
+    timestamp = event.resolved ? event.lifecycle.last['stime'] : event.ctime
     target = self.class.find_target(event.tags)
     {
       :ems_id              => target.try(:ext_management_system).try(:id),
       :generating_ems_id   => current_ems_id,
       :source              => 'DATAWAREHOUSE',
-      :timestamp           => Time.zone.at(event.ctime / 1000),
+      :timestamp           => Time.zone.at(timestamp / 1000),
       :event_type          => 'datawarehouse_alert',
       :target_type         => target.class.name.underscore,
       :target_id           => target.id,

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
@@ -12,9 +12,14 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
     $datawarehouse_log
   end
 
-  def hawkular_alert_criteria
+  def open_alert_criteria
     # Use "tagQuery" => "type==node AND not seen_by" when that becomes available in HAWKULAR API
-    {"tags" => "type|*", "thin" => true}
+    {"tags" => "type|*", "thin" => true, "statuses" => 'OPEN,ACKNOWLEDGED'}
+  end
+
+  def resolved_alert_criteria
+    # Use "tagQuery" => "type==node AND not resolved_seen_by" when that becomes available in HAWKULAR API
+    {"tags" => "type|*", "thin" => true, "statuses" => 'RESOLVED'}
   end
 
   def alert_tenants

--- a/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream_spec.rb
@@ -19,14 +19,14 @@ describe ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stre
         # :record                   => :new_episodes,
       ) do
         result = subject.instance_eval('fetch')
-        expect(result.count).to be == 1
-        expect(result.first[:text]).to eq "This text shows up on the alert"
-        expect(result.first[:tags]).to include(
+        expect(result.count).to be == 2
+        expect(result.last[:text]).to eq "This text shows up on the alerts screen"
+        expect(result.last[:tags]).to include(
           "nodename" => "vm-48-124.eng.lab.tlv.redhat.com",
           "type"     => "node",
           "url"      => "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
         )
-        expect(result.first[:severity]).to eq "HIGH"
+        expect(result.last[:severity]).to eq "HIGH"
       end
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7C*&thin=true
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?statuses=OPEN,ACKNOWLEDGED&tags=type%7C*&thin=true
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,103 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.0p0
+      Hawkular-Tenant:
+      - _system
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tdmtlN2siLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijg3MDQ5NzNjLWRiMjMtMTFlNi05NDlkLTAwMWE0YTE2MjY3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.nuNCehi01GT7sbGGliCjTdwzZjNo4mjsbgGwuyChCxZJhj2Jyb7C2ZUABfgh26g466EReMal5M4F7Nbah_cbZgfrWi1NK0h_f18g8kA_m3jn9CfbfajZAGSMEUrVwHx05IqVqEI4FMJM5XwYBP8pTSEGjYcuk5OOSEK_xXs-Lt_iJYaOUMjWNa-XnI3zjiD5f7eP-FBOek2-YtFlcSJt3lqQyM_fjrocnMF9B3JWYcFLQ-ctuRaOHvaK-eaXz1AzFctBfaBGYXSw0LrH0slWqNC0Fu1AWpKKvwrOwD70DhUgjBGnD3Va_3ewTe5KNwByib6ox6xOQVYnfg7SoSOdCg
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Date:
+      - Fri, 17 Mar 2017 15:07:12 GMT
+      Set-Cookie:
+      - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
+        HttpOnly; Secure
+      Cache-Control:
+      - private
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 17 Mar 2017 15:07:11 GMT
+- request:
+    method: get
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?statuses=OPEN,ACKNOWLEDGED&tags=type%7C*&thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.0p0
+      Hawkular-Tenant:
+      - _ops
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tdmtlN2siLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijg3MDQ5NzNjLWRiMjMtMTFlNi05NDlkLTAwMWE0YTE2MjY3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.nuNCehi01GT7sbGGliCjTdwzZjNo4mjsbgGwuyChCxZJhj2Jyb7C2ZUABfgh26g466EReMal5M4F7Nbah_cbZgfrWi1NK0h_f18g8kA_m3jn9CfbfajZAGSMEUrVwHx05IqVqEI4FMJM5XwYBP8pTSEGjYcuk5OOSEK_xXs-Lt_iJYaOUMjWNa-XnI3zjiD5f7eP-FBOek2-YtFlcSJt3lqQyM_fjrocnMF9B3JWYcFLQ-ctuRaOHvaK-eaXz1AzFctBfaBGYXSw0LrH0slWqNC0Fu1AWpKKvwrOwD70DhUgjBGnD3Va_3ewTe5KNwByib6ox6xOQVYnfg7SoSOdCg
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Total-Count:
+      - '1'
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1162'
+      Link:
+      - <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&statuses=OPEN,ACKNOWLEDGED>;
+        rel="current", <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&statuses=OPEN,ACKNOWLEDGED&page=0>;
+        rel="last"
+      Date:
+      - Fri, 17 Mar 2017 15:07:13 GMT
+      Set-Cookie:
+      - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
+        HttpOnly; Secure
+      Cache-Control:
+      - private
+    body:
+      encoding: UTF-8
+      string: '[{"eventType":"ALERT","tenantId":"_ops","id":"master-node-member-idle-cpu-1489316162713-ea35e85c-6d94-4bd4-bd4b-fe980d87d2b5","ctime":1489316162713,"dataSource":"_none_","dataId":"master-node-member-idle-cpu","category":"ALERT","text":"CPU
+        idle less than 5% on vm-48-124.eng.lab.tlv.redhat.com","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://youtu.be/IicmCu47pMo"},"trigger":{"tenantId":"_ops","id":"master-node-member-idle-cpu","name":"Idle
+        CPU Member","description":"CPU idle less than 5% on vm-48-124.eng.lab.tlv.redhat.com","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"MEDIUM","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://youtu.be/IicmCu47pMo"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"kernel.all.cpu.idle":"hm_g_node/vm-48-124.eng.lab.tlv.redhat.com/kernel.all.cpu.idle"},"memberOf":"test-cpu-idle","enabled":true,"firingMatch":"ALL","source":"_none_"},"severity":"MEDIUM","status":"OPEN","lifecycle":[{"status":"OPEN","user":"system","stime":1489316162713}]}]'
+    http_version: 
+  recorded_at: Fri, 17 Mar 2017 15:07:12 GMT
+- request:
+    method: get
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?statuses=RESOLVED&tags=type%7C*&thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.0p0
       Hawkular-Tenant:
       - _system
       Authorization:
@@ -33,13 +129,13 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1002'
+      - '1205'
       Link:
-      - <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true>;
-        rel="current", <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&page=0>;
+      - <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&statuses=RESOLVED>;
+        rel="current", <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&statuses=RESOLVED&page=0>;
         rel="last"
       Date:
-      - Mon, 27 Feb 2017 13:13:28 GMT
+      - Fri, 17 Mar 2017 15:07:13 GMT
       Set-Cookie:
       - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
         HttpOnly; Secure
@@ -47,15 +143,17 @@ http_interactions:
       - private
     body:
       encoding: UTF-8
-      string: '[{"eventType":"ALERT","tenantId":"_system","id":"ops-example-1487798421499-97db796d-b5a1-492c-9153-3b43cc6426d2","ctime":1487798421499,"dataSource":"_none_","dataId":"ops-example","category":"ALERT","text":"This
-        text shows up on the alert","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"trigger":{"tenantId":"_system","id":"ops-example","name":"Auto
-        Resolving trigger","description":"Auto resolving trigger example","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":"This
-        text shows up on the alert","severity":"HIGH","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"autoDisable":false,"autoEnable":false,"autoResolve":true,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ALL","source":"_none_"},"severity":"HIGH","status":"OPEN","lifecycle":[{"status":"OPEN","user":"system","stime":1487798421499}]}]'
+      string: '[{"eventType":"ALERT","tenantId":"_system","id":"ops-example-1489487734309-58f1aa1c-dafe-4285-bbae-ec7a788de50d","ctime":1489487734309,"dataSource":"_none_","dataId":"ops-example","category":"ALERT","text":"This
+        text shows up on the alerts screen","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"trigger":{"tenantId":"_system","id":"ops-example","name":"Auto
+        Resolving trigger","description":"This text shows up on the alert screen if
+        event.text is nil","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":"This
+        text shows up on the alerts screen","severity":"HIGH","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"autoDisable":false,"autoEnable":false,"autoResolve":true,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ALL","source":"_none_"},"severity":"HIGH","status":"RESOLVED","notes":[{"user":"AutoResolve","ctime":1489487766321,"text":"Trigger
+        AutoResolve=True"}],"lifecycle":[{"status":"OPEN","user":"system","stime":1489487734309},{"status":"RESOLVED","user":"AutoResolve","stime":1489487766321}]}]'
     http_version: 
-  recorded_at: Mon, 27 Feb 2017 13:13:27 GMT
+  recorded_at: Fri, 17 Mar 2017 15:07:12 GMT
 - request:
     method: get
-    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7C*&thin=true
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?statuses=RESOLVED&tags=type%7C*&thin=true
     body:
       encoding: US-ASCII
       string: ''
@@ -65,7 +163,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.0p0
       Hawkular-Tenant:
       - _ops
       Authorization:
@@ -86,7 +184,7 @@ http_interactions:
       Content-Length:
       - '2'
       Date:
-      - Mon, 27 Feb 2017 13:13:28 GMT
+      - Fri, 17 Mar 2017 15:07:13 GMT
       Set-Cookie:
       - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
         HttpOnly; Secure
@@ -96,5 +194,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 27 Feb 2017 13:13:27 GMT
+  recorded_at: Fri, 17 Mar 2017 15:07:12 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Retrieve resolved alerts from hawkular.
To see the type of hawkular alerts we plan to use with this see [this](https://github.com/moolitayer/hawkular-curl-examples/tree/4a22cbc4bf6e7f1ae7ae0e617eb730247c7d19aa/ops-example)

Depends on: #14295 [merged]
 
