### PR TITLE
Refactor/DRY logging for job

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,7 +29,7 @@ class Job < ApplicationRecord
     job.initialize_attributes
     job.save
     job.create_miq_task(job.attributes_for_task)
-    $log.info "Job created: guid: [#{job.guid}], userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], agent class: [#{job.agent_class}], agent id: [#{job.agent_id}], zone: [#{job.zone}]"
+    $log.info "Job created: #{job.attributes_log}"
     job.signal(:initializing)
     job
   end
@@ -55,11 +55,11 @@ class Job < ApplicationRecord
 
   def check_active_on_destroy
     if self.is_active?
-      _log.warn "Job is active, delete not allowed - guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+      _log.warn "Job is active, delete not allowed - #{attributes_log}"
       throw :abort
     end
 
-    _log.info "Job deleted: guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+    _log.info "Job deleted: #{attributes_log}"
     true
   end
 
@@ -250,5 +250,9 @@ class Job < ApplicationRecord
      :context_data  => context,
      :zone          => zone,
      :started_on    => started_on}
+  end
+
+  def attributes_log
+    "guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
   end
 end # class Job

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -165,7 +165,7 @@ class JobProxyDispatcher
 
   def start_job_on_proxy(job, proxy)
     assign_proxy_to_job(proxy, job)
-    _log.info "Job [#{job.guid}] update: userid: [#{job.userid}], name: [#{job.name}], target class: [#{job.target_class}], target id: [#{job.target_id}], process type: [#{job.type}], agent class: [#{job.agent_class}], agent id: [#{job.agent_id}]"
+    _log.info "Job #{job.attributes_log}"
     job_options = {:args => ["start"], :zone => MiqServer.my_zone}
     job_options.merge!(:server_guid => proxy.guid, :role => "smartproxy") if proxy.kind_of?(MiqServer)
     @active_vm_scans_by_zone[MiqServer.my_zone] += 1

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -293,6 +293,13 @@ describe Job do
     end
   end
 
+  describe "#attributes_log" do
+    it "returns attributes for logging" do
+      job = Job.create_job("VmScan", :name => "Hello, World!")
+      expect(job.attributes_log).to include("VmScan", "Hello, World!", job.guid)
+    end
+  end
+
   context "belongs_to task" do
     before(:each) do
       @job = Job.create_job("VmScan", :name => "Hello, World!")
@@ -320,6 +327,7 @@ describe Job do
         )
       end
     end
+
     context "after_update_commit callback calls" do
       describe "#update_linked_task" do
         it "executes when 'after_update_commit' callbacke triggered" do


### PR DESCRIPTION
Introduce `Job#attributes_log` - The Job's attributes that are logged.

This allows us to modify the logged attributes more easily.

@miq_bot add-label core, refactoring