### PR TITLE
Fix for TagControl issues after previous BZ1428133 fix

### DIFF
--- a/app/models/dialog_field_tag_control.rb
+++ b/app/models/dialog_field_tag_control.rb
@@ -40,10 +40,6 @@ class DialogFieldTagControl < DialogFieldSortedItem
     categories.sort_by { |tag| tag[:description] }
   end
 
-  def self.category_tags(category_id)
-    new(:category => category_id).values
-  end
-
   def value_from_dialog_fields(dialog_values)
     value = dialog_values[automate_key_name]
     value.gsub(/Classification::/, '') if value
@@ -59,7 +55,10 @@ class DialogFieldTagControl < DialogFieldSortedItem
       {:id => c.id, :name => c.name, :description => c.description}
     end
 
-    return available_tags if sort_field == :none
+    empty = required? ? "<Choose>" : "<None>"
+    blank_value = [{:id => nil, :name => empty, :description => empty}]
+
+    return blank_value + available_tags if sort_field == :none
 
     if data_type == "integer"
       available_tags.sort_by! { |cat| cat[sort_field].to_i }
@@ -68,6 +67,8 @@ class DialogFieldTagControl < DialogFieldSortedItem
     end
 
     available_tags.reverse! if sort_order == :descending
+
+    available_tags = blank_value + available_tags
     available_tags
   end
 

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -119,23 +119,9 @@ describe DialogFieldTagControl do
       expect(DialogFieldTagControl.allowed_tag_categories).to match_array(expected_array)
     end
 
-    it ".category_tags" do
-      category = Classification.where(:description => "Environment", :parent_id => 0).first
-      expected_array = category.entries.collect { |t| {:id => t.id, :name => t.name, :description => t.description} }
-      expect(DialogFieldTagControl.category_tags(category.id)).to match_array(expected_array)
-    end
-
     context "with dialog field tag control without options hash" do
       before(:each) do
         @df  = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag', :name => 'test tag', :options => {:force_single_select => true})
-      end
-
-      it "#values" do
-        cat = Classification.where(:description => "Environment").first
-        @df.options[:category_id] = cat.id
-
-        expected_array = cat.entries.collect { |c| {:id => c.id, :name => c.name, :description => c.description} }.sort_by { |cat| cat[:description] }
-        expect(@df.values).to match_array(expected_array)
       end
 
       it "automate_output_value with an empty value" do
@@ -152,6 +138,122 @@ describe DialogFieldTagControl do
         tags = [Classification.first, Classification.last]
         @df.value = tags.collect(&:id).join(",")
         expect(@df.automate_output_value.split(",")).to match_array tags.collect { |tag| "#{tag.class.name}::#{tag.id}" }
+      end
+    end
+  end
+
+  describe "#values" do
+    let(:dialog_field) { described_class.new(:options => options, :data_type => data_type, :required => required) }
+    let(:options) { {:category_id => category_id, :sort_by => sort_by, :sort_order => sort_order} }
+    let(:category_id) { 123 }
+    let(:required) { false }
+    let(:sort_by) { :none }
+    let(:sort_order) { :ascending }
+    let(:data_type) { "string" }
+
+    before do
+      allow(Classification).to receive(:find_by).with(:id => category_id).and_return(classification)
+    end
+
+    shared_examples_for "DialogFieldTagControl#values when required is true" do
+      let(:required) { true }
+
+      it "the blank value uses 'Choose' for its name and description" do
+        expect(dialog_field.values[0]).to eq(:id => nil, :name => "<Choose>", :description => "<Choose>")
+      end
+    end
+
+    context "when the classification exists" do
+      let(:classification) { instance_double("Classification", :entries => [entry1, entry2]) }
+      let(:entry1) { instance_double("Classification", :id => 321, :name => "dog", :description => "Dog") }
+      let(:entry2) { instance_double("Classification", :id => 312, :name => "cat", :description => "Cat") }
+
+      context "when the sort by is set to :value" do
+        let(:sort_by) { :value }
+
+        context "when the data type is integer" do
+          let(:data_type) { "integer" }
+          let(:entry1) { instance_double("Classification", :id => 321, :name => "2dog", :description => "Dog") }
+          let(:entry2) { instance_double("Classification", :id => 312, :name => "1cat", :description => "Cat") }
+
+          context "when the sort order is descending" do
+            let(:sort_order) { :descending }
+
+            it_behaves_like "DialogFieldTagControl#values when required is true"
+
+            it "sorts reverse by name converting to integer and adds a blank value to the front" do
+              expect(dialog_field.values).to eq([
+                {:id => nil, :name => "<None>", :description => "<None>"},
+                {:id => 321, :name => "2dog", :description => "Dog"},
+                {:id => 312, :name => "1cat", :description => "Cat"}
+              ])
+            end
+          end
+
+          context "when the sort order is not descending" do
+            let(:sort_order) { :ascending }
+
+            it_behaves_like "DialogFieldTagControl#values when required is true"
+
+            it "sorts by name converting to integer and adds a blank value to the front" do
+              expect(dialog_field.values).to eq([
+                {:id => nil, :name => "<None>", :description => "<None>"},
+                {:id => 312, :name => "1cat", :description => "Cat"},
+                {:id => 321, :name => "2dog", :description => "Dog"}
+              ])
+            end
+          end
+        end
+
+        context "when the data type is not integer" do
+          context "when the sort order is descending" do
+            let(:sort_order) { :descending }
+
+            it_behaves_like "DialogFieldTagControl#values when required is true"
+
+            it "sorts reverse by name and adds a blank value to the front" do
+              expect(dialog_field.values).to eq([
+                {:id => nil, :name => "<None>", :description => "<None>"},
+                {:id => 321, :name => "dog", :description => "Dog"},
+                {:id => 312, :name => "cat", :description => "Cat"}
+              ])
+            end
+          end
+
+          context "when the sort order is not descending" do
+            let(:sort_order) { :ascending }
+
+            it_behaves_like "DialogFieldTagControl#values when required is true"
+
+            it "sorts by name and adds a blank value to the front" do
+              expect(dialog_field.values).to eq([
+                {:id => nil, :name => "<None>", :description => "<None>"},
+                {:id => 312, :name => "cat", :description => "Cat"},
+                {:id => 321, :name => "dog", :description => "Dog"}
+              ])
+            end
+          end
+        end
+      end
+
+      context "when the sort by is set to :none" do
+        it_behaves_like "DialogFieldTagControl#values when required is true"
+
+        it "returns the available tags in whatever order they came in as with a blank value first" do
+          expect(dialog_field.values).to eq([
+            {:id => nil, :name => "<None>", :description => "<None>"},
+            {:id => 321, :name => "dog", :description => "Dog"},
+            {:id => 312, :name => "cat", :description => "Cat"},
+          ])
+        end
+      end
+    end
+
+    context "when the classification does not exist" do
+      let(:classification) { nil }
+
+      it "returns an empty array" do
+        expect(dialog_field.values).to eq([])
       end
     end
   end


### PR DESCRIPTION
This will ensure TagControl fields include a nil value, as previously it relied on a helper method, and now it does not so the model must provide the correct list of values.

https://bugzilla.redhat.com/show_bug.cgi?id=1428133

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, euwe/yes