### PR TITLE
RBAC filter only applies to associations and not attributes

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -118,7 +118,7 @@ module MiqAeMethodService
           method = options[:method] || method_name
           ret = object_send(method, *params)
           return options[:override_return] if options.key?(:override_return)
-          wrap_results(self.class.filter_objects(ret))
+          options[:association] ? wrap_results(self.class.filter_objects(ret)) : wrap_results(ret)
         end
       end
     end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_rbac_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_rbac_spec.rb
@@ -32,10 +32,10 @@ module MiqAeServiceModelSpec
     let(:vm23) { FactoryGirl.create(:vm_vmware, :tenant => tenant2, :host => host2, :miq_group => group2) }
 
     context "automate methods - enable rbac" do
-      def collect_ids_with_rbac
+      def collect_names_with_rbac
         <<-'RUBY'
           $evm.enable_rbac
-          $evm.root['vm_ids'] = $evm.vmdb('vm').all.collect(&:id)
+          $evm.root['vm_names'] = $evm.vmdb('vm').all.collect(&:name)
         RUBY
       end
 
@@ -46,10 +46,10 @@ module MiqAeServiceModelSpec
         create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
                                     :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
                                     :method_name => 'OBELIX',
-                                    :method_script => collect_ids_with_rbac)
+                                    :method_script => collect_names_with_rbac)
         ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user2)
-        ids = [vm21.id, vm22.id]
-        expect(ws.root("vm_ids")).to match_array(ids)
+        names = [vm21.name, vm22.name]
+        expect(ws.root("vm_names")).to match_array(names)
       end
 
       after do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1431822

The RBAC filter was being applied to regular attributes like name etc.
It only applies to associations which point to other VMDB objects.

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1431822

Steps for Testing/QA 
---------------------
Described in BZ
