### PR TITLE
Fixed refresh & save for Physical Infra.

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -3,6 +3,7 @@ module EmsRefresh
   extend EmsRefresh::SaveInventoryBlockStorage
   extend EmsRefresh::SaveInventoryCloud
   extend EmsRefresh::SaveInventoryInfra
+  extend EmsRefresh::SaveInventoryPhysicalInfra
   extend EmsRefresh::SaveInventoryContainer
   extend EmsRefresh::SaveInventoryMiddleware
   extend EmsRefresh::SaveInventoryDatawarehouse

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -12,6 +12,7 @@ module EmsRefresh::SaveInventory
     case ems
     when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target)
     when EmsInfra                                           then save_ems_infra_inventory(ems, hashes, target)
+    when EmsPhysicalInfra                                   then save_ems_physical_infra_inventory(ems, hashes, target)
     when ManageIQ::Providers::AutomationManager             then save_automation_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ConfigurationManager          then save_configuration_manager_inventory(ems, hashes, target)
     when ManageIQ::Providers::ContainerManager              then save_ems_container_inventory(ems, hashes, target)

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -5,8 +5,6 @@ class PhysicalServer < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
 
-  default_value_for :enabled, true
-
   def name_with_details
     details % {
       :name => name,


### PR DESCRIPTION
Added Physical Infra to the required classes to be included in save
inventory.

Remove `enabled` from PhysicalServers as the field is not in the
model, so was causing an issue trying to save a value that wasn't
there.