### PR TITLE
Remove uncalled miq_server lets

### DIFF
--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -17,7 +17,6 @@
 #
 describe "Policies Assignment API" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:provider)   { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host) }
   let(:cluster)    do

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -24,7 +24,6 @@
 #
 describe "Policies API" do
   let(:zone)        { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server)  { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)         { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)        { FactoryGirl.create(:host) }
 

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -7,7 +7,6 @@
 #
 describe "Provision Requests API" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host, :ext_management_system => ems) }
   let(:dialog)     { FactoryGirl.create(:miq_dialog_provision) }

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -3,7 +3,6 @@
 #
 describe "Queries API" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host) }
 

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -5,7 +5,6 @@
 #
 describe "Service Dialogs API" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host) }
 

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -3,7 +3,6 @@
 #
 describe "Tag Collections API" do
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)          { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)         { FactoryGirl.create(:host) }
 

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -3,7 +3,6 @@
 #
 describe "Tags API" do
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)          { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)         { FactoryGirl.create(:host) }
 

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -3,7 +3,6 @@
 #
 describe "Vms API" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host) }
 

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -100,10 +100,6 @@ module Spec
         role.update_attributes!(:miq_product_features => product_features)
       end
 
-      def miq_server_guid
-        @miq_server_guid ||= MiqUUID.new_guid
-      end
-
       def stub_api_action_role(collection, action_type, method, action, identifier)
         new_action_role = Config::Options.new.merge!("name" => action.to_s, "identifier" => identifier)
         updated_method = Api::ApiConfig.collections[collection][action_type][method].collect do |method_action|


### PR DESCRIPTION
Since these were the only things that depended on the
`miq_server_guid` helper, that can be removed too.

:scissors:

@miq-bot add-label api, test, technical debt
@miq-bot assign @abellotti 