### PR TITLE
Save assignee on MiqAlertStatus

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -4,18 +4,15 @@ class MiqAlertStatus < ApplicationRecord
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
   belongs_to :ext_management_system
+  belongs_to :assignee, :class_name => 'User'
   has_many :miq_alert_status_actions, -> { order "created_at" }, :dependent => :destroy
   virtual_column :assignee, :type => :string
   virtual_column :hidden, :type => :boolean
 
   validates :severity, :acceptance => { :accept => SEVERITY_LEVELS }
 
-  def assignee
-    miq_alert_status_actions.where(:action_type => %w(assign unassign)).last.try(:assignee)
-  end
-
   def assigned?
-    assignee.present?
+    assignee_id.present?
   end
 
   def hidden?

--- a/app/models/miq_alert_status_action.rb
+++ b/app/models/miq_alert_status_action.rb
@@ -13,6 +13,7 @@ class MiqAlertStatusAction < ApplicationRecord
   validate :only_assignee_can_acknowledge
 
   after_save :update_status_acknowledgement
+  after_save :update_status_assignee
 
   def only_assignee_can_acknowledge
     if ['acknowledge', 'unacknowledge', 'hide', 'show'].include?(action_type) &&
@@ -23,9 +24,13 @@ class MiqAlertStatusAction < ApplicationRecord
 
   def update_status_acknowledgement
     if %w(assign unassign unacknowledge).include?(action_type)
-      miq_alert_status.update(:acknowledged => false)
+      miq_alert_status.update_attributes!(:acknowledged => false)
     elsif "acknowledge" == action_type
-      miq_alert_status.update(:acknowledged => true)
+      miq_alert_status.update_attributes!(:acknowledged => true)
     end
+  end
+
+  def update_status_assignee
+    miq_alert_status.update_attributes!(:assignee => assignee) if %w(assign unassign).include?(action_type)
   end
 end

--- a/db/migrate/20170313170754_add_mas_assignee.rb
+++ b/db/migrate/20170313170754_add_mas_assignee.rb
@@ -1,0 +1,5 @@
+class AddMasAssignee < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :miq_alert_statuses, :assignee, :type => :bigint, :index => true
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4873,6 +4873,7 @@ miq_alert_statuses:
 - description
 - resolved
 - event_ems_ref
+- assignee_id
 miq_alerts:
 - id
 - guid


### PR DESCRIPTION
While adding a certain data duplication, this seems to be the most practical solution for removing an N+1 situation when querying the assignee of a MAS. 