### PR TITLE
[EUWE] No revert for "active" snapshot

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1154,7 +1154,8 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_snapshot_delete_all"
         return @record.is_available_now_error_message(:remove_all_snapshots) unless @record.is_available?(:remove_all_snapshots)
       when "vm_snapshot_revert"
-        return @record.is_available_now_error_message(:revert_to_snapshot) unless @record.is_available?(:revert_to_snapshot)
+        error_message = @record.try(:revert_to_snapshot_denied_message, @active)
+        return error_message || (@record.is_available_now_error_message(:revert_to_snapshot) unless @record.is_available?(:revert_to_snapshot))
       end
     when "MiqTemplate"
       case id

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -49,11 +49,20 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
 
   def validate_revert_to_snapshot
     {:available => allowed_to_revert?,
-     :message   => "Revert is allowed only when vm is down. Current state is #{current_state}"}
+     :message   => revert_unsupported_message}
   end
 
   def allowed_to_revert?
     current_state == 'off'
+  end
+
+  def revert_to_snapshot_denied_message(active = false)
+    return revert_unsupported_message unless allowed_to_revert?
+    return _("Revert is not allowed for a snapshot that is the active one") if active
+  end
+
+  def revert_unsupported_message
+    _("Revert is allowed only when vm is down. Current state is %{state}") % {:state => current_state}
   end
 
   def snapshotting_memory_allowed?

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1886,18 +1886,46 @@ describe ApplicationHelper do
         end
 
         context "id = vm_snapshot_revert" do
-          before { @id = "vm_snapshot_revert" }
-          context "when with available message" do
-            before { allow(@record).to receive(:is_available?).with(:revert_to_snapshot).and_return(false) }
-            it_behaves_like 'record with error message', 'revert_to_snapshot'
+          before do
+            @id = "vm_snapshot_revert"
           end
-          context "when without snapshots" do
-            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
-            it_behaves_like 'record with error message', 'revert_to_snapshot'
+
+          context "when @record does not respond to #revert_to_snapshot_denied_message" do
+            before do
+              allow(@record).to receive(:revert_to_snapshot_denied_message).with(@active).and_return(nil)
+            end
+
+            context "when with available message" do
+              before { allow(@record).to receive(:is_available?).with(:revert_to_snapshot).and_return(false) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
+            context "when without snapshots" do
+              before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
+            context "when with snapshots" do
+              before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
           end
-          context "when with snapshots" do
-            before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'record with error message', 'revert_to_snapshot'
+
+          context "when @record responds to #revert_to_snapshot_denied_message" do
+            before do
+              allow(@record).to receive(:revert_to_snapshot_denied_message).with(@active).and_return("xx revert_to_snapshot message")
+            end
+
+            context "when with available message" do
+              before { allow(@record).to receive(:is_available?).with(:revert_to_snapshot).and_return(false) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
+            context "when without snapshots" do
+              before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
+            context "when with snapshots" do
+              before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
+              it_behaves_like 'record with error message', 'revert_to_snapshot'
+            end
           end
         end
       end

--- a/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
@@ -47,4 +47,39 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#revert_to_snapshot_denied_message" do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+    let(:vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
+    let(:allowed_to_revert) { true }
+    let(:supported_api_versions) { [] }
+    let(:active) { true }
+    subject { vm.revert_to_snapshot_denied_message(active) }
+    before do
+      allow(vm).to receive(:allowed_to_revert?).and_return(allowed_to_revert)
+    end
+
+    context "allowed to revert" do
+      context "active snapshot" do
+        it { is_expected.to eq("Revert is not allowed for a snapshot that is the active one") }
+      end
+
+      context "inactive snapshot" do
+        let(:active) { false }
+        it { is_expected.to eq(nil) }
+      end
+    end
+
+    context "not allowed to revert" do
+      let(:allowed_to_revert) { false }
+      context "active snapshot" do
+        it { is_expected.to eq("Revert is allowed only when vm is down. Current state is on") }
+      end
+
+      context "inactive snapshot" do
+        let(:active) { false }
+        it { is_expected.to eq("Revert is allowed only when vm is down. Current state is on") }
+      end
+    end
+  end
 end


### PR DESCRIPTION
In the snapshot screen when the "active" snapshot is selected
the revert button should be disabled for RHV.

If VM is up, the 'revert' button is disabled due to VM status is UP.
If VM is down and the active snapshot is selected, the 'revert' button
is disabled due to selection of 'active' snapshot.

Vmware's VMs are not affected by this change.

http://bugzilla.redhat.com/1396068
