### PR TITLE
Do not use Job.agent_state attribute

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -63,10 +63,14 @@ class Job < ApplicationRecord
     true
   end
 
-  def self.agent_message_update_queue(jobid, state, message = nil)
+  def self.agent_state_update_queue(jobid, _state, message = nil)
+    agent_message_update_queue(jobid, message)
+  end
+
+  def self.agent_message_update_queue(jobid, message)
     job = Job.where("guid = ?", jobid).select("id, state, guid").first
     unless job.nil?
-      job.agent_message_update(state, message)
+      job.agent_message_update(message)
     else
       _log.warn "jobid: [#{jobid}] not found"
     end
@@ -75,12 +79,9 @@ class Job < ApplicationRecord
     _log.log_backtrace(err)
   end
 
-  def agent_message_update(agent_state, agent_message = nil)
-    # Handle a single array parm coming from the queue
-    agent_state, agent_message = agent_state if agent_state.kind_of?(Array)
-
-    $log.info("JOB([#{guid}] Agent state update: state: [#{agent_state}], message: [#{agent_message}]")
-    update_attributes(:agent_state => agent_state, :agent_message => agent_message)
+  def agent_message_update(agent_message)
+    $log.info("JOB([#{guid}] Agent message update: [#{agent_message}]")
+    update_attributes(:agent_message => agent_message)
 
     return unless self.is_active?
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -63,10 +63,10 @@ class Job < ApplicationRecord
     true
   end
 
-  def self.agent_state_update_queue(jobid, state, message = nil)
+  def self.agent_message_update_queue(jobid, state, message = nil)
     job = Job.where("guid = ?", jobid).select("id, state, guid").first
     unless job.nil?
-      job.agent_state_update(state, message)
+      job.agent_message_update(state, message)
     else
       _log.warn "jobid: [#{jobid}] not found"
     end
@@ -75,7 +75,7 @@ class Job < ApplicationRecord
     _log.log_backtrace(err)
   end
 
-  def agent_state_update(agent_state, agent_message = nil)
+  def agent_message_update(agent_state, agent_message = nil)
     # Handle a single array parm coming from the queue
     agent_state, agent_message = agent_state if agent_state.kind_of?(Array)
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -63,10 +63,6 @@ class Job < ApplicationRecord
     true
   end
 
-  def self.agent_state_update_queue(jobid, _state, message = nil)
-    agent_message_update_queue(jobid, message)
-  end
-
   def self.agent_message_update_queue(jobid, message)
     job = Job.where("guid = ?", jobid).select("id, state, guid").first
     unless job.nil?

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -210,7 +210,7 @@ module ScanningMixin
     ost.xml_class = XmlHash::Document
 
     _log.debug "Scanning - Initializing scan"
-    update_agent_message(ost, "Scanning", "Initializing scan")
+    update_agent_message(ost, "Initializing scan")
     bb, last_err = nil
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
@@ -246,10 +246,10 @@ module ScanningMixin
       _log.debug "categories = [ #{categories.join(', ')} ]"
 
       categories.each do |c|
-        update_agent_message(ost, "Scanning", "Scanning #{c}")
+        update_agent_message(ost, "Scanning #{c}")
         _log.info "Scanning [#{c}] information.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         st = Time.now
-        xml = extractor.extract(c) { |scan_data| update_agent_message(ost, "Scanning", scan_data[:msg]) }
+        xml = extractor.extract(c) { |scan_data| update_agent_message(ost, scan_data[:msg]) }
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         if xml
@@ -277,7 +277,7 @@ module ScanningMixin
       last_err = scanErr
     ensure
       bb.close if bb
-      update_agent_message(ost, "Scanning", "Scanning completed.")
+      update_agent_message(ost, "Scanning completed.")
 
       # If we are sent a TaskId transfer a end of job summary xml.
       _log.info "Starting: Sending scan summary to server.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
@@ -327,7 +327,7 @@ module ScanningMixin
       )
       bb = Manageiq::BlackBox.new(guid, ost)
 
-      update_agent_message(ost, "Synchronize", "Synchronization in progress")
+      update_agent_message(ost, "Synchronization in progress")
       categories.each do |c|
         c.delete!("\"")
         c.strip!
@@ -368,16 +368,15 @@ module ScanningMixin
       save_metadata_op(xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       _log.info "Completed: Sending target summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
 
-      update_agent_message(ost, "Synchronize", "Synchronization complete")
+      update_agent_message(ost, "Synchronization complete")
 
       raise syncErr if syncErr
     end
     ost.value = "OK\n"
   end
 
-  def update_agent_message(ost, state, message)
-    ost.agent_state = state
+  def update_agent_message(ost, message)
     ost.agent_message = message
-    agent_job_message_op(ost.taskid, ost.agent_state, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
+    agent_job_message_op(ost.taskid, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
   end
 end

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -210,7 +210,7 @@ module ScanningMixin
     ost.xml_class = XmlHash::Document
 
     _log.debug "Scanning - Initializing scan"
-    update_agent_state(ost, "Scanning", "Initializing scan")
+    update_agent_message(ost, "Scanning", "Initializing scan")
     bb, last_err = nil
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
@@ -246,10 +246,10 @@ module ScanningMixin
       _log.debug "categories = [ #{categories.join(', ')} ]"
 
       categories.each do |c|
-        update_agent_state(ost, "Scanning", "Scanning #{c}")
+        update_agent_message(ost, "Scanning", "Scanning #{c}")
         _log.info "Scanning [#{c}] information.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         st = Time.now
-        xml = extractor.extract(c) { |scan_data| update_agent_state(ost, "Scanning", scan_data[:msg]) }
+        xml = extractor.extract(c) { |scan_data| update_agent_message(ost, "Scanning", scan_data[:msg]) }
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         if xml
@@ -277,7 +277,7 @@ module ScanningMixin
       last_err = scanErr
     ensure
       bb.close if bb
-      update_agent_state(ost, "Scanning", "Scanning completed.")
+      update_agent_message(ost, "Scanning", "Scanning completed.")
 
       # If we are sent a TaskId transfer a end of job summary xml.
       _log.info "Starting: Sending scan summary to server.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
@@ -327,7 +327,7 @@ module ScanningMixin
       )
       bb = Manageiq::BlackBox.new(guid, ost)
 
-      update_agent_state(ost, "Synchronize", "Synchronization in progress")
+      update_agent_message(ost, "Synchronize", "Synchronization in progress")
       categories.each do |c|
         c.delete!("\"")
         c.strip!
@@ -368,16 +368,16 @@ module ScanningMixin
       save_metadata_op(xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       _log.info "Completed: Sending target summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
 
-      update_agent_state(ost, "Synchronize", "Synchronization complete")
+      update_agent_message(ost, "Synchronize", "Synchronization complete")
 
       raise syncErr if syncErr
     end
     ost.value = "OK\n"
   end
 
-  def update_agent_state(ost, state, message)
+  def update_agent_message(ost, state, message)
     ost.agent_state = state
     ost.agent_message = message
-    agent_job_state_op(ost.taskid, ost.agent_state, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
+    agent_job_message_op(ost.taskid, ost.agent_state, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
   end
 end

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -29,15 +29,15 @@ module ScanningOperationsMixin
     true
   end
 
-  def agent_job_message_op(jobid, state, message = nil)
+  def agent_job_message_op(jobid, message)
     _log.info "jobid: [#{jobid}] starting"
     begin
       Timeout.timeout(WS_TIMEOUT) do
         MiqQueue.put(
           :class_name  => "Job",
           :method_name => "agent_message_update_queue",
-          :args        => [jobid, state, message],
-          :task_id     => "agent_job_state_#{Time.now.to_i}",
+          :args        => [jobid, message],
+          :task_id     => "agent_job_message_#{Time.now.to_i}",
           :zone        => MiqServer.my_zone,
           :role        => "smartstate"
         )

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -29,13 +29,13 @@ module ScanningOperationsMixin
     true
   end
 
-  def agent_job_state_op(jobid, state, message = nil)
+  def agent_job_message_op(jobid, state, message = nil)
     _log.info "jobid: [#{jobid}] starting"
     begin
       Timeout.timeout(WS_TIMEOUT) do
         MiqQueue.put(
           :class_name  => "Job",
-          :method_name => "agent_state_update_queue",
+          :method_name => "agent_message_update_queue",
           :args        => [jobid, state, message],
           :task_id     => "agent_job_state_#{Time.now.to_i}",
           :zone        => MiqServer.my_zone,


### PR DESCRIPTION
Part of ManageIQ/manageiq#14030 - merging `MiqTask` and `Job`.

The SmartState Analysis agent is now part of the MiqServer.

This PR removes references to the agent_state and renames methods involved in agent_state processing.

