### PR TITLE
delete and update configuration script sources

### DIFF
--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -2,18 +2,26 @@ module Api
   class ConfigurationScriptSourcesController < BaseController
     def edit_resource(type, id, data)
       config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+      raise "Update not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:update_in_provider_queue)
       task_id = config_script_src.update_in_provider_queue(data)
-      action_result(true, "Updating Configuration Script Source with id #{id}", :task_id => task_id)
+      action_result(true, "Updating #{config_script_src_ident(config_script_src)}", :task_id => task_id)
     rescue => err
-      raise "Could not update Configuration Script Source - #{err}"
+      action_result(false, err.to_s)
     end
 
     def delete_resource(type, id, _data = {})
       config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+      raise "Delete not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:delete_in_provider_queue)
       task_id = config_script_src.delete_in_provider_queue
-      action_result(true, "Deleting Configuration Script Source with id #{id}", :task_id => task_id)
+      action_result(true, "Deleting #{config_script_src_ident(config_script_src)}", :task_id => task_id)
     rescue => err
-      raise "Could not delete Configuration Script Source - #{err}"
+      action_result(false, err.to_s)
+    end
+
+    private
+
+    def config_script_src_ident(config_script_src)
+      "ConfigurationScriptSource id:#{config_script_src.id} name: '#{config_script_src.name}'"
     end
   end
 end

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -1,4 +1,19 @@
 module Api
   class ConfigurationScriptSourcesController < BaseController
+    def edit_resource(type, id, data)
+      config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+      task_id = config_script_src.update_in_provider_queue(data)
+      action_result(true, "Updating Configuration Script Source with id #{id}", :task_id => task_id)
+    rescue => err
+      raise "Could not update Configuration Script Source - #{err}"
+    end
+
+    def delete_resource(type, id, _data = {})
+      config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
+      task_id = config_script_src.delete_in_provider_queue
+      action_result(true, "Deleting Configuration Script Source with id #{id}", :task_id => task_id)
+    rescue => err
+      raise "Could not delete Configuration Script Source - #{err}"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -572,16 +572,29 @@
     :description: Configuration Script Source
     :options:
     - :collection
-    :verbs: *g
+    :verbs: *gpppd
     :klass: ConfigurationScriptSource
     :collection_actions:
       :get:
       - :name: read
         :identifier: embedded_configuration_script_source_view
+      :post:
+      - :name: edit
+        :identifier: embedded_configuration_script_source_edit
+      - :name: delete
+        :identifier: embedded_configuration_script_source_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: embedded_configuration_script_source_view
+      :post:
+      - :name: edit
+        :identifier: embedded_configuration_script_source_edit
+      - :name: delete
+        :identifier: embedded_configuration_script_source_delete
+      :delete:
+      - :name: delete
+        :identifier: embedded_configuration_script_source_delete
   :container_deployments:
     :description: Container Provider Deployment
     :identifier: container_deployment

--- a/config/api.yml
+++ b/config/api.yml
@@ -572,7 +572,7 @@
     :description: Configuration Script Source
     :options:
     - :collection
-    :verbs: *gpppd
+    :verbs: *gpd
     :klass: ConfigurationScriptSource
     :collection_actions:
       :get:

--- a/spec/factories/configuration_script_source.rb
+++ b/spec/factories/configuration_script_source.rb
@@ -2,4 +2,8 @@ FactoryGirl.define do
   factory :configuration_script_source do
     sequence(:name) { |n| "configuration_script_source#{seq_padded_for_sorting(n)}" }
   end
+
+  factory :ansible_configuration_script_source,
+          :parent => :configuration_script_source,
+          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource"
 end

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe 'Configuration Script Sources API' do
         'results' => [
           a_hash_including(
             'success' => true,
-            'message' => "Updating Configuration Script Source with id #{config_script_src.id}",
+            'message' => a_string_including('Updating ConfigurationScriptSource'),
             'task_id' => a_kind_of(Numeric)
           ),
           a_hash_including(
             'success' => true,
-            'message' => "Updating Configuration Script Source with id #{config_script_src_2.id}",
+            'message' => a_string_including('Updating ConfigurationScriptSource'),
             'task_id' => a_kind_of(Numeric)
           )
         ]
@@ -103,12 +103,12 @@ RSpec.describe 'Configuration Script Sources API' do
         'results' => [
           a_hash_including(
             'success' => true,
-            'message' => "Deleting Configuration Script Source with id #{config_script_src.id}",
+            'message' => a_string_including('Deleting ConfigurationScriptSource'),
             'task_id' => a_kind_of(Numeric)
           ),
           a_hash_including(
             'success' => true,
-            'message' => "Deleting Configuration Script Source with id #{config_script_src_2.id}",
+            'message' => a_string_including('Deleting ConfigurationScriptSource'),
             'task_id' => a_kind_of(Numeric)
           )
         ]
@@ -141,8 +141,22 @@ RSpec.describe 'Configuration Script Sources API' do
 
       expected = {
         'success' => true,
-        'message' => "Updating Configuration Script Source with id #{config_script_src.id}",
+        'message' => a_string_including('Updating ConfigurationScriptSource'),
         'task_id' => a_kind_of(Numeric)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'requires that the type support update_in_provider_queue' do
+      config_script_src = FactoryGirl.create(:configuration_script_source)
+      api_basic_authorize action_identifier(:configuration_script_sources, :edit)
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+
+      expected = {
+        'success' => false,
+        'message' => "Update not supported for ConfigurationScriptSource id:#{config_script_src.id} name: '#{config_script_src.name}'"
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -163,8 +177,22 @@ RSpec.describe 'Configuration Script Sources API' do
 
       expected = {
         'success' => true,
-        'message' => "Deleting Configuration Script Source with id #{config_script_src.id}",
+        'message' => a_string_including('Deleting ConfigurationScriptSource'),
         'task_id' => a_kind_of(Numeric)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'requires that the type support delete_in_provider_queue' do
+      config_script_src = FactoryGirl.create(:configuration_script_source)
+      api_basic_authorize collection_action_identifier(:configuration_script_sources, :delete, :post)
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete', :resource => params)
+
+      expected = {
+        'success' => false,
+        'message' => "Delete not supported for ConfigurationScriptSource id:#{config_script_src.id} name: '#{config_script_src.name}'"
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe 'Configuration Script Sources API' do
+  let(:provider) { FactoryGirl.create(:ext_management_system) }
+  let(:config_script_src) { FactoryGirl.create(:ansible_configuration_script_source, :manager => provider) }
+  let(:config_script_src_2) { FactoryGirl.create(:ansible_configuration_script_source, :manager => provider) }
+
   describe 'GET /api/configuration_script_sources' do
     it 'lists all the configuration script sources with an appropriate role' do
       repository = FactoryGirl.create(:configuration_script_source)
@@ -44,6 +48,150 @@ RSpec.describe 'Configuration Script Sources API' do
       api_basic_authorize
 
       run_get(configuration_script_sources_url(repository.id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/configuration_script_sources' do
+    let(:params) do
+      {
+        :id          => config_script_src.id,
+        :name        => 'foo',
+        :description => 'bar'
+      }
+    end
+
+    it 'will bulk update configuration_script_sources with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:configuration_script_sources, :edit, :post)
+      params2 = params.dup.merge(:id => config_script_src_2.id)
+
+      run_post(configuration_script_sources_url, :action => 'edit', :resources => [params, params2])
+
+      expected = {
+        'results' => [
+          a_hash_including(
+            'success' => true,
+            'message' => "Updating Configuration Script Source with id #{config_script_src.id}",
+            'task_id' => a_kind_of(Numeric)
+          ),
+          a_hash_including(
+            'success' => true,
+            'message' => "Updating Configuration Script Source with id #{config_script_src_2.id}",
+            'task_id' => a_kind_of(Numeric)
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids updating configuration_script_sources without an appropriate role' do
+      api_basic_authorize
+
+      run_post(configuration_script_sources_url, :action => 'edit', :resources => [params])
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'will delete multiple configuration script source with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:configuration_script_sources, :delete, :post)
+
+      run_post(configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}, {:id => config_script_src_2.id}])
+
+      expected = {
+        'results' => [
+          a_hash_including(
+            'success' => true,
+            'message' => "Deleting Configuration Script Source with id #{config_script_src.id}",
+            'task_id' => a_kind_of(Numeric)
+          ),
+          a_hash_including(
+            'success' => true,
+            'message' => "Deleting Configuration Script Source with id #{config_script_src_2.id}",
+            'task_id' => a_kind_of(Numeric)
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids delete without an appropriate role' do
+      api_basic_authorize
+
+      run_post(configuration_script_sources_url, :action => 'delete', :resources => [{:id => config_script_src.id}])
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'POST /api/configuration_script_sources/:id' do
+    let(:params) do
+      {
+        :name        => 'foo',
+        :description => 'bar'
+      }
+    end
+
+    it 'updates a configuration_script_source with an appropriate role' do
+      api_basic_authorize action_identifier(:configuration_script_sources, :edit)
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+
+      expected = {
+        'success' => true,
+        'message' => "Updating Configuration Script Source with id #{config_script_src.id}",
+        'task_id' => a_kind_of(Numeric)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids updating a configuration_script_source without an appropriate role' do
+      api_basic_authorize
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can delete a configuration_script_source with an appropriate role' do
+      api_basic_authorize action_identifier(:configuration_script_sources, :delete)
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete')
+
+      expected = {
+        'success' => true,
+        'message' => "Deleting Configuration Script Source with id #{config_script_src.id}",
+        'task_id' => a_kind_of(Numeric)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'forbids configuration script source delete without an appropriate role' do
+      api_basic_authorize
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'delete')
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'DELETE /api/configuration_script_sources/:id' do
+    it 'can delete a configuration_script_source with an appropriate role' do
+      api_basic_authorize action_identifier(:configuration_script_sources, :delete, :resource_actions, :delete)
+
+      run_delete(configuration_script_sources_url(config_script_src.id))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'forbids configuration_script_source delete without an appropriate role' do
+      api_basic_authorize
+
+      run_delete(configuration_script_sources_url(config_script_src.id))
 
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
Delete and Update Configuration Script Sources via `delete_in_provider_queue` and `update_in_provider_queue`

Depends on #14305 
@miq-bot add_label enhancement, wip, api
@miq-bot assign @abellotti 
