### PR TITLE
Update CloudVolume class_by_ems

### DIFF
--- a/spec/models/cloud_volume_spec.rb
+++ b/spec/models/cloud_volume_spec.rb
@@ -6,4 +6,36 @@ describe CloudVolume do
 
     expect(described_class.available).to eq([cv2])
   end
+
+  context ".class_by_ems" do
+    let(:openstack_cloud) { FactoryGirl.create(:ems_openstack) }
+    let(:cinder) { FactoryGirl.create(:ems_cinder, :parent_ems_id => openstack_cloud.id) }
+    let(:amazon_cloud) { FactoryGirl.create(:ems_amazon) }
+    let(:ebs) { FactoryGirl.create(:ems_amazon_ebs, :parent_ems_id => amazon_cloud.id) }
+    let(:block_ems) { FactoryGirl.create(:ems_cinder) }
+
+    it "OpenStack cloud manager should return it's CloudVolume type" do
+      expect(CloudVolume.class_by_ems(openstack_cloud)).to eq(ManageIQ::Providers::Openstack::CloudManager::CloudVolume)
+    end
+
+    it "Cinder block storage manager should return CloudVolume type of the parent manager" do
+      expect(CloudVolume.class_by_ems(cinder)).to eq(ManageIQ::Providers::Openstack::CloudManager::CloudVolume)
+    end
+
+    it "Amazon cloud manager should return base CloudVolume type" do
+      expect(CloudVolume.class_by_ems(amazon_cloud)).to eq(CloudVolume)
+    end
+
+    it "Amazon block storage manager should return it's CloudVolume type" do
+      expect(CloudVolume.class_by_ems(ebs)).to eq(ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume)
+    end
+
+    it "should return nil when no ems is provided" do
+      expect(CloudVolume.class_by_ems(nil)).to eq(nil)
+    end
+
+    it "should return CloudVolume when parent manager is nil" do
+      expect(CloudVolume.class_by_ems(block_ems)).to eq(CloudVolume)
+    end
+  end
 end


### PR DESCRIPTION
While updating the UI for creating cloud volumes I noticed that volumes are being created on OpenStack, but they are never actually refreshed by the refresh parser and remain in `creating` state. Looking closely at the issue it turned out that the UI is using cloud tenant to choose the target EMS. However, EMS of a cloud tenant is the cloud manager and not the (cinder) block storage manager. Consequently, all cloud volumes are created in a wrong EMS.

A change in the UI is simple as we already have the target storage manager. The problem then is that using it while creating CloudVolume, it will fail because the Cinder manager does not provide its own CloudVolume but relies on OpenStack to provide one.

This patch thus tries to overcome this by adding a bit more logic into it:
 * if no ems is provided, we should return nil (to keep the original behaviour)
 * if ems already implements `CloudVolume` we return it
 * if not, we check whether the parent manager provides it
 * if this fails as well, we fallback to base CloudVolume (to keep the original behaviour)

Spec has been provided to check that all current possibilities are properly handled.

UI issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/688. With this patch, we can create the cloud volume in Cinder manager but still use OpenStack `CloudVolume` to create it on OpenStack.

@Ladas I am assigning you because you are mentioned in the code comment. Please, reassign if there is someone else that should look into it.

@miq-bot assign @Ladas
@miq-bot add_label providers/storage,providers/openstack/cloud,enhancement

(not sure if bug or enhancement... :smile:) 