### PR TITLE
Add pretty model name for Azure network manager

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -831,6 +831,7 @@ en:
       ManageIQ::Providers::Azure::CloudManager::OrchestrationStack:         Orchestration Stack (Microsoft Azure)
       ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack:        Orchestration Stack (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::NetworkPort:             Network Port (Amazon)
+      ManageIQ::Providers::Azure::NetworkManager:                           Network Manager (Azure)
       ManageIQ::Providers::Azure::NetworkManager::NetworkPort:              Network Port (Microsoft Azure)
       ManageIQ::Providers::Openstack::NetworkManager::NetworkPort:          Network Port (OpenStack)
       ManageIQ::Providers::StorageManager:                                  Storage Manager


### PR DESCRIPTION
The model name would (among other things) show in a pdf report for Azure Network Manager.

https://bugzilla.redhat.com/show_bug.cgi?id=1421684