### PR TITLE
Add job_plays to job

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -37,6 +37,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
     belongs_to :job_template, :foreign_key => :orchestration_template_id, :class_name => "ConfigurationScript"
     belongs_to :playbook, :foreign_key => :configuration_script_base_id
 
+    virtual_has_many :job_plays
+
     class << self
       alias create_job create_stack
       alias raw_create_job raw_create_stack


### PR DESCRIPTION
The Service UI needs to be able to retrieve `job_plays` from the newly added OrchestrationStacks subcollection (#14273)

@miq-bot add_label enhancement, services
@miq-bot assign @bzwei 