### PR TITLE
Add trait :with_provider for creating instances with factory girl

### DIFF
--- a/spec/factories/vm_amazon.rb
+++ b/spec/factories/vm_amazon.rb
@@ -2,5 +2,11 @@ FactoryGirl.define do
   factory :vm_amazon, :class => "ManageIQ::Providers::Amazon::CloudManager::Vm", :parent => :vm_cloud do
     location { |x| "#{x.name}.us-west-1.compute.amazonaws.com" }
     vendor   "amazon"
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryGirl.create(:ems_amazon, :vms => [x])
+      end
+    end
   end
 end

--- a/spec/factories/vm_azure.rb
+++ b/spec/factories/vm_azure.rb
@@ -6,5 +6,11 @@ FactoryGirl.define do
     ems_ref  "01234567890\\test_resource_group\\microsoft.resources\\vm_1"
     raw_power_state "VM running"
     name "vm_1"
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryGirl.create(:ems_azure, :vms => [x])
+      end
+    end
   end
 end

--- a/spec/factories/vm_google.rb
+++ b/spec/factories/vm_google.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :vm_google, :class => "ManageIQ::Providers::Google::CloudManager::Vm", :parent => :vm_cloud do
     vendor "google"
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryGirl.create(:ems_google, :vms => [x])
+      end
+    end
   end
 end

--- a/spec/factories/vm_openstack.rb
+++ b/spec/factories/vm_openstack.rb
@@ -9,4 +9,10 @@ FactoryGirl.define do
   factory :vm_perf_openstack, :parent => :vm_openstack do
     ems_ref         "openstack-perf-vm"
   end
+
+  trait :with_provider do
+    after(:create) do |x|
+      FactoryGirl.create(:ems_openstack, :vms => [x])
+    end
+  end
 end


### PR DESCRIPTION
to have possibility create instances with related provider
for example:
`FactoryGirl.create(:vm_azure, :with_provider)`

this is blocking:
https://github.com/ManageIQ/manageiq-ui-classic/pull/649
because there were failing specs and reason was that https://github.com/ManageIQ/manageiq-ui-classic/pull/649 relies on the fact that instance has related provider.

@miq-bot assign @gtanzillo 

@miq-bot add_label test



