### PR TITLE
Uses hawkular_metric_id from the inventory

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -504,10 +504,6 @@ module ManageIQ::Providers
       )
     end
 
-    def build_availability_metric_id(feed_id, resource_id, metric_id)
-      "AI~R~[#{feed_id}/#{resource_id}]~AT~#{metric_id}"
-    end
-
     def self.update_alert(*args)
       operation = args[0][:operation]
       alert = args[0][:alert]

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -156,15 +156,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
         'resource_id_1' => [{
           :status => 'Enabled'
         }],
-        'resource_id_2' => [{
-          :status => 'Unknown'
-        }],
-        'resource_id_3' => [{
-          :status => 'Unknown'
-        }],
-        'resource_id_4' => [{
-          :status => 'Unknown'
-        }]
+        'resource_id_2' => [{}],
+        'resource_id_3' => [{}],
+        'resource_id_4' => [{}]
       }
       expect(parser.send(:parse_availability,
                          availabilities,

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
                                         :port            => 8080,
                                         :authentications => [auth])
     @vm = FactoryGirl.create(:vm_redhat,
-                             :uid_ems => '20f0b6ee064748ed9b91d9dd1283396a')
+                             :uid_ems => '94f76aa25a3a')
   end
 
   it "will perform a full refresh on localhost" do
@@ -38,7 +38,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     expect(@ems_hawkular.middleware_deployments.first).to have_attributes(:status => 'Enabled')
     assert_specific_datasource(@ems_hawkular, 'Local~/subsystem=datasources/data-source=ExampleDS')
     assert_specific_datasource(@ems_hawkular,
-                               'Local~/host=master/server=server-one/subsystem=datasources/data-source=ExampleDS')
+                               'Local~/host=master/server=s/subsystem=datasources/data-source=ExampleDS')
     assert_specific_server_group(domain)
     assert_specific_domain_server
     assert_specific_domain
@@ -73,11 +73,11 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_server_group(domain)
-    server_group = domain.middleware_server_groups.find_by(:name => 'main-server-group')
+    server_group = domain.middleware_server_groups.find_by(:name => 'my-group')
     expect(server_group).to have_attributes(
-      :name     => 'main-server-group',
-      :nativeid => 'Local~/server-group=main-server-group',
-      :profile  => 'full',
+      :name     => 'my-group',
+      :nativeid => 'Local~/server-group=my-group',
+      :profile  => 'default',
     )
     expect(server_group.properties).not_to be_nil
     expect(server_group.middleware_deployments).to be_empty
@@ -85,12 +85,12 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_domain_server
-    server = @ems_hawkular.middleware_servers.find_by(:name => 'server-three')
+    server = @ems_hawkular.middleware_servers.find_by(:name => 's')
     expect(server).to have_attributes(
-      :name     => 'server-three',
-      :nativeid => 'Local~/host=master/server=server-three',
-      :product  => 'not yet available',
-      :hostname => 'not yet available',
+      :name     => 's',
+      :nativeid => 'Local~/host=master/server=s',
+      :product  => 'WildFly Full',
+      :hostname => '58ef2cf13071',
     )
     expect(server.properties).not_to be_nil
   end

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -31,20 +31,20 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '234'
+      - '233'
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "Implementation-Version" : "0.18.0.Final",
-          "Built-From-Git-SHA1" : "be1107e48907ebc1d8de4dc571275edd9daf0424",
+          "Implementation-Version" : "1.1.3.Final",
+          "Built-From-Git-SHA1" : "cd31cfcb438098b6d56886e4043f4ac51bb80fb0",
           "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
           "Initialized" : "true"
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/status
@@ -57,7 +57,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -76,14 +76,14 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '133'
+      - '150'
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
     body:
       encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.18.0.Final","Built-From-Git-SHA1":"d5281e70603719809bdada72249b9330b22ebf96"}'
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.24.1.Final","Built-From-Git-SHA1":"397e6ce2e56828276c6c38a8ae04ecadb548a101","Cassandra":"up"}'
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/type=f
@@ -96,7 +96,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -117,533 +117,35 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - '3'
+      - '2'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '818'
+      - '520'
       Link:
       - <http://localhost:8080/hawkular/inventory/traversal/type=f>; rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871",
-          "identityHash" : "cfd85919ae53b605c515770ea5056d4297f35f6",
-          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "ff6fb75be1bf6ca5c743a3cac9bffe63a7e216",
-          "id" : "e2daaa52-a9c1-4578-8a60-c6699de99871"
-        }, {
           "path" : "/t;hawkular/f;master.Unnamed%20Domain",
-          "identityHash" : "f1f49092d3a52a104dca649590e06c54d1e635d",
+          "identityHash" : "30f57c15827b92fbd6ae865f7a713a19fe5d92",
           "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "fa157743d6a24c6da70a0d8e1ddf11310789c54",
+          "syncHash" : "39586a9980cea65ba04eb4623cf11d843e942253",
           "id" : "master.Unnamed Domain"
         }, {
-          "path" : "/t;hawkular/f;feed_may_exist",
-          "identityHash" : "abc4c5719f1f4d4ef252d9b060f33ea09f48db",
+          "path" : "/t;hawkular/f;94f76aa25a3a",
+          "identityHash" : "52c22f6479aaa464a93a9ca3d993f2fd6838e74",
           "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "09efb56d1f187c7ae3fa6ce1c864b3dcf5e78e",
-          "id" : "feed_may_exist"
+          "syncHash" : "e4162397bb66dfc67838ac89a524d73d78de92a",
+          "id" : "94f76aa25a3a"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - '1'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '665'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~",
-          "name" : "WildFly Server [Local]",
-          "identityHash" : "3dea1e437737a93e607d69b7a6e3db517231a",
-          "contentHash" : "279ff07c7f8bb9a36853a063514dd723667afc",
-          "syncHash" : "3e84c1c5b54c0d38016a8a93c2edd872ad5f5",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server",
-            "name" : "WildFly Server",
-            "identityHash" : "ab7029efaddc2c15983a8e8a28576b5d6f24c7",
-            "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
-            "syncHash" : "eaff3fc55473c319fc4135147084ae425eb2ed6b",
-            "id" : "WildFly Server"
-          },
-          "id" : "Local~~"
-        } ]
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '811'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "993dcbcf56fcb99d3d5de6453431f4cefa6856e",
-          "contentHash" : "1bd15692631f24dd82be3f4adf3084889b8fd4b",
-          "syncHash" : "b03021e09d92e24a2c71d7c96e0e478f1595aa8",
-          "value" : {
-            "Suspend State" : "RUNNING",
-            "Bound Address" : "0.0.0.0",
-            "Running Mode" : "NORMAL",
-            "Home Directory" : "/home/josejulio/Documentos/redhat/hawkular/hawkular-services-new/dist/target/hawkular-services-dist-0.0.11.Final-SNAPSHOT",
-            "Version" : "0.0.11.Final-SNAPSHOT",
-            "Node Name" : "avalanche",
-            "Server State" : "running",
-            "Product Name" : "Hawkular",
-            "Hostname" : "avalanche",
-            "UUID" : "e2daaa52-a9c1-4578-8a60-c6699de99871",
-            "Name" : "avalanche"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/type=rt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - '27'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '8831'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/type=rt>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-          "name" : "Singleton EJB",
-          "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-          "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-          "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-          "id" : "Singleton EJB"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-          "name" : "Deployment",
-          "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-          "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-          "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-          "id" : "Deployment"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Messaging%20Server",
-          "name" : "Messaging Server",
-          "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
-          "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
-          "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
-          "id" : "Messaging Server"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;ModCluster",
-          "name" : "ModCluster",
-          "identityHash" : "364f9437230722b5892c9595b29c77b62d3396f",
-          "contentHash" : "dbf826da8a4c333766883dba8952e10746225e7",
-          "syncHash" : "3a43f4e6781e56c218cc9cdd548ff4d362858e2",
-          "id" : "ModCluster"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-          "name" : "Socket Binding",
-          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-          "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-          "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-          "id" : "Socket Binding"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System",
-          "name" : "Operating System",
-          "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
-          "contentHash" : "e5ba86326755952233b0543acced2995e5faf457",
-          "syncHash" : "49362562aaf85d55653d9772f88834b6decd9a2a",
-          "id" : "Operating System"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan",
-          "name" : "Infinispan",
-          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
-          "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
-          "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
-          "id" : "Infinispan"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding%20Group",
-          "name" : "Socket Binding Group",
-          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
-          "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
-          "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
-          "id" : "Socket Binding Group"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-          "name" : "Message Driven EJB",
-          "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-          "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-          "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-          "id" : "Message Driven EJB"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
-          "name" : "Remote Destination Outbound Socket Binding",
-          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
-          "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
-          "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
-          "id" : "Remote Destination Outbound Socket Binding"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JGroups%20Channel",
-          "name" : "JGroups Channel",
-          "identityHash" : "b076f142fbf9a283551583114ab2a58039bd488d",
-          "contentHash" : "bbc51e1ef3ddc3f6db28051af5f9ef3ac62ae59",
-          "syncHash" : "60d66189547e89e6bcaadaa74ccbf9d96444fdd1",
-          "id" : "JGroups Channel"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-          "name" : "JMS Queue",
-          "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-          "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-          "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-          "id" : "JMS Queue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Processor",
-          "name" : "Processor",
-          "identityHash" : "81d477a597103350cafceab3588c61e5f4895e34",
-          "contentHash" : "b74dd4bb546c66fff9ea6bb459c135aaf94616",
-          "syncHash" : "6facf7492026b8aafa104122101da37f15b824a",
-          "id" : "Processor"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;File%20Store",
-          "name" : "File Store",
-          "identityHash" : "1c35dc8269c6fd21df472c92f3d7aaee59fde",
-          "contentHash" : "e1698edca6d8d938fd7c84ea634847ab3e99fa9",
-          "syncHash" : "95ecd544d2e07079fa9decdcc3cddfdc149c81b",
-          "id" : "File Store"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server",
-          "name" : "WildFly Server",
-          "identityHash" : "ab7029efaddc2c15983a8e8a28576b5d6f24c7",
-          "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
-          "syncHash" : "eaff3fc55473c319fc4135147084ae425eb2ed6b",
-          "id" : "WildFly Server"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Hawkular%20WildFly%20Agent",
-          "name" : "Hawkular WildFly Agent",
-          "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
-          "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
-          "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
-          "id" : "Hawkular WildFly Agent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;SubDeployment",
-          "name" : "SubDeployment",
-          "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
-          "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
-          "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
-          "id" : "SubDeployment"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Transaction%20Manager",
-          "name" : "Transaction Manager",
-          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
-          "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
-          "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
-          "id" : "Transaction Manager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-          "name" : "Servlet",
-          "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-          "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-          "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-          "id" : "Servlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Memory",
-          "name" : "Memory",
-          "identityHash" : "3ed4d86c86c18faa2676e56879af947d776efba",
-          "contentHash" : "89c8a2851d1755cf87365b4a7c55e5551cf878c6",
-          "syncHash" : "c2aabe6ccc30e9cba8b04133541e6f30ad76049",
-          "id" : "Memory"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JGroups",
-          "name" : "JGroups",
-          "identityHash" : "dd6a37f1e791f41312ab3ce894dad8db26ee3ad",
-          "contentHash" : "7cb9431daf07a2dc58d3786ac5a76f915891564",
-          "syncHash" : "c5a9d8fab9907672ac042ae415ac7e62b2234",
-          "id" : "JGroups"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
-          "name" : "Stateless Session EJB",
-          "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
-          "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
-          "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
-          "id" : "Stateless Session EJB"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
-          "name" : "Infinispan Cache Container",
-          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-          "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-          "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-          "id" : "Infinispan Cache Container"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-          "name" : "JMS Topic",
-          "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-          "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-          "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-          "id" : "JMS Topic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Datasource",
-          "name" : "Datasource",
-          "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
-          "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
-          "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
-          "id" : "Datasource"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JDBC%20Driver",
-          "name" : "JDBC Driver",
-          "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
-          "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-          "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
-          "id" : "JDBC Driver"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;XA%20Datasource",
-          "name" : "XA Datasource",
-          "identityHash" : "738cead59778159f64fa3911e2eff113f0f9d8",
-          "contentHash" : "3e6a387dbbbcf637e951b8c4c5bfa3dbdce858",
-          "syncHash" : "fddf22b49da75825cb141ca5615d1292cfa4457",
-          "id" : "XA Datasource"
-        } ]
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - '1'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '854'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;platform~%2FOPERATING_SYSTEM%3De2daaa52-a9c1-4578-8a60-c6699de99871_OperatingSystem",
-          "name" : "e2daaa52-a9c1-4578-8a60-c6699de99871_OperatingSystem",
-          "identityHash" : "75edd2e2eb17c4dd15d599841a6cd37aba8259",
-          "contentHash" : "a62b86a117198b51f3934a3bd6e94da39d63b2d0",
-          "syncHash" : "7a64737ef5a4986efd8c1c6d2e198fe468934a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System",
-            "name" : "Operating System",
-            "identityHash" : "12ec4befc53b1ed52f39fb292ed1eea8213323",
-            "contentHash" : "e5ba86326755952233b0543acced2995e5faf457",
-            "syncHash" : "49362562aaf85d55653d9772f88834b6decd9a2a",
-            "id" : "Operating System"
-          },
-          "id" : "platform~/OPERATING_SYSTEM=e2daaa52-a9c1-4578-8a60-c6699de99871_OperatingSystem"
-        } ]
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;platform~%2FOPERATING_SYSTEM=e2daaa52-a9c1-4578-8a60-c6699de99871_OperatingSystem/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '448'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;platform~%2FOPERATING_SYSTEM%3De2daaa52-a9c1-4578-8a60-c6699de99871_OperatingSystem/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "cb6ffb992edab792931afc5fc79b58a465434e8",
-          "contentHash" : "6ffe9f15267ffe16b3dd22c50412fd53a4880",
-          "syncHash" : "87e34db91ca52212d99d7ec01636c545588a11",
-          "value" : {
-            "Machine Id" : "20f0b6ee064748ed9b91d9dd1283396a"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;WildFly%20Server/rl;defines/type=r
@@ -656,7 +158,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -677,9 +179,9 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - "-1"
+      - '0'
       Connection:
       - keep-alive
       Content-Type:
@@ -693,10 +195,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;WildFly%20Server/rl;defines/type=r
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;WildFly%20Server/rl;defines/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -706,7 +208,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -727,23 +229,474 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - "-1"
+      - '1'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '3'
+      - '622'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;WildFly%20Server/rl;defines/type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;WildFly%20Server/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
-      string: "[ ]"
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~",
+          "name" : "WildFly Server [Local]",
+          "identityHash" : "93949d3fc3992c8687b8e76304e13a1eb528c3",
+          "contentHash" : "279ff07c7f8bb9a36853a063514dd723667afc",
+          "syncHash" : "58e79c892fa460ab27f5c9d3d74df1959b32bc46",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;WildFly%20Server",
+            "name" : "WildFly Server",
+            "identityHash" : "755514da45467710ce1e458f6f957824ea1c1b7c",
+            "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
+            "syncHash" : "38f8b952a9c522c38fc42f4b87efdc13e6d9562",
+            "id" : "WildFly Server"
+          },
+          "id" : "Local~~"
+        } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '741'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "6daa67de3cad1d4dbcc7dd54fff6ff88d8e4d735",
+          "contentHash" : "9115e21561ef5ecc96ecfcd863629b558f2bec7",
+          "syncHash" : "102dc0829aa6c8494b7c7616c06420bf6853b7e6",
+          "value" : {
+            "Immutable" : "true",
+            "Bound Address" : "0.0.0.0",
+            "Home Directory" : "/opt/jboss/wildfly",
+            "Node Name" : "94f76aa25a3a",
+            "Server State" : "running",
+            "Product Name" : "Hawkular",
+            "Hostname" : "94f76aa25a3a",
+            "In Container" : "true",
+            "Name" : "94f76aa25a3a",
+            "Suspend State" : "RUNNING",
+            "Running Mode" : "NORMAL",
+            "Version" : "0.33.0.Final",
+            "UUID" : "8db55da3-fda7-4ff2-bef5-dd0316da60b0"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/type=rt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      X-Total-Count:
+      - '28'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '8575'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/type=rt>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Platform_Memory",
+          "name" : "Memory",
+          "identityHash" : "a9cae1bf58f7305834ab1f715092a1ff19c09792",
+          "contentHash" : "89c8a2851d1755cf87365b4a7c55e5551cf878c6",
+          "syncHash" : "63c252f9da9ffbaf9ad5ebbaab52b87c516f6fc6",
+          "id" : "Platform_Memory"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Platform_Processor",
+          "name" : "Processor",
+          "identityHash" : "dc2c42d6db87dde238adda3b1e231221d8a997e",
+          "contentHash" : "b74dd4bb546c66fff9ea6bb459c135aaf94616",
+          "syncHash" : "805d15af89246196997560ea7a772bda4b717b8",
+          "id" : "Platform_Processor"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Platform_Operating%20System",
+          "name" : "Operating System",
+          "identityHash" : "8098f1b9c46296fc5873dce9979c95692b7e7ea",
+          "contentHash" : "e5ba86326755952233b0543acced2995e5faf457",
+          "syncHash" : "e97372fe4fbca63cb7662a2b71d3e022ab4fdac",
+          "id" : "Platform_Operating System"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Platform_File%20Store",
+          "name" : "File Store",
+          "identityHash" : "80e01775b6149f31d2ecf2b6e8b2d85ad06cf7",
+          "contentHash" : "e1698edca6d8d938fd7c84ea634847ab3e99fa9",
+          "syncHash" : "7c77753bf56e3ca9bbcbb90faa11e40dbabb7",
+          "id" : "Platform_File Store"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Datasource",
+          "name" : "Datasource",
+          "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+          "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+          "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+          "id" : "Datasource"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+          "name" : "SubDeployment",
+          "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+          "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+          "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+          "id" : "SubDeployment"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Hawkular%20WildFly%20Agent",
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "2e59b7dd889e76c28508b931b37de26b16bfc20",
+          "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
+          "syncHash" : "4cbc757c804eb3fa5419bda6eac1db9a2912d2",
+          "id" : "Hawkular WildFly Agent"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateful%20Session%20EJB",
+          "name" : "Stateful Session EJB",
+          "identityHash" : "113c4e7fe012f6d1952ae3b8f27e865a01fc519",
+          "contentHash" : "848ca2bad67291fd1449c648265d6cd05c5f29",
+          "syncHash" : "cdd617cf5f718e38451b83a19fcc1fba4613e360",
+          "id" : "Stateful Session EJB"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
+          "name" : "Deployment",
+          "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
+          "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
+          "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
+          "id" : "Deployment"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Transaction%20Manager",
+          "name" : "Transaction Manager",
+          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+          "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
+          "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
+          "id" : "Transaction Manager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+          "name" : "JMS Topic",
+          "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+          "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+          "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+          "id" : "JMS Topic"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+          "name" : "Remote Destination Outbound Socket Binding",
+          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
+          "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
+          "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
+          "id" : "Remote Destination Outbound Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding%20Group",
+          "name" : "Socket Binding Group",
+          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+          "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
+          "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
+          "id" : "Socket Binding Group"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
+          "name" : "Message Driven EJB",
+          "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+          "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+          "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+          "id" : "Message Driven EJB"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+          "name" : "JMS Queue",
+          "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+          "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+          "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+          "id" : "JMS Queue"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Messaging%20Server",
+          "name" : "Messaging Server",
+          "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
+          "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
+          "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
+          "id" : "Messaging Server"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;WildFly%20Server",
+          "name" : "WildFly Server",
+          "identityHash" : "755514da45467710ce1e458f6f957824ea1c1b7c",
+          "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
+          "syncHash" : "38f8b952a9c522c38fc42f4b87efdc13e6d9562",
+          "id" : "WildFly Server"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+          "name" : "Socket Binding",
+          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+          "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+          "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+          "id" : "Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+          "name" : "Singleton EJB",
+          "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+          "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+          "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+          "id" : "Singleton EJB"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;JGroups",
+          "name" : "JGroups",
+          "identityHash" : "dd6a37f1e791f41312ab3ce894dad8db26ee3ad",
+          "contentHash" : "7cb9431daf07a2dc58d3786ac5a76f915891564",
+          "syncHash" : "c5a9d8fab9907672ac042ae415ac7e62b2234",
+          "id" : "JGroups"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;ModCluster",
+          "name" : "ModCluster",
+          "identityHash" : "364f9437230722b5892c9595b29c77b62d3396f",
+          "contentHash" : "dbf826da8a4c333766883dba8952e10746225e7",
+          "syncHash" : "3a43f4e6781e56c218cc9cdd548ff4d362858e2",
+          "id" : "ModCluster"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;JDBC%20Driver",
+          "name" : "JDBC Driver",
+          "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
+          "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+          "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
+          "id" : "JDBC Driver"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+          "name" : "Servlet",
+          "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+          "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+          "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+          "id" : "Servlet"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
+          "name" : "Infinispan Cache Container",
+          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+          "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+          "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+          "id" : "Infinispan Cache Container"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;XA%20Datasource",
+          "name" : "XA Datasource",
+          "identityHash" : "738cead59778159f64fa3911e2eff113f0f9d8",
+          "contentHash" : "3e6a387dbbbcf637e951b8c4c5bfa3dbdce858",
+          "syncHash" : "fddf22b49da75825cb141ca5615d1292cfa4457",
+          "id" : "XA Datasource"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;JGroups%20Channel",
+          "name" : "JGroups Channel",
+          "identityHash" : "b076f142fbf9a283551583114ab2a58039bd488d",
+          "contentHash" : "bbc51e1ef3ddc3f6db28051af5f9ef3ac62ae59",
+          "syncHash" : "60d66189547e89e6bcaadaa74ccbf9d96444fdd1",
+          "id" : "JGroups Channel"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan",
+          "name" : "Infinispan",
+          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+          "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
+          "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
+          "id" : "Infinispan"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateless%20Session%20EJB",
+          "name" : "Stateless Session EJB",
+          "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+          "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+          "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+          "id" : "Stateless Session EJB"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;Platform_Operating%20System/rl;defines/type=r
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '752'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;Platform_Operating%20System/rl;defines/type=r>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;platform~%2FOPERATING_SYSTEM%3D94f76aa25a3a_OperatingSystem",
+          "name" : "94f76aa25a3a_OperatingSystem",
+          "identityHash" : "f5a1e1863f68799f08d45763dd7ac91d2f363",
+          "contentHash" : "abf972a1d65d7cb6d524ff748addc7ca9a12e285",
+          "syncHash" : "11a18d382fc1f1219ffea8e6a4db4f7879e2b19",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Platform_Operating%20System",
+            "name" : "Operating System",
+            "identityHash" : "8098f1b9c46296fc5873dce9979c95692b7e7ea",
+            "contentHash" : "e5ba86326755952233b0543acced2995e5faf457",
+            "syncHash" : "e97372fe4fbca63cb7662a2b71d3e022ab4fdac",
+            "id" : "Platform_Operating System"
+          },
+          "id" : "platform~/OPERATING_SYSTEM=94f76aa25a3a_OperatingSystem"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;platform~%2FOPERATING_SYSTEM=94f76aa25a3a_OperatingSystem/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '381'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;platform~%2FOPERATING_SYSTEM%3D94f76aa25a3a_OperatingSystem/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "c216b5f7c9aaad6f90e3327a77f76a5b893f7d3",
+          "contentHash" : "2afe3e6473ddc99af0cc42647fbff8772cfafc",
+          "syncHash" : "719223bd5afd4a3e7c7d4d649618bef3d4e53b",
+          "value" : {
+            "Machine Id" : "94f76aa25a3a"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/type=f
@@ -756,7 +709,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -777,91 +730,35 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - '3'
+      - '2'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '818'
+      - '520'
       Link:
       - <http://localhost:8080/hawkular/inventory/traversal/type=f>; rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871",
-          "identityHash" : "cfd85919ae53b605c515770ea5056d4297f35f6",
-          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "ff6fb75be1bf6ca5c743a3cac9bffe63a7e216",
-          "id" : "e2daaa52-a9c1-4578-8a60-c6699de99871"
-        }, {
           "path" : "/t;hawkular/f;master.Unnamed%20Domain",
-          "identityHash" : "f1f49092d3a52a104dca649590e06c54d1e635d",
+          "identityHash" : "30f57c15827b92fbd6ae865f7a713a19fe5d92",
           "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "fa157743d6a24c6da70a0d8e1ddf11310789c54",
+          "syncHash" : "39586a9980cea65ba04eb4623cf11d843e942253",
           "id" : "master.Unnamed Domain"
         }, {
-          "path" : "/t;hawkular/f;feed_may_exist",
-          "identityHash" : "abc4c5719f1f4d4ef252d9b060f33ea09f48db",
+          "path" : "/t;hawkular/f;94f76aa25a3a",
+          "identityHash" : "52c22f6479aaa464a93a9ca3d993f2fd6838e74",
           "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "09efb56d1f187c7ae3fa6ce1c864b3dcf5e78e",
-          "id" : "feed_may_exist"
+          "syncHash" : "e4162397bb66dfc67838ac89a524d73d78de92a",
+          "id" : "94f76aa25a3a"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Domain%20Host/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - "-1"
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '3'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Domain%20Host/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: "[ ]"
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20Host/rl;defines/type=r
@@ -874,7 +771,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -895,7 +792,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -903,7 +800,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '725'
+      - '671'
       Link:
       - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20Host/rl;defines/type=r>;
         rel="current"
@@ -913,21 +810,21 @@ http_interactions:
         [ {
           "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster",
           "name" : "Domain Host [master]",
-          "identityHash" : "bb8b7590cc56634bbe20485844e46f6c5efb77",
+          "identityHash" : "d08612a678635da0924a28c753e2a2162d424561",
           "contentHash" : "8c8ad1b41b2554387c42213ccf01d40113048f3",
-          "syncHash" : "5aafb4c2d5abf182026de7146ee3e2721fcf8c6",
+          "syncHash" : "cae056d79173eb2c36b0163785f961e810ab052",
           "type" : {
             "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20Host",
             "name" : "Domain Host",
-            "identityHash" : "3055e7201760359a445af19576f1711ec1c586b",
+            "identityHash" : "a120408c84f91e411bb874f4f031efd1304a3d42",
             "contentHash" : "387c2379d35ec3f9251e8a08b61cf2a99f45d26",
-            "syncHash" : "ffa7368abffd6999b5e28b125927d2d5553af74",
+            "syncHash" : "3be3478bc09c756ab7afee7f4681275f15d874c",
             "id" : "Domain Host"
           },
           "id" : "Local~/host=master"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/d;configuration
@@ -940,7 +837,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -961,37 +858,37 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '727'
+      - '672'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
           "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/d;configuration",
           "name" : "configuration",
-          "identityHash" : "317571125845d1c6b38624898c76ca44605853d9",
-          "contentHash" : "a0f5b6e6d62a931baecaee7c6ce2f515ecee",
-          "syncHash" : "b9767d6523980ab8315d62ea9dfc35ef4f634f",
+          "identityHash" : "166b1f23f4db3cbfcae4b4f8279562acfe33",
+          "contentHash" : "2313b428cbea765c4b7ae8ad88cd6caa5713ef58",
+          "syncHash" : "7c2c6cd979fa4ffa7d12b2aebbdb8840ef3b99",
           "value" : {
             "Suspend State" : null,
             "Running Mode" : "NORMAL",
-            "Home Directory" : "/home/josejulio/Aplicaciones/jboss-eap-7.0",
-            "Version" : "7.0.1.GA",
+            "Home Directory" : "/opt/jboss/wildfly",
+            "Version" : "10.0.0.Final",
             "Server State" : null,
-            "Product Name" : "JBoss EAP",
+            "Product Name" : "WildFly Full",
             "Host State" : "running",
             "Is Domain Controller" : "true",
-            "UUID" : "8708f497-2200-4f5e-b465-3d9da3ff7554",
+            "UUID" : "74688f03-f6e1-4ebd-801f-4db1dba6fd5a",
             "Name" : "master"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20Server%20Group/rl;defines/type=r
@@ -1004,7 +901,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1025,15 +922,15 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - '2'
+      - '1'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '1618'
+      - '725'
       Link:
       - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20Server%20Group/rl;defines/type=r>;
         rel="current"
@@ -1041,41 +938,26 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dmain-server-group",
-          "name" : "Domain Server Group [main-server-group]",
-          "identityHash" : "4954be86eba29bbc288ca685309dbe142e494390",
-          "contentHash" : "b67691721a527bccd46e61b36558322faff4688",
-          "syncHash" : "a08b5cdbd4a26343d23afc301a6f615318e39771",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dmy-group",
+          "name" : "Domain Server Group [my-group]",
+          "identityHash" : "a3dc2d7617ce98ca7a710d5badb9618e0e589a4",
+          "contentHash" : "1e7e5efb3f4fdbdd90785c17cd4dc588fc6c852d",
+          "syncHash" : "1c4847e5936182aa0fc52c3174d2f77a2a77965",
           "type" : {
             "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20Server%20Group",
             "name" : "Domain Server Group",
-            "identityHash" : "3162985c8e06a496190377b2f2dd6365af54356",
+            "identityHash" : "7efd282ab36449a1be70b9e3e370ebb416e1c0e3",
             "contentHash" : "c7375392e9185867d1bfa4d30d25d2560b92fcd",
-            "syncHash" : "2273fd5d5bae42684a07299859a93abd5441373",
+            "syncHash" : "ca2f585097a821ff5c7bd724c5ddc49499b75",
             "id" : "Domain Server Group"
           },
-          "id" : "Local~/server-group=main-server-group"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dother-server-group",
-          "name" : "Domain Server Group [other-server-group]",
-          "identityHash" : "69da1afb2d18693d984d7f1a1d199a886fb8d3f",
-          "contentHash" : "3f16186afc11b7d151b77de7a435e1bcb82",
-          "syncHash" : "e0bfc06543ff286499421a843a64bce3db6eac33",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20Server%20Group",
-            "name" : "Domain Server Group",
-            "identityHash" : "3162985c8e06a496190377b2f2dd6365af54356",
-            "contentHash" : "c7375392e9185867d1bfa4d30d25d2560b92fcd",
-            "syncHash" : "2273fd5d5bae42684a07299859a93abd5441373",
-            "id" : "Domain Server Group"
-          },
-          "id" : "Local~/server-group=other-server-group"
+          "id" : "Local~/server-group=my-group"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group=main-server-group/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group=my-group/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -1085,7 +967,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1106,31 +988,31 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '410'
+      - '369'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dmain-server-group/d;configuration",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dmy-group/d;configuration",
           "name" : "configuration",
-          "identityHash" : "2431a4d7edf1fc73df8929f13ab9bc4eab57d6",
-          "contentHash" : "cca4e28b6e75746f6a219580bd73222643e757",
-          "syncHash" : "7ab1018d09574ee1b6ba22696af4185bdd8685",
+          "identityHash" : "8013bda966191367d023be4cb3e9f1d569b70cb",
+          "contentHash" : "d2d7929fd43ae2c47e05210ccc0ae2797ca2a91",
+          "syncHash" : "a8f08fbf2cef60b89518a9fc7c2c49be23c11df",
           "value" : {
-            "Profile" : "full"
+            "Profile" : "default"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group=other-server-group/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -1140,7 +1022,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1161,82 +1043,27 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '418'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fserver-group%3Dother-server-group/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "a626d2ed8c6ede479232c9f1312986172a6fdb80",
-          "contentHash" : "7a793c271cff92b83226785fc3585f582072e74e",
-          "syncHash" : "67bf8698dbc96722347776db481df1d6ea4e5e",
-          "value" : {
-            "Profile" : "full-ha"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - '7'
+      - '1'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '6174'
+      - '753'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three",
-          "name" : "Domain WildFly Server [server-three]",
-          "identityHash" : "3e19eb6ef46dde8b96ee1996e26306ae4577",
-          "contentHash" : "f91dd171df9499743c8d937a4858a2b57a3f2",
-          "syncHash" : "17c12bed52d63e7935a1a15ed9a542ff921949c3",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds",
+          "name" : "Domain WildFly Server [s]",
+          "identityHash" : "79adf4977ca954da47f68605c2ab6ce692f623",
+          "contentHash" : "7cd92c55db55abc564e6d7deb36fe82e891424c",
+          "syncHash" : "ea35b3e1ac911f39f1bf83a8b81abe1261ae8b6",
           "type" : {
             "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
             "name" : "Domain WildFly Server",
@@ -1245,103 +1072,13 @@ http_interactions:
             "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
             "id" : "Domain WildFly Server"
           },
-          "id" : "Local~/host=master/server=server-three"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fsubsystem%3Dhawkular-wildfly-agent",
-          "name" : "Hawkular WildFly Agent",
-          "identityHash" : "9565c53bb4a51eec22849659b3b4a9f31761d4fa",
-          "contentHash" : "415d46a6894de8b59dd0c96042c07fd48205cb",
-          "syncHash" : "7bacc1c820ebf00f8e4fcc7084cec1a8737785",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Hawkular%20WildFly%20Agent",
-            "name" : "Hawkular WildFly Agent",
-            "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
-            "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
-            "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
-            "id" : "Hawkular WildFly Agent"
-          },
-          "id" : "Local~/host=master/subsystem=hawkular-wildfly-agent"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-two",
-          "name" : "Domain WildFly Server Controller [server-two]",
-          "identityHash" : "d64bf09b40b9b560f11635b96645fe08a37b87c",
-          "contentHash" : "fd2ccba85955a412e46999d8755bc181f48b5054",
-          "syncHash" : "318a8c0df25596d4d53c33988edee3dc4f97fe",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server%20Controller",
-            "name" : "Domain WildFly Server Controller",
-            "identityHash" : "6e1c33eb4ee14237bf415143b443af379aa9762b",
-            "contentHash" : "ffcded8355f9bc482143f2c5dec491f7180a89d",
-            "syncHash" : "b5b3954c634f63e849f23d1ac27fff68125",
-            "id" : "Domain WildFly Server Controller"
-          },
-          "id" : "Local~/host=master/server-config=server-two"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-one",
-          "name" : "Domain WildFly Server Controller [server-one]",
-          "identityHash" : "27d0217d29c57311bf115661ae8ab47a118e77",
-          "contentHash" : "70ad725124c53a942bcac5c382340b3a06ed9b4",
-          "syncHash" : "64f44a7948e55db758be8e62d7076edd4ba3a1d",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server%20Controller",
-            "name" : "Domain WildFly Server Controller",
-            "identityHash" : "6e1c33eb4ee14237bf415143b443af379aa9762b",
-            "contentHash" : "ffcded8355f9bc482143f2c5dec491f7180a89d",
-            "syncHash" : "b5b3954c634f63e849f23d1ac27fff68125",
-            "id" : "Domain WildFly Server Controller"
-          },
-          "id" : "Local~/host=master/server-config=server-one"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two",
-          "name" : "Domain WildFly Server [server-two]",
-          "identityHash" : "b5319b22faf61370f3f75bfaca34dfd53b89a9b",
-          "contentHash" : "33f194ba088df5d7e5dcdc72c1bee57617cbef",
-          "syncHash" : "765cc3c1c1efde976274bf2627bfe2d3e113c",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
-            "name" : "Domain WildFly Server",
-            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
-            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
-            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
-            "id" : "Domain WildFly Server"
-          },
-          "id" : "Local~/host=master/server=server-two"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one",
-          "name" : "Domain WildFly Server [server-one]",
-          "identityHash" : "b843fd3b6502c563983c98a5e322163fae67283",
-          "contentHash" : "705759e8a9d7833b8293d6acfc2e6e4d75ca2f",
-          "syncHash" : "b9515ab0ace28d1e5f194c7b8de164617d7b1a",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
-            "name" : "Domain WildFly Server",
-            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
-            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
-            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
-            "id" : "Domain WildFly Server"
-          },
-          "id" : "Local~/host=master/server=server-one"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-three",
-          "name" : "Domain WildFly Server Controller [server-three]",
-          "identityHash" : "4183689da12a3d367b40aeef3f113413e5a463b8",
-          "contentHash" : "ce43fb411573f2dca6c6581f42d6cedcc7ab60",
-          "syncHash" : "8951f3c1c23473eca5b26f43f9f0b8ec7572cd",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server%20Controller",
-            "name" : "Domain WildFly Server Controller",
-            "identityHash" : "6e1c33eb4ee14237bf415143b443af379aa9762b",
-            "contentHash" : "ffcded8355f9bc482143f2c5dec491f7180a89d",
-            "syncHash" : "b5b3954c634f63e849f23d1ac27fff68125",
-            "id" : "Domain WildFly Server Controller"
-          },
-          "id" : "Local~/host=master/server-config=server-three"
+          "id" : "Local~/host=master/server=s"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-three/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=s/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -1351,7 +1088,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1372,157 +1109,44 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '469'
+      - '860'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three/d;configuration",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/d;configuration",
           "name" : "configuration",
-          "identityHash" : "6817a1dc544c55618664b5771d9f3736d827ef",
-          "contentHash" : "92dde2bb93332a8d69ba582738341c890cdb1ee",
-          "syncHash" : "f880def1e8b7275e53d350d43621f82c4e4b3b6",
+          "identityHash" : "ad23fe63086863f7f2f58dee733fb7ca837e3e1",
+          "contentHash" : "4f64fe9d4d28adcd7d37154575683712d4819d8c",
+          "syncHash" : "b9bc70144d1215df95fb416d593fa03ebe254cb9",
           "value" : {
-            "Server State" : "STOPPED"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver-config=server-three/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '573'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-three/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "b24edf4284c5c7ce4a2b533c5bd1265837f2dbd",
-          "contentHash" : "b7fcf2916ff29b189b94575346c899ee45c9cf65",
-          "syncHash" : "ad2f4a186491c69b0b5cfd8a2974a2d49aca96c",
-          "value" : {
-            "Status" : "DISABLED",
-            "Server Group" : "other-server-group",
-            "Auto Start" : "false",
-            "Name" : "server-three"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '979'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "9d4e99469ab8a32c4084932539184f31e9afbd",
-          "contentHash" : "5fc7c913b21666592f46fd6524a3c4b311a9585d",
-          "syncHash" : "e75a5988cecd74106d69e6c862ec180b6d07073",
-          "value" : {
-            "Node Name" : "master:server-two",
-            "Base Directory" : "/home/josejulio/Aplicaciones/jboss-eap-7.0/domain/servers/server-two",
+            "Node Name" : "master:s",
+            "Base Directory" : "/opt/jboss/wildfly/domain/servers/s",
             "Server State" : "running",
-            "Product Name" : "JBoss EAP",
-            "Hostname" : "virtual-avalanche",
+            "Product Name" : "WildFly Full",
+            "Hostname" : "58ef2cf13071",
             "Host" : "master",
-            "Server Group" : "main-server-group",
+            "Server Group" : "my-group",
             "Initial Running Mode" : "NORMAL",
-            "Name" : "server-two",
+            "Name" : "s",
             "Suspend State" : "RUNNING",
             "Running Mode" : "NORMAL",
-            "Version" : "7.0.1.GA",
-            "Profile Name" : "full",
-            "UUID" : "7c93292d-bb67-4ea9-a076-b12ae28ea9e6"
+            "Version" : "10.0.0.Final",
+            "Profile Name" : "default",
+            "UUID" : "81ac390d-882d-4887-80e5-5225a719adae"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver-config=server-two/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver-config=s/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -1532,7 +1156,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1553,34 +1177,34 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '565'
+      - '482'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-two/d;configuration",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Ds/d;configuration",
           "name" : "configuration",
-          "identityHash" : "6dbcc02ac442a17af7f41cb85ff12f91616f192",
-          "contentHash" : "1dc3f343fcceedd59554ae9f2237152f4750d5",
-          "syncHash" : "1196f36468698696548dc8c52fa417dd468840dc",
+          "identityHash" : "9b9d1d4005114196eaf88ac723e186e59bc3e2e",
+          "contentHash" : "3b92bfe173453f416e209ba94cb0d065778b9825",
+          "syncHash" : "f472ac5ec5c64ece3a3a83d9310e3e1b4c3e4f9",
           "value" : {
             "Status" : "STARTED",
-            "Server Group" : "main-server-group",
+            "Server Group" : "my-group",
             "Auto Start" : "true",
-            "Name" : "server-two"
+            "Name" : "s"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;Domain%20Host/rl;defines/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -1590,7 +1214,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1611,135 +1235,9 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '978'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "504dd4ac9478d0817b4665666e61e664ce5f98",
-          "contentHash" : "d575419a7825e338efc83d4f48da65441b5a37f",
-          "syncHash" : "b02f5848edb8f69c1a3f56b39e151201994be64",
-          "value" : {
-            "Node Name" : "master:server-one",
-            "Base Directory" : "/home/josejulio/Aplicaciones/jboss-eap-7.0/domain/servers/server-one",
-            "Server State" : "running",
-            "Product Name" : "JBoss EAP",
-            "Hostname" : "virtual-avalanche",
-            "Host" : "master",
-            "Server Group" : "main-server-group",
-            "Initial Running Mode" : "NORMAL",
-            "Name" : "server-one",
-            "Suspend State" : "RUNNING",
-            "Running Mode" : "NORMAL",
-            "Version" : "7.0.1.GA",
-            "Profile Name" : "full",
-            "UUID" : "d9b4f2b9-3220-4f97-9e37-674f99d24f20"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver-config=server-one/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '565'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver-config%3Dserver-one/d;configuration",
-          "name" : "configuration",
-          "identityHash" : "ae13571ff97fac3fbf315bbd341dd55b253376c9",
-          "contentHash" : "a69054b9c81f135235a941e69ace47556fd4db",
-          "syncHash" : "67713d1e29c226c14571e82b357f18abb5334f8",
-          "value" : {
-            "Status" : "STARTED",
-            "Server Group" : "main-server-group",
-            "Auto Start" : "true",
-            "Name" : "server-one"
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;Domain%20Host/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - "-1"
+      - '0'
       Connection:
       - keep-alive
       Content-Type:
@@ -1747,16 +1245,16 @@ http_interactions:
       Content-Length:
       - '3'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;Domain%20Host/rl;defines/type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/rt;Domain%20Host/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/recursive;over=isParentOf;type=r
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/r;Local~~/recursive;over=isParentOf;type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -1766,7 +1264,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1787,239 +1285,29 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - '88'
+      - '86'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '76742'
+      - '75987'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/recursive;over=isParentOf;type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/r;Local~~/recursive;over=isParentOf;type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "Datasource [ExampleDS]",
-          "identityHash" : "b1ad1d93643dccfbd37acdeb9d5f9c7de3294eb",
-          "contentHash" : "b58b567684c11abcad41d4c9987f5ab7dcc91e9b",
-          "syncHash" : "a43968939bf36bfeeeb7cb5845b8cd749e462df",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Datasource",
-            "name" : "Datasource",
-            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
-            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
-            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
-            "id" : "Datasource"
-          },
-          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
-          "name" : "Deployment [hawkular-inventory-dist.war]",
-          "identityHash" : "f3defdd75b42a2d48a6c17fcd06751833bacf2e5",
-          "contentHash" : "417c20bda5537eb48b72cc26a72d0a6c0b3cbe5",
-          "syncHash" : "6c9be5a14585f8c5b4cf270725a21c95fbaf7e9",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war",
-          "name" : "Deployment [hawkular-status.war]",
-          "identityHash" : "f237ce157626d4fa8254f3325e569fcd5651de",
-          "contentHash" : "6dc4efef84b9a54a70f61074934b7c853a1e17a",
-          "syncHash" : "9e3b71955c795d7734b6ff40f3f74e22913bd8c2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-status.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
-          "name" : "Deployment [hawkular-rest-api.war]",
-          "identityHash" : "538440b748e7a36aaec485d19d6e6d5632b13d",
-          "contentHash" : "2bfba7848683914b7dc337df6a9e9a299d10f4",
-          "syncHash" : "53d3fa370cdff6e3f92359511ad5aa78176a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
-          "name" : "Socket Binding Group [standard-sockets]",
-          "identityHash" : "f866ca4321d1d3c9217722d156ec098138e766",
-          "contentHash" : "57c78c644c2360bfc5251e501570bbc27b1f5466",
-          "syncHash" : "538f17bcb94c7465967834a2a5cff95e831db888",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding%20Group",
-            "name" : "Socket Binding Group",
-            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
-            "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
-            "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
-            "id" : "Socket Binding Group"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
-          "name" : "Deployment [hawkular-alerts-actions-email.war]",
-          "identityHash" : "16986eecf77de6c8f42c7ec75daefa86e18622c",
-          "contentHash" : "c9e46694a372af5d839b126e4f8e9eaf7f2146a",
-          "syncHash" : "a64fec3af385dcb4941529afcc35284b043d7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
-          "name" : "Messaging Server [default]",
-          "identityHash" : "2e2ffd20fd3a3b7bc5472069cce1fc4da1c7d68",
-          "contentHash" : "e4e99f5c774164440fdc28a9037ffdf7262a9f8",
-          "syncHash" : "1418784f20487eb568972475bd1f7b2d2e622de",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Messaging%20Server",
-            "name" : "Messaging Server",
-            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
-            "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
-            "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
-            "id" : "Messaging Server"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-war.war",
-          "name" : "Deployment [hawkular-commons-embedded-cassandra-war.war]",
-          "identityHash" : "241312a3f1023f5137ad26bde4dd6b130b856db",
-          "contentHash" : "4eae3596373e3c1e74972f272c95552192bde178",
-          "syncHash" : "4f721a87a764d1fba957160a1709e5bf611eec8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-commons-embedded-cassandra-war.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
-          "name" : "Deployment [hawkular-command-gateway-war.war]",
-          "identityHash" : "fc197b476ad389a1dadbd4877235abbf9208769",
-          "contentHash" : "3d65bb3dceb1e32f1289d923e51a926271e0d723",
-          "syncHash" : "62daa8574c2129689930913971f534ce0556ff2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
-          "name" : "Deployment [hawkular-wildfly-agent-download.war]",
-          "identityHash" : "c1d2d36294248a6b7f4c526a1c6e9fff1fc9252",
-          "contentHash" : "e0784bf0dd411af714d5b85a98ffaaf9a612b24",
-          "syncHash" : "c953eac0a7405aaba5443850a0aa8f39dec2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
-          "name" : "Hawkular WildFly Agent",
-          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
-          "contentHash" : "fba7866bc34d2ba1ed776115ad9eceb79b6e1c",
-          "syncHash" : "8793bb7095a6da432b3b53773e66d7b02cc7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Hawkular%20WildFly%20Agent",
-            "name" : "Hawkular WildFly Agent",
-            "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
-            "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
-            "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
-            "id" : "Hawkular WildFly Agent"
-          },
-          "id" : "Local~/subsystem=hawkular-wildfly-agent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
-          "name" : "Deployment [hawkular-metrics-component.war]",
-          "identityHash" : "39bf1128fee24c49fe1c919432ad13a2da57d",
-          "contentHash" : "e37c6946d156e34663ccd46773d91ac55b61",
-          "syncHash" : "9fdd223a94ffd34988f3d497ec1bd17b4cffe24",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-metrics-component.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
-          "name" : "Transaction Manager",
-          "identityHash" : "fd4c6c6ae631c9d3574596722ecabcd248329087",
-          "contentHash" : "a6c39bff42bb3c59cb2a9df90bd9ba46ecfd4c",
-          "syncHash" : "b3ca44e58ac6adc4de54f9b40b52f7079d8e7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Transaction%20Manager",
-            "name" : "Transaction Manager",
-            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
-            "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
-            "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
-            "id" : "Transaction Manager"
-          },
-          "id" : "Local~/subsystem=transactions"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "JDBC Driver [h2]",
-          "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
-          "contentHash" : "8bcc62c8866ea8f4667c8e881cb848896ef63fa",
-          "syncHash" : "3a11f1aae220d43d6fbaae9187193f680b86c8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JDBC%20Driver",
-            "name" : "JDBC Driver",
-            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
-            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-            "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
-            "id" : "JDBC Driver"
-          },
-          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
           "name" : "Infinispan",
-          "identityHash" : "ba921964165d1775fa543a8e2ae78f89c1270",
+          "identityHash" : "91494e7521ad56b546a393cc950ba43eb90574d",
           "contentHash" : "87f6d31913ce5af34bde86aa383aa81d9958a",
-          "syncHash" : "16bdc1813cba768518be82fb5bd93ba617dee9c",
+          "syncHash" : "1c4bc4ce97af8df33bc923c67d9ec389c55da3b",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan",
             "name" : "Infinispan",
             "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
             "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
@@ -2028,733 +1316,253 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
-          "name" : "Deployment [hawkular-alerts-rest.war]",
-          "identityHash" : "cefdcdbbac39815926c1549583d7dcf3fd6b9d35",
-          "contentHash" : "9d248c86d3673fcd56d63bd7bc3c2f2bfd0b3f0",
-          "syncHash" : "bcef86db9ea1e3202e48c80413914df2dabb353",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_h2",
+          "name" : "Datasource [HawkularInventoryDS_h2]",
+          "identityHash" : "e7d541fc11952760b1e5b33bb419b3ff6fde9b",
+          "contentHash" : "edd709c9685c05550b77349ea11acb33a72dda3",
+          "syncHash" : "23d656292b424e70a87c9a8ebbaf281a2976e5a",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=HawkularInventoryDS_h2"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "5b9b6d3ac513c88aea531cb62acb2e97a7b13f0",
+          "contentHash" : "b58b567684c11abcad41d4c9987f5ab7dcc91e9b",
+          "syncHash" : "2c284ee75d302b9ecab443ad1e6215c8b89746b",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "name" : "Transaction Manager",
+          "identityHash" : "e1bd9260d5d2d9182f3ee5ef3215881af2f4c39",
+          "contentHash" : "a6c39bff42bb3c59cb2a9df90bd9ba46ecfd4c",
+          "syncHash" : "30bed6b5e3747e92bcefaa744617db016136bda",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Transaction%20Manager",
+            "name" : "Transaction Manager",
+            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+            "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
+            "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
+            "id" : "Transaction Manager"
+          },
+          "id" : "Local~/subsystem=transactions"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "name" : "Deployment [hawkular-rest-api.war]",
+          "identityHash" : "33d0559d68ec58f35920fa9a5b4acacf0cd744e",
+          "contentHash" : "2bfba7848683914b7dc337df6a9e9a299d10f4",
+          "syncHash" : "3c10f16d4a8863922f1b909cd650d4b85b3877d",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war"
+          "id" : "Local~/deployment=hawkular-rest-api.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample.war",
-          "name" : "Deployment [sample.war]",
-          "identityHash" : "c1d86b7e823bc99ba03ca3e98dbf07893ed3dad",
-          "contentHash" : "da37e26342d0c2529db1d9ffabd7929473457fd5",
-          "syncHash" : "5730c573eb29b9434c5536b0c1f5a2e1702db2ea",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "name" : "Socket Binding Group [standard-sockets]",
+          "identityHash" : "a3adfda2eec71903f2e6def315fe5c519934fb",
+          "contentHash" : "57c78c644c2360bfc5251e501570bbc27b1f5466",
+          "syncHash" : "892c2f96c3e3030259b693ba796969091ba45",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding%20Group",
+            "name" : "Socket Binding Group",
+            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+            "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
+            "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
+            "id" : "Socket Binding Group"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war",
+          "name" : "Deployment [hawkular-status.war]",
+          "identityHash" : "afed6d71c1cfc830e6b880241a8bbe655e27913c",
+          "contentHash" : "6dc4efef84b9a54a70f61074934b7c853a1e17a",
+          "syncHash" : "aaa833d7f228709422fc66da2a04c6b4e4ae41",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample.war"
+          "id" : "Local~/deployment=hawkular-status.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_2.war",
-          "name" : "Deployment [sample_2.war]",
-          "identityHash" : "c270bb4247acf59173cfe6d86f3e24baca2e94d5",
-          "contentHash" : "ca86fe6e4d6aa4dc6be6e83cdf6db2174ad5b64",
-          "syncHash" : "770777dfea619d795c0bf14fe19c54cf2cf2c5",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "40317a54118b5a655d12e0fa3b3af435ffb35b1a",
+          "contentHash" : "fba7866bc34d2ba1ed776115ad9eceb79b6e1c",
+          "syncHash" : "b090a9dce0e3b6148a69653d6c3225cd7abad9c",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Hawkular%20WildFly%20Agent",
+            "name" : "Hawkular WildFly Agent",
+            "identityHash" : "2e59b7dd889e76c28508b931b37de26b16bfc20",
+            "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
+            "syncHash" : "4cbc757c804eb3fa5419bda6eac1db9a2912d2",
+            "id" : "Hawkular WildFly Agent"
+          },
+          "id" : "Local~/subsystem=hawkular-wildfly-agent"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "2a2c8737af4420e578da6c99becbf77c870f9",
+          "contentHash" : "8bcc62c8866ea8f4667c8e881cb848896ef63fa",
+          "syncHash" : "b580b85385941ad714139cfcaa6cdaf55748f",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
+            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+            "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dpostgresql",
+          "name" : "JDBC Driver [postgresql]",
+          "identityHash" : "b4d3931a55fc762aac8fc6203f4a2dc26231251",
+          "contentHash" : "5417188b1f91eb354979783bd4845d9d84522e2b",
+          "syncHash" : "ba51d98bd0a5ccc8db6c558f5b6ca564aa7371",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
+            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+            "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=postgresql"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "name" : "Messaging Server [default]",
+          "identityHash" : "dd7313aa4fd69025cde6673bbcfbd89c1e8cd86a",
+          "contentHash" : "e4e99f5c774164440fdc28a9037ffdf7262a9f8",
+          "syncHash" : "bc2d1853b56ab7c693c7dcca3ee4e05bda7466",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Messaging%20Server",
+            "name" : "Messaging Server",
+            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
+            "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
+            "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
+            "id" : "Messaging Server"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_postgres",
+          "name" : "Datasource [HawkularInventoryDS_postgres]",
+          "identityHash" : "de3083b559513fa1dcee34e78f1136ce6115ab3c",
+          "contentHash" : "90d8565f98575c636cd1e2a6da2d09bea5345",
+          "syncHash" : "c121d2042aedbf1ec7b7448c35d1135caef89",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=HawkularInventoryDS_postgres"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear",
+          "name" : "Deployment [hawkular-metrics.ear]",
+          "identityHash" : "eae6cadbdfe05b74535aaf932b44cb662882c79c",
+          "contentHash" : "ceff67ea9b17c1303497484c30c558c38766fba1",
+          "syncHash" : "c9cdf7dd9ad52a52db7ac53fca12dc26565514",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample_2.war"
+          "id" : "Local~/deployment=hawkular-metrics.ear"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample3.war",
-          "name" : "Deployment [sample3.war]",
-          "identityHash" : "329ce4d838c6e447e4752b9b8cb3c65a4c92a58",
-          "contentHash" : "69f2af546197c7b75bf16524f796b9418b9ab4f2",
-          "syncHash" : "17a381961a88f867c19db1c42ba2405880e21aa3",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
+          "name" : "Deployment [hawkular-wildfly-agent-download.war]",
+          "identityHash" : "46edf25df8e8473082965ab1bd99aaf0ddce9316",
+          "contentHash" : "e0784bf0dd411af714d5b85a98ffaaf9a612b24",
+          "syncHash" : "d9378f9bdb27ad53ca8674b025676124f6bb5699",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample3.war"
+          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample4.war",
-          "name" : "Deployment [sample4.war]",
-          "identityHash" : "a749743a297d3ac0a4eb17b888b319b0abc7496",
-          "contentHash" : "503ec7c7de4bd1d80ae5d4f4a5b81e5d5998ad",
-          "syncHash" : "d2fb8c8f43b455473a8342bc76b84861917cacd",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
+          "name" : "Deployment [hawkular-inventory-dist.war]",
+          "identityHash" : "d94af92a18ef33b714dce2561e96da858c04f60",
+          "contentHash" : "417c20bda5537eb48b72cc26a72d0a6c0b3cbe5",
+          "syncHash" : "d93cb5912c1b941ded56a84eb50ddd743e63a95",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample4.war"
+          "id" : "Local~/deployment=hawkular-inventory-dist.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample5.war",
-          "name" : "Deployment [sample5.war]",
-          "identityHash" : "2bfba888d4fb56649e13a74fcb1e83b61f07d24",
-          "contentHash" : "a41ff112f0853d3d95593359bd254f219deb95c",
-          "syncHash" : "d8529cbccb08de8c93887ce5fb2a5e896da3c",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+          "name" : "Deployment [hawkular-command-gateway-war.war]",
+          "identityHash" : "9d0e6288f43614c6a37bb457ae26818c94f7b",
+          "contentHash" : "3d65bb3dceb1e32f1289d923e51a926271e0d723",
+          "syncHash" : "e0aae51df17cb1db65f21e869642bd1ba1dead",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample5.war"
+          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_final.war",
-          "name" : "Deployment [sample_final.war]",
-          "identityHash" : "6627d7859911f625d0edf8d268a76bff9de1e62",
-          "contentHash" : "2fccfc75a6f2d1d01f3d9dbf3add906ffb9256e0",
-          "syncHash" : "149dc2df16829b2d6eb33c804938efcfbebe7b8",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-metrics",
+          "name" : "Infinispan Cache Container [hawkular-metrics]",
+          "identityHash" : "ff5b7837c537c6e19ca48acd83e0a673bab4198f",
+          "contentHash" : "d9a3a3237f06fa14883ab93c88ed9f417db59f0",
+          "syncHash" : "5fbd554c72ca85bb6f2732746888f627e1fd3b",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=sample_final.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.inventory.rest.HawkularRestApi",
-          "name" : "Servlet [org.hawkular.inventory.rest.HawkularRestApi]",
-          "identityHash" : "6d1974925c87cf4d0e3794a855287a0b25c856",
-          "contentHash" : "80c5f042a119325548bd8871f4b1843eff977cde",
-          "syncHash" : "884e302bd15594b571737bee25bc83c8317b58",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=undertow/servlet=org.hawkular.inventory.rest.HawkularRestApi"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DInventoryJNDIPublisher",
-          "name" : "Singleton EJB [InventoryJNDIPublisher]",
-          "identityHash" : "161d87b9c82b5b4610335274f4b566b7f7d7d9",
-          "contentHash" : "d6f27fdf33cb9586cc2ed3d548a8a7535d7e8d7",
-          "syncHash" : "1382d4162e14502dabcfbcbb54e4691d440c0a8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=ejb3/singleton-bean=InventoryJNDIPublisher"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/r;Local~%2Fdeployment%3Dhawkular-status.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.services.rest.HawkularServicesStatusApp",
-          "name" : "Servlet [org.hawkular.services.rest.HawkularServicesStatusApp]",
-          "identityHash" : "531358b275e9fa94debfa42cf625efdcc3cc74c",
-          "contentHash" : "c14bdf75c5f086b26bf840c65b1d2fbe3cd338",
-          "syncHash" : "da6fc4beabf4112bb5fd61b4b9cad23ccd09a86",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-status.war/subsystem=undertow/servlet=org.hawkular.services.rest.HawkularServicesStatusApp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularTopicListener",
-          "name" : "Message Driven EJB [HawkularTopicListener]",
-          "identityHash" : "c23315e4552e2d84cdb2cd14a82c12ea0695947",
-          "contentHash" : "b6d3cdf29a882af2494fc7bd79f8aad45c9216",
-          "syncHash" : "33421522fe2e836d3cbfb5a35a17931a1f0b567",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularTopicListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularQueueListener",
-          "name" : "Message Driven EJB [HawkularQueueListener]",
-          "identityHash" : "23cc67cb54ff64a8374ab83e7e5d0436d7f5351",
-          "contentHash" : "74a0db3da72d8b1cb4d7ba03f570b5ea48d1f5",
-          "syncHash" : "97509b76921fd65e42e6ca1573a8831199728587",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularQueueListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DCommandEventListener",
-          "name" : "Message Driven EJB [CommandEventListener]",
-          "identityHash" : "fac175aab4439e2f90221cf6a46ea5e88def72fe",
-          "contentHash" : "51f2121ca985cdac97f693c4e87cfdf433a6ac7",
-          "syncHash" : "a718672eb5e4407a651aab12a8e75bfe30b28f",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=CommandEventListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3DHystrixMetricsStreamServlet",
-          "name" : "Servlet [HystrixMetricsStreamServlet]",
-          "identityHash" : "2ebc6f793eaaf3c5295988376e385cfb69a71e6e",
-          "contentHash" : "57b26a489a755ea379a116ae7dd25dc6e6964896",
-          "syncHash" : "308136a5b81d3766145cc04064c1e9c8e529a3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=HystrixMetricsStreamServlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DInventoryEventListener",
-          "name" : "Message Driven EJB [InventoryEventListener]",
-          "identityHash" : "7145aea182b7e0eafeecf4f195c15d7a5dcad6",
-          "contentHash" : "3ea2444e55c07a42b7e475494d3eefa645587675",
-          "syncHash" : "979adecf7ebbd422c4ec35d29d3e46fd29f05181",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=InventoryEventListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.rest.HawkularRestApi",
-          "name" : "Servlet [org.hawkular.rest.HawkularRestApi]",
-          "identityHash" : "84ff2b3bf6ac1b16a246f8b83199b231ddb3d79",
-          "contentHash" : "d61918d1e73eb4598bb083327133ebd729375cc4",
-          "syncHash" : "31d594a78ee2cd2f2d65d76c29d7ba5cfaeede3c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=org.hawkular.rest.HawkularRestApi"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBackfillCacheManager",
-          "name" : "Singleton EJB [BackfillCacheManager]",
-          "identityHash" : "bd6e11875c39d2c06ae158a41c3df6464b533a30",
-          "contentHash" : "288bc219108342e8c97ef2de33fcd33cec443271",
-          "syncHash" : "30d5a1c218a605822a72f199d9ac47e97880da",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/singleton-bean=BackfillCacheManager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DFeedAvailabilityDataListener",
-          "name" : "Message Driven EJB [FeedAvailabilityDataListener]",
-          "identityHash" : "284cc3de5752f718cd56cac3859cd62423aa557",
-          "contentHash" : "b94a587e1ce9bb23ccbceef6694b733d041e7a5",
-          "syncHash" : "9cadf3d578cae52f22bd4c7b161a03942f47d2a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=FeedAvailabilityDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fremote-destination-outbound-socket-binding%3Dmail-smtp",
-          "name" : "Remote Destination Outbound Socket Binding [mail-smtp]",
-          "identityHash" : "8f5567368a3e0488abed7549f49cdc3b560",
-          "contentHash" : "4ec0c3c604848b38c42c4a6edc475ed7c1154",
-          "syncHash" : "fc3d51df947984cb9924763588f9021aedf37fa",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
-            "name" : "Remote Destination Outbound Socket Binding",
-            "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
-            "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
-            "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
-            "id" : "Remote Destination Outbound Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=mail-smtp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-https",
-          "name" : "Socket Binding [management-https]",
-          "identityHash" : "b5ac4a2956b86d1f152f24922dde82ad3ca66dc",
-          "contentHash" : "40aa76f8d78ac3349e73e180a4c0e690bbe11cb5",
-          "syncHash" : "ca7c0abd3e8ee2b877bb8f1156057c242b9918",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-https"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-status-manager",
-          "name" : "Socket Binding [txn-status-manager]",
-          "identityHash" : "63de5c556bf2f47fbda31b721af1d6d2c88c9e",
-          "contentHash" : "5b48a46c9e51a680549f6167f6aae133e973383",
-          "syncHash" : "ae521aa916de28bcf7e9818ff34ea41569df4a3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-status-manager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-recovery-environment",
-          "name" : "Socket Binding [txn-recovery-environment]",
-          "identityHash" : "4cea53782366671d1f168840d3c075cc83a99083",
-          "contentHash" : "11233a14674ce338b31cc5f68f6658d1d948d",
-          "syncHash" : "16abb365abb4ce39a278ff9c7d1f8487255683c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-recovery-environment"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-http",
-          "name" : "Socket Binding [management-http]",
-          "identityHash" : "559c23ae196531eb25496c4b4d46a2dab5ac7a8",
-          "contentHash" : "d0eba94951038818d2481856c63186614f9b",
-          "syncHash" : "c6d12e11bf5ddca1172a4dd389aeb2f7414f6",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-http"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dajp",
-          "name" : "Socket Binding [ajp]",
-          "identityHash" : "244af65e7e1e55b5a852469b482eafebd95b4e25",
-          "contentHash" : "db6790ce6ce289b458312e959762f4e061b7e1bd",
-          "syncHash" : "4947a569bad6bd87f189bc34cb1b19b8f16242d3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=ajp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttps",
-          "name" : "Socket Binding [https]",
-          "identityHash" : "84d81febdaf2c958b49c8611bf91f5fd4f8335a0",
-          "contentHash" : "b17723a696316dc7ecb44406fc34d7313b91b10",
-          "syncHash" : "d368db5f6ca6286cfe5a337e759bbc7b87e646c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=https"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttp",
-          "name" : "Socket Binding [http]",
-          "identityHash" : "62f4e95378a414f03ab19a60f64c4cfc9075b",
-          "contentHash" : "cbf2764bfc934aad65762cfb5569e281c1ebd34",
-          "syncHash" : "75e3577cf7efa67df79d5dfc336b69ba54da2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=http"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBusActionPluginRegister",
-          "name" : "Singleton EJB [BusActionPluginRegister]",
-          "identityHash" : "722628b893a8767753d4477d1d42bd210548c1",
-          "contentHash" : "d257564168a210f5126264de3958eff30dc56c1",
-          "syncHash" : "ebc7b543ccb9dff8955eb6bf22761928349fc4f",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war/subsystem=ejb3/singleton-bean=BusActionPluginRegister"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DBusActionPluginListener",
-          "name" : "Message Driven EJB [BusActionPluginListener]",
-          "identityHash" : "2dcf5264402b70817452fc6cbeebf5916135c5f",
-          "contentHash" : "4428e1cff72d34d2d179b9f673ae5afdd97143c",
-          "syncHash" : "4d2d1ab65753a0d87c9753a749869d7fa3af3d2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war/subsystem=ejb3/message-driven-bean=BusActionPluginListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData",
-          "name" : "JMS Topic [HawkularAvailData]",
-          "identityHash" : "52d45ca771bc846174342df9ff28a449eee0c2",
-          "contentHash" : "6e6c882c85e3a114b61296df4ea7394844f12b58",
-          "syncHash" : "bdb7a33c761b702faeba6c54c4e33a3cb0ebfd81",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAvailData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/counters/new]",
-          "identityHash" : "79d3d6c3b8bfdf6253fa761e1a90733c826a6",
-          "contentHash" : "64b9f569ed88d2171fc81483f2e184675855ee5",
-          "syncHash" : "dbe94255b8f4f6beb3dbc599383f5da4a668fa5",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/counters/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue",
-          "name" : "JMS Queue [HawkularAlertsActionsResponseQueue]",
-          "identityHash" : "2f89df98b8de26c5358e23774191987ec347d0",
-          "contentHash" : "bf6243633217684994a84e6b205ddb9043457",
-          "syncHash" : "261bacff1477605ed579df56689d487272334bc",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsActionsResponseQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic",
-          "name" : "JMS Topic [HawkularTopic]",
-          "identityHash" : "993c56c39b3fbdabcf961c6d739987469e159c",
-          "contentHash" : "132c6fe445f88da736c2f97816614bd7843669",
-          "syncHash" : "278ca8b775f184d3e4133437673e372b774c119",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularTopic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
-          "name" : "JMS Queue [ExpiryQueue]",
-          "identityHash" : "ed74bf0731fb5d4d73fcb84715d7447f5bc58",
-          "contentHash" : "be8465843986b46521f790755ed20ed975fc02a",
-          "syncHash" : "9b87fd9537412bdda236374e24da8796494fe4fc",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue",
-          "name" : "JMS Topic [HawkularQueue]",
-          "identityHash" : "f8df9ce1c70f3b681543bc46ffade8deae543",
-          "contentHash" : "dd68e13095c7664bc65476f3ee5563edeecbef2b",
-          "syncHash" : "40395192bff5b4d9b229be038dc3e01324c58",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData",
-          "name" : "JMS Topic [HawkularAlertData]",
-          "identityHash" : "e7f57dc1b12aadc2b75ad1f2cae7903b7b7ea4",
-          "contentHash" : "7b23ec77694928edcc51d935169c6ab1da3dac7",
-          "syncHash" : "4ec24b5a34b3d59080288929aa3d5051d28998e3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic",
-          "name" : "JMS Topic [HawkularAlertsActionsTopic]",
-          "identityHash" : "828edac588a6afc7eb6b75a6fe0aa90c6e9d410",
-          "contentHash" : "257c3ac6e910183bcff651a68243f5fa5764324c",
-          "syncHash" : "8426e4a22da29809b1488407cdf98e3ebd468e4",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertsActionsTopic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/availability/new]",
-          "identityHash" : "aad7c6218f8a49273e69c41c628aeece57b8e",
-          "contentHash" : "9dc1ddde8aa08f6ff5a5188d72679a2970113a",
-          "syncHash" : "9d9af02acde0dd93e332d5c378643227793dd3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/availability/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue",
-          "name" : "JMS Queue [HawkularAlertsPluginsQueue]",
-          "identityHash" : "56d62887d465c7449e322cb1e9291ae65ba9e8",
-          "contentHash" : "d91e28d8d63bec9035e47b37f3211b21c8eb528",
-          "syncHash" : "74d4fbfd8725895f19ebbdabbb63daff784e7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsPluginsQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges",
-          "name" : "JMS Topic [HawkularInventoryChanges]",
-          "identityHash" : "bab0d1dd66d31ace7f45ba669e595db0859c27",
-          "contentHash" : "2ce11418d61867e6b6594bebbb521b13de13e46",
-          "syncHash" : "e7c68d56fee52e3dcb71ba72a51a1d54f8d72c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularInventoryChanges"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
-          "name" : "JMS Queue [DLQ]",
-          "identityHash" : "d02acaaaba2970a370749fb042411d80a12c6f",
-          "contentHash" : "b7fd1bfbed2ce39f8d402fac606758a241c6708b",
-          "syncHash" : "be7ba941e9885edc820fd3e6dd3755d2787b8ea",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/gauges/new]",
-          "identityHash" : "b9a04dc6cb9aad98c94049e0a0ce44d73d095f9",
-          "contentHash" : "34dfac349816c672f3958e517a71dac46438da7",
-          "syncHash" : "d0bc9b23276de7435a1ad6fc5ddab4a4bbdde",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/gauges/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData",
-          "name" : "JMS Topic [HawkularMetricData]",
-          "identityHash" : "b3ef1c855abd05f4b4bd5768814fee2e8217a6",
-          "contentHash" : "ebbcb56478b2a9167fe12540c2d7f85a96bca",
-          "syncHash" : "de674a97df1444ca4c9be5faea6c9aa9ec5706",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularMetricData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent",
-          "name" : "JMS Topic [HawkularCommandEvent]",
-          "identityHash" : "c68f25b4dc8a501ee7abb37e90fa8f79b5b7c2b4",
-          "contentHash" : "4059e5718dadc5704f17227ea74616a3751b6e7",
-          "syncHash" : "2b5d7ec018785d0cf52b59bd23bc588424c1475",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularCommandEvent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.component.wildflymonitor.WildFlyAgentServlet",
-          "name" : "Servlet [org.hawkular.component.wildflymonitor.WildFlyAgentServlet]",
-          "identityHash" : "c3ee124ecd27a833a94ec93041cd6272e987954",
-          "contentHash" : "ea8c5721c3fc4b31a96f91d847875a91b1b7c9f",
-          "syncHash" : "7fb2c7eb9752dc38ed96d0d02ef4a49b14f4728",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war/subsystem=undertow/servlet=org.hawkular.component.wildflymonitor.WildFlyAgentServlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp",
-          "name" : "Servlet [org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp]",
-          "identityHash" : "c991134cc7b03f7cfc7a591fa0d92aa05bf2b85c",
-          "contentHash" : "a1e8def843659d7df3781cb01642199d53f54199",
-          "syncHash" : "3276202f48324bbe4ed1e025f6af6fcbaa848d3a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-metrics-component.war/subsystem=undertow/servlet=org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war%2Fsubsystem%3Dundertow%2Fservlet%3DstaticContent",
-          "name" : "Servlet [staticContent]",
-          "identityHash" : "ac6fa1d991457eb824929cccc9aea86f4512888",
-          "contentHash" : "e16131c1e93e9f3449f8f8ce7f97064365cc794",
-          "syncHash" : "13417c2029ab6f5752b9a51e9ea87b7798757bd8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-metrics-component.war/subsystem=undertow/servlet=staticContent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-services",
-          "name" : "Infinispan Cache Container [hawkular-services]",
-          "identityHash" : "8374cd28e214ec8b9be620b3bb3bd25f6c4eac",
-          "contentHash" : "65ec123fa39c4e749c775918ac515dbb1288a5",
-          "syncHash" : "13224deb7eeb8766c63f4566b7995429263ee91",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
             "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
             "id" : "Infinispan Cache Container"
           },
-          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-services"
+          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-metrics"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
-          "name" : "Infinispan Cache Container [hibernate]",
-          "identityHash" : "4025a3689a6a5cf962aa46d0f6b081a8fbee466",
-          "contentHash" : "5a777a7148a779aa56734ce2e4d8e7c3e2e61ab",
-          "syncHash" : "ec6a149ea245f551fedd1188e62c1e159aeed4f",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/subsystem=infinispan/cache-container=hibernate"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
           "name" : "Infinispan Cache Container [ejb]",
           "identityHash" : "68c0b22be25496dc6265938f39d77b24485ce9c0",
           "contentHash" : "8b679c14ec55cd786065fee979cb6a17c4e44",
           "syncHash" : "3bfe56952250d98f6cff6f7eafea54be5e2d993",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -2763,13 +1571,28 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=ejb"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-alerts",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-services",
+          "name" : "Infinispan Cache Container [hawkular-services]",
+          "identityHash" : "8374cd28e214ec8b9be620b3bb3bd25f6c4eac",
+          "contentHash" : "65ec123fa39c4e749c775918ac515dbb1288a5",
+          "syncHash" : "13224deb7eeb8766c63f4566b7995429263ee91",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-services"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-alerts",
           "name" : "Infinispan Cache Container [hawkular-alerts]",
           "identityHash" : "bbebfb8789bf5d3e45a36abc3d9379f86da2d",
           "contentHash" : "4c41305fab18f53a59a6e5fff8eacecceabd5647",
           "syncHash" : "b34524e8a03de3772884c3b683f2ef162ede4a6",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -2778,13 +1601,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=hawkular-alerts"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
           "name" : "Infinispan Cache Container [server]",
           "identityHash" : "9140987ff67afe217c820a260cc4d6cb782564",
           "contentHash" : "d81fd4695e41fcf94e311556eab6e1f32ceb6cb8",
           "syncHash" : "33b186309bbdf0afcbef11d32ac2bbba63d1e1bd",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -2793,13 +1616,28 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=server"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
+          "name" : "Infinispan Cache Container [hibernate]",
+          "identityHash" : "4025a3689a6a5cf962aa46d0f6b081a8fbee466",
+          "contentHash" : "5a777a7148a779aa56734ce2e4d8e7c3e2e61ab",
+          "syncHash" : "ec6a149ea245f551fedd1188e62c1e159aeed4f",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/subsystem=infinispan/cache-container=hibernate"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
           "name" : "Infinispan Cache Container [web]",
           "identityHash" : "d3bdd424a8671ff0fe63139a13eb8e834373d5ac",
           "contentHash" : "ca9516408b86fb4bf97daa8f6439347aa615356",
           "syncHash" : "199798bea9193cb52eee18be90a219d1eaeb65d0",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -2808,326 +1646,956 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=web"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DActionPluginRegistrationListener",
-          "name" : "Message Driven EJB [ActionPluginRegistrationListener]",
-          "identityHash" : "71be63102d997cb6a8577981a993bc53ff3747b",
-          "contentHash" : "9cbcffc664d78afe6b55cbdd9d48edbf7f1919",
-          "syncHash" : "89d82f65b8d33c0c1c5a126ba114fc13b68f82f",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DCommandEventListener",
+          "name" : "Message Driven EJB [CommandEventListener]",
+          "identityHash" : "99823b948b7b9ce92724d662952121647c7679",
+          "contentHash" : "51f2121ca985cdac97f693c4e87cfdf433a6ac7",
+          "syncHash" : "dfafc5b515bf7134b74653a2efe7f54f535254f",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
             "name" : "Message Driven EJB",
             "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
             "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
             "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
             "id" : "Message Driven EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=ActionPluginRegistrationListener"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=CommandEventListener"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DCacheManager",
-          "name" : "Singleton EJB [CacheManager]",
-          "identityHash" : "763a897fe1def1661759fbd041d62cf072ded",
-          "contentHash" : "4c92d93bfb695befde72a6e77ea1a852dcfcae",
-          "syncHash" : "3d4e3cf27f7e17484bf5ac12ae3d2e9af3b5c88",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DFeedAvailabilityDataListener",
+          "name" : "Message Driven EJB [FeedAvailabilityDataListener]",
+          "identityHash" : "8eb974d73a20f4df5dd406016a639b9677d4ca",
+          "contentHash" : "b94a587e1ce9bb23ccbceef6694b733d041e7a5",
+          "syncHash" : "9b455bb02bface7153a84c10aea235ecffb9dbe5",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=CacheManager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassAlertsServiceImpl",
-          "name" : "Stateless Session EJB [CassAlertsServiceImpl]",
-          "identityHash" : "47bc76ca4099417d1981c3549f3e13ab8013debb",
-          "contentHash" : "f474a07c477cc96c4867c2e5747e2710709ba423",
-          "syncHash" : "f5dd0347b9ce67e738ec41dceed138bb8bf44",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
-            "name" : "Stateless Session EJB",
-            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
-            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
-            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
-            "id" : "Stateless Session EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassAlertsServiceImpl"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassDefinitionsServiceImpl",
-          "name" : "Stateless Session EJB [CassDefinitionsServiceImpl]",
-          "identityHash" : "f7ce5790e967e45b86c1985e2b6e91f3d8a5ffd",
-          "contentHash" : "85a5198d542fca9809ff1be02ee252cf8466",
-          "syncHash" : "1a111aa66e406a94cc9fa187303b7a63846dd2c1",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
-            "name" : "Stateless Session EJB",
-            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
-            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
-            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
-            "id" : "Stateless Session EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassDefinitionsServiceImpl"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAlertDataListener",
-          "name" : "Message Driven EJB [AlertDataListener]",
-          "identityHash" : "8e6e34cacca395b88eb5c6ceef273569d65df7b",
-          "contentHash" : "b39e12f327683b13e45796b63fe7023f91fc98",
-          "syncHash" : "24fa8a258af3ecbed5bfe1a41276ef41b44eba",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
             "name" : "Message Driven EJB",
             "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
             "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
             "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
             "id" : "Message Driven EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=AlertDataListener"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=FeedAvailabilityDataListener"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.rest.HawkularAlertsApp",
-          "name" : "Servlet [org.hawkular.alerts.rest.HawkularAlertsApp]",
-          "identityHash" : "d79ae59a06ba827d670c962e23e3b728833adf9",
-          "contentHash" : "76aabb1808c205f5a27253cb1c5605066e8f8f",
-          "syncHash" : "714f8c6654613a2caf8c151a7754eae96c25881b",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3DHystrixMetricsStreamServlet",
+          "name" : "Servlet [HystrixMetricsStreamServlet]",
+          "identityHash" : "1f6ee2b1441c7659301fb1bf14c73a6c782ade1d",
+          "contentHash" : "57b26a489a755ea379a116ae7dd25dc6e6964896",
+          "syncHash" : "6dab5527a31b8cc0e575c6d3957627d68e1f15",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=undertow/servlet=org.hawkular.alerts.rest.HawkularAlertsApp"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=HystrixMetricsStreamServlet"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DActionPluginResponsesListener",
-          "name" : "Message Driven EJB [ActionPluginResponsesListener]",
-          "identityHash" : "e063a22b9c16473392d9641143f5b8a7cbfc13f",
-          "contentHash" : "299c733513731bf02c3ab12ffea5dfbd84d99f",
-          "syncHash" : "6ed55fdd567b7a0a68d97eaf1fa14b574cf990",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.rest.HawkularRestApi",
+          "name" : "Servlet [org.hawkular.rest.HawkularRestApi]",
+          "identityHash" : "fab15a673e86eac0b14556b76ab8d1060828",
+          "contentHash" : "d61918d1e73eb4598bb083327133ebd729375cc4",
+          "syncHash" : "d98c892d646c67822fc769132c2f55241f2a848",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=org.hawkular.rest.HawkularRestApi"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DInventoryEventListener",
+          "name" : "Message Driven EJB [InventoryEventListener]",
+          "identityHash" : "e3243df54e3ff3485294c615991ae9c8ce7675a",
+          "contentHash" : "3ea2444e55c07a42b7e475494d3eefa645587675",
+          "syncHash" : "4b8aa849aae91af939aecc8ba6db71c98ca2b41c",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
             "name" : "Message Driven EJB",
             "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
             "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
             "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
             "id" : "Message Driven EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=ActionPluginResponsesListener"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=InventoryEventListener"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDroolsRulesEngineImpl",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularQueueListener",
+          "name" : "Message Driven EJB [HawkularQueueListener]",
+          "identityHash" : "ca8555de7c3bd9e9a87c7350a6bdfd5b5781b45",
+          "contentHash" : "74a0db3da72d8b1cb4d7ba03f570b5ea48d1f5",
+          "syncHash" : "19a00fa4845f3d601e6aa8c7b7b2bbb63a75a",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularQueueListener"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularTopicListener",
+          "name" : "Message Driven EJB [HawkularTopicListener]",
+          "identityHash" : "96dbf299296f3dbb6eeb05eda701183df122ef",
+          "contentHash" : "b6d3cdf29a882af2494fc7bd79f8aad45c9216",
+          "syncHash" : "67875f1e4833b7ea788eba7d869384db3d4825",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularTopicListener"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBackfillCacheManager",
+          "name" : "Singleton EJB [BackfillCacheManager]",
+          "identityHash" : "e9839632abeb1a98ffd3bed1a18396452a21c3",
+          "contentHash" : "288bc219108342e8c97ef2de33fcd33cec443271",
+          "syncHash" : "22a1a164e75b9e64b648fff887aaeed553f",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/singleton-bean=BackfillCacheManager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fremote-destination-outbound-socket-binding%3Dmail-smtp",
+          "name" : "Remote Destination Outbound Socket Binding [mail-smtp]",
+          "identityHash" : "8f5567368a3e0488abed7549f49cdc3b560",
+          "contentHash" : "4ec0c3c604848b38c42c4a6edc475ed7c1154",
+          "syncHash" : "fc3d51df947984cb9924763588f9021aedf37fa",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+            "name" : "Remote Destination Outbound Socket Binding",
+            "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
+            "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
+            "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
+            "id" : "Remote Destination Outbound Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=mail-smtp"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-recovery-environment",
+          "name" : "Socket Binding [txn-recovery-environment]",
+          "identityHash" : "4cea53782366671d1f168840d3c075cc83a99083",
+          "contentHash" : "11233a14674ce338b31cc5f68f6658d1d948d",
+          "syncHash" : "16abb365abb4ce39a278ff9c7d1f8487255683c",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-recovery-environment"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-http",
+          "name" : "Socket Binding [management-http]",
+          "identityHash" : "0ec285d1d4125503c260293a5472c4f55a75c",
+          "contentHash" : "d0eba94951038818d2481856c63186614f9b",
+          "syncHash" : "d79d1fdf3d915e6d67bc49b68ea9f858315f068",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-http"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-https",
+          "name" : "Socket Binding [management-https]",
+          "identityHash" : "35fba6824b5f3b1cf29138545bec67de312eaa1c",
+          "contentHash" : "40aa76f8d78ac3349e73e180a4c0e690bbe11cb5",
+          "syncHash" : "bcd793ec232d5c74af92c576740a659ec9e6f36",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-https"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-status-manager",
+          "name" : "Socket Binding [txn-status-manager]",
+          "identityHash" : "63de5c556bf2f47fbda31b721af1d6d2c88c9e",
+          "contentHash" : "5b48a46c9e51a680549f6167f6aae133e973383",
+          "syncHash" : "ae521aa916de28bcf7e9818ff34ea41569df4a3",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-status-manager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dajp",
+          "name" : "Socket Binding [ajp]",
+          "identityHash" : "304cf7f1b5ca5560824096d8b2cbbd2b5d2e65bd",
+          "contentHash" : "db6790ce6ce289b458312e959762f4e061b7e1bd",
+          "syncHash" : "d156a555983b5fdfeddb2b85ecaa29c4869738",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=ajp"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttps",
+          "name" : "Socket Binding [https]",
+          "identityHash" : "5db7ca31ed6268ebe89f7012dce398f3f58e8d7c",
+          "contentHash" : "b17723a696316dc7ecb44406fc34d7313b91b10",
+          "syncHash" : "4aa7946c118c2ad71a38a665b9dfb7143ee5682",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=https"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttp",
+          "name" : "Socket Binding [http]",
+          "identityHash" : "69d234f1f2fe88986b9cccc1e6b9e5b1fd1ef6e",
+          "contentHash" : "cbf2764bfc934aad65762cfb5569e281c1ebd34",
+          "syncHash" : "cc52e9196fe761ac46ae47f163695e91376e9eb",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=http"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/r;Local~%2Fdeployment%3Dhawkular-status.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.services.rest.HawkularServicesStatusApp",
+          "name" : "Servlet [org.hawkular.services.rest.HawkularServicesStatusApp]",
+          "identityHash" : "863c235d7c36a7d9cea8239fd3e73abe1687b1f",
+          "contentHash" : "c14bdf75c5f086b26bf840c65b1d2fbe3cd338",
+          "syncHash" : "52dde68fd43c5d8d0d5c722cf154e25905252b9",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-status.war/subsystem=undertow/servlet=org.hawkular.services.rest.HawkularServicesStatusApp"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData",
+          "name" : "JMS Topic [HawkularAlertData]",
+          "identityHash" : "bc46c0eb7c51de7cfcc96b2dbe248a42d165b1",
+          "contentHash" : "7b23ec77694928edcc51d935169c6ab1da3dac7",
+          "syncHash" : "a2f37b5ce726f382210f3ee63a6551aa54f21e3",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges",
+          "name" : "JMS Topic [HawkularInventoryChanges]",
+          "identityHash" : "5ff465371cc74543302d5a452cf5c1602323338a",
+          "contentHash" : "2ce11418d61867e6b6594bebbb521b13de13e46",
+          "syncHash" : "226c4c37a0f1cbb96869e9dbea58474227432722",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularInventoryChanges"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue",
+          "name" : "JMS Queue [HawkularAlertsPluginsQueue]",
+          "identityHash" : "d996d863a34247486c78b511fcaf6a4636e368",
+          "contentHash" : "d91e28d8d63bec9035e47b37f3211b21c8eb528",
+          "syncHash" : "10621fe5f8c08089f37eed99a8b05772f2bac8ec",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsPluginsQueue"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic",
+          "name" : "JMS Topic [HawkularAlertsActionsTopic]",
+          "identityHash" : "61d97499296cb95dc4b98a91b5e4047bc652b6",
+          "contentHash" : "257c3ac6e910183bcff651a68243f5fa5764324c",
+          "syncHash" : "faca3ca0b40e261f3e7cab659af7541615b5e1",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertsActionsTopic"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
+          "name" : "JMS Queue [DLQ]",
+          "identityHash" : "28d43195745dcb50cbff108cc94f716698175d98",
+          "contentHash" : "b7fd1bfbed2ce39f8d402fac606758a241c6708b",
+          "syncHash" : "766b606317abbcf01bc2d2e1855ee1db3b469d8",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/availability/new]",
+          "identityHash" : "d4fb9aa2bc49ac5565cf4f3a65767bf7e4f6ad6",
+          "contentHash" : "9dc1ddde8aa08f6ff5a5188d72679a2970113a",
+          "syncHash" : "5afb1b8ae1447058a403390b328f6c613e60",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/availability/new"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic",
+          "name" : "JMS Topic [HawkularTopic]",
+          "identityHash" : "c6b8eebdda99cf218b191d999f4c4fc6ae85626",
+          "contentHash" : "132c6fe445f88da736c2f97816614bd7843669",
+          "syncHash" : "36c993981d6e7ca826f1be29f2919f1e2a2eca",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularTopic"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
+          "name" : "JMS Queue [ExpiryQueue]",
+          "identityHash" : "80a44fb658d380864a2c78af1d23bf96d34cdd35",
+          "contentHash" : "be8465843986b46521f790755ed20ed975fc02a",
+          "syncHash" : "5950eef266d6513f22ad5e6683c7cd523899364e",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue",
+          "name" : "JMS Topic [HawkularQueue]",
+          "identityHash" : "5863dff75396d592126dc5d4977469119445742",
+          "contentHash" : "dd68e13095c7664bc65476f3ee5563edeecbef2b",
+          "syncHash" : "d5d339902d4fa28e93928fbd21517eb425a3af",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularQueue"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue",
+          "name" : "JMS Queue [HawkularAlertsActionsResponseQueue]",
+          "identityHash" : "aa22f2cbd44f64c43fda0c097fbec50999efa11",
+          "contentHash" : "bf6243633217684994a84e6b205ddb9043457",
+          "syncHash" : "2864d93f896bf3035dccb61a1abdd51cf55ff1",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsActionsResponseQueue"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/counters/new]",
+          "identityHash" : "eb658016c74eecc1817cdd61635b69dbdda9d7ef",
+          "contentHash" : "64b9f569ed88d2171fc81483f2e184675855ee5",
+          "syncHash" : "a0d8dc4e9eb5f0fab421c8e03cf01876125eca98",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/counters/new"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/gauges/new]",
+          "identityHash" : "e1421d2b03f7f135c411caebc13a807fbc90a8",
+          "contentHash" : "34dfac349816c672f3958e517a71dac46438da7",
+          "syncHash" : "fcad9bcfda82c94cbefc215799a7265b783f5aa0",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/gauges/new"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent",
+          "name" : "JMS Topic [HawkularCommandEvent]",
+          "identityHash" : "f172ca90d332c7c721ffdc12e3090213ca2c459",
+          "contentHash" : "4059e5718dadc5704f17227ea74616a3751b6e7",
+          "syncHash" : "90494dd596446667c124f836f84b5ee6284ba77",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularCommandEvent"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war",
+          "name" : "SubDeployment [hawkular-metrics.war]",
+          "identityHash" : "d1af7c8da2ce8fdfd1fd54e2a612c182bde47",
+          "contentHash" : "77d9f4923eb55950d2c034c5be73aeef28faee",
+          "syncHash" : "4e363ee68fc13513137f7e7b154ec1572e74ed",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war",
+          "name" : "SubDeployment [hawkular-alerts.war]",
+          "identityHash" : "2e38c4a7f66da06d78d5fa1f97eb589c85d59721",
+          "contentHash" : "867658459c1c9be3286209898fb799345ed7ca",
+          "syncHash" : "d48218ea957120d0f0d22ce1b53dccb79f63643",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war",
+          "name" : "SubDeployment [hawkular-alerts-action-webhook.war]",
+          "identityHash" : "aad488407b304e85a6a13cec18f3dbe37fc17c6",
+          "contentHash" : "4a4ecc5d65f364483f56ba43eb78732aaa47b375",
+          "syncHash" : "d14436ed9947bd419ff12a54285dbb9be441dee",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war",
+          "name" : "SubDeployment [hawkular-alerts-action-email.war]",
+          "identityHash" : "c72c44fdff6d5da472fd14d3bddd1aeffefa25a",
+          "contentHash" : "616971c77a2c9d21697a13ea781a26d1352aa4",
+          "syncHash" : "28ad30647bb2af37147645451c379283fc1e19",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war",
+          "name" : "SubDeployment [hawkular-metrics-alerter.war]",
+          "identityHash" : "dc51535c8ebed9bd1dcac8fe4393f1bc9a343ba2",
+          "contentHash" : "e2d665615c785368de3512a48a401740c23c3910",
+          "syncHash" : "1028c88d5c6f8ce2fb488360a0acb643473824",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.component.wildflymonitor.WildFlyAgentServlet",
+          "name" : "Servlet [org.hawkular.component.wildflymonitor.WildFlyAgentServlet]",
+          "identityHash" : "2eba2ecc97549f428a64f25db58752b0fb44608c",
+          "contentHash" : "ea8c5721c3fc4b31a96f91d847875a91b1b7c9f",
+          "syncHash" : "15647c32824fd37cbac7ead52185f44b55c4adc",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war/subsystem=undertow/servlet=org.hawkular.component.wildflymonitor.WildFlyAgentServlet"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DInventoryJNDIPublisher",
+          "name" : "Singleton EJB [InventoryJNDIPublisher]",
+          "identityHash" : "6dc580b6ececcf222a1cf784fb65ecdf52afa5c",
+          "contentHash" : "d6f27fdf33cb9586cc2ed3d548a8a7535d7e8d7",
+          "syncHash" : "69a5b7e2bf1b8cba1a56de0a893644e57c256a1",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=ejb3/singleton-bean=InventoryJNDIPublisher"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.inventory.rest.HawkularRestApi",
+          "name" : "Servlet [org.hawkular.inventory.rest.HawkularRestApi]",
+          "identityHash" : "2a27dca8c025737b6ec1f6a51b65d5ab6ee6fb0",
+          "contentHash" : "80c5f042a119325548bd8871f4b1843eff977cde",
+          "syncHash" : "63c2d76b2aacbcabbd5b2f30e7151f62424460d4",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=undertow/servlet=org.hawkular.inventory.rest.HawkularRestApi"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp",
+          "name" : "Servlet [org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp]",
+          "identityHash" : "9c97e4f72825db1cf315d9922c469432a9919d1b",
+          "contentHash" : "251b5d9d19d549f158b83e45b5c2f9b03fcad0f7",
+          "syncHash" : "2bc0c4f9fabfb58d6d1f51712e918fdb9c1cdacd",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=undertow/servlet=org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DMetricsJNDIPublisher",
+          "name" : "Singleton EJB [MetricsJNDIPublisher]",
+          "identityHash" : "4f38c9d170ae1db3df878b8b6e9c35e317afb44",
+          "contentHash" : "825048415b37efaffb5f2dd349ba144648ea4a",
+          "syncHash" : "21b6c6f43ecad99f9b17b8ce1a8c31ab912079",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=ejb3/singleton-bean=MetricsJNDIPublisher"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dundertow%2Fservlet%3DstaticContent",
+          "name" : "Servlet [staticContent]",
+          "identityHash" : "4a26e752ab15e8152d60aa8d4db38c14ab793f",
+          "contentHash" : "ad19e6b507977da7e37f2d77db0206f861e30",
+          "syncHash" : "b3c2cb8ffbc082112635dc3ae8f465cedd68d9",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=undertow/servlet=staticContent"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPropertiesServiceImpl",
+          "name" : "Singleton EJB [PropertiesServiceImpl]",
+          "identityHash" : "be949297975f7bbc313d06665f0202c8bebf1c8",
+          "contentHash" : "44a9bbcc6392b24c713352c6caf9c91d89e2c82",
+          "syncHash" : "f0ca6c614b3fa0d61ecd845c94dcddc4645e9f5c",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PropertiesServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDroolsRulesEngineImpl",
           "name" : "Singleton EJB [DroolsRulesEngineImpl]",
-          "identityHash" : "c66f8e6f723b75d75cf3d1937ccfbc0dcb6dc1a",
-          "contentHash" : "777b133977b0b09520df64e695ed62505ec8bb",
-          "syncHash" : "56d2f3b4b4488583107f86c3e7458bac389bef5",
+          "identityHash" : "dcc832ab281c8fd030d7f5c733e378548bb67817",
+          "contentHash" : "c89a4071954658cfc93e34ebe6913414721c6575",
+          "syncHash" : "5b39d89c82b233257b2a6cb5ed64642a5d6c617d",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=DroolsRulesEngineImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=DroolsRulesEngineImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPartitionManagerImpl",
-          "name" : "Singleton EJB [PartitionManagerImpl]",
-          "identityHash" : "5a81475ebeac2a25da2085cc74e629276d5690",
-          "contentHash" : "205b89cd629ffa187cf6849e46fae45aafbbcbf",
-          "syncHash" : "b3386b58a655ca9ff0fbd0222a1ae836d5cb5e7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=PartitionManagerImpl"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DMetricDataListener",
-          "name" : "Message Driven EJB [MetricDataListener]",
-          "identityHash" : "bb96ae88a2d28d7144cda899ee316093ff7a95",
-          "contentHash" : "9cdcead6a37570ded0ea4befe869eea7111b4a22",
-          "syncHash" : "fcc03efc7ec430428b9c4014f5a438a6682d9c7c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=MetricDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertEngineRegister",
-          "name" : "Singleton EJB [AlertEngineRegister]",
-          "identityHash" : "a0effaf4d23f68867f510e9d9035db740ce39",
-          "contentHash" : "9436e69b459f9379a915e886ff8592c18ab182",
-          "syncHash" : "98958dffd932b1f6623f7a4121b378df6723c6d",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertEngineRegister"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsContext",
-          "name" : "Singleton EJB [AlertsContext]",
-          "identityHash" : "ea316f2f77da5d7744b1257ce24416f614b921b",
-          "contentHash" : "801922d756979ae0da204ccd1664bec8eb6491",
-          "syncHash" : "2d59365b1d279c4906d28e9abf2c6bb0b4a81",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertsContext"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAvailDataListener",
-          "name" : "Message Driven EJB [AvailDataListener]",
-          "identityHash" : "6d9d9e655a6d9fc6b21078bc89233cceb6a84a67",
-          "contentHash" : "af24f9e1207e11ad84d0f8847f869153eac568f7",
-          "syncHash" : "73877f89a4c41424e477dfd24cf2e46cec5318",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=AvailDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDataDrivenGroupCacheManager",
-          "name" : "Singleton EJB [DataDrivenGroupCacheManager]",
-          "identityHash" : "8c38614cb897e9c78409327324ce39b68ac65d9",
-          "contentHash" : "1ba3fcf9f1d084facb846b3c35dd774fcbf8d6d",
-          "syncHash" : "396f778596aca846d46439b395e6db8721826a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=DataDrivenGroupCacheManager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsEngineImpl",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsEngineImpl",
           "name" : "Singleton EJB [AlertsEngineImpl]",
-          "identityHash" : "fd905b10a7620258d7a920368980cac830e62d",
-          "contentHash" : "eab04a5efa45190db94861b5f11fa56af3a290",
-          "syncHash" : "507d1df6fe62c910d5dbfbc8e15e405c1ef28173",
+          "identityHash" : "eabd1fd7bda8f2c6e636c459293d48db8873bae",
+          "contentHash" : "99e7d8d08695fa6512ac9395b3dbcf5a02f1d72",
+          "syncHash" : "36d72d51a6acd7e22d2374537f2d29a39765a9b",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertsEngineImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=AlertsEngineImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassActionsServiceImpl",
-          "name" : "Stateless Session EJB [CassActionsServiceImpl]",
-          "identityHash" : "573d391f59dc88960876a6a98941274c2f403b",
-          "contentHash" : "1267c32e2aee569563398f8c57416f57affa81a5",
-          "syncHash" : "d2ca1652ecb31d75f639407da5d67d6084712b28",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DActionsCacheManager",
+          "name" : "Singleton EJB [ActionsCacheManager]",
+          "identityHash" : "d180e7a548b4376481094b0f324497e43d01c3",
+          "contentHash" : "95cf657f26427d8dcb2ec788b4e7fbb4e6c99cd",
+          "syncHash" : "9dcd21beea85b2f57a665b07f9e56c3f6887d2",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=ActionsCacheManager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassAlertsServiceImpl",
+          "name" : "Stateless Session EJB [CassAlertsServiceImpl]",
+          "identityHash" : "b6f666c9ea71d31a59307d2ecf1a8985b5e3adb5",
+          "contentHash" : "372b9dcd629699a632ac481199641c3a31e4c0",
+          "syncHash" : "e979d959f2995c0707723169263876b8a98d336",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateless%20Session%20EJB",
             "name" : "Stateless Session EJB",
             "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
             "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
             "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
             "id" : "Stateless Session EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassActionsServiceImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassAlertsServiceImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_2.war/r;Local~%2Fdeployment%3Dsample_2.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "1648bb92a1f33596a647692b29c9e9735f953fc",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "c724af55a81112d42444b11f3d72d38ccd8",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAlertDataListener",
+          "name" : "Message Driven EJB [AlertDataListener]",
+          "identityHash" : "76dfb1a474e6aa766aaf79e4f7c599c0ba5b7548",
+          "contentHash" : "433c82c5758cbe974057ca2cf3218692d5ab66f5",
+          "syncHash" : "2ad64d967350698f26ba25974774ed6697c677f",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/message-driven-bean=AlertDataListener"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DCassCluster",
+          "name" : "Singleton EJB [CassCluster]",
+          "identityHash" : "897910b7e3ab163595c0e567fc93b33c277fd17",
+          "contentHash" : "9cab617cb65b3c4968db7b1afecb15d93daa3ae",
+          "syncHash" : "1b4b893ab9696255b67a81a43d1285aaac62e6",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=CassCluster"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDataDrivenGroupCacheManager",
+          "name" : "Singleton EJB [DataDrivenGroupCacheManager]",
+          "identityHash" : "a56e3111f9aaa192d5955a21987bd3966e132765",
+          "contentHash" : "641b914d31a1a992635a9a742b22b3d716ce16b",
+          "syncHash" : "2783bd11ef76cff6f2f2c1d3266bb345286f96",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=DataDrivenGroupCacheManager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPublishCacheManager",
+          "name" : "Singleton EJB [PublishCacheManager]",
+          "identityHash" : "ffe62618a78488ebf6e9e11c26c2996746b9c9aa",
+          "contentHash" : "a31b1880af3c187940fa984e6e8dfe77e29165d",
+          "syncHash" : "993e08be3bf3f359135a83ffa3d67ad379beb9",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PublishCacheManager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsContext",
+          "name" : "Singleton EJB [AlertsContext]",
+          "identityHash" : "a0652441747b48808799c0cd7665138690f86b",
+          "contentHash" : "115754177edcf6c74d2c4164eec955497993f3",
+          "syncHash" : "9e16e8b5fa5acbdb311a8aa42816fea53ae349b",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=AlertsContext"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DStatusServiceImpl",
+          "name" : "Stateless Session EJB [StatusServiceImpl]",
+          "identityHash" : "ee625c156eb882f989af6f5b2615b346a18f7",
+          "contentHash" : "8211793411ac16388c48653d899c15deed1034",
+          "syncHash" : "fafed82c207229b1b96ace723d584e6b6d262bda",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateless%20Session%20EJB",
+            "name" : "Stateless Session EJB",
+            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+            "id" : "Stateless Session EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=StatusServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DIncomingDataManagerImpl",
+          "name" : "Singleton EJB [IncomingDataManagerImpl]",
+          "identityHash" : "14a08244dea7d3ccfabf601afe9e21d3ee8eec6",
+          "contentHash" : "ce9fece4768677988fe9bb72ee8ba70e9f51a91",
+          "syncHash" : "6029b9f25623268a9c1e6e735eddd4f67ff687f7",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=IncomingDataManagerImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.rest.HawkularAlertsApp",
+          "name" : "Servlet [org.hawkular.alerts.rest.HawkularAlertsApp]",
+          "identityHash" : "8fa44f0f6865bc4ed35bb2578b01d3cf2902ca4",
+          "contentHash" : "3ca457d49e546add93cae38ff782a4c472ac2ea1",
+          "syncHash" : "679e9b7b8883c13b5821cd0ac9ee1eb18bb2a0",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample_2.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=undertow/servlet=org.hawkular.alerts.rest.HawkularAlertsApp"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample3.war/r;Local~%2Fdeployment%3Dsample3.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "8113a5362bdf623555c1311da821b19b470e16b",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "7b3f5b75bbb08eacac3db74ebd25fcea2fd74f7",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPartitionManagerImpl",
+          "name" : "Singleton EJB [PartitionManagerImpl]",
+          "identityHash" : "1f97a8227dbf3d621e6fa3768444c918dfb83450",
+          "contentHash" : "8aad7835a13a570c0c7d06277f8322f89fe80",
+          "syncHash" : "da27841c47167ca8ac542a8f2eee12d41808b53",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PartitionManagerImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassActionsServiceImpl",
+          "name" : "Stateless Session EJB [CassActionsServiceImpl]",
+          "identityHash" : "4010b892c531e9dc25ed6d49c983beb497b487",
+          "contentHash" : "c898b10c8cf8faab3c0f2c57159bb6d653a568",
+          "syncHash" : "611e2fc5cdbd43f1959758d354ef5586646494cb",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateless%20Session%20EJB",
+            "name" : "Stateless Session EJB",
+            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+            "id" : "Stateless Session EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassActionsServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassDefinitionsServiceImpl",
+          "name" : "Stateless Session EJB [CassDefinitionsServiceImpl]",
+          "identityHash" : "ece7ffece2de8145ebfcaadf6f5b5ad75f55641",
+          "contentHash" : "74ca92bb5f2a785c68adc366bd5cfcfce84a0eb",
+          "syncHash" : "343e827e6693454c929ace85d367e4a081f7a86a",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Stateless%20Session%20EJB",
+            "name" : "Stateless Session EJB",
+            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+            "id" : "Stateless Session EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassDefinitionsServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.actions.webhook.WebHookApp",
+          "name" : "Servlet [org.hawkular.alerts.actions.webhook.WebHookApp]",
+          "identityHash" : "7536448f3e26f407333f02b4d2a466fd88d756e",
+          "contentHash" : "f821ab6b1d5460219fe44a77b27fd4467e52825",
+          "syncHash" : "8987b2ae7d63a83e6da5a2211edf323987f5772b",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample3.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war/subsystem=undertow/servlet=org.hawkular.alerts.actions.webhook.WebHookApp"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample4.war/r;Local~%2Fdeployment%3Dsample4.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "4fd4e46c7d1f7993c917f12139bb733c9c872fd",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "ae2180a5a7b18e24fde86f6932ba90881bbc35",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DStandaloneActionPluginRegister",
+          "name" : "Singleton EJB [StandaloneActionPluginRegister]",
+          "identityHash" : "813480c42686ab39835b13398f4a5c6c1bb6f43",
+          "contentHash" : "25b3e9b28fa3c68b5e0cee8b40bb626a26a3bf",
+          "syncHash" : "d6fefe591e3c70d594899dd0dc319634f3904170",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war/subsystem=ejb3/singleton-bean=StandaloneActionPluginRegister"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DStandaloneActionPluginRegister",
+          "name" : "Singleton EJB [StandaloneActionPluginRegister]",
+          "identityHash" : "e38a73440dd118fa21d91de64135df2230daa2",
+          "contentHash" : "25b3e9b28fa3c68b5e0cee8b40bb626a26a3bf",
+          "syncHash" : "e69121fceb4efb73dddc7b465757b72e02d295",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war/subsystem=ejb3/singleton-bean=StandaloneActionPluginRegister"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war%2Fsubsystem%3Dundertow%2Fservlet%3Djavax.ws.rs.core.Application",
+          "name" : "Servlet [javax.ws.rs.core.Application]",
+          "identityHash" : "5980f663d26af9fc55ca29f92a427ebaf6cda3a8",
+          "contentHash" : "e4bf16a56b698d3b32ebc024f147b088f2a31569",
+          "syncHash" : "97d2a6c19b4e9c8359d760ee55e4d3ccc19665f",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample4.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war/subsystem=undertow/servlet=javax.ws.rs.core.Application"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample5.war/r;Local~%2Fdeployment%3Dsample5.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "ced422351168d10f4c5b83e03debefb44aadf",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "5f3d46280d93034b030c435dfafe3ceb32a4f",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DConditionManager",
+          "name" : "Singleton EJB [ConditionManager]",
+          "identityHash" : "9150ec4a925c6ec0a3855cbc1dc7481c81b9",
+          "contentHash" : "4d60123b1909e85d43886e3d2631ba36d2983c7",
+          "syncHash" : "d9cbe8e782a51b8b104c6c4167a833cd6e4e5e5d",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war/subsystem=ejb3/singleton-bean=ConditionManager"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war%2Fsubsystem%3Dundertow%2Fservlet%3Djavax.ws.rs.core.Application",
+          "name" : "Servlet [javax.ws.rs.core.Application]",
+          "identityHash" : "5c5c8dfcaa0a0bfc64a357e766d2e134c02bf8",
+          "contentHash" : "e4bf16a56b698d3b32ebc024f147b088f2a31569",
+          "syncHash" : "75ba3ffd1ea0267c6632633796b827ab86299e",
+          "type" : {
+            "path" : "/t;hawkular/f;94f76aa25a3a/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample5.war/subsystem=undertow/servlet=HelloServlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_final.war/r;Local~%2Fdeployment%3Dsample_final.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "2b5da84b1ee48e4caca1b1ff44c14cdb66e78e8",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "4b3d3cd758a7eb8b6e57feaeecc362b6b60e39c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=sample_final.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war/subsystem=undertow/servlet=javax.ws.rs.core.Application"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=HawkularInventoryDS_h2/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3137,7 +2605,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3158,18 +2626,82 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '740'
+      - '757'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_h2/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "30a3ce2fd5b8e66657d6e0f8307ced4db67dd0ad",
+          "contentHash" : "2a705856d22153724077fa9d5e20bc64b6c21877",
+          "syncHash" : "646facd8d0d78a98643ab5cfb06f50b4a9ee9b",
+          "value" : {
+            "Connection Properties" : null,
+            "Datasource Class" : null,
+            "Security Domain" : null,
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:/jboss/datasources/HawkularInventoryDS_h2",
+            "Connection URL" : "jdbc:h2:/opt/data/data/hawkular-inventory/db;MVCC=true;CACHE_SIZE=32768",
+            "Enabled" : "true",
+            "Driver Class" : null,
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '716'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
           "name" : "configuration",
           "identityHash" : "823ca07d76929e39fc468d25111455355aa81a8",
           "contentHash" : "20125a70ce2d55719321b336bf632eb518bcb4a",
@@ -3188,10 +2720,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAvailData/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=HawkularInventoryDS_postgres/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3201,15 +2733,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Expires:
       - '0'
@@ -3222,30 +2754,40 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '536'
+      - '782'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData/d;configuration" ]
-            } ] ]
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_postgres/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "fc78a4431302d998e117455b1765ab0c76dd72",
+          "contentHash" : "66984e7ae614cf6db5f24afd1b174f5932dc3",
+          "syncHash" : "955b3588aab981ae2ad9387d44e91e5f1c3edb17",
+          "value" : {
+            "Connection Properties" : "{\"prepareThreshold\":\"0\"}",
+            "Datasource Class" : null,
+            "Security Domain" : null,
+            "Username" : "hawkular",
+            "Driver Name" : "postgresql",
+            "JNDI Name" : "java:/jboss/datasources/HawkularInventoryDS_postgres",
+            "Connection URL" : "jdbc:postgresql://localhost:5432/hawkular",
+            "Enabled" : "true",
+            "Driver Class" : null,
+            "Password" : "hawkular"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertData/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3255,7 +2797,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3276,30 +2818,30 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '572'
+      - '488'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsActionsResponseQueue/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularInventoryChanges/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3309,7 +2851,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3330,30 +2872,30 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '570'
+      - '502'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularTopic/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsPluginsQueue/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3363,7 +2905,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3384,30 +2926,30 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '528'
+      - '506'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertsActionsTopic/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3417,7 +2959,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3438,7 +2980,385 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '506'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '460'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Favailability%2Fnew/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '532'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularTopic/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '480'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '476'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '480'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsActionsResponseQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -3449,19 +3369,19 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularQueue/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3471,7 +3391,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3492,30 +3412,30 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '528'
+      - '520'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertData/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularCommandEvent/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -3525,7 +3445,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3546,30 +3466,30 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '536'
+      - '494'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration]]]",
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration]]]",
           "details" : {
             "entityType" : "DataEntity",
             "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration" ]
+              "paths" : [ "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration" ]
             } ] ]
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertsActionsTopic/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=s/recursive;over=isParentOf;type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -3579,439 +3499,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Favailability%2Fnew/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '580'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsPluginsQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularInventoryChanges/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '508'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '568'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularMetricData/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '538'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularCommandEvent/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '542'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-three/recursive;over=isParentOf;type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -4032,137 +3520,27 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       X-Total-Count:
-      - "-1"
+      - '8'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '3'
+      - '7157'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three/recursive;over=isParentOf;type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: "[ ]"
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/recursive;over=isParentOf;type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      X-Total-Count:
-      - '11'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '11472'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/recursive;over=isParentOf;type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/recursive;over=isParentOf;type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "JDBC Driver [h2]",
-          "identityHash" : "8f2f139ba6854f7bdcb18ebf4748e3873463f32",
-          "contentHash" : "f8c46c1ba786b4aebed5f1f6ebf96ce848557f3",
-          "syncHash" : "f19be2c5afbe952bb98ce4b23ee4f39bd418a",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JDBC%20Driver",
-            "name" : "JDBC Driver",
-            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
-            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-            "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
-            "id" : "JDBC Driver"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=datasources/jdbc-driver=h2"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "Datasource [ExampleDS]",
-          "identityHash" : "f98976a18454d9e0768193c7c816d5f49a23ae2a",
-          "contentHash" : "ddba59ad66b121b5e59f1c39adf915628cf6cc",
-          "syncHash" : "992412a2ea16f4ff122a45783af3f3f5677330",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Datasource",
-            "name" : "Datasource",
-            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
-            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
-            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
-            "id" : "Datasource"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=datasources/data-source=ExampleDS"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
-          "name" : "Messaging Server [default]",
-          "identityHash" : "30eac6f4e38e4b3cb843d7ddf95ba165a03adaf4",
-          "contentHash" : "ae6780c1868e17bd5a34402ec71fe69e35419",
-          "syncHash" : "23ff7a2fffb3e259d2b71c1e88d048418990c2",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Messaging%20Server",
-            "name" : "Messaging Server",
-            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
-            "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
-            "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
-            "id" : "Messaging Server"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=messaging-activemq/server=default"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan",
-          "name" : "Infinispan",
-          "identityHash" : "751b519caa41936b71024bfcc96731ff71804c",
-          "contentHash" : "0e01d148288143e57624eb996f8fcf551aa5148",
-          "syncHash" : "242456b39eb3eef98a71f67dd293c1e8af5cac",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan",
-            "name" : "Infinispan",
-            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
-            "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
-            "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
-            "id" : "Infinispan"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=infinispan"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dtransactions",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dtransactions",
           "name" : "Transaction Manager",
-          "identityHash" : "66c1bcc4deb3c25071c5927310c3eea4af34a53",
+          "identityHash" : "45ba7e10d7425894667615883805be2b4282616",
           "contentHash" : "8e90fd10711e88f57c0320407746b293fca579",
-          "syncHash" : "f75279144df1686a159a93ccdab23298811dbd5",
+          "syncHash" : "25e463fb2723ee225cc6319f84816928f4b1c2",
           "type" : {
             "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Transaction%20Manager",
             "name" : "Transaction Manager",
@@ -4171,88 +3549,58 @@ http_interactions:
             "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
             "id" : "Transaction Manager"
           },
-          "id" : "Local~/host=master/server=server-two/subsystem=transactions"
+          "id" : "Local~/host=master/server=s/subsystem=transactions"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
-          "name" : "JMS Queue [ExpiryQueue]",
-          "identityHash" : "d2876a4776b42106bf8a75c3b6e10261ebda3e1",
-          "contentHash" : "153196a1d5742afe8f4c595dd5f65d441b7a1c91",
-          "syncHash" : "3ef2c742e3b3da455c2947d7d76f0f0e2a9ecb8",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "6a1a285e0bb619f5fb7a7b6bff29aa56fd15958",
+          "contentHash" : "f8c46c1ba786b4aebed5f1f6ebf96ce848557f3",
+          "syncHash" : "6b5fe6eee8cc5fd9274e788821b54275d82a9195",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
+            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+            "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
+            "id" : "JDBC Driver"
           },
-          "id" : "Local~/host=master/server=server-two/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
+          "id" : "Local~/host=master/server=s/subsystem=datasources/jdbc-driver=h2"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
-          "name" : "JMS Queue [DLQ]",
-          "identityHash" : "233244af6ce9c9621da86375cf4954f3963b45b3",
-          "contentHash" : "323890421628d3b454d11871d1a9f4253b957bf",
-          "syncHash" : "ec59a318090dfa42f97b1ec1a27da4c23c3395",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan",
+          "name" : "Infinispan",
+          "identityHash" : "5065311867641abd5124490dd820de1d3e7916",
+          "contentHash" : "0e01d148288143e57624eb996f8fcf551aa5148",
+          "syncHash" : "feb4c1a8d8e126ceebc32b890f09cee4bb24e4d",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan",
+            "name" : "Infinispan",
+            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+            "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
+            "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
+            "id" : "Infinispan"
           },
-          "id" : "Local~/host=master/server=server-two/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
+          "id" : "Local~/host=master/server=s/subsystem=infinispan"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
-          "name" : "Infinispan Cache Container [server]",
-          "identityHash" : "c82f8d444e665745aa9dc184d1dfabf4170f276",
-          "contentHash" : "96a97558eea27231389480adb4d6a54e24bb4e33",
-          "syncHash" : "d44c6af7c5176a469d49c4294ef70817d5b5f",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "f7b173fb4a8acf6839dd154eb9b484902c3a6b2c",
+          "contentHash" : "ddba59ad66b121b5e59f1c39adf915628cf6cc",
+          "syncHash" : "53dbef73a809b13a430624b6c3dbcf54c016c",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
           },
-          "id" : "Local~/host=master/server=server-two/subsystem=infinispan/cache-container=server"
+          "id" : "Local~/host=master/server=s/subsystem=datasources/data-source=ExampleDS"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
-          "name" : "Infinispan Cache Container [web]",
-          "identityHash" : "98f5a8ec94ee17eae69d67ef7f8f5038c181bb",
-          "contentHash" : "4abf467f7671dd43c81eff75a99a70c664186d",
-          "syncHash" : "5df3efe877b293fab87405954a33519ac56ee8b",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=infinispan/cache-container=web"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
-          "name" : "Infinispan Cache Container [hibernate]",
-          "identityHash" : "c3a6e8fcd749ea7dba9183c6858d1b1c5630fa",
-          "contentHash" : "2f8a87eedcbad55c868e2bf6414351333dca96",
-          "syncHash" : "69aace6d5fdbe62e71016f3d69ca6a284284ea8",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-two/subsystem=infinispan/cache-container=hibernate"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
           "name" : "Infinispan Cache Container [ejb]",
-          "identityHash" : "3d595fc5712e3ae0e04b9eed79b3a2a895a4e0",
+          "identityHash" : "22e9571fe8965bc78aa79abb5978a4fd493c2cc5",
           "contentHash" : "6fadc1319031dbfacf9c62ea1bccba84d4e849",
-          "syncHash" : "f8f58a3b257ac6f7867812e4d3dd65861f65479d",
+          "syncHash" : "8abfe8edfafbf08daaff29d08f67762972cf5a40",
           "type" : {
             "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
@@ -4261,13 +3609,58 @@ http_interactions:
             "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
             "id" : "Infinispan Cache Container"
           },
-          "id" : "Local~/host=master/server=server-two/subsystem=infinispan/cache-container=ejb"
+          "id" : "Local~/host=master/server=s/subsystem=infinispan/cache-container=ejb"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
+          "name" : "Infinispan Cache Container [web]",
+          "identityHash" : "a6d4f2e0121a9d8a634c2f62dbe7a9584aaec4b",
+          "contentHash" : "4abf467f7671dd43c81eff75a99a70c664186d",
+          "syncHash" : "819df99faddf76295b759302380416b093da",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/host=master/server=s/subsystem=infinispan/cache-container=web"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
+          "name" : "Infinispan Cache Container [server]",
+          "identityHash" : "df1af28e9189f6d9a14be523be6f31a98bf2d",
+          "contentHash" : "96a97558eea27231389480adb4d6a54e24bb4e33",
+          "syncHash" : "29c31914c74759514eefd8fbdcffc4950ff67f8",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/host=master/server=s/subsystem=infinispan/cache-container=server"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
+          "name" : "Infinispan Cache Container [hibernate]",
+          "identityHash" : "86452cb6bb78ea4623f022b6d62c4aeb3337885a",
+          "contentHash" : "2f8a87eedcbad55c868e2bf6414351333dca96",
+          "syncHash" : "f5e5e2476ae6dd695f5bc9148205dd9be9050",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/host=master/server=s/subsystem=infinispan/cache-container=hibernate"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=s/r;Local~%2Fhost=master%2Fserver=s%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -4277,169 +3670,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '672'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '724'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '708'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/recursive;over=isParentOf;type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -4460,371 +3691,275 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      X-Total-Count:
-      - '11'
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '11475'
+      - '819'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds/r;Local~%2Fhost%3Dmaster%2Fserver%3Ds%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "823ca07d76929e39fc468d25111455355aa81a8",
+          "contentHash" : "20125a70ce2d55719321b336bf632eb518bcb4a",
+          "syncHash" : "765d944a948b9f54ffe4b98d869f8b6ee16b2121",
+          "value" : {
+            "Connection Properties" : null,
+            "Datasource Class" : null,
+            "Security Domain" : null,
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Driver Class" : null,
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/type=f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      X-Total-Count:
+      - '2'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '520'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/recursive;over=isParentOf;type=r>;
+      - <http://localhost:8080/hawkular/inventory/traversal/type=f>; rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain",
+          "identityHash" : "30f57c15827b92fbd6ae865f7a713a19fe5d92",
+          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
+          "syncHash" : "39586a9980cea65ba04eb4623cf11d843e942253",
+          "id" : "master.Unnamed Domain"
+        }, {
+          "path" : "/t;hawkular/f;94f76aa25a3a",
+          "identityHash" : "52c22f6479aaa464a93a9ca3d993f2fd6838e74",
+          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
+          "syncHash" : "e4162397bb66dfc67838ac89a524d73d78de92a",
+          "id" : "94f76aa25a3a"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:58:47 GMT
+      X-Total-Count:
+      - '6'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6285'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "JDBC Driver [h2]",
-          "identityHash" : "532b722ebb2854c52dd67b303557abdb61e82f9",
-          "contentHash" : "f8c46c1ba786b4aebed5f1f6ebf96ce848557f3",
-          "syncHash" : "153f9cd2d9e6ba15adbdc79481d442b42d7fb8f",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-rest-api.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "c091d6bc3a4277549cf35ea59f497dc4a7b9e2",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "8c35e06592e1aaecebdddad85913591ec14b894d",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JDBC%20Driver",
-            "name" : "JDBC Driver",
-            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
-            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-            "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
-            "id" : "JDBC Driver"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=datasources/jdbc-driver=h2"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-rest-api.war]~AT~Deployment Status~Deployment Status"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "Datasource [ExampleDS]",
-          "identityHash" : "fcea1948a45d2d4aaf78af952be71217687fb3f2",
-          "contentHash" : "ddba59ad66b121b5e59f1c39adf915628cf6cc",
-          "syncHash" : "5abb523dbae7ce3df635ed7d92a70f2296b6b29",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-status.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "93ce5f53a4f74c7bfc9281776531a7767f1b2",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "7ce3e4de4fbe977e44a2c5ccd9c42adf1685d3",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Datasource",
-            "name" : "Datasource",
-            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
-            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
-            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
-            "id" : "Datasource"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=datasources/data-source=ExampleDS"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-status.war]~AT~Deployment Status~Deployment Status"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dtransactions",
-          "name" : "Transaction Manager",
-          "identityHash" : "33ef85f83f79331c464fd588fcb81aaae8ea47b",
-          "contentHash" : "8e90fd10711e88f57c0320407746b293fca579",
-          "syncHash" : "12645e67fb59b075d8115f62578067bd32ba6bc",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-metrics.ear%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "8122a17dbfb37b5b60c3981e97c559fa6ed51f4",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "2690ec63c249e3425c4f2c3e9aa466a315a32d3",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Transaction%20Manager",
-            "name" : "Transaction Manager",
-            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
-            "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
-            "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
-            "id" : "Transaction Manager"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=transactions"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-metrics.ear]~AT~Deployment Status~Deployment Status"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
-          "name" : "Messaging Server [default]",
-          "identityHash" : "8df92a426b33fac68a1da7f651b6d7ae2cff3d4e",
-          "contentHash" : "ae6780c1868e17bd5a34402ec71fe69e35419",
-          "syncHash" : "3dd6d1b040c132615802190f48f5bd4cc17d6c4",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "38defa1381efa9d63e23914631675f8ca338c770",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "50f4f41c6ea86490a4d9b9374e2be9566e846",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Messaging%20Server",
-            "name" : "Messaging Server",
-            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
-            "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
-            "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
-            "id" : "Messaging Server"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=messaging-activemq/server=default"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment Status~Deployment Status"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan",
-          "name" : "Infinispan",
-          "identityHash" : "5d9a879d186a2dfa7cf378a7646150e3b5c2b1",
-          "contentHash" : "0e01d148288143e57624eb996f8fcf551aa5148",
-          "syncHash" : "a4ffdb6972fe97d93a960b56959cea986d99dc1",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-inventory-dist.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "95db75df5a65633231721fd52501b6ef1a4ae6",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "995a122393ee2549849fb21e175f1b3a74b1d513",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan",
-            "name" : "Infinispan",
-            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
-            "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
-            "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
-            "id" : "Infinispan"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=infinispan"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment Status~Deployment Status"
         }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
-          "name" : "JMS Queue [DLQ]",
-          "identityHash" : "5c3cbf6b51595177cbafa292d62aab54669e29fe",
-          "contentHash" : "323890421628d3b454d11871d1a9f4253b957bf",
-          "syncHash" : "cbdbdb3675f4c2f02bb87129abeba8d21aa767d3",
+          "path" : "/t;hawkular/f;94f76aa25a3a/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war/m;AI~R~%5B94f76aa25a3a%2FLocal~%2Fdeployment%3Dhawkular-command-gateway-war.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "144a68e8784a7a2e41a1116d8708ae1eabaf58d",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "302f754f55537d5c38b1db2a787e398822e996",
           "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
+            "path" : "/t;hawkular/f;94f76aa25a3a/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
           },
-          "id" : "Local~/host=master/server=server-one/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
-          "name" : "JMS Queue [ExpiryQueue]",
-          "identityHash" : "5030666e5c5bc87bc28a0ab2e167752a18c4",
-          "contentHash" : "153196a1d5742afe8f4c595dd5f65d441b7a1c91",
-          "syncHash" : "a4b81e9bf46c11a5696e846641a78c77a3f8723",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/host=master/server=server-one/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
-          "name" : "Infinispan Cache Container [hibernate]",
-          "identityHash" : "be75dfe2e75a944b27fe135e7969a1142dc2f3f",
-          "contentHash" : "2f8a87eedcbad55c868e2bf6414351333dca96",
-          "syncHash" : "7c230f3d6ad086255f6aa95fc42ec767b032",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-one/subsystem=infinispan/cache-container=hibernate"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
-          "name" : "Infinispan Cache Container [ejb]",
-          "identityHash" : "f5a2de551824fc02e1881ba9f29e834d8c6e3a",
-          "contentHash" : "6fadc1319031dbfacf9c62ea1bccba84d4e849",
-          "syncHash" : "1493f3aaa6c63ded4e83fae1498d12649335d3",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-one/subsystem=infinispan/cache-container=ejb"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
-          "name" : "Infinispan Cache Container [server]",
-          "identityHash" : "5a8173a6da9daeb43eb7e46d5cd45d64e042b3bf",
-          "contentHash" : "96a97558eea27231389480adb4d6a54e24bb4e33",
-          "syncHash" : "5abcf9dae42ea122d863d7cd37c410ac682519",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-one/subsystem=infinispan/cache-container=server"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
-          "name" : "Infinispan Cache Container [web]",
-          "identityHash" : "79d1b1bc9455747278bd779dc1af9867dc69ab",
-          "contentHash" : "4abf467f7671dd43c81eff75a99a70c664186d",
-          "syncHash" : "c5e1a05730cf1df14f82e68df663efd6c7f85f6f",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/host=master/server=server-one/subsystem=infinispan/cache-container=web"
+          "id" : "AI~R~[94f76aa25a3a/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment Status~Deployment Status"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '672'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '708'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '724'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/raw/query
     body:
       encoding: UTF-8
-      string: '{"ids":["AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-status.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-actions-email.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-commons-embedded-cassandra-war.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-metrics-component.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-rest.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_2.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample3.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample4.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample5.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_final.war]~AT~Deployment
+      string: '{"ids":["AI~R~[94f76aa25a3a/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[94f76aa25a3a/Local~/deployment=hawkular-status.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[94f76aa25a3a/Local~/deployment=hawkular-metrics.ear]~AT~Deployment
+        Status~Deployment Status","AI~R~[94f76aa25a3a/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[94f76aa25a3a/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[94f76aa25a3a/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
         Status~Deployment Status"],"start":null,"end":null,"limit":1,"order":"DESC"}'
     headers:
       Accept:
@@ -4832,13 +3967,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
       - application/json
       Content-Length:
-      - '1953'
+      - '692'
   response:
     status:
       code: 200
@@ -4855,465 +3990,22 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:21 GMT
+      - Thu, 16 Mar 2017 17:58:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '2753'
+      - '977'
     body:
       encoding: UTF-8
-      string: '[{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-status.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-actions-email.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-commons-embedded-cassandra-war.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-metrics-component.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-rest.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"down"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_2.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample3.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample4.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample5.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_final.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]}]'
+      string: '[{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]},{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-status.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]},{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-metrics.ear]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]},{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110002,"value":"up"}]},{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]},{"id":"AI~R~[94f76aa25a3a/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489687110001,"value":"up"}]}]'
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:21 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '682'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
-          "properties" : {
-            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
-          },
-          "name" : "configuration",
-          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
-          "value" : {
-            "Username" : "sa",
-            "Driver Name" : "h2",
-            "JNDI Name" : "java:jboss/datasources/ExampleDS",
-            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-            "Enabled" : "true",
-            "Password" : "sa"
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '718'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '702'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '682'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
-          "properties" : {
-            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
-          },
-          "name" : "configuration",
-          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
-          "value" : {
-            "Username" : "sa",
-            "Driver Name" : "h2",
-            "JNDI Name" : "java:jboss/datasources/ExampleDS",
-            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-            "Enabled" : "true",
-            "Password" : "sa"
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '702'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 26 Sep 2016 13:57:55 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '718'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Fri, 21 Oct 2016 17:01:18 GMT
-      X-Total-Count:
-      - '3'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2338'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one",
-          "name" : "Domain WildFly Server [server-one]",
-          "identityHash" : "db1945a8f54a1d9c7769bf44729c94a84fec1",
-          "contentHash" : "705759e8a9d7833b8293d6acfc2e6e4d75ca2f",
-          "syncHash" : "17c6a82927c6c1f5c54791913e2105ff3799ea5",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
-            "name" : "Domain WildFly Server",
-            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
-            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
-            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
-            "id" : "Domain WildFly Server"
-          },
-          "id" : "Local~/host=master/server=server-one"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three",
-          "name" : "Domain WildFly Server [server-three]",
-          "identityHash" : "9af84d40e44f91a7576e212aa5e832cf62fb874",
-          "contentHash" : "f91dd171df9499743c8d937a4858a2b57a3f2",
-          "syncHash" : "b6a175a8080b5b76d5f6dcff8cb4fb2e4d7b0ca",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
-            "name" : "Domain WildFly Server",
-            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
-            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
-            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
-            "id" : "Domain WildFly Server"
-          },
-          "id" : "Local~/host=master/server=server-three"
-        }, {
-          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two",
-          "name" : "Domain WildFly Server [server-two]",
-          "identityHash" : "1ae2848bad79c3ec8316d54150520d6862c9d31",
-          "contentHash" : "33f194ba088df5d7e5dcdc72c1bee57617cbef",
-          "syncHash" : "df633ccaca8f15d9262f3bb2b21b7dbcb2a0e5",
-          "type" : {
-            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
-            "name" : "Domain WildFly Server",
-            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
-            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
-            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
-            "id" : "Domain WildFly Server"
-          },
-          "id" : "Local~/host=master/server=server-two"
-        } ]
-    http_version: 
-  recorded_at: Fri, 21 Oct 2016 17:01:18 GMT
+  recorded_at: Thu, 16 Mar 2017 17:58:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher_without_os.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher_without_os.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -31,20 +31,20 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '234'
+      - '233'
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "Implementation-Version" : "0.18.0.Final",
-          "Built-From-Git-SHA1" : "be1107e48907ebc1d8de4dc571275edd9daf0424",
+          "Implementation-Version" : "1.1.3.Final",
+          "Built-From-Git-SHA1" : "cd31cfcb438098b6d56886e4043f4ac51bb80fb0",
           "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
           "Initialized" : "true"
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
     uri: http://jdoe:password@127.0.0.1:8080/hawkular/metrics/status
@@ -57,7 +57,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -76,14 +76,14 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '133'
+      - '150'
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
     body:
       encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.18.0.Final","Built-From-Git-SHA1":"d5281e70603719809bdada72249b9330b22ebf96"}'
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.23.4.Final","Built-From-Git-SHA1":"965e1ed680f75932277033dff3ee8e34e52737ec","Cassandra":"up"}'
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
     uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/type=f
@@ -96,7 +96,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -117,69 +117,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - '3'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '818'
-      Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/type=f>; rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871",
-          "identityHash" : "cfd85919ae53b605c515770ea5056d4297f35f6",
-          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "ff6fb75be1bf6ca5c743a3cac9bffe63a7e216",
-          "id" : "e2daaa52-a9c1-4578-8a60-c6699de99871"
-        }, {
-          "path" : "/t;hawkular/f;feed_may_exist",
-          "identityHash" : "abc4c5719f1f4d4ef252d9b060f33ea09f48db",
-          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "09efb56d1f187c7ae3fa6ce1c864b3dcf5e78e",
-          "id" : "feed_may_exist"
-        } ]
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -187,34 +125,90 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '665'
+      - '298'
       Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server/rl;defines/type=r>;
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/type=f>; rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5",
+          "identityHash" : "f7e836c9967586ced2414b70167752639090c5",
+          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
+          "syncHash" : "5a23e853298dd5822d1de0e36aae466c66868fb",
+          "id" : "5d8b69af-4fce-492d-9aeb-93cbd7e557a5"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;WildFly%20Server/rl;defines/type=r
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '670'
+      Link:
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;WildFly%20Server/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~",
           "name" : "WildFly Server [Local]",
-          "identityHash" : "3dea1e437737a93e607d69b7a6e3db517231a",
+          "identityHash" : "6bf0b87f50d81d58f7826419d01ae691f18a2415",
           "contentHash" : "279ff07c7f8bb9a36853a063514dd723667afc",
-          "syncHash" : "3e84c1c5b54c0d38016a8a93c2edd872ad5f5",
+          "syncHash" : "f03eedf61cef75cd3debd4346edd1d8cb614135",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;WildFly%20Server",
             "name" : "WildFly Server",
-            "identityHash" : "ab7029efaddc2c15983a8e8a28576b5d6f24c7",
+            "identityHash" : "57bae53766e460329415872b2510f94127fc566",
             "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
-            "syncHash" : "eaff3fc55473c319fc4135147084ae425eb2ed6b",
+            "syncHash" : "3893e5533c5acc4258e688baa161828bc174f31",
             "id" : "WildFly Server"
           },
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/d;configuration
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -224,7 +218,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -245,41 +239,41 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '811'
+      - '706'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/d;configuration",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/d;configuration",
           "name" : "configuration",
-          "identityHash" : "993dcbcf56fcb99d3d5de6453431f4cefa6856e",
-          "contentHash" : "1bd15692631f24dd82be3f4adf3084889b8fd4b",
-          "syncHash" : "b03021e09d92e24a2c71d7c96e0e478f1595aa8",
+          "identityHash" : "181448c3bf634cb933a2fa1844c44994654d3a",
+          "contentHash" : "79964fd25b60bc1785a246f1d26c6629367b1a",
+          "syncHash" : "b1e9a7e7f3df81a9bfe46bb286a1f92c2e275d9",
           "value" : {
             "Suspend State" : "RUNNING",
             "Bound Address" : "0.0.0.0",
             "Running Mode" : "NORMAL",
-            "Home Directory" : "/home/josejulio/Documentos/redhat/hawkular/hawkular-services-new/dist/target/hawkular-services-dist-0.0.11.Final-SNAPSHOT",
-            "Version" : "0.0.11.Final-SNAPSHOT",
-            "Node Name" : "avalanche",
+            "Home Directory" : "/opt/jboss/wildfly",
+            "Version" : "0.31.0.Final",
+            "Node Name" : "51b64af1dabe",
             "Server State" : "running",
             "Product Name" : "Hawkular",
-            "Hostname" : "avalanche",
-            "UUID" : "e2daaa52-a9c1-4578-8a60-c6699de99871",
-            "Name" : "avalanche"
+            "Hostname" : "51b64af1dabe",
+            "UUID" : "5d8b69af-4fce-492d-9aeb-93cbd7e557a5",
+            "Name" : "51b64af1dabe"
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/type=rt
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/type=rt
     body:
       encoding: US-ASCII
       string: ''
@@ -289,7 +283,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -310,188 +304,223 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
-      - '27'
+      - '28'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '8831'
+      - '9247'
       Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/type=rt>;
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/type=rt>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-          "name" : "Singleton EJB",
-          "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-          "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-          "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-          "id" : "Singleton EJB"
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_Memory",
+          "name" : "Memory",
+          "identityHash" : "a9cae1bf58f7305834ab1f715092a1ff19c09792",
+          "contentHash" : "89c8a2851d1755cf87365b4a7c55e5551cf878c6",
+          "syncHash" : "63c252f9da9ffbaf9ad5ebbaab52b87c516f6fc6",
+          "id" : "Platform_Memory"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-          "name" : "Deployment",
-          "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-          "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-          "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-          "id" : "Deployment"
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_Processor",
+          "name" : "Processor",
+          "identityHash" : "dc2c42d6db87dde238adda3b1e231221d8a997e",
+          "contentHash" : "b74dd4bb546c66fff9ea6bb459c135aaf94616",
+          "syncHash" : "805d15af89246196997560ea7a772bda4b717b8",
+          "id" : "Platform_Processor"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Messaging%20Server",
-          "name" : "Messaging Server",
-          "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
-          "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
-          "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
-          "id" : "Messaging Server"
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_Operating%20System",
+          "name" : "Operating System",
+          "identityHash" : "8098f1b9c46296fc5873dce9979c95692b7e7ea",
+          "contentHash" : "e5ba86326755952233b0543acced2995e5faf457",
+          "syncHash" : "e97372fe4fbca63cb7662a2b71d3e022ab4fdac",
+          "id" : "Platform_Operating System"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;ModCluster",
-          "name" : "ModCluster",
-          "identityHash" : "364f9437230722b5892c9595b29c77b62d3396f",
-          "contentHash" : "dbf826da8a4c333766883dba8952e10746225e7",
-          "syncHash" : "3a43f4e6781e56c218cc9cdd548ff4d362858e2",
-          "id" : "ModCluster"
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_File%20Store",
+          "name" : "File Store",
+          "identityHash" : "80e01775b6149f31d2ecf2b6e8b2d85ad06cf7",
+          "contentHash" : "e1698edca6d8d938fd7c84ea634847ab3e99fa9",
+          "syncHash" : "7c77753bf56e3ca9bbcbb90faa11e40dbabb7",
+          "id" : "Platform_File Store"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-          "name" : "Socket Binding",
-          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-          "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-          "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-          "id" : "Socket Binding"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan",
-          "name" : "Infinispan",
-          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
-          "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
-          "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
-          "id" : "Infinispan"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding%20Group",
-          "name" : "Socket Binding Group",
-          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
-          "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
-          "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
-          "id" : "Socket Binding Group"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-          "name" : "Message Driven EJB",
-          "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-          "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-          "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-          "id" : "Message Driven EJB"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
-          "name" : "Remote Destination Outbound Socket Binding",
-          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
-          "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
-          "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
-          "id" : "Remote Destination Outbound Socket Binding"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JGroups%20Channel",
-          "name" : "JGroups Channel",
-          "identityHash" : "b076f142fbf9a283551583114ab2a58039bd488d",
-          "contentHash" : "bbc51e1ef3ddc3f6db28051af5f9ef3ac62ae59",
-          "syncHash" : "60d66189547e89e6bcaadaa74ccbf9d96444fdd1",
-          "id" : "JGroups Channel"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-          "name" : "JMS Queue",
-          "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-          "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-          "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-          "id" : "JMS Queue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;WildFly%20Server",
-          "name" : "WildFly Server",
-          "identityHash" : "ab7029efaddc2c15983a8e8a28576b5d6f24c7",
-          "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
-          "syncHash" : "eaff3fc55473c319fc4135147084ae425eb2ed6b",
-          "id" : "WildFly Server"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Hawkular%20WildFly%20Agent",
-          "name" : "Hawkular WildFly Agent",
-          "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
-          "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
-          "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
-          "id" : "Hawkular WildFly Agent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;SubDeployment",
-          "name" : "SubDeployment",
-          "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
-          "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
-          "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
-          "id" : "SubDeployment"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Transaction%20Manager",
-          "name" : "Transaction Manager",
-          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
-          "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
-          "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
-          "id" : "Transaction Manager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-          "name" : "Servlet",
-          "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-          "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-          "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-          "id" : "Servlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JGroups",
-          "name" : "JGroups",
-          "identityHash" : "dd6a37f1e791f41312ab3ce894dad8db26ee3ad",
-          "contentHash" : "7cb9431daf07a2dc58d3786ac5a76f915891564",
-          "syncHash" : "c5a9d8fab9907672ac042ae415ac7e62b2234",
-          "id" : "JGroups"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
-          "name" : "Stateless Session EJB",
-          "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
-          "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
-          "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
-          "id" : "Stateless Session EJB"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
-          "name" : "Infinispan Cache Container",
-          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-          "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-          "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-          "id" : "Infinispan Cache Container"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-          "name" : "JMS Topic",
-          "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-          "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-          "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-          "id" : "JMS Topic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Datasource",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Datasource",
           "name" : "Datasource",
           "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
           "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
           "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
           "id" : "Datasource"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JDBC%20Driver",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+          "name" : "SubDeployment",
+          "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+          "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+          "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+          "id" : "SubDeployment"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Hawkular%20WildFly%20Agent",
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
+          "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
+          "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
+          "id" : "Hawkular WildFly Agent"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateful%20Session%20EJB",
+          "name" : "Stateful Session EJB",
+          "identityHash" : "113c4e7fe012f6d1952ae3b8f27e865a01fc519",
+          "contentHash" : "848ca2bad67291fd1449c648265d6cd05c5f29",
+          "syncHash" : "cdd617cf5f718e38451b83a19fcc1fba4613e360",
+          "id" : "Stateful Session EJB"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
+          "name" : "Deployment",
+          "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
+          "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
+          "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
+          "id" : "Deployment"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Transaction%20Manager",
+          "name" : "Transaction Manager",
+          "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+          "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
+          "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
+          "id" : "Transaction Manager"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
+          "name" : "JMS Topic",
+          "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+          "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+          "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+          "id" : "JMS Topic"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+          "name" : "Remote Destination Outbound Socket Binding",
+          "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
+          "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
+          "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
+          "id" : "Remote Destination Outbound Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding%20Group",
+          "name" : "Socket Binding Group",
+          "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+          "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
+          "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
+          "id" : "Socket Binding Group"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+          "name" : "Message Driven EJB",
+          "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+          "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+          "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+          "id" : "Message Driven EJB"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+          "name" : "JMS Queue",
+          "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+          "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+          "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+          "id" : "JMS Queue"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Messaging%20Server",
+          "name" : "Messaging Server",
+          "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
+          "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
+          "syncHash" : "35896341e6bfb41fe41e262adfe462dd854ada88",
+          "id" : "Messaging Server"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;WildFly%20Server",
+          "name" : "WildFly Server",
+          "identityHash" : "57bae53766e460329415872b2510f94127fc566",
+          "contentHash" : "96dfab5fa91ff8fea2be793138eb9f9d84399bc",
+          "syncHash" : "3893e5533c5acc4258e688baa161828bc174f31",
+          "id" : "WildFly Server"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+          "name" : "Socket Binding",
+          "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+          "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+          "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+          "id" : "Socket Binding"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+          "name" : "Singleton EJB",
+          "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+          "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+          "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+          "id" : "Singleton EJB"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JGroups",
+          "name" : "JGroups",
+          "identityHash" : "dd6a37f1e791f41312ab3ce894dad8db26ee3ad",
+          "contentHash" : "7cb9431daf07a2dc58d3786ac5a76f915891564",
+          "syncHash" : "c5a9d8fab9907672ac042ae415ac7e62b2234",
+          "id" : "JGroups"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;ModCluster",
+          "name" : "ModCluster",
+          "identityHash" : "364f9437230722b5892c9595b29c77b62d3396f",
+          "contentHash" : "dbf826da8a4c333766883dba8952e10746225e7",
+          "syncHash" : "3a43f4e6781e56c218cc9cdd548ff4d362858e2",
+          "id" : "ModCluster"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JDBC%20Driver",
           "name" : "JDBC Driver",
-          "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
+          "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
           "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-          "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
+          "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
           "id" : "JDBC Driver"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;XA%20Datasource",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+          "name" : "Servlet",
+          "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+          "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+          "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+          "id" : "Servlet"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
+          "name" : "Infinispan Cache Container",
+          "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+          "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+          "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+          "id" : "Infinispan Cache Container"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;XA%20Datasource",
           "name" : "XA Datasource",
           "identityHash" : "738cead59778159f64fa3911e2eff113f0f9d8",
           "contentHash" : "3e6a387dbbbcf637e951b8c4c5bfa3dbdce858",
           "syncHash" : "fddf22b49da75825cb141ca5615d1292cfa4457",
           "id" : "XA Datasource"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JGroups%20Channel",
+          "name" : "JGroups Channel",
+          "identityHash" : "b076f142fbf9a283551583114ab2a58039bd488d",
+          "contentHash" : "bbc51e1ef3ddc3f6db28051af5f9ef3ac62ae59",
+          "syncHash" : "60d66189547e89e6bcaadaa74ccbf9d96444fdd1",
+          "id" : "JGroups Channel"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan",
+          "name" : "Infinispan",
+          "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
+          "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
+          "syncHash" : "4daf646564159dbdc4ec5b5c8f9ba62a0ffb6",
+          "id" : "Infinispan"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateless%20Session%20EJB",
+          "name" : "Stateless Session EJB",
+          "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+          "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+          "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+          "id" : "Stateless Session EJB"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System/rl;defines/type=r
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_Operating%20System/rl;defines/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -501,7 +530,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -522,60 +551,9 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
-      - '1'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '854'
-      Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Operating%20System/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ ]
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;WildFly%20Server/rl;defines/type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
       - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
-      X-Total-Count:
-      - "-1"
       Connection:
       - keep-alive
       Content-Type:
@@ -583,13 +561,13 @@ http_interactions:
       Content-Length:
       - '3'
       Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;WildFly%20Server/rl;defines/type=r>;
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Platform_Operating%20System/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
     uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/type=f
@@ -602,7 +580,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -623,38 +601,32 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
-      - '3'
+      - '1'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '818'
+      - '298'
       Link:
       - <http://127.0.0.1:8080/hawkular/inventory/traversal/type=f>; rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871",
-          "identityHash" : "cfd85919ae53b605c515770ea5056d4297f35f6",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5",
+          "identityHash" : "f7e836c9967586ced2414b70167752639090c5",
           "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "ff6fb75be1bf6ca5c743a3cac9bffe63a7e216",
-          "id" : "e2daaa52-a9c1-4578-8a60-c6699de99871"
-        }, {
-          "path" : "/t;hawkular/f;feed_may_exist",
-          "identityHash" : "abc4c5719f1f4d4ef252d9b060f33ea09f48db",
-          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
-          "syncHash" : "09efb56d1f187c7ae3fa6ce1c864b3dcf5e78e",
-          "id" : "feed_may_exist"
+          "syncHash" : "5a23e853298dd5822d1de0e36aae466c66868fb",
+          "id" : "5d8b69af-4fce-492d-9aeb-93cbd7e557a5"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Domain%20Host/rl;defines/type=r
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Domain%20Host/rl;defines/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -664,7 +636,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -685,9 +657,9 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
-      - "-1"
+      - '0'
       Connection:
       - keep-alive
       Content-Type:
@@ -695,16 +667,16 @@ http_interactions:
       Content-Length:
       - '3'
       Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Domain%20Host/rl;defines/type=r>;
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Domain%20Host/rl;defines/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: "[ ]"
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;Domain%20Host/rl;defines/type=r
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/recursive;over=isParentOf;type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -714,7 +686,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -735,169 +707,29 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:19 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       X-Total-Count:
-      - "-1"
+      - '86'
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '3'
+      - '80100'
       Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;feed_may_exist/rt;Domain%20Host/rl;defines/type=r>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: "[ ]"
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:19 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/recursive;over=isParentOf;type=r
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      X-Total-Count:
-      - '88'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '76742'
-      Link:
-      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/recursive;over=isParentOf;type=r>;
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/recursive;over=isParentOf;type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
-          "name" : "Datasource [ExampleDS]",
-          "identityHash" : "b1ad1d93643dccfbd37acdeb9d5f9c7de3294eb",
-          "contentHash" : "b58b567684c11abcad41d4c9987f5ab7dcc91e9b",
-          "syncHash" : "a43968939bf36bfeeeb7cb5845b8cd749e462df",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Datasource",
-            "name" : "Datasource",
-            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
-            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
-            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
-            "id" : "Datasource"
-          },
-          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
-          "name" : "Deployment [hawkular-inventory-dist.war]",
-          "identityHash" : "f3defdd75b42a2d48a6c17fcd06751833bacf2e5",
-          "contentHash" : "417c20bda5537eb48b72cc26a72d0a6c0b3cbe5",
-          "syncHash" : "6c9be5a14585f8c5b4cf270725a21c95fbaf7e9",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war",
-          "name" : "Deployment [hawkular-status.war]",
-          "identityHash" : "f237ce157626d4fa8254f3325e569fcd5651de",
-          "contentHash" : "6dc4efef84b9a54a70f61074934b7c853a1e17a",
-          "syncHash" : "9e3b71955c795d7734b6ff40f3f74e22913bd8c2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-status.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
-          "name" : "Deployment [hawkular-rest-api.war]",
-          "identityHash" : "538440b748e7a36aaec485d19d6e6d5632b13d",
-          "contentHash" : "2bfba7848683914b7dc337df6a9e9a299d10f4",
-          "syncHash" : "53d3fa370cdff6e3f92359511ad5aa78176a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
-          "name" : "Socket Binding Group [standard-sockets]",
-          "identityHash" : "f866ca4321d1d3c9217722d156ec098138e766",
-          "contentHash" : "57c78c644c2360bfc5251e501570bbc27b1f5466",
-          "syncHash" : "538f17bcb94c7465967834a2a5cff95e831db888",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding%20Group",
-            "name" : "Socket Binding Group",
-            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
-            "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
-            "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
-            "id" : "Socket Binding Group"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
-          "name" : "Deployment [hawkular-alerts-actions-email.war]",
-          "identityHash" : "16986eecf77de6c8f42c7ec75daefa86e18622c",
-          "contentHash" : "c9e46694a372af5d839b126e4f8e9eaf7f2146a",
-          "syncHash" : "a64fec3af385dcb4941529afcc35284b043d7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
           "name" : "Messaging Server [default]",
-          "identityHash" : "2e2ffd20fd3a3b7bc5472069cce1fc4da1c7d68",
+          "identityHash" : "608dde3a813fa889b74ae8465c8061159c705bee",
           "contentHash" : "e4e99f5c774164440fdc28a9037ffdf7262a9f8",
-          "syncHash" : "1418784f20487eb568972475bd1f7b2d2e622de",
+          "syncHash" : "11943b3f88b2dced94deee5727c76aed8f9e6fc",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Messaging%20Server",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Messaging%20Server",
             "name" : "Messaging Server",
             "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
             "contentHash" : "333ae92fb6535ccf71d18badfd388f14a441d0",
@@ -906,118 +738,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-war.war",
-          "name" : "Deployment [hawkular-commons-embedded-cassandra-war.war]",
-          "identityHash" : "241312a3f1023f5137ad26bde4dd6b130b856db",
-          "contentHash" : "4eae3596373e3c1e74972f272c95552192bde178",
-          "syncHash" : "4f721a87a764d1fba957160a1709e5bf611eec8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-commons-embedded-cassandra-war.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
-          "name" : "Deployment [hawkular-command-gateway-war.war]",
-          "identityHash" : "fc197b476ad389a1dadbd4877235abbf9208769",
-          "contentHash" : "3d65bb3dceb1e32f1289d923e51a926271e0d723",
-          "syncHash" : "62daa8574c2129689930913971f534ce0556ff2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
-          "name" : "Deployment [hawkular-wildfly-agent-download.war]",
-          "identityHash" : "c1d2d36294248a6b7f4c526a1c6e9fff1fc9252",
-          "contentHash" : "e0784bf0dd411af714d5b85a98ffaaf9a612b24",
-          "syncHash" : "c953eac0a7405aaba5443850a0aa8f39dec2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
-          "name" : "Hawkular WildFly Agent",
-          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
-          "contentHash" : "fba7866bc34d2ba1ed776115ad9eceb79b6e1c",
-          "syncHash" : "8793bb7095a6da432b3b53773e66d7b02cc7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Hawkular%20WildFly%20Agent",
-            "name" : "Hawkular WildFly Agent",
-            "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
-            "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
-            "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
-            "id" : "Hawkular WildFly Agent"
-          },
-          "id" : "Local~/subsystem=hawkular-wildfly-agent"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
-          "name" : "Deployment [hawkular-metrics-component.war]",
-          "identityHash" : "39bf1128fee24c49fe1c919432ad13a2da57d",
-          "contentHash" : "e37c6946d156e34663ccd46773d91ac55b61",
-          "syncHash" : "9fdd223a94ffd34988f3d497ec1bd17b4cffe24",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-metrics-component.war"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
-          "name" : "Transaction Manager",
-          "identityHash" : "fd4c6c6ae631c9d3574596722ecabcd248329087",
-          "contentHash" : "a6c39bff42bb3c59cb2a9df90bd9ba46ecfd4c",
-          "syncHash" : "b3ca44e58ac6adc4de54f9b40b52f7079d8e7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Transaction%20Manager",
-            "name" : "Transaction Manager",
-            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
-            "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
-            "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
-            "id" : "Transaction Manager"
-          },
-          "id" : "Local~/subsystem=transactions"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
-          "name" : "JDBC Driver [h2]",
-          "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
-          "contentHash" : "8bcc62c8866ea8f4667c8e881cb848896ef63fa",
-          "syncHash" : "3a11f1aae220d43d6fbaae9187193f680b86c8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JDBC%20Driver",
-            "name" : "JDBC Driver",
-            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
-            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
-            "syncHash" : "fa298d5f329ae7313f8648b70c0a4816a2734e0",
-            "id" : "JDBC Driver"
-          },
-          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
           "name" : "Infinispan",
-          "identityHash" : "ba921964165d1775fa543a8e2ae78f89c1270",
+          "identityHash" : "91494e7521ad56b546a393cc950ba43eb90574d",
           "contentHash" : "87f6d31913ce5af34bde86aa383aa81d9958a",
-          "syncHash" : "16bdc1813cba768518be82fb5bd93ba617dee9c",
+          "syncHash" : "1c4bc4ce97af8df33bc923c67d9ec389c55da3b",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan",
             "name" : "Infinispan",
             "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
             "contentHash" : "acbd2d38de78a774e94c399a2922ae46bea3783",
@@ -1026,463 +753,223 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
-          "name" : "Deployment [hawkular-alerts-rest.war]",
-          "identityHash" : "cefdcdbbac39815926c1549583d7dcf3fd6b9d35",
-          "contentHash" : "9d248c86d3673fcd56d63bd7bc3c2f2bfd0b3f0",
-          "syncHash" : "bcef86db9ea1e3202e48c80413914df2dabb353",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_postgres",
+          "name" : "Datasource [HawkularInventoryDS_postgres]",
+          "identityHash" : "a4794f635a57b89fbabd3134ffa385cec9f64fe1",
+          "contentHash" : "90d8565f98575c636cd1e2a6da2d09bea5345",
+          "syncHash" : "2eaa27352f2c6c3103d4099fca4d2b4e57d51e5",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=HawkularInventoryDS_postgres"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "name" : "Deployment [hawkular-rest-api.war]",
+          "identityHash" : "2d6df7abfffcee93f63ef77e395d9f2add51de70",
+          "contentHash" : "2bfba7848683914b7dc337df6a9e9a299d10f4",
+          "syncHash" : "50f34b3a562652e7b0f3a5351f4f8841b3582b",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war"
+          "id" : "Local~/deployment=hawkular-rest-api.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample.war",
-          "name" : "Deployment [sample.war]",
-          "identityHash" : "c1d86b7e823bc99ba03ca3e98dbf07893ed3dad",
-          "contentHash" : "da37e26342d0c2529db1d9ffabd7929473457fd5",
-          "syncHash" : "5730c573eb29b9434c5536b0c1f5a2e1702db2ea",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+          "name" : "Deployment [hawkular-command-gateway-war.war]",
+          "identityHash" : "d1d0d57b0231cd1fb2c15ecffb6f1480f1c4",
+          "contentHash" : "3d65bb3dceb1e32f1289d923e51a926271e0d723",
+          "syncHash" : "674abbec27be542aa4d9afa956d14ebd3418279",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample.war"
+          "id" : "Local~/deployment=hawkular-command-gateway-war.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_2.war",
-          "name" : "Deployment [sample_2.war]",
-          "identityHash" : "c270bb4247acf59173cfe6d86f3e24baca2e94d5",
-          "contentHash" : "ca86fe6e4d6aa4dc6be6e83cdf6db2174ad5b64",
-          "syncHash" : "770777dfea619d795c0bf14fe19c54cf2cf2c5",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "name" : "Hawkular WildFly Agent",
+          "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
+          "contentHash" : "fba7866bc34d2ba1ed776115ad9eceb79b6e1c",
+          "syncHash" : "8793bb7095a6da432b3b53773e66d7b02cc7",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Hawkular%20WildFly%20Agent",
+            "name" : "Hawkular WildFly Agent",
+            "identityHash" : "3f3074f6ccbc1d5aa93ef70b46860249b2ac755",
+            "contentHash" : "5631a1c89f7b7a5f5adcd5c8555cd43dcfe588",
+            "syncHash" : "f368b5149662f5a59c6e77b33a1f6beee35c5f0",
+            "id" : "Hawkular WildFly Agent"
+          },
+          "id" : "Local~/subsystem=hawkular-wildfly-agent"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "name" : "Socket Binding Group [standard-sockets]",
+          "identityHash" : "a3adfda2eec71903f2e6def315fe5c519934fb",
+          "contentHash" : "57c78c644c2360bfc5251e501570bbc27b1f5466",
+          "syncHash" : "892c2f96c3e3030259b693ba796969091ba45",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding%20Group",
+            "name" : "Socket Binding Group",
+            "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
+            "contentHash" : "cb6167f7e9aabb8464bef22c93e8e16f6365ea3",
+            "syncHash" : "50a5241e87dab3c4b71cad0632ac8f13395e69",
+            "id" : "Socket Binding Group"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear",
+          "name" : "Deployment [hawkular-metrics.ear]",
+          "identityHash" : "e44178b4acc8d737f05e75cd322cede478d0c7",
+          "contentHash" : "ceff67ea9b17c1303497484c30c558c38766fba1",
+          "syncHash" : "9d8682752256a64a84df236b6af2ff78cc291e31",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample_2.war"
+          "id" : "Local~/deployment=hawkular-metrics.ear"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample3.war",
-          "name" : "Deployment [sample3.war]",
-          "identityHash" : "329ce4d838c6e447e4752b9b8cb3c65a4c92a58",
-          "contentHash" : "69f2af546197c7b75bf16524f796b9418b9ab4f2",
-          "syncHash" : "17a381961a88f867c19db1c42ba2405880e21aa3",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
+          "name" : "Deployment [hawkular-wildfly-agent-download.war]",
+          "identityHash" : "59a06e3b88cd38e5701dfa18678da5dfb2556d7",
+          "contentHash" : "e0784bf0dd411af714d5b85a98ffaaf9a612b24",
+          "syncHash" : "a762cc4f51ece1739eef4f4d034576c449c7f",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample3.war"
+          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample4.war",
-          "name" : "Deployment [sample4.war]",
-          "identityHash" : "a749743a297d3ac0a4eb17b888b319b0abc7496",
-          "contentHash" : "503ec7c7de4bd1d80ae5d4f4a5b81e5d5998ad",
-          "syncHash" : "d2fb8c8f43b455473a8342bc76b84861917cacd",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war",
+          "name" : "Deployment [hawkular-status.war]",
+          "identityHash" : "123bc81c7b8cd26cd54823e8fe2c8dd53cd5c",
+          "contentHash" : "6dc4efef84b9a54a70f61074934b7c853a1e17a",
+          "syncHash" : "aa3cabcdcb6b37f4186339fd2dbd8751c376a1d4",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample4.war"
+          "id" : "Local~/deployment=hawkular-status.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample5.war",
-          "name" : "Deployment [sample5.war]",
-          "identityHash" : "2bfba888d4fb56649e13a74fcb1e83b61f07d24",
-          "contentHash" : "a41ff112f0853d3d95593359bd254f219deb95c",
-          "syncHash" : "d8529cbccb08de8c93887ce5fb2a5e896da3c",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "name" : "Transaction Manager",
+          "identityHash" : "cbe5645ab32e85154fe04a352cdb7bfb9e96e1",
+          "contentHash" : "a6c39bff42bb3c59cb2a9df90bd9ba46ecfd4c",
+          "syncHash" : "ab15ce68bb4dfbb223d6c9ae7ac2e260a765d6d8",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Transaction%20Manager",
+            "name" : "Transaction Manager",
+            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
+            "contentHash" : "46c527a46c609bf03a66b2b9d8e091838a28107",
+            "syncHash" : "af0db9d805244129d4b12e8d4c5167ad52c2ca1",
+            "id" : "Transaction Manager"
+          },
+          "id" : "Local~/subsystem=transactions"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "name" : "JDBC Driver [h2]",
+          "identityHash" : "2a2c8737af4420e578da6c99becbf77c870f9",
+          "contentHash" : "8bcc62c8866ea8f4667c8e881cb848896ef63fa",
+          "syncHash" : "b580b85385941ad714139cfcaa6cdaf55748f",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
+            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+            "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dpostgresql",
+          "name" : "JDBC Driver [postgresql]",
+          "identityHash" : "b4d3931a55fc762aac8fc6203f4a2dc26231251",
+          "contentHash" : "5417188b1f91eb354979783bd4845d9d84522e2b",
+          "syncHash" : "ba51d98bd0a5ccc8db6c558f5b6ca564aa7371",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JDBC%20Driver",
+            "name" : "JDBC Driver",
+            "identityHash" : "7c311a2fb888f2334317cf055191db7811b7f4a",
+            "contentHash" : "3f1b769e6846f49e2d5cfc55b8fe7a58e2742f2",
+            "syncHash" : "e28b2abe7a5746ecdcd12910ecc1baaf5593cca",
+            "id" : "JDBC Driver"
+          },
+          "id" : "Local~/subsystem=datasources/jdbc-driver=postgresql"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "name" : "Datasource [ExampleDS]",
+          "identityHash" : "32edb3c9fed3d1ff4958264e66e1cfd264994",
+          "contentHash" : "b58b567684c11abcad41d4c9987f5ab7dcc91e9b",
+          "syncHash" : "bde836ff11de25794f925e255a78580d7c37445",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
+          },
+          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
+          "name" : "Deployment [hawkular-inventory-dist.war]",
+          "identityHash" : "d8251247dd26a5b95d2d523c63a7993863df72",
+          "contentHash" : "417c20bda5537eb48b72cc26a72d0a6c0b3cbe5",
+          "syncHash" : "ed5bc3719638f24560c3b0e46ce383c8fb75df2a",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Deployment",
             "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
+            "identityHash" : "92a9199548fbbcd8acebf2e3e8e2816886c1ce2",
             "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
+            "syncHash" : "c8796acaee8cc41a97c3999ce696ab50a9d6f8",
             "id" : "Deployment"
           },
-          "id" : "Local~/deployment=sample5.war"
+          "id" : "Local~/deployment=hawkular-inventory-dist.war"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_final.war",
-          "name" : "Deployment [sample_final.war]",
-          "identityHash" : "6627d7859911f625d0edf8d268a76bff9de1e62",
-          "contentHash" : "2fccfc75a6f2d1d01f3d9dbf3add906ffb9256e0",
-          "syncHash" : "149dc2df16829b2d6eb33c804938efcfbebe7b8",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_h2",
+          "name" : "Datasource [HawkularInventoryDS_h2]",
+          "identityHash" : "65b28629b6ebc325bba0f3ef3cc3adc973affa",
+          "contentHash" : "edd709c9685c05550b77349ea11acb33a72dda3",
+          "syncHash" : "f234608b8d25c7d263d8befb4b263767c06f43e0",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "aaa121a15de5fbf47393e9eedccab2f3e4f479bd",
-            "contentHash" : "327a55f82dc6818877a68e37b722bb7f2360b633",
-            "syncHash" : "2a7d8da2a747badbac21bd58531b31afd17c723",
-            "id" : "Deployment"
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Datasource",
+            "name" : "Datasource",
+            "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
+            "contentHash" : "546c2a207bd841a0c2d94a6ae8a87371c36ffa9f",
+            "syncHash" : "f65ba261ef70efe3812e95a9ecb68d4fb6f3157",
+            "id" : "Datasource"
           },
-          "id" : "Local~/deployment=sample_final.war"
+          "id" : "Local~/subsystem=datasources/data-source=HawkularInventoryDS_h2"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.inventory.rest.HawkularRestApi",
-          "name" : "Servlet [org.hawkular.inventory.rest.HawkularRestApi]",
-          "identityHash" : "6d1974925c87cf4d0e3794a855287a0b25c856",
-          "contentHash" : "80c5f042a119325548bd8871f4b1843eff977cde",
-          "syncHash" : "884e302bd15594b571737bee25bc83c8317b58",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=undertow/servlet=org.hawkular.inventory.rest.HawkularRestApi"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DInventoryJNDIPublisher",
-          "name" : "Singleton EJB [InventoryJNDIPublisher]",
-          "identityHash" : "161d87b9c82b5b4610335274f4b566b7f7d7d9",
-          "contentHash" : "d6f27fdf33cb9586cc2ed3d548a8a7535d7e8d7",
-          "syncHash" : "1382d4162e14502dabcfbcbb54e4691d440c0a8",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=ejb3/singleton-bean=InventoryJNDIPublisher"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/r;Local~%2Fdeployment%3Dhawkular-status.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.services.rest.HawkularServicesStatusApp",
-          "name" : "Servlet [org.hawkular.services.rest.HawkularServicesStatusApp]",
-          "identityHash" : "531358b275e9fa94debfa42cf625efdcc3cc74c",
-          "contentHash" : "c14bdf75c5f086b26bf840c65b1d2fbe3cd338",
-          "syncHash" : "da6fc4beabf4112bb5fd61b4b9cad23ccd09a86",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-status.war/subsystem=undertow/servlet=org.hawkular.services.rest.HawkularServicesStatusApp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularTopicListener",
-          "name" : "Message Driven EJB [HawkularTopicListener]",
-          "identityHash" : "c23315e4552e2d84cdb2cd14a82c12ea0695947",
-          "contentHash" : "b6d3cdf29a882af2494fc7bd79f8aad45c9216",
-          "syncHash" : "33421522fe2e836d3cbfb5a35a17931a1f0b567",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularTopicListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularQueueListener",
-          "name" : "Message Driven EJB [HawkularQueueListener]",
-          "identityHash" : "23cc67cb54ff64a8374ab83e7e5d0436d7f5351",
-          "contentHash" : "74a0db3da72d8b1cb4d7ba03f570b5ea48d1f5",
-          "syncHash" : "97509b76921fd65e42e6ca1573a8831199728587",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularQueueListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DCommandEventListener",
-          "name" : "Message Driven EJB [CommandEventListener]",
-          "identityHash" : "fac175aab4439e2f90221cf6a46ea5e88def72fe",
-          "contentHash" : "51f2121ca985cdac97f693c4e87cfdf433a6ac7",
-          "syncHash" : "a718672eb5e4407a651aab12a8e75bfe30b28f",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=CommandEventListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3DHystrixMetricsStreamServlet",
-          "name" : "Servlet [HystrixMetricsStreamServlet]",
-          "identityHash" : "2ebc6f793eaaf3c5295988376e385cfb69a71e6e",
-          "contentHash" : "57b26a489a755ea379a116ae7dd25dc6e6964896",
-          "syncHash" : "308136a5b81d3766145cc04064c1e9c8e529a3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=HystrixMetricsStreamServlet"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DInventoryEventListener",
-          "name" : "Message Driven EJB [InventoryEventListener]",
-          "identityHash" : "7145aea182b7e0eafeecf4f195c15d7a5dcad6",
-          "contentHash" : "3ea2444e55c07a42b7e475494d3eefa645587675",
-          "syncHash" : "979adecf7ebbd422c4ec35d29d3e46fd29f05181",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=InventoryEventListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.rest.HawkularRestApi",
-          "name" : "Servlet [org.hawkular.rest.HawkularRestApi]",
-          "identityHash" : "84ff2b3bf6ac1b16a246f8b83199b231ddb3d79",
-          "contentHash" : "d61918d1e73eb4598bb083327133ebd729375cc4",
-          "syncHash" : "31d594a78ee2cd2f2d65d76c29d7ba5cfaeede3c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=org.hawkular.rest.HawkularRestApi"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBackfillCacheManager",
-          "name" : "Singleton EJB [BackfillCacheManager]",
-          "identityHash" : "bd6e11875c39d2c06ae158a41c3df6464b533a30",
-          "contentHash" : "288bc219108342e8c97ef2de33fcd33cec443271",
-          "syncHash" : "30d5a1c218a605822a72f199d9ac47e97880da",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/singleton-bean=BackfillCacheManager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DFeedAvailabilityDataListener",
-          "name" : "Message Driven EJB [FeedAvailabilityDataListener]",
-          "identityHash" : "284cc3de5752f718cd56cac3859cd62423aa557",
-          "contentHash" : "b94a587e1ce9bb23ccbceef6694b733d041e7a5",
-          "syncHash" : "9cadf3d578cae52f22bd4c7b161a03942f47d2a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=FeedAvailabilityDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fremote-destination-outbound-socket-binding%3Dmail-smtp",
-          "name" : "Remote Destination Outbound Socket Binding [mail-smtp]",
-          "identityHash" : "8f5567368a3e0488abed7549f49cdc3b560",
-          "contentHash" : "4ec0c3c604848b38c42c4a6edc475ed7c1154",
-          "syncHash" : "fc3d51df947984cb9924763588f9021aedf37fa",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
-            "name" : "Remote Destination Outbound Socket Binding",
-            "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
-            "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
-            "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
-            "id" : "Remote Destination Outbound Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=mail-smtp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-https",
-          "name" : "Socket Binding [management-https]",
-          "identityHash" : "b5ac4a2956b86d1f152f24922dde82ad3ca66dc",
-          "contentHash" : "40aa76f8d78ac3349e73e180a4c0e690bbe11cb5",
-          "syncHash" : "ca7c0abd3e8ee2b877bb8f1156057c242b9918",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-https"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-status-manager",
-          "name" : "Socket Binding [txn-status-manager]",
-          "identityHash" : "63de5c556bf2f47fbda31b721af1d6d2c88c9e",
-          "contentHash" : "5b48a46c9e51a680549f6167f6aae133e973383",
-          "syncHash" : "ae521aa916de28bcf7e9818ff34ea41569df4a3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-status-manager"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-recovery-environment",
-          "name" : "Socket Binding [txn-recovery-environment]",
-          "identityHash" : "4cea53782366671d1f168840d3c075cc83a99083",
-          "contentHash" : "11233a14674ce338b31cc5f68f6658d1d948d",
-          "syncHash" : "16abb365abb4ce39a278ff9c7d1f8487255683c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-recovery-environment"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-http",
-          "name" : "Socket Binding [management-http]",
-          "identityHash" : "559c23ae196531eb25496c4b4d46a2dab5ac7a8",
-          "contentHash" : "d0eba94951038818d2481856c63186614f9b",
-          "syncHash" : "c6d12e11bf5ddca1172a4dd389aeb2f7414f6",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-http"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dajp",
-          "name" : "Socket Binding [ajp]",
-          "identityHash" : "244af65e7e1e55b5a852469b482eafebd95b4e25",
-          "contentHash" : "db6790ce6ce289b458312e959762f4e061b7e1bd",
-          "syncHash" : "4947a569bad6bd87f189bc34cb1b19b8f16242d3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=ajp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttps",
-          "name" : "Socket Binding [https]",
-          "identityHash" : "84d81febdaf2c958b49c8611bf91f5fd4f8335a0",
-          "contentHash" : "b17723a696316dc7ecb44406fc34d7313b91b10",
-          "syncHash" : "d368db5f6ca6286cfe5a337e759bbc7b87e646c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=https"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttp",
-          "name" : "Socket Binding [http]",
-          "identityHash" : "62f4e95378a414f03ab19a60f64c4cfc9075b",
-          "contentHash" : "cbf2764bfc934aad65762cfb5569e281c1ebd34",
-          "syncHash" : "75e3577cf7efa67df79d5dfc336b69ba54da2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Socket%20Binding",
-            "name" : "Socket Binding",
-            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
-            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
-            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
-            "id" : "Socket Binding"
-          },
-          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=http"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBusActionPluginRegister",
-          "name" : "Singleton EJB [BusActionPluginRegister]",
-          "identityHash" : "722628b893a8767753d4477d1d42bd210548c1",
-          "contentHash" : "d257564168a210f5126264de3958eff30dc56c1",
-          "syncHash" : "ebc7b543ccb9dff8955eb6bf22761928349fc4f",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
-            "name" : "Singleton EJB",
-            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
-            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
-            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
-            "id" : "Singleton EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war/subsystem=ejb3/singleton-bean=BusActionPluginRegister"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DBusActionPluginListener",
-          "name" : "Message Driven EJB [BusActionPluginListener]",
-          "identityHash" : "2dcf5264402b70817452fc6cbeebf5916135c5f",
-          "contentHash" : "4428e1cff72d34d2d179b9f673ae5afdd97143c",
-          "syncHash" : "4d2d1ab65753a0d87c9753a749869d7fa3af3d2",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-actions-email.war/subsystem=ejb3/message-driven-bean=BusActionPluginListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData",
-          "name" : "JMS Topic [HawkularAvailData]",
-          "identityHash" : "52d45ca771bc846174342df9ff28a449eee0c2",
-          "contentHash" : "6e6c882c85e3a114b61296df4ea7394844f12b58",
-          "syncHash" : "bdb7a33c761b702faeba6c54c4e33a3cb0ebfd81",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAvailData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/counters/new]",
-          "identityHash" : "79d3d6c3b8bfdf6253fa761e1a90733c826a6",
-          "contentHash" : "64b9f569ed88d2171fc81483f2e184675855ee5",
-          "syncHash" : "dbe94255b8f4f6beb3dbc599383f5da4a668fa5",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/counters/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue",
           "name" : "JMS Queue [HawkularAlertsActionsResponseQueue]",
-          "identityHash" : "2f89df98b8de26c5358e23774191987ec347d0",
+          "identityHash" : "952b944b6d9d895eb77ac499edbc4f495c3a38",
           "contentHash" : "bf6243633217684994a84e6b205ddb9043457",
-          "syncHash" : "261bacff1477605ed579df56689d487272334bc",
+          "syncHash" : "4ea96640768f803d486bbbaae2d6d21ff88c",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
             "name" : "JMS Queue",
             "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
             "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
@@ -1491,43 +978,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsActionsResponseQueue"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic",
-          "name" : "JMS Topic [HawkularTopic]",
-          "identityHash" : "993c56c39b3fbdabcf961c6d739987469e159c",
-          "contentHash" : "132c6fe445f88da736c2f97816614bd7843669",
-          "syncHash" : "278ca8b775f184d3e4133437673e372b774c119",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularTopic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
-          "name" : "JMS Queue [ExpiryQueue]",
-          "identityHash" : "ed74bf0731fb5d4d73fcb84715d7447f5bc58",
-          "contentHash" : "be8465843986b46521f790755ed20ed975fc02a",
-          "syncHash" : "9b87fd9537412bdda236374e24da8796494fe4fc",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue",
           "name" : "JMS Topic [HawkularQueue]",
-          "identityHash" : "f8df9ce1c70f3b681543bc46ffade8deae543",
+          "identityHash" : "82744b91a0bd8b2a137e28b0f69e39cef947695",
           "contentHash" : "dd68e13095c7664bc65476f3ee5563edeecbef2b",
-          "syncHash" : "40395192bff5b4d9b229be038dc3e01324c58",
+          "syncHash" : "53b9efecd6b2ac110e8e27293502966eb94ad3",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
             "name" : "JMS Topic",
             "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
             "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
@@ -1536,133 +993,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularQueue"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData",
-          "name" : "JMS Topic [HawkularAlertData]",
-          "identityHash" : "e7f57dc1b12aadc2b75ad1f2cae7903b7b7ea4",
-          "contentHash" : "7b23ec77694928edcc51d935169c6ab1da3dac7",
-          "syncHash" : "4ec24b5a34b3d59080288929aa3d5051d28998e3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic",
-          "name" : "JMS Topic [HawkularAlertsActionsTopic]",
-          "identityHash" : "828edac588a6afc7eb6b75a6fe0aa90c6e9d410",
-          "contentHash" : "257c3ac6e910183bcff651a68243f5fa5764324c",
-          "syncHash" : "8426e4a22da29809b1488407cdf98e3ebd468e4",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertsActionsTopic"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/availability/new]",
-          "identityHash" : "aad7c6218f8a49273e69c41c628aeece57b8e",
-          "contentHash" : "9dc1ddde8aa08f6ff5a5188d72679a2970113a",
-          "syncHash" : "9d9af02acde0dd93e332d5c378643227793dd3",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/availability/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue",
-          "name" : "JMS Queue [HawkularAlertsPluginsQueue]",
-          "identityHash" : "56d62887d465c7449e322cb1e9291ae65ba9e8",
-          "contentHash" : "d91e28d8d63bec9035e47b37f3211b21c8eb528",
-          "syncHash" : "74d4fbfd8725895f19ebbdabbb63daff784e7",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsPluginsQueue"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges",
-          "name" : "JMS Topic [HawkularInventoryChanges]",
-          "identityHash" : "bab0d1dd66d31ace7f45ba669e595db0859c27",
-          "contentHash" : "2ce11418d61867e6b6594bebbb521b13de13e46",
-          "syncHash" : "e7c68d56fee52e3dcb71ba72a51a1d54f8d72c",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularInventoryChanges"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
-          "name" : "JMS Queue [DLQ]",
-          "identityHash" : "d02acaaaba2970a370749fb042411d80a12c6f",
-          "contentHash" : "b7fd1bfbed2ce39f8d402fac606758a241c6708b",
-          "syncHash" : "be7ba941e9885edc820fd3e6dd3755d2787b8ea",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew",
-          "name" : "JMS Queue [hawkular/metrics/gauges/new]",
-          "identityHash" : "b9a04dc6cb9aad98c94049e0a0ce44d73d095f9",
-          "contentHash" : "34dfac349816c672f3958e517a71dac46438da7",
-          "syncHash" : "d0bc9b23276de7435a1ad6fc5ddab4a4bbdde",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Queue",
-            "name" : "JMS Queue",
-            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
-            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
-            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
-            "id" : "JMS Queue"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/gauges/new"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData",
-          "name" : "JMS Topic [HawkularMetricData]",
-          "identityHash" : "b3ef1c855abd05f4b4bd5768814fee2e8217a6",
-          "contentHash" : "ebbcb56478b2a9167fe12540c2d7f85a96bca",
-          "syncHash" : "de674a97df1444ca4c9be5faea6c9aa9ec5706",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
-            "name" : "JMS Topic",
-            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
-            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
-            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
-            "id" : "JMS Topic"
-          },
-          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularMetricData"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent",
           "name" : "JMS Topic [HawkularCommandEvent]",
-          "identityHash" : "c68f25b4dc8a501ee7abb37e90fa8f79b5b7c2b4",
+          "identityHash" : "ae17be55a3de17ba08d856b2bd20e540c722bf",
           "contentHash" : "4059e5718dadc5704f17227ea74616a3751b6e7",
-          "syncHash" : "2b5d7ec018785d0cf52b59bd23bc588424c1475",
+          "syncHash" : "9fa4fcbd688c59dc60b25357b75b085a17d4f9",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;JMS%20Topic",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
             "name" : "JMS Topic",
             "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
             "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
@@ -1671,58 +1008,178 @@ http_interactions:
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularCommandEvent"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.component.wildflymonitor.WildFlyAgentServlet",
-          "name" : "Servlet [org.hawkular.component.wildflymonitor.WildFlyAgentServlet]",
-          "identityHash" : "c3ee124ecd27a833a94ec93041cd6272e987954",
-          "contentHash" : "ea8c5721c3fc4b31a96f91d847875a91b1b7c9f",
-          "syncHash" : "7fb2c7eb9752dc38ed96d0d02ef4a49b14f4728",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/counters/new]",
+          "identityHash" : "ccac5cd28c7b156949594fdcf991eb7169d9820",
+          "contentHash" : "64b9f569ed88d2171fc81483f2e184675855ee5",
+          "syncHash" : "397e1836c11f5ceb9b6ac3829286b2348b2e181",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
           },
-          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war/subsystem=undertow/servlet=org.hawkular.component.wildflymonitor.WildFlyAgentServlet"
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/counters/new"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp",
-          "name" : "Servlet [org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp]",
-          "identityHash" : "c991134cc7b03f7cfc7a591fa0d92aa05bf2b85c",
-          "contentHash" : "a1e8def843659d7df3781cb01642199d53f54199",
-          "syncHash" : "3276202f48324bbe4ed1e025f6af6fcbaa848d3a",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/gauges/new]",
+          "identityHash" : "d8c929cf469895d4641c321994c32ed6a93dc",
+          "contentHash" : "34dfac349816c672f3958e517a71dac46438da7",
+          "syncHash" : "32a3647bd3b41b8b0b5d121de2255573c774c1",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
           },
-          "id" : "Local~/deployment=hawkular-metrics-component.war/subsystem=undertow/servlet=org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp"
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/gauges/new"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war%2Fsubsystem%3Dundertow%2Fservlet%3DstaticContent",
-          "name" : "Servlet [staticContent]",
-          "identityHash" : "ac6fa1d991457eb824929cccc9aea86f4512888",
-          "contentHash" : "e16131c1e93e9f3449f8f8ce7f97064365cc794",
-          "syncHash" : "13417c2029ab6f5752b9a51e9ea87b7798757bd8",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue",
+          "name" : "JMS Queue [ExpiryQueue]",
+          "identityHash" : "b487287b92ec4393b616e7eead4fe36f7fc58f",
+          "contentHash" : "be8465843986b46521f790755ed20ed975fc02a",
+          "syncHash" : "9429405d40c24ccbaa721649f79074d4d38db332",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
           },
-          "id" : "Local~/deployment=hawkular-metrics-component.war/subsystem=undertow/servlet=staticContent"
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=ExpiryQueue"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-services",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData",
+          "name" : "JMS Topic [HawkularAlertData]",
+          "identityHash" : "54ae2840ca593c48e9bba2754981aa3ae559f",
+          "contentHash" : "7b23ec77694928edcc51d935169c6ab1da3dac7",
+          "syncHash" : "9e236322d0cff6cad5352858d164edde28da6392",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic",
+          "name" : "JMS Topic [HawkularAlertsActionsTopic]",
+          "identityHash" : "5889aa881d8bff121ebb925eaf114746d1d5f32",
+          "contentHash" : "257c3ac6e910183bcff651a68243f5fa5764324c",
+          "syncHash" : "5fbe2b52aebb4bffba938ef1503f2bdc0335438",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertsActionsTopic"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges",
+          "name" : "JMS Topic [HawkularInventoryChanges]",
+          "identityHash" : "a65dc6f4769749147f980e115c3df75c6f3f",
+          "contentHash" : "2ce11418d61867e6b6594bebbb521b13de13e46",
+          "syncHash" : "b7dbb7317e6d84c4a998b75fe5f07385483cd",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularInventoryChanges"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew",
+          "name" : "JMS Queue [hawkular/metrics/availability/new]",
+          "identityHash" : "22141a9cd1fc936b2e3ec6d4229e9ed0c7997bb",
+          "contentHash" : "9dc1ddde8aa08f6ff5a5188d72679a2970113a",
+          "syncHash" : "141a6d72a32bb6bdca4eb35f946386e164ac9c8e",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=hawkular/metrics/availability/new"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue",
+          "name" : "JMS Queue [HawkularAlertsPluginsQueue]",
+          "identityHash" : "a4e24717a74c21af76cb9178d252ab323506b89",
+          "contentHash" : "d91e28d8d63bec9035e47b37f3211b21c8eb528",
+          "syncHash" : "3d101a3fb22d9c0c4ff2919c757e11f9dc77eb",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=HawkularAlertsPluginsQueue"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ",
+          "name" : "JMS Queue [DLQ]",
+          "identityHash" : "50f15f3696874d828449c246718bdd3323f9a8",
+          "contentHash" : "b7fd1bfbed2ce39f8d402fac606758a241c6708b",
+          "syncHash" : "7d23cd95f6d2f16e4be0f39d95a231e555fe7a50",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Queue",
+            "name" : "JMS Queue",
+            "identityHash" : "e231d2d4c8c38b428725c32f4e695fad772c1db8",
+            "contentHash" : "75b04b43485b3d9ee4da2153e44944e2f63ef",
+            "syncHash" : "646cd44497a45d7afbdabbd466c412829c3262",
+            "id" : "JMS Queue"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic",
+          "name" : "JMS Topic [HawkularTopic]",
+          "identityHash" : "8435ce1b2dfe4f1ad04928a5e8c7fb648baf785",
+          "contentHash" : "132c6fe445f88da736c2f97816614bd7843669",
+          "syncHash" : "e74f4fd6cb5c1a214022e625ed4c72b65d19259",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;JMS%20Topic",
+            "name" : "JMS Topic",
+            "identityHash" : "75c24027bbd562b062152731fd59a0cee80ffa2",
+            "contentHash" : "2eb3b63ebb579817658d11a75d0299b2daf334a",
+            "syncHash" : "f3d5fa41258b4ab487abd41428b89a15372533",
+            "id" : "JMS Topic"
+          },
+          "id" : "Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularTopic"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-metrics",
+          "name" : "Infinispan Cache Container [hawkular-metrics]",
+          "identityHash" : "ff5b7837c537c6e19ca48acd83e0a673bab4198f",
+          "contentHash" : "d9a3a3237f06fa14883ab93c88ed9f417db59f0",
+          "syncHash" : "5fbd554c72ca85bb6f2732746888f627e1fd3b",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-metrics"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-services",
           "name" : "Infinispan Cache Container [hawkular-services]",
           "identityHash" : "8374cd28e214ec8b9be620b3bb3bd25f6c4eac",
           "contentHash" : "65ec123fa39c4e749c775918ac515dbb1288a5",
           "syncHash" : "13224deb7eeb8766c63f4566b7995429263ee91",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -1731,13 +1188,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=hawkular-services"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhibernate",
           "name" : "Infinispan Cache Container [hibernate]",
           "identityHash" : "4025a3689a6a5cf962aa46d0f6b081a8fbee466",
           "contentHash" : "5a777a7148a779aa56734ce2e4d8e7c3e2e61ab",
           "syncHash" : "ec6a149ea245f551fedd1188e62c1e159aeed4f",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -1746,13 +1203,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=hibernate"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dejb",
           "name" : "Infinispan Cache Container [ejb]",
           "identityHash" : "68c0b22be25496dc6265938f39d77b24485ce9c0",
           "contentHash" : "8b679c14ec55cd786065fee979cb6a17c4e44",
           "syncHash" : "3bfe56952250d98f6cff6f7eafea54be5e2d993",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -1761,28 +1218,13 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=ejb"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-alerts",
-          "name" : "Infinispan Cache Container [hawkular-alerts]",
-          "identityHash" : "bbebfb8789bf5d3e45a36abc3d9379f86da2d",
-          "contentHash" : "4c41305fab18f53a59a6e5fff8eacecceabd5647",
-          "syncHash" : "b34524e8a03de3772884c3b683f2ef162ede4a6",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
-            "name" : "Infinispan Cache Container",
-            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
-            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
-            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
-            "id" : "Infinispan Cache Container"
-          },
-          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-alerts"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dserver",
           "name" : "Infinispan Cache Container [server]",
           "identityHash" : "9140987ff67afe217c820a260cc4d6cb782564",
           "contentHash" : "d81fd4695e41fcf94e311556eab6e1f32ceb6cb8",
           "syncHash" : "33b186309bbdf0afcbef11d32ac2bbba63d1e1bd",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -1791,13 +1233,28 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=server"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dhawkular-alerts",
+          "name" : "Infinispan Cache Container [hawkular-alerts]",
+          "identityHash" : "bbebfb8789bf5d3e45a36abc3d9379f86da2d",
+          "contentHash" : "4c41305fab18f53a59a6e5fff8eacecceabd5647",
+          "syncHash" : "b34524e8a03de3772884c3b683f2ef162ede4a6",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
+            "name" : "Infinispan Cache Container",
+            "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
+            "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
+            "syncHash" : "f2771559147eedc294f187c9d2acfa94df82175",
+            "id" : "Infinispan Cache Container"
+          },
+          "id" : "Local~/subsystem=infinispan/cache-container=hawkular-alerts"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan/r;Local~%2Fsubsystem%3Dinfinispan%2Fcache-container%3Dweb",
           "name" : "Infinispan Cache Container [web]",
           "identityHash" : "d3bdd424a8671ff0fe63139a13eb8e834373d5ac",
           "contentHash" : "ca9516408b86fb4bf97daa8f6439347aa615356",
           "syncHash" : "199798bea9193cb52eee18be90a219d1eaeb65d0",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Infinispan%20Cache%20Container",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Infinispan%20Cache%20Container",
             "name" : "Infinispan Cache Container",
             "identityHash" : "53f33112d2fa8726fd7a36b3b09827b874f36c2",
             "contentHash" : "58e8394667e6d252b359de36a5fd148a2c15352",
@@ -1806,326 +1263,761 @@ http_interactions:
           },
           "id" : "Local~/subsystem=infinispan/cache-container=web"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DActionPluginRegistrationListener",
-          "name" : "Message Driven EJB [ActionPluginRegistrationListener]",
-          "identityHash" : "71be63102d997cb6a8577981a993bc53ff3747b",
-          "contentHash" : "9cbcffc664d78afe6b55cbdd9d48edbf7f1919",
-          "syncHash" : "89d82f65b8d33c0c1c5a126ba114fc13b68f82f",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularTopicListener",
+          "name" : "Message Driven EJB [HawkularTopicListener]",
+          "identityHash" : "bc114a20b84a28679165ea3351fc8fd68fbafb0",
+          "contentHash" : "b6d3cdf29a882af2494fc7bd79f8aad45c9216",
+          "syncHash" : "1a664eac518c57eebd7fd064b3a085eb492282f3",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
             "name" : "Message Driven EJB",
             "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
             "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
             "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
             "id" : "Message Driven EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=ActionPluginRegistrationListener"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularTopicListener"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DCacheManager",
-          "name" : "Singleton EJB [CacheManager]",
-          "identityHash" : "763a897fe1def1661759fbd041d62cf072ded",
-          "contentHash" : "4c92d93bfb695befde72a6e77ea1a852dcfcae",
-          "syncHash" : "3d4e3cf27f7e17484bf5ac12ae3d2e9af3b5c88",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DHawkularQueueListener",
+          "name" : "Message Driven EJB [HawkularQueueListener]",
+          "identityHash" : "f76a2c8d3288e95ea6fd11faa6d5f8e7a5d1552",
+          "contentHash" : "74a0db3da72d8b1cb4d7ba03f570b5ea48d1f5",
+          "syncHash" : "d0378788c0f14749cec4649abf4beb042275e7",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=HawkularQueueListener"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.rest.HawkularRestApi",
+          "name" : "Servlet [org.hawkular.rest.HawkularRestApi]",
+          "identityHash" : "8e1e464a77fad532eea55c232bde49352ca48e",
+          "contentHash" : "d61918d1e73eb4598bb083327133ebd729375cc4",
+          "syncHash" : "5ec7b68be720733481aafbf7ce5f32e86856778",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=org.hawkular.rest.HawkularRestApi"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DFeedAvailabilityDataListener",
+          "name" : "Message Driven EJB [FeedAvailabilityDataListener]",
+          "identityHash" : "4355373b9f1f5af094206dd646ccc1ac15a7fe79",
+          "contentHash" : "b94a587e1ce9bb23ccbceef6694b733d041e7a5",
+          "syncHash" : "39973d5178ebd4639cdabce384b740cdeb686c5e",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=FeedAvailabilityDataListener"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DCommandEventListener",
+          "name" : "Message Driven EJB [CommandEventListener]",
+          "identityHash" : "37d5e2968d8f3d28eab2059b6ea9f082ae6e55",
+          "contentHash" : "51f2121ca985cdac97f693c4e87cfdf433a6ac7",
+          "syncHash" : "736da5cfaf090e7f2033585af6f44a9554f2e",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=CommandEventListener"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dundertow%2Fservlet%3DHystrixMetricsStreamServlet",
+          "name" : "Servlet [HystrixMetricsStreamServlet]",
+          "identityHash" : "16161cb68760d84da8706afd423ebbf829db6dfe",
+          "contentHash" : "57b26a489a755ea379a116ae7dd25dc6e6964896",
+          "syncHash" : "3d32e2b526f6d116df3e897737720b217b0d026",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=undertow/servlet=HystrixMetricsStreamServlet"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DBackfillCacheManager",
+          "name" : "Singleton EJB [BackfillCacheManager]",
+          "identityHash" : "e852958f43c866c5c28dfad6b183ce1674fe2133",
+          "contentHash" : "288bc219108342e8c97ef2de33fcd33cec443271",
+          "syncHash" : "778afeca93af76a21dca1d4d6afcd97cf2ef5ec5",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=CacheManager"
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/singleton-bean=BackfillCacheManager"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassAlertsServiceImpl",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/r;Local~%2Fdeployment%3Dhawkular-rest-api.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DInventoryEventListener",
+          "name" : "Message Driven EJB [InventoryEventListener]",
+          "identityHash" : "498e582aa16c0cce14cd8f87f314c1f3265f",
+          "contentHash" : "3ea2444e55c07a42b7e475494d3eefa645587675",
+          "syncHash" : "fdb3a8832d4e0c0cf805ea53d1dccd412322954",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-rest-api.war/subsystem=ejb3/message-driven-bean=InventoryEventListener"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fremote-destination-outbound-socket-binding%3Dmail-smtp",
+          "name" : "Remote Destination Outbound Socket Binding [mail-smtp]",
+          "identityHash" : "8f5567368a3e0488abed7549f49cdc3b560",
+          "contentHash" : "4ec0c3c604848b38c42c4a6edc475ed7c1154",
+          "syncHash" : "fc3d51df947984cb9924763588f9021aedf37fa",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Remote%20Destination%20Outbound%20Socket%20Binding",
+            "name" : "Remote Destination Outbound Socket Binding",
+            "identityHash" : "35c9cb7b4ea86e90f10e3fe64c6d14d3456ee96",
+            "contentHash" : "ae41459183688898119286f4e1d5c972297b54f",
+            "syncHash" : "5d39254c7e28d0fbbd30d6f34e7c51bfb8f3a1ce",
+            "id" : "Remote Destination Outbound Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=mail-smtp"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-recovery-environment",
+          "name" : "Socket Binding [txn-recovery-environment]",
+          "identityHash" : "4cea53782366671d1f168840d3c075cc83a99083",
+          "contentHash" : "11233a14674ce338b31cc5f68f6658d1d948d",
+          "syncHash" : "16abb365abb4ce39a278ff9c7d1f8487255683c",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-recovery-environment"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-https",
+          "name" : "Socket Binding [management-https]",
+          "identityHash" : "35fba6824b5f3b1cf29138545bec67de312eaa1c",
+          "contentHash" : "40aa76f8d78ac3349e73e180a4c0e690bbe11cb5",
+          "syncHash" : "bcd793ec232d5c74af92c576740a659ec9e6f36",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-https"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttp",
+          "name" : "Socket Binding [http]",
+          "identityHash" : "69d234f1f2fe88986b9cccc1e6b9e5b1fd1ef6e",
+          "contentHash" : "cbf2764bfc934aad65762cfb5569e281c1ebd34",
+          "syncHash" : "cc52e9196fe761ac46ae47f163695e91376e9eb",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=http"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dajp",
+          "name" : "Socket Binding [ajp]",
+          "identityHash" : "304cf7f1b5ca5560824096d8b2cbbd2b5d2e65bd",
+          "contentHash" : "db6790ce6ce289b458312e959762f4e061b7e1bd",
+          "syncHash" : "d156a555983b5fdfeddb2b85ecaa29c4869738",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=ajp"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dhttps",
+          "name" : "Socket Binding [https]",
+          "identityHash" : "5db7ca31ed6268ebe89f7012dce398f3f58e8d7c",
+          "contentHash" : "b17723a696316dc7ecb44406fc34d7313b91b10",
+          "syncHash" : "4aa7946c118c2ad71a38a665b9dfb7143ee5682",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=https"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dmanagement-http",
+          "name" : "Socket Binding [management-http]",
+          "identityHash" : "0ec285d1d4125503c260293a5472c4f55a75c",
+          "contentHash" : "d0eba94951038818d2481856c63186614f9b",
+          "syncHash" : "d79d1fdf3d915e6d67bc49b68ea9f858315f068",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=management-http"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets/r;Local~%2Fsocket-binding-group%3Dstandard-sockets%2Fsocket-binding%3Dtxn-status-manager",
+          "name" : "Socket Binding [txn-status-manager]",
+          "identityHash" : "63de5c556bf2f47fbda31b721af1d6d2c88c9e",
+          "contentHash" : "5b48a46c9e51a680549f6167f6aae133e973383",
+          "syncHash" : "ae521aa916de28bcf7e9818ff34ea41569df4a3",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Socket%20Binding",
+            "name" : "Socket Binding",
+            "identityHash" : "9e8eefdeb8e37da1b2fa96e756b262caeea5",
+            "contentHash" : "2f81bc49e564e3806c1179824029ffcac3ecb8ed",
+            "syncHash" : "429b6e781fd8cc8734d8e7c74dcded0cf716a39",
+            "id" : "Socket Binding"
+          },
+          "id" : "Local~/socket-binding-group=standard-sockets/socket-binding=txn-status-manager"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war",
+          "name" : "SubDeployment [hawkular-alerts-action-email.war]",
+          "identityHash" : "a2e28226d1c48f3be23add52cc7df62446b38e3f",
+          "contentHash" : "616971c77a2c9d21697a13ea781a26d1352aa4",
+          "syncHash" : "c0a087f86a80d4eb79d69e137917053192ed44",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war",
+          "name" : "SubDeployment [hawkular-alerts.war]",
+          "identityHash" : "77aa19e9b7bc74b33879d191c054f8644a3dff8a",
+          "contentHash" : "867658459c1c9be3286209898fb799345ed7ca",
+          "syncHash" : "dfa8abcdd8665514c94e35de6723ba458c5499a",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war",
+          "name" : "SubDeployment [hawkular-metrics-alerter.war]",
+          "identityHash" : "a999821d422e3c3b145ffd227eee41a6ca338e1",
+          "contentHash" : "e2d665615c785368de3512a48a401740c23c3910",
+          "syncHash" : "474e957dc2614e3412c685843eed5d526426f877",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war",
+          "name" : "SubDeployment [hawkular-metrics.war]",
+          "identityHash" : "595dba7424fb2aacbeae436dfb7d43e975793c6",
+          "contentHash" : "77d9f4923eb55950d2c034c5be73aeef28faee",
+          "syncHash" : "82ebf81c80e1c1bea894c68ff6ffebd6bfa1de2b",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war",
+          "name" : "SubDeployment [hawkular-alerts-action-webhook.war]",
+          "identityHash" : "d6bd3531d77f7113840e5c629ba2b562bbfaf84",
+          "contentHash" : "4a4ecc5d65f364483f56ba43eb78732aaa47b375",
+          "syncHash" : "eef84b9f1ac54469cd2413acf3e233667ee151",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;SubDeployment",
+            "name" : "SubDeployment",
+            "identityHash" : "e7c36274c35e9eeeb9564de6c5e7f14697bdbdc",
+            "contentHash" : "ed9a1f4e8965cb7c17a2278f406ef1d9bae45d7",
+            "syncHash" : "a7fcbe50b890591b1346776254aa8c2826ec4b3f",
+            "id" : "SubDeployment"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.component.wildflymonitor.WildFlyAgentServlet",
+          "name" : "Servlet [org.hawkular.component.wildflymonitor.WildFlyAgentServlet]",
+          "identityHash" : "986d25e628f1b083e323b4d7e2ecd71ebe50a2",
+          "contentHash" : "ea8c5721c3fc4b31a96f91d847875a91b1b7c9f",
+          "syncHash" : "35c9bb85f8c3a8fa68fd717c11ee00c72f2f96",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-wildfly-agent-download.war/subsystem=undertow/servlet=org.hawkular.component.wildflymonitor.WildFlyAgentServlet"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/r;Local~%2Fdeployment%3Dhawkular-status.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.services.rest.HawkularServicesStatusApp",
+          "name" : "Servlet [org.hawkular.services.rest.HawkularServicesStatusApp]",
+          "identityHash" : "83d9de24789a68dc2bbfd4609788b760426ed1e8",
+          "contentHash" : "c14bdf75c5f086b26bf840c65b1d2fbe3cd338",
+          "syncHash" : "45d05742f2f272dfa74d177263fa4fbda21b5046",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-status.war/subsystem=undertow/servlet=org.hawkular.services.rest.HawkularServicesStatusApp"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.inventory.rest.HawkularRestApi",
+          "name" : "Servlet [org.hawkular.inventory.rest.HawkularRestApi]",
+          "identityHash" : "80337581f72317f468f2dd31716d04ab8354b4a",
+          "contentHash" : "80c5f042a119325548bd8871f4b1843eff977cde",
+          "syncHash" : "17fd6915d4e4d613fe83ff163a41c1575583a6f",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=undertow/servlet=org.hawkular.inventory.rest.HawkularRestApi"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DInventoryJNDIPublisher",
+          "name" : "Singleton EJB [InventoryJNDIPublisher]",
+          "identityHash" : "58b0a4d97efa43c015978f1429b794f9e0677c10",
+          "contentHash" : "d6f27fdf33cb9586cc2ed3d548a8a7535d7e8d7",
+          "syncHash" : "211c145a95d8d5ef13ce7d2bdfce0946ff061ca",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war/subsystem=ejb3/singleton-bean=InventoryJNDIPublisher"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war%2Fsubsystem%3Dundertow%2Fservlet%3Djavax.ws.rs.core.Application",
+          "name" : "Servlet [javax.ws.rs.core.Application]",
+          "identityHash" : "972668b4a5a653ad4dfb9125219e7b026918095",
+          "contentHash" : "e4bf16a56b698d3b32ebc024f147b088f2a31569",
+          "syncHash" : "afa690fff91bb76d358ff0526a5740fff7eb1068",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
+            "name" : "Servlet",
+            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
+            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
+            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
+            "id" : "Servlet"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war/subsystem=undertow/servlet=javax.ws.rs.core.Application"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-email.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DStandaloneActionPluginRegister",
+          "name" : "Singleton EJB [StandaloneActionPluginRegister]",
+          "identityHash" : "74fca4c2ca845d49b3d2377252eb97225c96eeaf",
+          "contentHash" : "25b3e9b28fa3c68b5e0cee8b40bb626a26a3bf",
+          "syncHash" : "2d94831b2538ed1f92be2cfe09c7c69e7697ae",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-email.war/subsystem=ejb3/singleton-bean=StandaloneActionPluginRegister"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassAlertsServiceImpl",
           "name" : "Stateless Session EJB [CassAlertsServiceImpl]",
-          "identityHash" : "47bc76ca4099417d1981c3549f3e13ab8013debb",
-          "contentHash" : "f474a07c477cc96c4867c2e5747e2710709ba423",
-          "syncHash" : "f5dd0347b9ce67e738ec41dceed138bb8bf44",
+          "identityHash" : "5a538597d277a0a860a19585b286fc1866e24ec",
+          "contentHash" : "372b9dcd629699a632ac481199641c3a31e4c0",
+          "syncHash" : "6e5eb1bd97dc64cc040a01d957012fdced9944",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateless%20Session%20EJB",
             "name" : "Stateless Session EJB",
             "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
             "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
             "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
             "id" : "Stateless Session EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassAlertsServiceImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassAlertsServiceImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassDefinitionsServiceImpl",
-          "name" : "Stateless Session EJB [CassDefinitionsServiceImpl]",
-          "identityHash" : "f7ce5790e967e45b86c1985e2b6e91f3d8a5ffd",
-          "contentHash" : "85a5198d542fca9809ff1be02ee252cf8466",
-          "syncHash" : "1a111aa66e406a94cc9fa187303b7a63846dd2c1",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPublishCacheManager",
+          "name" : "Singleton EJB [PublishCacheManager]",
+          "identityHash" : "23e20a7199f1419452faaf7c57f755a047a3",
+          "contentHash" : "a31b1880af3c187940fa984e6e8dfe77e29165d",
+          "syncHash" : "95a518aaf86c4aa5dfb4b2efb3cb8a5fbb9549",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
-            "name" : "Stateless Session EJB",
-            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
-            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
-            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
-            "id" : "Stateless Session EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassDefinitionsServiceImpl"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAlertDataListener",
-          "name" : "Message Driven EJB [AlertDataListener]",
-          "identityHash" : "8e6e34cacca395b88eb5c6ceef273569d65df7b",
-          "contentHash" : "b39e12f327683b13e45796b63fe7023f91fc98",
-          "syncHash" : "24fa8a258af3ecbed5bfe1a41276ef41b44eba",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=AlertDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.rest.HawkularAlertsApp",
-          "name" : "Servlet [org.hawkular.alerts.rest.HawkularAlertsApp]",
-          "identityHash" : "d79ae59a06ba827d670c962e23e3b728833adf9",
-          "contentHash" : "76aabb1808c205f5a27253cb1c5605066e8f8f",
-          "syncHash" : "714f8c6654613a2caf8c151a7754eae96c25881b",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
-            "name" : "Servlet",
-            "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
-            "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
-            "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
-            "id" : "Servlet"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=undertow/servlet=org.hawkular.alerts.rest.HawkularAlertsApp"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DActionPluginResponsesListener",
-          "name" : "Message Driven EJB [ActionPluginResponsesListener]",
-          "identityHash" : "e063a22b9c16473392d9641143f5b8a7cbfc13f",
-          "contentHash" : "299c733513731bf02c3ab12ffea5dfbd84d99f",
-          "syncHash" : "6ed55fdd567b7a0a68d97eaf1fa14b574cf990",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=ActionPluginResponsesListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDroolsRulesEngineImpl",
-          "name" : "Singleton EJB [DroolsRulesEngineImpl]",
-          "identityHash" : "c66f8e6f723b75d75cf3d1937ccfbc0dcb6dc1a",
-          "contentHash" : "777b133977b0b09520df64e695ed62505ec8bb",
-          "syncHash" : "56d2f3b4b4488583107f86c3e7458bac389bef5",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=DroolsRulesEngineImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PublishCacheManager"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPartitionManagerImpl",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPartitionManagerImpl",
           "name" : "Singleton EJB [PartitionManagerImpl]",
-          "identityHash" : "5a81475ebeac2a25da2085cc74e629276d5690",
-          "contentHash" : "205b89cd629ffa187cf6849e46fae45aafbbcbf",
-          "syncHash" : "b3386b58a655ca9ff0fbd0222a1ae836d5cb5e7",
+          "identityHash" : "8c43f0fff49a1b3f6bfa685262541f461c8c4d",
+          "contentHash" : "8aad7835a13a570c0c7d06277f8322f89fe80",
+          "syncHash" : "3485d47a1bdf792677ea86d4b5d151e0cda0c771",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=PartitionManagerImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PartitionManagerImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DMetricDataListener",
-          "name" : "Message Driven EJB [MetricDataListener]",
-          "identityHash" : "bb96ae88a2d28d7144cda899ee316093ff7a95",
-          "contentHash" : "9cdcead6a37570ded0ea4befe869eea7111b4a22",
-          "syncHash" : "fcc03efc7ec430428b9c4014f5a438a6682d9c7c",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DActionsCacheManager",
+          "name" : "Singleton EJB [ActionsCacheManager]",
+          "identityHash" : "8d22bab95768d8e3c7b25ecf5b6bf68165e6f76",
+          "contentHash" : "95cf657f26427d8dcb2ec788b4e7fbb4e6c99cd",
+          "syncHash" : "69d98ed83cf660199ef63eeda9c741075be9ebd",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=MetricDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertEngineRegister",
-          "name" : "Singleton EJB [AlertEngineRegister]",
-          "identityHash" : "a0effaf4d23f68867f510e9d9035db740ce39",
-          "contentHash" : "9436e69b459f9379a915e886ff8592c18ab182",
-          "syncHash" : "98958dffd932b1f6623f7a4121b378df6723c6d",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertEngineRegister"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=ActionsCacheManager"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsContext",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsContext",
           "name" : "Singleton EJB [AlertsContext]",
-          "identityHash" : "ea316f2f77da5d7744b1257ce24416f614b921b",
-          "contentHash" : "801922d756979ae0da204ccd1664bec8eb6491",
-          "syncHash" : "2d59365b1d279c4906d28e9abf2c6bb0b4a81",
+          "identityHash" : "d557469adc1e732e8fcaad7242dac9205035e614",
+          "contentHash" : "115754177edcf6c74d2c4164eec955497993f3",
+          "syncHash" : "2c2bab199aa0aa5020e1d18c5e4beeadbd59ba17",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertsContext"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=AlertsContext"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAvailDataListener",
-          "name" : "Message Driven EJB [AvailDataListener]",
-          "identityHash" : "6d9d9e655a6d9fc6b21078bc89233cceb6a84a67",
-          "contentHash" : "af24f9e1207e11ad84d0f8847f869153eac568f7",
-          "syncHash" : "73877f89a4c41424e477dfd24cf2e46cec5318",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DPropertiesServiceImpl",
+          "name" : "Singleton EJB [PropertiesServiceImpl]",
+          "identityHash" : "edb818f118e217f22ca2069b2bbd64b289433ad",
+          "contentHash" : "44a9bbcc6392b24c713352c6caf9c91d89e2c82",
+          "syncHash" : "cd54409aad4baf9b27f91d174a16c199ffd9799",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Message%20Driven%20EJB",
-            "name" : "Message Driven EJB",
-            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
-            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
-            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
-            "id" : "Message Driven EJB"
-          },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/message-driven-bean=AvailDataListener"
-        }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDataDrivenGroupCacheManager",
-          "name" : "Singleton EJB [DataDrivenGroupCacheManager]",
-          "identityHash" : "8c38614cb897e9c78409327324ce39b68ac65d9",
-          "contentHash" : "1ba3fcf9f1d084facb846b3c35dd774fcbf8d6d",
-          "syncHash" : "396f778596aca846d46439b395e6db8721826a",
-          "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=DataDrivenGroupCacheManager"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=PropertiesServiceImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsEngineImpl",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DAlertsEngineImpl",
           "name" : "Singleton EJB [AlertsEngineImpl]",
-          "identityHash" : "fd905b10a7620258d7a920368980cac830e62d",
-          "contentHash" : "eab04a5efa45190db94861b5f11fa56af3a290",
-          "syncHash" : "507d1df6fe62c910d5dbfbc8e15e405c1ef28173",
+          "identityHash" : "74b0498a8012cf66895c24f7a9eabd9112cd9fc2",
+          "contentHash" : "99e7d8d08695fa6512ac9395b3dbcf5a02f1d72",
+          "syncHash" : "26a033fede71382dfab7395e73805026db629e22",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Singleton%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
             "name" : "Singleton EJB",
             "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
             "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
             "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
             "id" : "Singleton EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/singleton-bean=AlertsEngineImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=AlertsEngineImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassActionsServiceImpl",
-          "name" : "Stateless Session EJB [CassActionsServiceImpl]",
-          "identityHash" : "573d391f59dc88960876a6a98941274c2f403b",
-          "contentHash" : "1267c32e2aee569563398f8c57416f57affa81a5",
-          "syncHash" : "d2ca1652ecb31d75f639407da5d67d6084712b28",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDroolsRulesEngineImpl",
+          "name" : "Singleton EJB [DroolsRulesEngineImpl]",
+          "identityHash" : "5ab2cf59ec953b83f31bc7f84f5c14cc13382",
+          "contentHash" : "c89a4071954658cfc93e34ebe6913414721c6575",
+          "syncHash" : "3bda1b3eac8d68cf0ed1251739df9f3ef66cc",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Stateless%20Session%20EJB",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=DroolsRulesEngineImpl"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassDefinitionsServiceImpl",
+          "name" : "Stateless Session EJB [CassDefinitionsServiceImpl]",
+          "identityHash" : "ca4eac54fd0f221b4bb2f2fa76359cb1e3892c7",
+          "contentHash" : "74ca92bb5f2a785c68adc366bd5cfcfce84a0eb",
+          "syncHash" : "632e168e6958e3814a2f25decc31bf1ad7a8c",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateless%20Session%20EJB",
             "name" : "Stateless Session EJB",
             "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
             "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
             "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
             "id" : "Stateless Session EJB"
           },
-          "id" : "Local~/deployment=hawkular-alerts-rest.war/subsystem=ejb3/stateless-session-bean=CassActionsServiceImpl"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassDefinitionsServiceImpl"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_2.war/r;Local~%2Fdeployment%3Dsample_2.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "1648bb92a1f33596a647692b29c9e9735f953fc",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "c724af55a81112d42444b11f3d72d38ccd8",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.rest.HawkularAlertsApp",
+          "name" : "Servlet [org.hawkular.alerts.rest.HawkularAlertsApp]",
+          "identityHash" : "154327da17b8bc11104b2448743e34111fcfc56",
+          "contentHash" : "3ca457d49e546add93cae38ff782a4c472ac2ea1",
+          "syncHash" : "dc953ab31fc9a82ab05eee32846c2ad615cf59b",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample_2.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=undertow/servlet=org.hawkular.alerts.rest.HawkularAlertsApp"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample3.war/r;Local~%2Fdeployment%3Dsample3.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "8113a5362bdf623555c1311da821b19b470e16b",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "7b3f5b75bbb08eacac3db74ebd25fcea2fd74f7",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DIncomingDataManagerImpl",
+          "name" : "Singleton EJB [IncomingDataManagerImpl]",
+          "identityHash" : "a4f3e97ee6c8274b453d6384c1877210253ae",
+          "contentHash" : "ce9fece4768677988fe9bb72ee8ba70e9f51a91",
+          "syncHash" : "ce7883b13565c4b9996359b69c57c69be79087ec",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=IncomingDataManagerImpl"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DCassActionsServiceImpl",
+          "name" : "Stateless Session EJB [CassActionsServiceImpl]",
+          "identityHash" : "13ec8236d28b58c3b64b71af273e44dfd4d5f65e",
+          "contentHash" : "c898b10c8cf8faab3c0f2c57159bb6d653a568",
+          "syncHash" : "d95af72fbf7fb8ec22d8e0d3f9813f9b6f224167",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateless%20Session%20EJB",
+            "name" : "Stateless Session EJB",
+            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+            "id" : "Stateless Session EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=CassActionsServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DCassCluster",
+          "name" : "Singleton EJB [CassCluster]",
+          "identityHash" : "4d1d8a5dcef3da8a1c5545c03d6c44c6764695",
+          "contentHash" : "9cab617cb65b3c4968db7b1afecb15d93daa3ae",
+          "syncHash" : "6e2197af2a7ac1df1bd6c65f1865dade3de4",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=CassCluster"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DDataDrivenGroupCacheManager",
+          "name" : "Singleton EJB [DataDrivenGroupCacheManager]",
+          "identityHash" : "c4af93935ac719c1eb5acb9d2382e6daaebd63d",
+          "contentHash" : "641b914d31a1a992635a9a742b22b3d716ce16b",
+          "syncHash" : "84f12c597faa64f671d85d36c29d570be962f69",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/singleton-bean=DataDrivenGroupCacheManager"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fmessage-driven-bean%3DAlertDataListener",
+          "name" : "Message Driven EJB [AlertDataListener]",
+          "identityHash" : "a39f33855f73a66c5bb5a3b2ae1bc21265b65c5",
+          "contentHash" : "433c82c5758cbe974057ca2cf3218692d5ab66f5",
+          "syncHash" : "723fd85db753dcdf4f1c6e325a7fd5543d2448c",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Message%20Driven%20EJB",
+            "name" : "Message Driven EJB",
+            "identityHash" : "2eee38e96ef09ab44422a49bc5a8623596a34bc",
+            "contentHash" : "f410641c3079566b173ec6274a361357a77cd49",
+            "syncHash" : "5a568d8bb5d49c38a303f667fa432a3de6b5cfd",
+            "id" : "Message Driven EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/message-driven-bean=AlertDataListener"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts.war%2Fsubsystem%3Dejb3%2Fstateless-session-bean%3DStatusServiceImpl",
+          "name" : "Stateless Session EJB [StatusServiceImpl]",
+          "identityHash" : "5720b4b9db49b0225dbd896752d1966c914f8371",
+          "contentHash" : "8211793411ac16388c48653d899c15deed1034",
+          "syncHash" : "b1a19920e15a52f684e4608fbbbcd569b797f3ac",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Stateless%20Session%20EJB",
+            "name" : "Stateless Session EJB",
+            "identityHash" : "8db06fc15c4b85fdfc5843944dde9594652a634",
+            "contentHash" : "bfa5b10fe4963014f26cdf5a6541b7f42814",
+            "syncHash" : "dc33e68f960d5393464f9cec9e915d5842b3835",
+            "id" : "Stateless Session EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts.war/subsystem=ejb3/stateless-session-bean=StatusServiceImpl"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DExpressionManager",
+          "name" : "Singleton EJB [ExpressionManager]",
+          "identityHash" : "5b875bbadbdb8c6262de18bf1d503da5cbe38",
+          "contentHash" : "514614863fc97b479ae7ae97bfa24ff174c9c95",
+          "syncHash" : "42add53ba92e8932db83b9f4b7465db18442fbc4",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war/subsystem=ejb3/singleton-bean=ExpressionManager"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics-alerter.war%2Fsubsystem%3Dundertow%2Fservlet%3Djavax.ws.rs.core.Application",
+          "name" : "Servlet [javax.ws.rs.core.Application]",
+          "identityHash" : "8be8cb6d7d2a4cf22c39d1396414fa5eb42c087",
+          "contentHash" : "e4bf16a56b698d3b32ebc024f147b088f2a31569",
+          "syncHash" : "b8bc44bb6c77cd0452c9a2ecd5248111260048",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample3.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics-alerter.war/subsystem=undertow/servlet=javax.ws.rs.core.Application"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample4.war/r;Local~%2Fdeployment%3Dsample4.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "4fd4e46c7d1f7993c917f12139bb733c9c872fd",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "ae2180a5a7b18e24fde86f6932ba90881bbc35",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp",
+          "name" : "Servlet [org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp]",
+          "identityHash" : "5aefb937cdf64b6342c994d7bc5d5776e67115",
+          "contentHash" : "251b5d9d19d549f158b83e45b5c2f9b03fcad0f7",
+          "syncHash" : "cda2dda2e496d11e547eec6a52de384f1d3c3c39",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample4.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=undertow/servlet=org.hawkular.metrics.api.jaxrs.HawkularMetricsRestApp"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample5.war/r;Local~%2Fdeployment%3Dsample5.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "ced422351168d10f4c5b83e03debefb44aadf",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "5f3d46280d93034b030c435dfafe3ceb32a4f",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DMetricsJNDIPublisher",
+          "name" : "Singleton EJB [MetricsJNDIPublisher]",
+          "identityHash" : "d03a326a5330bd46c89ef4b36e87f58a16153c",
+          "contentHash" : "825048415b37efaffb5f2dd349ba144648ea4a",
+          "syncHash" : "5d1694b074a86d3e38c65f2759ef22d8ea3cb9f5",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=ejb3/singleton-bean=MetricsJNDIPublisher"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-metrics.war%2Fsubsystem%3Dundertow%2Fservlet%3DstaticContent",
+          "name" : "Servlet [staticContent]",
+          "identityHash" : "beb5f516b7e11d44ac9eb817ed452c2adc4983a",
+          "contentHash" : "ad19e6b507977da7e37f2d77db0206f861e30",
+          "syncHash" : "afe6053ef443b73485e29a27e8eab7415ee22a",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample5.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-metrics.war/subsystem=undertow/servlet=staticContent"
         }, {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fdeployment%3Dsample_final.war/r;Local~%2Fdeployment%3Dsample_final.war%2Fsubsystem%3Dundertow%2Fservlet%3DHelloServlet",
-          "name" : "Servlet [HelloServlet]",
-          "identityHash" : "2b5da84b1ee48e4caca1b1ff44c14cdb66e78e8",
-          "contentHash" : "35b556164feffc1cd352c5617949038ab2ef3",
-          "syncHash" : "4b3d3cd758a7eb8b6e57feaeecc362b6b60e39c",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war%2Fsubsystem%3Dundertow%2Fservlet%3Dorg.hawkular.alerts.actions.webhook.WebHookApp",
+          "name" : "Servlet [org.hawkular.alerts.actions.webhook.WebHookApp]",
+          "identityHash" : "9b8dec69e89486bdd550f5c732c5faff39dd4e",
+          "contentHash" : "f821ab6b1d5460219fe44a77b27fd4467e52825",
+          "syncHash" : "a23e9be791b7f058692db7683af63820793c42",
           "type" : {
-            "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/rt;Servlet",
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Servlet",
             "name" : "Servlet",
             "identityHash" : "d844da746834ebfc4aa7782c94eeaea85b4abb74",
             "contentHash" : "8a3d655f3696d872a783c7b5b2888a97188bc29",
             "syncHash" : "c225714570836f79fdafeeb5eb71fe2ce8b987",
             "id" : "Servlet"
           },
-          "id" : "Local~/deployment=sample_final.war/subsystem=undertow/servlet=HelloServlet"
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war/subsystem=undertow/servlet=org.hawkular.alerts.actions.webhook.WebHookApp"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war/r;Local~%2Fdeployment%3Dhawkular-metrics.ear%2Fsubdeployment%3Dhawkular-alerts-action-webhook.war%2Fsubsystem%3Dejb3%2Fsingleton-bean%3DStandaloneActionPluginRegister",
+          "name" : "Singleton EJB [StandaloneActionPluginRegister]",
+          "identityHash" : "d8be125248b89589c98a541378481b6b48baf723",
+          "contentHash" : "25b3e9b28fa3c68b5e0cee8b40bb626a26a3bf",
+          "syncHash" : "063166cd3251239057c7bce44b7f952aba364",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/rt;Singleton%20EJB",
+            "name" : "Singleton EJB",
+            "identityHash" : "42f0638e5e8e266d17d2f7e95f35313e96fa9b39",
+            "contentHash" : "9c45b8135d1640115bd1e16ddf6ed623abe9833",
+            "syncHash" : "2260ecbd58da298aae11888aaa666a21dbe71f",
+            "id" : "Singleton EJB"
+          },
+          "id" : "Local~/deployment=hawkular-metrics.ear/subdeployment=hawkular-alerts-action-webhook.war/subsystem=ejb3/singleton-bean=StandaloneActionPluginRegister"
         } ]
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=HawkularInventoryDS_postgres/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -2135,7 +2027,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2156,7 +2048,71 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '806'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_postgres/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "fc78a4431302d998e117455b1765ab0c76dd72",
+          "contentHash" : "66984e7ae614cf6db5f24afd1b174f5932dc3",
+          "syncHash" : "955b3588aab981ae2ad9387d44e91e5f1c3edb17",
+          "value" : {
+            "Connection Properties" : "{\"prepareThreshold\":\"0\"}",
+            "Datasource Class" : null,
+            "Security Domain" : null,
+            "Username" : "hawkular",
+            "Driver Name" : "postgresql",
+            "JNDI Name" : "java:/jboss/datasources/HawkularInventoryDS_postgres",
+            "Connection URL" : "jdbc:postgresql://localhost:5432/hawkular",
+            "Enabled" : "true",
+            "Driver Class" : null,
+            "Password" : "hawkular"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -2167,7 +2123,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
           "name" : "configuration",
           "identityHash" : "823ca07d76929e39fc468d25111455355aa81a8",
           "contentHash" : "20125a70ce2d55719321b336bf632eb518bcb4a",
@@ -2186,10 +2142,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAvailData/d;configuration
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=HawkularInventoryDS_h2/d;configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -2199,838 +2155,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
       Hawkular-Tenant:
       - hawkular
       Content-Type:
       - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '536'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAvailData/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '572'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsActionsResponseQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '570'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularTopic/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '528'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '524'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '528'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertData/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '536'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertsActionsTopic/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Favailability%2Fnew/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '580'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsPluginsQueue/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularInventoryChanges/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '550'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '508'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '568'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularMetricData/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '538'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularMetricData/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularCommandEvent/d;configuration
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Tue, 30 Aug 2016 23:12:20 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '542'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration]]]",
-          "details" : {
-            "entityType" : "DataEntity",
-            "path" : [ [ {
-              "paths" : [ "/t;hawkular/f;e2daaa52-a9c1-4578-8a60-c6699de99871/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration" ]
-            } ] ]
-          }
-        }
-    http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:20 GMT
-- request:
-    method: post
-    uri: http://jdoe:password@127.0.0.1:8080/hawkular/metrics/availability/raw/query
-    body:
-      encoding: UTF-8
-      string: '{"ids":["AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-status.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-actions-email.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-commons-embedded-cassandra-war.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-metrics-component.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-rest.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_2.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample3.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample4.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample5.war]~AT~Deployment
-        Status~Deployment Status","AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_final.war]~AT~Deployment
-        Status~Deployment Status"],"start":null,"end":null,"limit":1,"order":"DESC"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1953'
   response:
     status:
       code: 200
@@ -3047,31 +2176,1017 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 30 Aug 2016 23:12:21 GMT
+      - Thu, 16 Mar 2017 17:05:01 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '2753'
+      - '781'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DHawkularInventoryDS_h2/d;configuration",
+          "name" : "configuration",
+          "identityHash" : "30a3ce2fd5b8e66657d6e0f8307ced4db67dd0ad",
+          "contentHash" : "2a705856d22153724077fa9d5e20bc64b6c21877",
+          "syncHash" : "646facd8d0d78a98643ab5cfb06f50b4a9ee9b",
+          "value" : {
+            "Connection Properties" : null,
+            "Datasource Class" : null,
+            "Security Domain" : null,
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:/jboss/datasources/HawkularInventoryDS_h2",
+            "Connection URL" : "jdbc:h2:/opt/data/data/hawkular-inventory/db;MVCC=true;CACHE_SIZE=32768",
+            "Enabled" : "true",
+            "Driver Class" : null,
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsActionsResponseQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '570'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsActionsResponseQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '528'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularCommandEvent/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '542'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularCommandEvent/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '572'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fcounters%2Fnew/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '568'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Fgauges%2Fnew/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '524'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertData/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '536'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertData/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularAlertsActionsTopic/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '554'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularAlertsActionsTopic/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularInventoryChanges/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '550'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularInventoryChanges/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=hawkular%2Fmetrics%2Favailability%2Fnew/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '580'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3Dhawkular%2Fmetrics%2Favailability%2Fnew/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=HawkularAlertsPluginsQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '554'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DHawkularAlertsPluginsQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '508'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/entity/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-topic=HawkularTopic/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '528'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-topic%3DHawkularTopic/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/type=f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '298'
+      Link:
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/type=f>; rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5",
+          "identityHash" : "f7e836c9967586ced2414b70167752639090c5",
+          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
+          "syncHash" : "5a23e853298dd5822d1de0e36aae466c66868fb",
+          "id" : "5d8b69af-4fce-492d-9aeb-93cbd7e557a5"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      X-Total-Count:
+      - '6'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6857'
+      Link:
+      - <http://127.0.0.1:8080/hawkular/inventory/traversal/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status/rl;defines/type=m>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-rest-api.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "7e94e0687ac46940d0dc84f7c2ec81f1642ff96",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "a993fe9db7fd4f478214341cc57bf7302b61d",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-rest-api.war]~AT~Deployment Status~Deployment Status"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-command-gateway-war.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "d47936d11a42b84d719d34c94946fcb8329325",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "8323fcfad92760cfe379c8dc94d1adf11970e4",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment Status~Deployment Status"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics.ear/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-metrics.ear%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "5cb48762a290f92e776f48e19184b1ed484c788",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "1d8f652a78cbad39a95489cd6688074ecea4c8",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-metrics.ear]~AT~Deployment Status~Deployment Status"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-wildfly-agent-download.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "e038e39750a5503a9a6b8187a7e64cd272bc819",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "fc36dd5933bc60f7bde15b58c7df92da673e9b4",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment Status~Deployment Status"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-status.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "fb7af8c25935e6af32a75f7fbe90cd9196f0",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "bfd28ad7561524445f7d49776d70ab4522cda86",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-status.war]~AT~Deployment Status~Deployment Status"
+        }, {
+          "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war/m;AI~R~%5B5d8b69af-4fce-492d-9aeb-93cbd7e557a5%2FLocal~%2Fdeployment%3Dhawkular-inventory-dist.war%5D~AT~Deployment%20Status~Deployment%20Status",
+          "name" : "Deployment Status",
+          "identityHash" : "a073d05260e808170f19338265830134aa0ba74",
+          "contentHash" : "f9c48e98e9aa2926f3ee81cad694b40457c1613",
+          "syncHash" : "badbf3d28d23ab454e48db981855b93bd833d0",
+          "type" : {
+            "path" : "/t;hawkular/f;5d8b69af-4fce-492d-9aeb-93cbd7e557a5/mt;Deployment%20Status~Deployment%20Status",
+            "name" : "Deployment Status",
+            "identityHash" : "92b2ec6a8ce2b54a435a3e0305c11dd6e993417",
+            "contentHash" : "f3c6534da64d2a8686b1d4e236c44d16bfffe431",
+            "syncHash" : "f3b33cc32943d9447a53350891e915198d844b",
+            "unit" : "NONE",
+            "metricDataType" : "availability",
+            "collectionInterval" : 60,
+            "type" : "AVAILABILITY",
+            "id" : "Deployment Status~Deployment Status"
+          },
+          "id" : "AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment Status~Deployment Status"
+        } ]
+    http_version: 
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@127.0.0.1:8080/hawkular/metrics/availability/raw/query
     body:
       encoding: UTF-8
-      string: '[{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-status.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-actions-email.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-commons-embedded-cassandra-war.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-metrics-component.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=hawkular-alerts-rest.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"down"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_2.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample3.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample4.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample5.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684001,"value":"up"}]},{"id":"AI~R~[e2daaa52-a9c1-4578-8a60-c6699de99871/Local~/deployment=sample_final.war]~AT~Deployment
-        Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]}]'
+      string: '{"ids":["AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-metrics.ear]~AT~Deployment
+        Status~Deployment Status","AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-status.war]~AT~Deployment
+        Status~Deployment Status","AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
+        Status~Deployment Status"],"start":null,"end":null,"limit":1,"order":"DESC"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '836'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 16 Mar 2017 17:05:01 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1121'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-rest-api.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887001,"value":"up"}]},{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-command-gateway-war.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887001,"value":"up"}]},{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-metrics.ear]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887001,"value":"up"}]},{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-wildfly-agent-download.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887001,"value":"up"}]},{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-status.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887001,"value":"up"}]},{"id":"AI~R~[5d8b69af-4fce-492d-9aeb-93cbd7e557a5/Local~/deployment=hawkular-inventory-dist.war]~AT~Deployment
+        Status~Deployment Status","data":[{"timestamp":1489683887000,"value":"up"}]}]'
     http_version: 
-  recorded_at: Tue, 30 Aug 2016 23:12:21 GMT
+  recorded_at: Thu, 16 Mar 2017 17:05:01 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Uses `hawkular_metric_id` from the inventory instead of building a metric id.
Metric id format is configurable [1], so we need to fetch it from the inventory before querying hawkular-metrics for its value.

As a side effect, `parse_availability` is easier to read.

[1] https://issues.jboss.org/browse/HWKAGENT-78