### PR TITLE
Allowed sections of custom attributes to display

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -67,5 +67,9 @@ module ManageIQ::Providers
     def port_show
       port.to_s
     end
+
+    def displayed_custom_attribute_sections
+      ['metadata']
+    end
   end
 end


### PR DESCRIPTION
A function to return the displayable sections of custom attributes.

Helper method for https://github.com/ManageIQ/manageiq-ui-classic/pull/290