### PR TITLE
[DARGA] Fix creating trees for new group

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -358,8 +358,8 @@ class OpsController < ApplicationController
     when :rbac_tree
       @sb[:active_tab] = "rbac_details"
 
-      # default to the first tab in group detail
-      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node[0] == 'g'
+      # default to the first tab in group detail or creating new group
+      @sb[:active_rbac_group_tab] ||= "rbac_customer_tags" if node.last == 'g' || node.first == 'g'
     when :diagnostics_tree
       case node[0]
       when "root"

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -926,18 +926,22 @@ module OpsController::OpsRbac
 
   def rbac_group_get_details(id)
     @record = @group = MiqGroup.find_by_id(from_cid(id))
-    get_tagdata(@group)
-    # Build the belongsto filters hash
     @belongsto = {}
-    @group.get_belongsto_filters.each do |b|            # Go thru the belongsto tags
-      bobj = MiqFilter.belongsto2object(b)            # Convert to an object
-      next unless bobj
-      @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
-    end
     @filters = {}
-    # Build the managed filters hash
-    [@group.get_managed_filters].flatten.each do |f|
-      @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
+    if @record.present?
+      get_tagdata(@group)
+      # Build the belongsto filters hash
+
+      @group.get_belongsto_filters.each do |b|            # Go thru the belongsto tags
+        bobj = MiqFilter.belongsto2object(b)            # Convert to an object
+        next unless bobj
+        @belongsto[bobj.class.to_s + "_" + bobj.id.to_s] = b # Store in hash as <class>_<id> string
+      end
+
+      # Build the managed filters hash
+      [@group.get_managed_filters].flatten.each do |f|
+        @filters[f.split("/")[-2] + "-" + f.split("/")[-1]] = f
+      end
     end
 
     rbac_group_right_tree(@belongsto.keys)

--- a/app/views/ops/rbac_group/_customer_tags.html.haml
+++ b/app/views/ops/rbac_group/_customer_tags.html.haml
@@ -11,5 +11,5 @@
                         :onmouseout     => "miqOnMouseOutHostNet",
                         :oncheck        => @edit.nil? ? nil : "miqOnCheckUserFilters",
                         :disable_checks => @edit.nil?,
-                        :check_url      => "ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :check_url      => "ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                         :checkboxes     => true})

--- a/app/views/ops/rbac_group/_hosts_clusters.html.haml
+++ b/app/views/ops/rbac_group/_hosts_clusters.html.haml
@@ -11,5 +11,5 @@
                         :onmouseout     => "miqOnMouseOutHostNet",
                         :oncheck        => @edit.nil? ? nil : "miqOnCheckUserFilters",
                         :disable_checks => @edit.nil?,
-                        :check_url      => "ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :check_url      => "ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                         :checkboxes     => true})

--- a/app/views/ops/rbac_group/_vms_templates.html.haml
+++ b/app/views/ops/rbac_group/_vms_templates.html.haml
@@ -11,5 +11,5 @@
                         :onmouseout     => "miqOnMouseOutHostNet",
                         :oncheck        => @edit.nil? ? nil : "miqOnCheckUserFilters",
                         :disable_checks => @edit.nil?,
-                        :check_url      => "/ops/rbac_group_field_changed/#{@group.id || "new"}___",
+                        :check_url      => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
                         :checkboxes     => true})


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1427322

Configuration -> Access Control -> Groups -> Configuration -> Add new group -> try tabs Red Hat Tags, Hosts/Nodes & Clusters/Deployment Roles, VMs &Templates

One tree maybe rendered but others won't.

Before:
<img width="908" alt="screen shot 2017-02-14 at 11 40 27 am" src="https://cloud.githubusercontent.com/assets/9210860/22925817/67b40310-f2aa-11e6-9021-52b2bd5cd419.png">

After:
<img width="880" alt="screen shot 2017-02-14 at 11 36 29 am" src="https://cloud.githubusercontent.com/assets/9210860/22925684/f40e85d4-f2a9-11e6-9d6e-2564b8540054.png">

Darga version of https://github.com/ManageIQ/manageiq-ui-classic/pull/379.

@miq-bot assign @mzazrivec 

@miq-bot add_label bug, ui, darga/yes