### PR TITLE
Merge service template options on update

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -458,8 +458,9 @@ class ServiceTemplate < ApplicationRecord
     ]
   end
 
-  def update_from_options(options)
-    update_attributes!(options.except(:config_info).merge(:options => { :config_info => options[:config_info] }))
+  def update_from_options(params)
+    options[:config_info] = params[:config_info]
+    update_attributes!(params.except(:config_info))
   end
 
   def provision_workflow(user, options = nil)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -601,6 +601,7 @@ describe ServiceTemplate do
 
     before do
       @catalog_item = ServiceTemplate.create_catalog_item(catalog_item_options, user)
+      @catalog_item.update_attributes!(:options => @catalog_item.options.merge(:foo => 'bar'))
     end
 
     it 'updates the catalog item' do
@@ -613,6 +614,7 @@ describe ServiceTemplate do
       expect(updated.name).to eq('Updated Template Name')
       expect(updated.service_resources.first.resource.source_id).to eq(new_vm.id) # Validate request update
       expect(updated.config_info).to eq(updated_catalog_item_options[:config_info])
+      expect(updated.options.key?(:foo)).to be_truthy # Test that the options were merged
     end
 
     it 'does not allow service_type to be changed' do


### PR DESCRIPTION
As @bzwei pointed out, we should not assume that `:config_info` is the only key within `options`, and therefore the options should be merged.

@miq-bot add_label services
@miq-bot assign @gmcculloug 
