### PR TITLE
Screens now display include columns

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -377,8 +377,8 @@ module MiqReport::Generator
       self.col_order = (col_order + res_cols).uniq
     end
 
-    only_cols = options[:only] || ((cols || []) + build_cols_from_include(include)).uniq + ['id']
-    self.col_order = ((cols || []) + build_cols_from_include(include)).uniq if col_order.blank?
+    only_cols = options[:only] || cols_for_report(['id'])
+    self.col_order = cols_for_report if col_order.blank?
 
     build_trend_data(objs)
     build_trend_limits(objs)
@@ -427,7 +427,7 @@ module MiqReport::Generator
     result = generate_rows_from_data(get_data_from_report(db_options[:report]))
 
     self.cols ||= []
-    only_cols = options[:only] || (self.cols + generate_cols + build_cols_from_include(include)).uniq
+    only_cols = options[:only] || cols_for_report(generate_cols)
     column_names = result.empty? ? self.cols : result.first.keys
     @table = Ruport::Data::Table.new(:data => result, :column_names => column_names)
     @table.reorder(only_cols) unless @table.data.empty?
@@ -619,6 +619,13 @@ module MiqReport::Generator
       end
       a << row
     end
+  end
+
+  # the columns that are needed for this report.
+  # there may be some columns that are used to derive columns,
+  # so we currently include '*'
+  def cols_for_report(extra_cols = [])
+    ((cols || []) + (extra_cols || []) + build_cols_from_include(include)).uniq
   end
 
   def build_cols_from_include(hash, parent_association = nil)

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -625,7 +625,7 @@ module MiqReport::Generator
   # there may be some columns that are used to derive columns,
   # so we currently include '*'
   def cols_for_report(extra_cols = [])
-    ((cols || []) + (extra_cols || []) + build_cols_from_include(include)).uniq
+    ((cols || []) + (col_order || []) + (extra_cols || []) + build_cols_from_include(include)).uniq
   end
 
   def build_cols_from_include(hash, parent_association = nil)

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -45,7 +45,7 @@ module MiqReport::Generator::Trend
     klass = db.kind_of?(Class) ? db : Object.const_get(db)
     self.title = klass.report_title(db_options)
     self.cols, self.headers = klass.report_cols(db_options)
-    options[:only] ||= (cols + build_cols_from_include(include) + ['id']).uniq
+    options[:only] ||= cols_for_report
 
     # Build and filter trend data from performance data
     build_apply_time_profile(results)

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -77,4 +77,21 @@ describe MiqReport::Generator do
       end
     end
   end
+
+  describe "#cols_for_report" do
+    it "uses cols" do
+      rpt = MiqReport.new(:db => "VmOrTemplate", :cols => %w(vendor version name))
+      expect(rpt.cols_for_report).to eq(%w(vendor version name))
+    end
+
+    it "uses include" do
+      rpt = MiqReport.new(:db => "VmOrTemplate", :include => {"host" => { "columns" => %w(name hostname guid)}})
+      expect(rpt.cols_for_report).to eq(%w(host.name host.hostname host.guid))
+    end
+
+    it "uses extra_cols" do
+      rpt = MiqReport.new(:db => "VmOrTemplate")
+      expect(rpt.cols_for_report(%w(vendor))).to eq(%w(vendor))
+    end
+  end
 end

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -93,5 +93,19 @@ describe MiqReport::Generator do
       rpt = MiqReport.new(:db => "VmOrTemplate")
       expect(rpt.cols_for_report(%w(vendor))).to eq(%w(vendor))
     end
+
+    it "derives include" do
+      rpt = MiqReport.new(:db => "VmOrTemplate", :cols => %w(vendor), :col_order =>%w(host.name vendor))
+      expect(rpt.cols_for_report).to match_array(%w(vendor host.name))
+    end
+
+    it "works with col, col_order and include together" do
+      rpt = MiqReport.new(:db        => "VmOrTemplate",
+                          :cols      => %w(vendor),
+                          :col_order => %w(host.name host.hostname vendor),
+                          :include   => {"host" => { "columns" => %w(name hostname)}}
+                         )
+      expect(rpt.cols_for_report).to match_array(%w(vendor host.name host.hostname))
+    end
   end
 end


### PR DESCRIPTION
This is a fallout from #13675 
The `includes` were put back into the reports #14439, but I still have ambitions to remove them.
This duplicate meta-data is causing extra queries. This goes against our goal to fetch less data.

`MiqReport#include` is referenced in many places.
The goal is now to consolidate the references to `MiqReport#include`.

This PR simplifies one of the references to `include` field.
The remaining reference is in `build_reportable_data` (and too complicated to tackle in this PR)

----
Personal side notes:

To reproduce the original bug:

1. remove `include` hash from CloudSubnet.yaml
2. Menu > Network / Subnets -- "Cloud Subnets" screen
3. Note Column "Network Provider" (`ems.name`) is blank

Outstanding work:

grep `"include"` in `miq_report/generator.rb` Fix `build_reportable_data` to handle `col_order` OR `include`.