### PR TITLE
Move Credential's API_ATTRIBUTES to the shared one

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
@@ -1,7 +1,3 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Credential < ManageIQ::Providers::ExternalAutomationManager::Authentication
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
-
-  COMMON_ATTRIBUTES = {}.freeze
-  EXTRA_ATTRIBUTES = {}.freeze
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -71,4 +71,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
     action = "Deleting #{self.class.name} with manager_ref=#{manager_ref}"
     self.class.send('queue', resource.my_zone, id, "delete_in_provider", [], action)
   end
+
+  COMMON_ATTRIBUTES = {}.freeze
+  EXTRA_ATTRIBUTES = {}.freeze
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential <
   ManageIQ::Providers::EmbeddedAutomationManager::Authentication
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
-
-  COMMON_ATTRIBUTES = {}.freeze
-  EXTRA_ATTRIBUTES = {}.freeze
-  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 end


### PR DESCRIPTION
Some refactoring

@miq-bot add_labels refactoring, providers/ansible_tower