### PR TITLE
delete authentication in provider

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -1,4 +1,11 @@
 module Api
   class AuthenticationsController < BaseController
+    def delete_resource(type, id, _data = {})
+      auth = resource_search(id, type, collection_class(:authentications))
+      task_id = auth.delete_in_provider_queue
+      action_result(true, "Deleting Authentication with id #{id}", :task_id => task_id)
+    rescue => err
+      raise "Could not delete authentication - #{err}"
+    end
   end
 end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -2,10 +2,17 @@ module Api
   class AuthenticationsController < BaseController
     def delete_resource(type, id, _data = {})
       auth = resource_search(id, type, collection_class(:authentications))
+      raise 'type not currently supported' unless auth.respond_to?(:delete_in_provider_queue)
       task_id = auth.delete_in_provider_queue
-      action_result(true, "Deleting Authentication with id #{id}", :task_id => task_id)
+      action_result(true, "Deleting #{authentication_ident(auth)}", :task_id => task_id)
     rescue => err
-      raise "Could not delete authentication - #{err}"
+      action_result(false, err.to_s)
+    end
+
+    private
+
+    def authentication_ident(auth)
+      "Authentication id:#{auth.id} name: '#{auth.name}'"
     end
   end
 end

--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -2,7 +2,7 @@ module Api
   class AuthenticationsController < BaseController
     def delete_resource(type, id, _data = {})
       auth = resource_search(id, type, collection_class(:authentications))
-      raise 'type not currently supported' unless auth.respond_to?(:delete_in_provider_queue)
+      raise "Delete not supported for #{authentication_ident(auth)}" unless auth.respond_to?(:delete_in_provider_queue)
       task_id = auth.delete_in_provider_queue
       action_result(true, "Deleting #{authentication_ident(auth)}", :task_id => task_id)
     rescue => err

--- a/config/api.yml
+++ b/config/api.yml
@@ -233,7 +233,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: Authentication
     :collection_actions:
       :get:
@@ -247,6 +247,9 @@
       - :name: read
         :identifier: embedded_automation_manager_credentials_view
       :post:
+      - :name: delete
+        :identifier: embedded_automation_manager_credentials_delete
+      :delete:
       - :name: delete
         :identifier: embedded_automation_manager_credentials_delete
     :subcollection_actions:

--- a/config/api.yml
+++ b/config/api.yml
@@ -233,7 +233,7 @@
     :options:
     - :collection
     - :subcollection
-    :verbs: *gpd
+    :verbs: *gp
     :klass: Authentication
     :collection_actions:
       :get:
@@ -247,9 +247,6 @@
       - :name: read
         :identifier: embedded_automation_manager_credentials_view
       :post:
-      - :name: delete
-        :identifier: embedded_automation_manager_credentials_delete
-      :delete:
       - :name: delete
         :identifier: embedded_automation_manager_credentials_delete
     :subcollection_actions:

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -80,7 +80,10 @@ RSpec.describe 'Authentications API' do
 
       expected = {
         'results' => [
-          { 'success' => false, 'message' => 'type not currently supported' }
+          {
+            'success' => false,
+            'message' => "Delete not supported for Authentication id:#{auth.id} name: '#{auth.name}'"
+          }
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -138,6 +141,26 @@ RSpec.describe 'Authentications API' do
       api_basic_authorize
 
       run_post(authentications_url(auth.id), :action => 'delete')
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'DELETE /api/authentications/:id' do
+    it 'will delete an authentication' do
+      auth = FactoryGirl.create(:authentication)
+      api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
+
+      run_delete(authentications_url(auth.id))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'will not delete an authentication without an appropriate role' do
+      auth = FactoryGirl.create(:authentication)
+      api_basic_authorize
+
+      run_delete(authentications_url(auth.id))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Authentications API' do
         'results' => [
           a_hash_including(
             'success' => true,
-            'message' => "Deleting Authentication with id #{auth.id}",
+            'message' => a_string_including('Deleting Authentication'),
             'task_id' => a_kind_of(Numeric)
           )
         ]
@@ -72,6 +72,21 @@ RSpec.describe 'Authentications API' do
       expect(response).to have_http_status(:ok)
     end
 
+    it 'verifies that the type is supported' do
+      api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
+      auth = FactoryGirl.create(:authentication)
+
+      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
+
+      expected = {
+        'results' => [
+          { 'success' => false, 'message' => 'type not currently supported' }
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it 'will delete multiple authentications' do
       api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
 
@@ -79,12 +94,12 @@ RSpec.describe 'Authentications API' do
         'results' => [
           a_hash_including(
             'success' => true,
-            'message' => "Deleting Authentication with id #{auth.id}",
+            'message' => a_string_including('Deleting Authentication'),
             'task_id' => a_kind_of(Numeric)
           ),
           a_hash_including(
             'success' => true,
-            'message' => "Deleting Authentication with id #{auth_2.id}",
+            'message' => a_string_including('Deleting Authentication'),
             'task_id' => a_kind_of(Numeric)
           )
         ]
@@ -112,7 +127,7 @@ RSpec.describe 'Authentications API' do
 
       expected = {
         'success' => true,
-        'message' => "Deleting Authentication with id #{auth.id}",
+        'message' => a_string_including('Deleting Authentication'),
         'task_id' => a_kind_of(Numeric)
       }
       expect(response.parsed_body).to include(expected)
@@ -123,24 +138,6 @@ RSpec.describe 'Authentications API' do
       api_basic_authorize
 
       run_post(authentications_url(auth.id), :action => 'delete')
-
-      expect(response).to have_http_status(:forbidden)
-    end
-  end
-
-  describe 'DELETE /api/authentications/:id' do
-    it 'will delete an authentication' do
-      api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
-
-      run_delete(authentications_url(auth.id))
-
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it 'will not delete an authentication without an appropriate role' do
-      api_basic_authorize
-
-      run_delete(authentications_url(auth.id))
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe 'Authentications API' do
+  let(:provider) { FactoryGirl.create(:provider_ansible_tower) }
+  let(:auth) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
+  let(:auth_2) { FactoryGirl.create(:ansible_cloud_credential, :resource => provider) }
+
   describe 'GET/api/authentications' do
     it 'lists all the authentication configuration script bases with an appropriate role' do
       auth = FactoryGirl.create(:authentication)
@@ -51,15 +55,42 @@ RSpec.describe 'Authentications API' do
 
   describe 'POST /api/authentications' do
     it 'will delete an authentication' do
-      auth = FactoryGirl.create(:authentication)
       api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
 
       expected = {
-        'results' => [a_hash_including('success' => true)]
+        'results' => [
+          a_hash_including(
+            'success' => true,
+            'message' => "Deleting Authentication with id #{auth.id}",
+            'task_id' => a_kind_of(Numeric)
+          )
+        ]
       }
-      expect do
-        run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
-      end.to change(Authentication, :count).by(-1)
+      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }])
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'will delete multiple authentications' do
+      api_basic_authorize collection_action_identifier(:authentications, :delete, :post)
+
+      expected = {
+        'results' => [
+          a_hash_including(
+            'success' => true,
+            'message' => "Deleting Authentication with id #{auth.id}",
+            'task_id' => a_kind_of(Numeric)
+          ),
+          a_hash_including(
+            'success' => true,
+            'message' => "Deleting Authentication with id #{auth_2.id}",
+            'task_id' => a_kind_of(Numeric)
+          )
+        ]
+      }
+      run_post(authentications_url, :action => 'delete', :resources => [{ 'id' => auth.id }, { 'id' => auth_2.id }])
+
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
@@ -75,18 +106,20 @@ RSpec.describe 'Authentications API' do
 
   describe 'POST /api/authentications/:id' do
     it 'will delete an authentication' do
-      auth = FactoryGirl.create(:authentication)
       api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :post)
 
-      expect do
-        run_post(authentications_url(auth.id), :action => 'delete')
-      end.to change(Authentication, :count).by(-1)
-      expect(response.parsed_body).to include('success' => true)
+      run_post(authentications_url(auth.id), :action => 'delete')
+
+      expected = {
+        'success' => true,
+        'message' => "Deleting Authentication with id #{auth.id}",
+        'task_id' => a_kind_of(Numeric)
+      }
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
 
     it 'will not delete an authentication without an appropriate role' do
-      auth = FactoryGirl.create(:authentication)
       api_basic_authorize
 
       run_post(authentications_url(auth.id), :action => 'delete')
@@ -97,17 +130,14 @@ RSpec.describe 'Authentications API' do
 
   describe 'DELETE /api/authentications/:id' do
     it 'will delete an authentication' do
-      auth = FactoryGirl.create(:authentication)
       api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
 
-      expect do
-        run_delete(authentications_url(auth.id))
-      end.to change(Authentication, :count).by(-1)
+      run_delete(authentications_url(auth.id))
+
       expect(response).to have_http_status(:no_content)
     end
 
     it 'will not delete an authentication without an appropriate role' do
-      auth = FactoryGirl.create(:authentication)
       api_basic_authorize
 
       run_delete(authentications_url(auth.id))


### PR DESCRIPTION
Update  delete of authentications (*whoops how'd that get in there*) to use `delete_in_provider_queue` in #14305 

@miq-bot add_label enhancement, api, wip 
@miq-bot assign @abellotti 