### PR TITLE
Move fog-vcloud-director to manageiq-providers-vmware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     ">=0.5.2",       :require => false
-gem "fog-vcloud-director",            "~>0.1.8",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false


### PR DESCRIPTION
The fog-vcloud-director gem is only used by `ManageIQ::Providers::Vmware::CloudManager` so move it to the `manageiq-providers-vmware` repository.

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/28