### PR TITLE
Drop 'jobs.agent_state' column 

### DIFF
--- a/db/migrate/20170316200500_remove_agent_state_from_jobs.rb
+++ b/db/migrate/20170316200500_remove_agent_state_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveAgentStateFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :agent_state, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1579,7 +1579,6 @@ jobs:
 - process
 - agent_id
 - agent_class
-- agent_state
 - agent_message
 - started_on
 - dispatch_status


### PR DESCRIPTION
All references to `jobs.agent_state` were removed in https://github.com/ManageIQ/manageiq/pull/14330, and this column not in use.
Dropping it will make future merging of `Job` and `MiqTask` models simpler.

@miq-bot add-label core, technical debt

@Fryguy