### PR TITLE
Always evaluate datawarehouse_alerts

### DIFF
--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -472,4 +472,29 @@ describe MiqAlert do
       msg.delivered(status, message, result)
     end
   end
+
+  describe '.validate_automate_expressions' do
+    it 'Does not allow creation of dwh_generic miq_alerts with delay_next_evaluation > 0 ' do
+      expect do
+        FactoryGirl.create(
+          :miq_alert,
+          :options    => {:notifications => {:delay_next_evaluation => 600, :evm_event => {}}},
+          :expression => {:eval_method => "dwh_generic"}
+        )
+      end.to raise_error(
+        ActiveRecord::RecordInvalid,
+        'Validation failed: Notifications Datawarehouse alerts must have a 0 notification frequency'
+      )
+    end
+
+    it 'Does allow creation of hawkular_alert miq_alerts with delay_next_evaluation > 0 ' do
+      expect do
+        FactoryGirl.create(
+          :miq_alert,
+          :options    => {:notifications => {:delay_next_evaluation => 600, :evm_event => {}}},
+          :expression => {:eval_method => "mw_heap_used"}
+        )
+      end.to_not raise_error
+    end
+  end
 end

--- a/spec/requests/api/alert_definitions_spec.rb
+++ b/spec/requests/api/alert_definitions_spec.rb
@@ -117,8 +117,8 @@ describe "Alerts Definitions API" do
     sample_alert_definition = {
       :description => "Test Alert Definition",
       :db          => "ContainerNode",
-      :expression  => { :eval_method => "dwh_generic", :mode => "internal", :options => {} },
-      :options     => { :notifications => {:delay_next_evaluation => 600, :evm_event => {} } },
+      :expression  => { :eval_method => "mw_heap_used", :mode => "internal", :options => {} },
+      :options     => { :notifications => {:delay_next_evaluation => 0, :evm_event => {} } },
       :enabled     => true
     }
     updated_options = { :notifications => {:delay_next_evaluation => 60, :evm_event => {} } }


### PR DESCRIPTION
Since hawkular alerts are evaluated in an external system, each alerts coming into the system already represents a created alert. Since an opening or resolving alert is picked only once up by the system, skipping an evaluation will always cause us to miss the alert. This PR works in conjunction with https://github.com/ManageIQ/manageiq-ui-classic/pull/678 allowing to add 0 frequency alerts (although rest is more important for us)