### PR TITLE
[EUWE] Set session[:snap_selected] to nil if Snapshot does not exist

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -280,6 +280,7 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
+      session[:snap_selected] = nil if Snapshot.find_by(:id => session[:snap_selected]).nil?
       @sb[@sb[:active_accord]] = TreeBuilder.build_node_id(@record)
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @active = if @snapshot_tree.selected_node

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -149,6 +149,26 @@ describe VmOrTemplateController do
         post :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
         expect(session[:snap_selected]).to eq(@snapshot.id)
       end
+
+      it 'set session[:snap_selected] to nil if Snapshot does not exist' do
+        tree_hash = {
+          :trees         => {
+            :vandt_tree => {
+              :active_node => "v-#{@vm.id}"
+            }
+          },
+          :active_tree   => :vandt_tree,
+          :active_accord => :vandt
+        }
+        session[:sandboxes] = {'vm_or_template' => tree_hash}
+        @lastaction = 'show'
+        @display = 'snapshot_info'
+        @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+
+        session[:snap_selected] = '21'
+        get :show, :params => {:id => @vm.id, :display => 'snapshot_info'}
+        expect(session[:snap_selected]).to be(nil)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes an error in the logs and the page not loading when the currently selected snapshot is deleted and attempting to view the Snapshot Summary page.

Fixes an Euwe merge conflict with https://github.com/ManageIQ/manageiq-ui-classic/pull/183

https://bugzilla.redhat.com/show_bug.cgi?id=1417763
