### PR TITLE
Migrate oVirt API path from /api to /ovirt-engine/api

### DIFF
--- a/db/migrate/20170315082311_update_o_virt_api_path.rb
+++ b/db/migrate/20170315082311_update_o_virt_api_path.rb
@@ -1,0 +1,32 @@
+#
+# Starting with version 4.0 of oVirt, the support for the /api URL path has been removed, and replaced
+# by /ovirt-engine/api, which was introduced in oVirt 3.5. All previous versions of oVirt are already
+# out of support. The providers that were created with previous versions of oVirt will have stored in
+# the database the old path, and will stop working when migrated to oVirt 4.0. To avoid that issue this
+# migration updates all the relevant providers to use the new supported URL path.
+#
+class UpdateOVirtApiPath < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Upddate oVirt providers API path to /ovirt-engine/api') do
+      providers = ExtManagementSystem.where(:type => 'ManageIQ::Providers::Redhat::InfraManager')
+      providers.each do |provider|
+        Endpoint.where(
+          :resource_type => 'ExtManagementSystem',
+          :resource_id   => provider.id,
+          :role          => 'default',
+          :path          => '/api'
+        ).update_all(
+          :path => '/ovirt-engine/api'
+        )
+      end
+    end
+  end
+end

--- a/spec/migrations/20170315082311_update_o_virt_api_path_spec.rb
+++ b/spec/migrations/20170315082311_update_o_virt_api_path_spec.rb
@@ -1,0 +1,106 @@
+require_migration
+
+describe UpdateOVirtApiPath do
+  let(:ems_stub) { migration_stub(:ExtManagementSystem) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it 'updates the path for the default endpoint of oVirt providers' do
+      ems_stub.create!(
+        :type => 'ManageIQ::Providers::Redhat::InfraManager',
+        :id   => 1
+      )
+      endpoint_stub.create!(
+        :id            => 1,
+        :resource_type => 'ExtManagementSystem',
+        :resource_id   => 1,
+        :role          => 'default',
+        :path          => '/api'
+      )
+
+      migrate
+
+      expect(endpoint_stub.where(:id => 1).first.path).to eq('/ovirt-engine/api')
+    end
+
+    it 'does not update the path if it has been already customized' do
+      ems_stub.create!(
+        :type => 'ManageIQ::Providers::Redhat::InfraManager',
+        :id   => 1
+      )
+      endpoint_stub.create!(
+        :id            => 1,
+        :resource_type => 'ExtManagementSystem',
+        :resource_id   => 1,
+        :role          => 'default',
+        :path          => '/myapi'
+      )
+
+      migrate
+
+      expect(endpoint_stub.where(:id => 1).first.path).to eq('/myapi')
+    end
+
+    it 'does not update the path for the metrics endpoint of oVirt providers' do
+      ems_stub.create!(
+        :type => 'ManageIQ::Providers::Redhat::InfraManager',
+        :id   => 1
+      )
+      endpoint_stub.create!(
+        :id            => 1,
+        :resource_type => 'ExtManagementSystem',
+        :resource_id   => 1,
+        :role          => 'metrics',
+        :path          => '/api'
+      )
+
+      migrate
+
+      expect(endpoint_stub.where(:id => 1).first.path).to eq('/api')
+    end
+
+    it 'does not update the path for other type of provider' do
+      ems_stub.create!(
+        :type => 'ManageIQ::Providers::Amazon::InfraManager',
+        :id   => 1
+      )
+      endpoint_stub.create!(
+        :id            => 1,
+        :resource_type => 'ExtManagementSystem',
+        :resource_id   => 1,
+        :role          => 'default',
+        :path          => '/api'
+      )
+
+      migrate
+
+      expect(endpoint_stub.where(:id => 1).first.path).to eq('/api')
+    end
+
+    it 'does not update the path for other type of resource, even if they have the same resource id' do
+      ems_stub.create!(
+        :type => 'ManageIQ::Providers::Redhat::InfraManager',
+        :id   => 1
+      )
+      endpoint_stub.create!(
+        :id            => 1,
+        :resource_type => 'ExtManagementSystem',
+        :resource_id   => 1,
+        :role          => 'default',
+        :path          => '/api'
+      )
+      endpoint_stub.create!(
+        :id            => 2,
+        :resource_type => 'DoNotTouch',
+        :resource_id   => 1,
+        :role          => 'default',
+        :path          => '/api'
+      )
+
+      migrate
+
+      expect(endpoint_stub.where(:id => 1).first.path).to eq('/ovirt-engine/api')
+      expect(endpoint_stub.where(:id => 2).first.path).to eq('/api')
+    end
+  end
+end


### PR DESCRIPTION
Starting with version 4.0 of oVirt, the support for the /api URL path
has been removed, and replaced by /ovirt-engine/api, which was
introduced in oVirt 3.5.  All previous versions of oVirt are already out
of support. The providers that were created with previous versions of
oVirt will have stored in the database the old path, and will stop
working when migrated to oVirt 4.0. To avoid that issue this migration
updates all the relevant providers to use the new supported URL path.

https://bugzilla.redhat.com/1427653