### PR TITLE
Always evaluate datawarehouse_alerts

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -181,6 +181,10 @@ class EmsEvent < EventStream
     ]
   end
 
+  def always_evaluate_alerts?
+    event_type == "datawarehouse_alert"
+  end
+
   def first_chained_event
     @first_chained_event ||= EmsEvent.first_chained_event(ems_id, chain_id) || self
   end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -109,7 +109,7 @@ class MiqAlert < ApplicationRecord
     _log.info("#{log_header} #{log_target}")
 
     assigned_to_target(target, event).each do |a|
-      next if a.postpone_evaluation?(target)
+      next if a.postpone_evaluation?(target, inputs[:ems_event])
       _log.info("#{log_header} #{log_target} Queuing evaluation of Alert: [#{a.description}]")
       a.evaluate_queue(target, inputs)
     end
@@ -158,8 +158,8 @@ class MiqAlert < ApplicationRecord
     end
   end
 
-  def postpone_evaluation?(target)
-    # TODO: Are there some alerts that we always want to evaluate?
+  def postpone_evaluation?(target, event)
+    return false if event.try(:always_evaluate_alerts?)
 
     # If a miq alert status exists for our resource and alert, and it has not been delay_next_evaluation seconds since
     # it was evaluated, return true so we can skip evaluation
@@ -184,7 +184,7 @@ class MiqAlert < ApplicationRecord
       raise "Unable to find object with class: [#{klass}], Id: [#{id}]" unless target
     end
 
-    return if self.postpone_evaluation?(target)
+    return if self.postpone_evaluation?(target, inputs[:ems_event])
 
     _log.info("Evaluating Alert [#{description}] for target: [#{target.name}]...")
     result = eval_expression(target, inputs)


### PR DESCRIPTION
Since hawkular alerts are evaluated in an external system, each alerts coming into the system already represents a created alert. When they come into the system we should always pick them up.