### PR TITLE
Added support for API slugs

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -13,4 +13,12 @@ class ApplicationRecord < ActiveRecord::Base
   # FIXME: UI code - decorator support
   extend MiqDecorator::Klass
   include MiqDecorator::Instance
+
+  # API Support
+  virtual_column :slug, :type => :string
+
+  def slug
+    collection = Api::CollectionConfig.new.name_for_subklass(self.class)
+    "#{collection}/#{id}" if collection && id
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,6 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ArRegion
   include ArLock
   include ArNestedCountBy
+  include ArSlug
   include ToModelHash
 
   extend ArTableLock
@@ -13,12 +14,4 @@ class ApplicationRecord < ActiveRecord::Base
   # FIXME: UI code - decorator support
   extend MiqDecorator::Klass
   include MiqDecorator::Instance
-
-  # API Support
-  virtual_column :slug, :type => :string
-
-  def slug
-    collection = Api::CollectionConfig.new.name_for_subklass(self.class)
-    "#{collection}/#{id}" if collection && id
-  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,7 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ArRegion
   include ArLock
   include ArNestedCountBy
-  include ArSlug
+  include ArHrefSlug
   include ToModelHash
 
   extend ArTableLock

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -73,10 +73,10 @@ module Api
       @cfg.detect { |_, spec| spec[:klass] == resource_klass.name }.try(:first)
     end
 
-    def name_for_subklass(resource_klass)
+    def name_for_subclass(resource_class)
       @cfg.detect do |collection, _|
         collection_class = klass(collection)
-        collection_class && (collection_class == resource_klass || collection_class.descendants.include?(resource_klass))
+        collection_class && (collection_class == resource_class || collection_class.descendants.include?(resource_class))
       end.try(:first)
     end
 

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -73,6 +73,13 @@ module Api
       @cfg.detect { |_, spec| spec[:klass] == resource_klass.name }.try(:first)
     end
 
+    def name_for_subklass(resource_klass)
+      @cfg.detect do |collection, _|
+        collection_class = klass(collection)
+        collection_class && (collection_class == resource_klass || collection_class.descendants.include?(resource_klass))
+      end.try(:first)
+    end
+
     def what_refers_to_feature(product_feature_name)
       referenced_identifiers[product_feature_name]
     end

--- a/lib/api/utils.rb
+++ b/lib/api/utils.rb
@@ -1,0 +1,9 @@
+module Api
+  module Utils
+    def self.build_href_slug(klass, id)
+      return unless id
+      collection = Api::CollectionConfig.new.name_for_subclass(klass)
+      "#{collection}/#{id}" if collection
+    end
+  end
+end

--- a/lib/extensions/ar_href_slug.rb
+++ b/lib/extensions/ar_href_slug.rb
@@ -1,4 +1,4 @@
-module ArSlug
+module ArHrefSlug
   extend ActiveSupport::Concern
 
   included do

--- a/lib/extensions/ar_slug.rb
+++ b/lib/extensions/ar_slug.rb
@@ -1,0 +1,13 @@
+module ArSlug
+  extend ActiveSupport::Concern
+
+  included do
+    virtual_column :href_slug, :type => :string
+
+    def href_slug
+      return unless id
+      collection = Api::CollectionConfig.new.name_for_subklass(self.class)
+      "#{collection}/#{id}" if collection
+    end
+  end
+end

--- a/lib/extensions/ar_slug.rb
+++ b/lib/extensions/ar_slug.rb
@@ -5,9 +5,7 @@ module ArSlug
     virtual_column :href_slug, :type => :string
 
     def href_slug
-      return unless id
-      collection = Api::CollectionConfig.new.name_for_subklass(self.class)
-      "#{collection}/#{id}" if collection
+      Api::Utils.build_href_slug(self.class, id)
     end
   end
 end

--- a/spec/lib/api/collection_config_spec.rb
+++ b/spec/lib/api/collection_config_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe Api::CollectionConfig do
     end
   end
 
-  describe "#name_for_subklass" do
+  describe "#name_for_subclass" do
     it "returns the collection name for classes declared by the API" do
-      expect(subject.name_for_subklass(Vm)).to eq(:vms)
+      expect(subject.name_for_subclass(Vm)).to eq(:vms)
     end
 
     it "returns the collection name for classes that are accessible via collection_class" do
-      expect(subject.name_for_subklass(ManageIQ::Providers::Vmware::InfraManager::Vm)).to eq(:vms)
+      expect(subject.name_for_subclass(ManageIQ::Providers::Vmware::InfraManager::Vm)).to eq(:vms)
     end
 
     it "returns nil for classes unknown to the API" do
-      expect(subject.name_for_subklass(String)).to be_nil
+      expect(subject.name_for_subclass(String)).to be_nil
     end
   end
 end

--- a/spec/lib/api/collection_config_spec.rb
+++ b/spec/lib/api/collection_config_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe Api::CollectionConfig do
       expect(subject.name_for_klass(String)).to be_nil
     end
   end
+
+  describe "#name_for_subklass" do
+    it "returns the collection name for classes declared by the API" do
+      expect(subject.name_for_subklass(Vm)).to eq(:vms)
+    end
+
+    it "returns the collection name for classes that are accessible via collection_class" do
+      expect(subject.name_for_subklass(ManageIQ::Providers::Vmware::InfraManager::Vm)).to eq(:vms)
+    end
+
+    it "returns nil for classes unknown to the API" do
+      expect(subject.name_for_subklass(String)).to be_nil
+    end
+  end
 end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -506,7 +506,7 @@ describe "Querying" do
       api_basic_authorize collection_action_identifier(:vms, :read, :get)
       vm = create_vms_by_name(%w(aa)).first
 
-      run_get vms_url, :expand => "resources", :attributes => "slug,name,vendor"
+      run_get vms_url, :expand => "resources", :attributes => "href_slug,name,vendor"
 
       expected = {
         "name"      => "vms",
@@ -514,11 +514,11 @@ describe "Querying" do
         "subcount"  => 1,
         "resources" => [
           {
-            "id"     => vm.id,
-            "href"   => a_string_matching(vms_url(vm.id)),
-            "slug"   => "vms/#{vm.id}",
-            "name"   => "aa",
-            "vendor" => anything
+            "id"        => vm.id,
+            "href"      => a_string_matching(vms_url(vm.id)),
+            "href_slug" => "vms/#{vm.id}",
+            "name"      => "aa",
+            "vendor"    => anything
           }
         ]
       }

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -506,7 +506,7 @@ describe "Querying" do
       api_basic_authorize collection_action_identifier(:vms, :read, :get)
       vm = create_vms_by_name(%w(aa)).first
 
-      run_get vms_url, :expand => "resources", :attributes => "name,vendor"
+      run_get vms_url, :expand => "resources", :attributes => "slug,name,vendor"
 
       expected = {
         "name"      => "vms",
@@ -516,6 +516,7 @@ describe "Querying" do
           {
             "id"     => vm.id,
             "href"   => a_string_matching(vms_url(vm.id)),
+            "slug"   => "vms/#{vm.id}",
             "name"   => "aa",
             "vendor" => anything
           }


### PR DESCRIPTION
- added slug method on application record instances
- returns ":collection/:id" if instance class matches a collection class or any of its descendants, nil otherwise.
- declared as a virtual_column so it's accessible from API.
- Added specs

Closes Issue #11635