### PR TITLE
Add balancer members after configs have been written

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -88,6 +88,15 @@ module MiqServer::EnvironmentManagement
       MiqUiWorker.install_apache_proxy_config
       MiqWebServiceWorker.install_apache_proxy_config
       MiqWebsocketWorker.install_apache_proxy_config
+
+      # Because adding balancer members does a validation of the configuration
+      # files and these files try to load the redirect files among others,
+      # we need to add the balancers members after all configuration files have
+      # been written by install_apache_proxy_config.
+      MiqUiWorker.add_apache_balancer_members
+      MiqWebServiceWorker.add_apache_balancer_members
+      MiqWebsocketWorker.add_apache_balancer_members
+
       MiqApache::Control.restart
     end
   end

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -112,7 +112,6 @@ module MiqWebServerWorkerMixin
 
       _log.info("[#{options.inspect}")
       MiqApache::Conf.install_default_config(options)
-      add_apache_balancer_members
     end
 
     def port_range


### PR DESCRIPTION
Fixes a regression in #14007 that affects the initial start of the
appliance which caused a 503 error when trying to access the UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1422988

Because adding balancer members does a validation of the configuration
files and these files try to load the redirect files among others,
we need to add the balancers members after all configuration files have
been written by install_apache_proxy_config.

I wish I knew how to test this outside of an appliance.  ❓ 