### PR TITLE
Split metric collections into smaller intervals

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -17,17 +17,15 @@ module Metric::CiMixin::Capture
     ems.metrics_collector_queue_name
   end
 
-  def split_capture_intervals(start_time, end_time)
-    intervals = []
-    start_hour = start_time
-    while start_hour != end_time
-      #TODO: replace 1.day with a configurable threshold defined by provider type
-      end_hour = start_hour + 1.day
-      end_hour = end_time if end_hour > end_time
-      intervals << [start_hour, end_hour]
-      start_hour = end_hour
-    end
-    intervals
+  def split_capture_intervals(start_time, end_time, threshold=1.day)
+    raise _("Start time must be earlier than End time") if start_time > end_time
+    # Create an array of ordered pairs from start_time and end_time so that each ordered pair is contained
+    # within the threshold.  Then, reverse it so the newest ordered pair is first:
+    # start_time = 2017/01/01 12:00:00, end_time = 2017/01/04 12:00:00
+    # [[2017-01-03 12:00:00 UTC, 2017-01-04 12:00:00 UTC],
+    #  [2017-01-02 12:00:00 UTC, 2017-01-03 12:00:00 UTC],
+    #  [2017-01-01 12:00:00 UTC, 2017-01-02 12:00:00 UTC]]
+    (start_time..end_time).step_value(threshold).each_cons(2).collect { |s_time, e_time| [s_time, e_time] }.reverse
   end
   private :split_capture_intervals
 

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -25,9 +25,7 @@ module Metric::CiMixin::Capture
     # [[interval_name, 2017-01-03 12:00:00 UTC, 2017-01-04 12:00:00 UTC],
     #  [interval_name, 2017-01-02 12:00:00 UTC, 2017-01-03 12:00:00 UTC],
     #  [interval_name, 2017-01-01 12:00:00 UTC, 2017-01-02 12:00:00 UTC]]
-    start_time = start_time.utc
-    end_time = end_time.utc
-    (start_time..end_time).step_value(threshold).each_cons(2).collect do |s_time, e_time|
+    (start_time.utc..end_time.utc).step_value(threshold).each_cons(2).collect do |s_time, e_time|
       [interval_name, s_time, e_time]
     end.reverse
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -17,7 +17,7 @@ module Metric::CiMixin::Capture
     ems.metrics_collector_queue_name
   end
 
-  def split_capture_intervals(interval_name, start_time, end_time, threshold=1.day)
+  def split_capture_intervals(interval_name, start_time, end_time, threshold = 1.day)
     raise _("Start time must be earlier than End time") if start_time > end_time
     # Create an array of ordered pairs from start_time and end_time so that each ordered pair is contained
     # within the threshold.  Then, reverse it so the newest ordered pair is first:

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -58,7 +58,7 @@ describe Metric::CiMixin::Capture do
           expect(q_end_time).to be_same_time_as interval_end_time
           interval_end_time = interval_start_time
           # if the collection threshold is ever parameterized, then this 1.day will have to change
-          interval_start_time = interval_start_time - 1.day
+          interval_start_time -= 1.day
         end
       end
     end

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -36,6 +36,16 @@ describe Metric::CiMixin::Capture do
     parse_datetime('2013-08-28T12:41:40Z')
   end
 
+  context "#perf_capture_queue" do
+    it "splits up long perf_capture durations for old last_perf_capture_on" do
+      # there should be 10 days + a partial day, or 11 queue items
+      original_queue_count = MiqQueue.count
+      @vm.last_perf_capture_on = 10.days.ago - 5.hours - 23.minutes
+      @vm.perf_capture_queue("realtime")
+      expect(MiqQueue.count - original_queue_count).to eq 11
+    end
+  end
+
   context "2 collection periods total, end of 1. period has incomplete stat" do
     ###################################################################################################################
     # DESCRIPTION FOR: net_usage_rate_average

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -37,31 +37,44 @@ describe Metric::CiMixin::Capture do
   end
 
   context "#perf_capture_queue" do
-    it "splits up long perf_capture durations for old last_perf_capture_on" do
-      # there should be 10 days + a partial day, or 11 queue items
-      Timecop.freeze
-      original_queue_count = MiqQueue.count
-      start_time = 10.days.ago - 5.hours - 23.minutes
-      @vm.last_perf_capture_on = start_time
-      @vm.perf_capture_queue("realtime")
-      expect(MiqQueue.count - original_queue_count).to eq 11
+    def test_perf_capture_queue(time_since_last_perf_capture, total_queue_items, verify_queue_items_count)
+      # There are usually some lingering queue items from creating the provider above.  Notably `stop_event_monitor`
+      MiqQueue.delete_all
+      Timecop.freeze do
+        start_time = (Time.now.utc - time_since_last_perf_capture)
+        @vm.last_perf_capture_on = start_time
+        @vm.perf_capture_queue("realtime")
+        expect(MiqQueue.count).to eq total_queue_items
 
-      # make sure the queue items are in the correct order
-      queue_items = MiqQueue.peek(:conditions => {:zone       => @vm.my_zone,
-                                                  :queue_name => @vm.queue_name_for_metrics_collection,
-                                                  :role       => "ems_metrics_collector"},
-                                  :limit      => 3)
-      start_time = (start_time + 10.days).utc
-      end_time = (start_time + 5.hours + 23.minutes).utc
-      queue_items.each do |q_item|
-        q_start_time, q_end_time = q_item.args
-        expect(q_start_time).to eq start_time
-        expect(q_end_time).to eq end_time
-        end_time = start_time
-        start_time = start_time - 1.day
+        # make sure the queue items are in the correct order
+        queue_items = MiqQueue.order(:id).limit(verify_queue_items_count)
+        days_ago = (time_since_last_perf_capture.to_i / 1.day.to_i).days
+        partial_days = time_since_last_perf_capture - days_ago
+        interval_start_time = (start_time + days_ago).utc
+        interval_end_time = (interval_start_time + partial_days).utc
+        queue_items.each do |q_item|
+          q_start_time, q_end_time = q_item.args
+          expect(q_start_time).to be_same_time_as interval_start_time
+          expect(q_end_time).to be_same_time_as interval_end_time
+          interval_end_time = interval_start_time
+          # if the collection threshold is ever parameterized, then this 1.day will have to change
+          interval_start_time = interval_start_time - 1.day
+        end
       end
+    end
 
-      Timecop.return
+    it "splits up long perf_capture durations for old last_perf_capture_on" do
+      # test when last perf capture was many days ago
+      # total queue items == 11
+      # verify last 3 queue items
+      test_perf_capture_queue(10.days + 5.hours + 23.minutes, 11, 3)
+    end
+
+    it "does not get confused when dealing with a single day" do
+      # test when perf capture is just a few hours ago
+      # total queue items == 1
+      # verify last 1 queue item
+      test_perf_capture_queue(0.days + 2.hours + 5.minutes, 1, 1)
     end
   end
 


### PR DESCRIPTION
When a target's `last_perf_capture_on` is far into the past, the next attempt to capture metrics for that target will result in an attempt to gather a potentially huge amount of metrics at one time.

This change will break down the intervals between `last_perf_capture_on` and `today` into individual days.  This is the same logic that's used when collecting gap metrics.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1429593
https://bugzilla.redhat.com/show_bug.cgi?id=1432719


Steps for Testing/QA
-------------------------------

1) Take any active VM and manually change the `last_perf_capture_on` field to some time in the past.
2) Collect metrics for that VM

The expected result is the MiqQueue should receive `N` number of queue entries, 1 for each full or partial day since `last_perf_capture_on`.

/cc @simon3z 