### PR TITLE
Fix mixed values in Low and High operating ranges for CU charts

### DIFF
--- a/product/charts/miq_reports/vim_perf_daily.yaml
+++ b/product/charts/miq_reports/vim_perf_daily.yaml
@@ -204,7 +204,6 @@ headers:
 - EVM Managed/Registered
 - EVM Managed/Unregistered
 - Not Managed
-- All Non-VM Files
 - High Oper Range
 - Low Oper Range
 - High % Oper Range

--- a/product/charts/miq_reports/vim_perf_daily_cloud.yaml
+++ b/product/charts/miq_reports/vim_perf_daily_cloud.yaml
@@ -199,7 +199,6 @@ headers:
 - EVM Managed/Registered
 - EVM Managed/Unregistered
 - Not Managed
-- All Non-VM Files
 - High Oper Range
 - Low Oper Range
 - High % Oper Range


### PR DESCRIPTION
There were mix indexes in these reports.  `col_order` and `headers` has different number of fields. I find that the extra one is `All Non-VM Files`. Its possible that `All Non-VM Files` should be there and in `col_order` is missing related field. But i didnt find any related code to `All Non-VM Files` so i deleted it.

https://bugzilla.redhat.com/show_bug.cgi?id=1305115

Screenshots
----------------
Before:
![screencapture-localhost-3000-vm_infra-explorer-1489497298972](https://cloud.githubusercontent.com/assets/9535558/23903541/255f4976-08c5-11e7-81bf-dbb892fdb37e.png)


After:
![screencapture-localhost-3000-vm_infra-explorer-1489497371497](https://cloud.githubusercontent.com/assets/9535558/23903537/234cc1d6-08c5-11e7-969c-94949aec8727.png)

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1305115
