### PR TITLE
Add embedded_ansible to the list of roles that need apache

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -1,7 +1,7 @@
 module MiqServer::RoleManagement
   extend ActiveSupport::Concern
 
-  ROLES_NEEDING_APACHE = %w(user_interface web_services websocket).freeze
+  ROLES_NEEDING_APACHE = %w(user_interface web_services websocket embedded_ansible).freeze
 
   included do
     has_many :assigned_server_roles, :dependent => :destroy


### PR DESCRIPTION
We handle apache in a weird way.

Rather than starting it when we need it, we always issue a restart when the server comes up (in `MiqServer::EnvironmentManagement.prep_apache_proxying`) but then shut it down if none of our active roles require it.

That definition of requirement is governed by this array of roles so just adding the role name to the array will keep apache up if the role is active.