### PR TITLE
[EUWE] Suppots dots in custom attributes

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -124,8 +124,12 @@ class MiqReport < ApplicationRecord
     return [] if cols.nil?
     cols.inject([]) do |r, c|
       # eg. c = ["Host.Hardware.Disks : File Name", "Host.hardware.disks-filename"]
-      parts = c.last.split(".")
+      field = c.last
+      field, virtual_custom_attribute = MiqExpression.escape_virtual_custom_attribute(field)
+      parts = field.split(".")
       parts[-1] = parts.last.split("-").first # Strip off field name from last element
+
+      parts.map!{ |x| URI::RFC2396_Parser.new.unescape(x) } if virtual_custom_attribute
 
       if parts.last == "managed"
         next(r) unless mode == :tag

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -190,7 +190,9 @@ module ActsAsTaggable
     ns = Tag.get_namespace(options)
 
     ns.gsub!('/virtual/','')  # throw away /virtual
+    ns, virtual_custom_attribute = MiqExpression.escape_virtual_custom_attribute(ns)
     predicate = ns.split('/')
+    predicate.map!{ |x| URI::RFC2396_Parser.new.unescape(x) } if virtual_custom_attribute
 
     # p "ns: [#{ns}]"
     # p "predicate: [#{predicate.inspect}]"

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -189,7 +189,8 @@ module ActsAsTaggable
   def vtag_list(options = {})
     ns = Tag.get_namespace(options)
 
-    predicate = ns.split("/")[2..-1] # throw away /virtual
+    ns.gsub!('/virtual/','')  # throw away /virtual
+    predicate = ns.split('/')
 
     # p "ns: [#{ns}]"
     # p "predicate: [#{predicate.inspect}]"

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1047,8 +1047,19 @@ class MiqExpression
     tag
   end
 
+  def self.escape_virtual_custom_attribute(attribute)
+    if attribute.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
+      uri_parser = URI::RFC2396_Parser.new
+      [uri_parser.escape(attribute, /[^A-Za-z0-9:\-_]/), true]
+    else
+      [attribute, false]
+    end
+  end
+
   def self.value2tag(tag, val = nil)
+    tag, virtual_custom_attribute = escape_virtual_custom_attribute(tag)
     model, *values = tag.to_s.gsub(/[\.-]/, "/").split("/") # replace model path ".", column name "-" with "/"
+    values.map!{ |x|  URI::RFC2396_Parser.new.unescape(x) } if virtual_custom_attribute
 
     case values.first
     when "user_tag"

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -2,14 +2,19 @@ class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 \.?(?<associations>[a-z_\.]+)*
--(?<column>[a-z]+(_[[:alnum:]]+)*)
+-
+(?:
+  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[_\-.\/[:alnum:]]*)|
+  (?<column>[a-z]+(_[[:alnum:]]+)*)
+)
 /x
 
   ParseError = Class.new(StandardError)
 
   def self.parse(field)
     match = FIELD_REGEX.match(field) or raise ParseError, field
-    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
+    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:virtual_custom_column] ||
+        match[:column])
   end
 
   attr_reader :model, :associations, :column

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -81,16 +81,16 @@ describe MiqReport do
 
   context "report with virtual dynamic custom attributes" do
     let(:options)              { {:targets_hash => true, :userid => "admin"} }
-    let(:custom_column_key_1)  { 'ATTR_Name_1' }
-    let(:custom_column_key_2)  { 'ATTR_Name_2' }
+    let(:custom_column_key_1)  { 'kubernetes.io/hostname' }
+    let(:custom_column_key_2)  { 'manageiq.org' }
     let(:custom_column_key_3)  { 'ATTR_Name_3' }
     let(:custom_column_value)  { 'value1' }
     let(:user)                 { FactoryGirl.create(:user_with_group) }
     let(:ems)                  { FactoryGirl.create(:ems_vmware) }
     let!(:vm_1)                { FactoryGirl.create(:vm_vmware) }
     let!(:vm_2)                { FactoryGirl.create(:vm_vmware, :retired => false, :ext_management_system => ems) }
-    let(:virtual_column_key_1) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_1" }
-    let(:virtual_column_key_2) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_2" }
+    let(:virtual_column_key_1) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}kubernetes.io/hostname" }
+    let(:virtual_column_key_2) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}manageiq.org" }
     let(:virtual_column_key_3) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_3" }
     let(:miq_task)             { FactoryGirl.create(:miq_task) }
 
@@ -111,9 +111,9 @@ describe MiqReport do
       MiqReport.new(
         :name => "Custom VM report", :title => "Custom VM report", :rpt_group => "Custom", :rpt_type => "Custom",
         :db        => "ManageIQ::Providers::InfraManager::Vm",
-        :cols      => %w(name virtual_custom_attribute_ATTR_Name_1 virtual_custom_attribute_ATTR_Name_2),
+        :cols      => %w(name virtual_custom_attribute_kubernetes.io/hostname virtual_custom_attribute_manageiq.org),
         :include   => {:custom_attributes => {}},
-        :col_order => %w(name virtual_custom_attribute_ATTR_Name_1 virtual_custom_attribute_ATTR_Name_2),
+        :col_order => %w(name virtual_custom_attribute_kubernetes.io/hostname virtual_custom_attribute_manageiq.org),
         :headers   => ["Name", custom_column_key_1, custom_column_key_1],
         :order     => "Ascending"
       )
@@ -151,6 +151,7 @@ describe MiqReport do
       end
 
       expected_results = ["name" => vm_1.name, virtual_column_key_1 => custom_column_value, virtual_column_key_2 => nil]
+
       expect(report_result).to match_array(expected_results)
     end
 


### PR DESCRIPTION
temporarily replacing https://github.com/ManageIQ/manageiq/pull/11112
fixes https://github.com/ManageIQ/manageiq/issues/10482 point 1
Using  `URI::RFC2396_Parser` from https://github.com/ManageIQ/manageiq/pull/13713 - thanks! @gtanzillo @cben @zeari 

@miq-bot add_label euwe/yes, bug, reporting

cc @simon3z 

please review @cben @zeari 

@miq-bot assign @gtanzillo 

I have explanation in commit messages.
tested:
- creating/updating UI reports with these attributes
- using filtering with MiqExpression with virtual custom attributes in report 

Links [Optional]
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1416345
