### PR TITLE
extract vmware settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,8 +138,6 @@
   :refresh_interval: 24.hours
   :scvmm:
     :refresh_interval: 15.minutes
-  :vmware_cloud:
-    :get_public_images: false
 :event_handling:
   :bottleneck_event_groups:
     :Capacity:
@@ -1231,17 +1229,6 @@
         :poll: 20.seconds
       :event_catcher_redhat:
         :poll: 15.seconds
-      :event_catcher_vmware:
-        :flooding_monitor_enabled: true
-        :poll: 1.seconds
-        :ems_event_max_wait: 60
-      :event_catcher_vmware_cloud:
-        :poll: 15.seconds
-        :duration: 10.seconds
-        :capacity: 50
-        :amqp_port: 5672
-        :amqp_heartbeat: 30
-        :amqp_recovery_attempts: 4
       :event_catcher_openstack:
         :poll: 15.seconds
         :topics:
@@ -1323,7 +1310,6 @@
         :ems_metrics_collector_worker_openstack_infra: {}
         :ems_metrics_collector_worker_openstack_network: {}
         :ems_metrics_collector_worker_redhat: {}
-        :ems_metrics_collector_worker_vmware: {}
         :ems_metrics_openstack_default_service: "auto"
       :ems_metrics_processor_worker:
         :count: 2
@@ -1355,9 +1341,6 @@
         :ems_refresh_worker_openstack_network: {}
         :ems_refresh_worker_nuage_network: {}
         :ems_refresh_worker_redhat: {}
-        :ems_refresh_worker_vmware: {}
-        :ems_refresh_worker_vmware_cloud: {}
-        :ems_refresh_worker_vmware_cloud_network: {}
         :ems_refresh_worker_cinder: {}
         :ems_refresh_worker_swift: {}
       :event_handler:


### PR DESCRIPTION
Extracting the obvious setting

Missing:
* log: level_vim - wait for vim broker to be extracted
* events
  * https://github.com/ManageIQ/manageiq-content/tree/master/content/automate/ManageIQ/System/Event/EmsEvent/VC.class
  * https://github.com/ManageIQ/manageiq-content/tree/master/content/automate/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class


related and merged vmware PR https://github.com/ManageIQ/manageiq-providers-vmware/pull/29

@miq-bot remove_label wip
@miq-bot add_label pluggable providers, providers/vmware