### PR TITLE
[DARGA] Add jquery ~2.1.4 to bower's resolutions section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "bootstrap-hover-dropdown": "~2.0.11",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "jasmine-jquery": "~2.1.1",
+    "jquery": "~2.1.4",
     "jquery-1.8": "~1.8.3",
     "jquery-ujs": "~1.1.0",
     "jquery-ui": "jqueryui#~1.9.2",
@@ -43,5 +44,8 @@
     "phantomjs-polyfill": "~0.0.2",
     "fetch": "~1.0.0",
     "codemirror": "~5.19.0"
+  },
+  "resolutions": {
+    "jquery": "~2.1.4"
   }
 }


### PR DESCRIPTION
meant to prevent jquery 3 from becoming a valid choice on dependency conflict

Contrary to the euwe PR (#14200), this also adds jquery to bower dependencies. This is because while darga is still installing jquery from gems, it's *also* installing jquery as a dependency of other bower packages .. and the bower version wins.
So adding jquery explicitly, and adding to resolutions to fix the conflict.

@miq-bot assign simaishi
@miq-bot add_label bug/sporadic test failure, ui