### PR TITLE
MiqApache::Conf.create_balancer_config expects a :lbmethod key

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -104,7 +104,7 @@ module MiqWebServerWorkerMixin
       options = {
         :member_file    => self::BALANCE_MEMBER_CONFIG_FILE,
         :redirects_file => self::REDIRECTS_CONFIG_FILE,
-        :method         => self::LB_METHOD,
+        :lbmethod       => self::LB_METHOD,
         :redirects      => self::REDIRECTS,
         :cluster        => self::CLUSTER,
         :protocol       => self::PROTOCOL


### PR DESCRIPTION
This will allow us to pick methods other than byrequests, which was the default in MiqApache::Conf
