### PR TITLE
Do not use Job.agent_class attribute

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -163,10 +163,8 @@ class Job < ApplicationRecord
           next unless job.updated_on < job.current_job_timeout(job.timeout_adjustment).seconds.ago
 
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
-          if job.agent_class == "MiqServer"
-            # TODO: can we add method_name, queue_name, role, instance_id to the exists?
-            next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => job.agent_class)
-          end
+          # TODO: can we add method_name, queue_name, role, instance_id to the exists?
+          next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid)
           job.timeout!
         end
     rescue Exception
@@ -250,6 +248,6 @@ class Job < ApplicationRecord
   end
 
   def attributes_log
-    "guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent class: [#{agent_class}], agent id: [#{agent_id}], zone: [#{zone}]"
+    "guid: [#{guid}], userid: [#{self.userid}], name: [#{self.name}], target class: [#{target_class}], target id: [#{target_id}], process type: [#{type}], agent id: [#{agent_id}], zone: [#{zone}]"
   end
 end # class Job

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -166,9 +166,7 @@ class JobProxyDispatcher
   def start_job_on_proxy(job, proxy)
     assign_proxy_to_job(proxy, job)
     _log.info "Job #{job.attributes_log}"
-    job_options = {:args => ["start"], :zone => MiqServer.my_zone}
-    job_options[:server_guid => proxy.guid]
-    job_options[:role => "smartproxy"]
+    job_options = {:args => ["start"], :zone => MiqServer.my_zone, :server_guid => proxy.guid, :role => "smartproxy"}
     @active_vm_scans_by_zone[MiqServer.my_zone] += 1
     queue_signal(job, job_options)
   end
@@ -185,8 +183,7 @@ class JobProxyDispatcher
     busy_proxies["MiqServer_#{job.agent_id}"] += 1
 
     # Track the host/vc resource for embedded scans so we can limit the resource impact
-    key = embedded_scan_resource(@vm)
-    if key
+    if (key = embedded_scan_resource(@vm))
       busy_resources_for_embedded_scanning[key] ||= 0
       busy_resources_for_embedded_scanning[key] += 1
     end

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -171,7 +171,7 @@ class VmScan < Job
                                                                    :name => ems_list[scan_ci_type][:hostname]}
         end
       end
-      unless ems_list[scan_ci_type].nil?
+      if ems_list[scan_ci_type]
         _log.info "[#{host.name}] communicates with [#{scan_ci_type}:#{ems_list[scan_ci_type][:hostname]}"\
                   "(#{ems_list[scan_ci_type][:address]})] to scan vm [#{vm.name}]"
       end

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -101,8 +101,7 @@ class VmScan < Job
          vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
         return unless create_snapshot(vm)
       elsif vm.require_snapshot_for_scan?
-        host  = Object.const_get(agent_class).find(agent_id)
-        proxy = host.respond_to?("miq_proxy") ? host.miq_proxy : nil
+        proxy = MiqServer.find(agent_id)
 
         # Check if the broker is available
         if MiqServer.use_broker_for_embedded_proxy? && !MiqVimBrokerWorker.available?
@@ -156,7 +155,7 @@ class VmScan < Job
     _log.info "Enter"
 
     begin
-      host = Object.const_get(agent_class).find(agent_id)
+      MiqServer.find(agent_id)
       vm = VmOrTemplate.find(target_id)
       # Send down metadata to allow the host to make decisions.
       scan_args = create_scan_args(vm)
@@ -172,8 +171,10 @@ class VmScan < Job
                                                                    :name => ems_list[scan_ci_type][:hostname]}
         end
       end
-
-      _log.info "[#{host.name}] communicates with [#{scan_ci_type}:#{ems_list[scan_ci_type][:hostname]}(#{ems_list[scan_ci_type][:address]})] to scan vm [#{vm.name}]" if agent_class == "MiqServer" && !ems_list[scan_ci_type].nil?
+      unless ems_list[scan_ci_type].nil?
+        _log.info "[#{host.name}] communicates with [#{scan_ci_type}:#{ems_list[scan_ci_type][:hostname]}"\
+                  "(#{ems_list[scan_ci_type][:address]})] to scan vm [#{vm.name}]"
+      end
       vm.scan_metadata(options[:categories], "taskid" => jobid, "host" => host, "args" => [YAML.dump(scan_args)])
     rescue Timeout::Error
       message = "timed out attempting to scan, aborting"
@@ -272,7 +273,7 @@ class VmScan < Job
     _log.info "Enter"
 
     begin
-      host = Object.const_get(agent_class).find(agent_id)
+      host = MiqServer.find(agent_id)
       vm = VmOrTemplate.find(target_id)
       vm.sync_metadata(options[:categories],
                        "taskid" => jobid,

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -9,7 +9,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
     NUM_OF_STORAGES = 3
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
-      vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"])
+      vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND target_class = ?", "active", "finished", "VmOrTemplate"])
                                     .pluck(:target_id).compact.uniq
       expect(vms_in_embedded_scanning.length).to be > 0
 

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -303,4 +303,18 @@ describe JobProxyDispatcher do
       end
     end
   end
+
+  describe "#start_job_on_proxy" do
+    it "creates job options and passing it to `queue_signal'" do
+      job = Job.create_job("VmScan", :agent_id => @server.id, :name => "Hello, World")
+      proxy_dispatcher = JobProxyDispatcher.new
+      proxy_dispatcher.instance_variable_set(:@active_vm_scans_by_zone, @server.my_zone => 0)
+
+      job_options = {:args => ["start"], :zone => @server.my_zone, :server_guid => @server.guid, :role => "smartproxy"}
+      expect(proxy_dispatcher).to receive(:assign_proxy_to_job)
+      expect(proxy_dispatcher).to receive(:queue_signal).with(job, job_options)
+
+      proxy_dispatcher.start_job_on_proxy(job, @server)
+    end
+  end
 end


### PR DESCRIPTION
Part of ManageIQ/manageiq#14030 - merging `MiqTask` and `Job`

Concept of agents for SmartState Analysis was simplified and now agent is instance of `MiqServer`. 

This PR removes references to `Job.agent_class`

@miq-bot add-label core, refactoring