### PR TITLE
fix seeding

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -53,7 +53,7 @@ class EvmDatabase
   end
 
   def self.seed_last
-    if ENV['SKIP_SEEDING'] && MiqDatabase.count > 0
+    unless ENV['SKIP_SEEDING'] && MiqDatabase.count > 0
       seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
     end
   end


### PR DESCRIPTION
The goal of https://github.com/ManageIQ/manageiq/pull/14207 is to not seed if the flag was set.

The code that went in unfortunately only seeded if the flag WAS set.

solution: swap the operator.

I'm not an `unless` fan, but wanted that logic to mimic the cohort:

```ruby
  def self.seed_primordial
    if ENV['SKIP_SEEDING'] && MiqDatabase.count > 0
      puts "** seedings is skipped on startup."
      puts "** Unset SKIP_SEEDING to re-enable"
    else
      seed(PRIMORDIAL_CLASSES)
    end
  end

  def self.seed_last
    unless ENV['SKIP_SEEDING'] && MiqDatabase.count > 0 # the change / fix
      seed(seedable_model_class_names - PRIMORDIAL_CLASSES)
    end
  end

```