### PR TITLE
Don't require user/token and log request on options

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -27,12 +27,12 @@ module Api
     include ActionController::HttpAuthentication::Basic::ControllerMethods
     extend ErrorHandler::ClassMethods
 
-    before_action :require_api_user_or_token, :except => [:handle_options_request]
+    before_action :require_api_user_or_token, :except => [:options]
     before_action :set_gettext_locale
     before_action :set_access_control_headers
     before_action :parse_api_request, :log_api_request, :validate_api_request
     before_action :validate_api_action, :except => [:options]
-    before_action :log_request_initiated, :only => [:handle_options_request]
+    before_action :log_request_initiated, :only => [:options]
     before_action :validate_response_format, :except => [:destroy]
     after_action :log_api_response
 

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -181,8 +181,6 @@ RSpec.describe 'Arbitration Rule API' do
 
   context 'OPTIONS /api/arbitration_rules' do
     it 'returns arbitration rule field_values' do
-      api_basic_authorize
-
       run_options(arbitration_rules_url)
 
       additional_options = { 'field_values' => ArbitrationRule.field_values }

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -419,8 +419,6 @@ RSpec.describe 'Authentications API' do
 
   describe 'OPTIONS /api/authentications' do
     it 'returns expected and additional attributes' do
-      api_basic_authorize
-
       run_options(authentications_url)
 
       additional_options = {

--- a/spec/requests/api/clusters_spec.rb
+++ b/spec/requests/api/clusters_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe 'Clusters API' do
   context 'OPTIONS /api/clusters' do
     it 'returns clusters node_types' do
-      api_basic_authorize
-
       expected_data = {"node_types" => EmsCluster.node_types.to_s}
 
       run_options(clusters_url)

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -1,7 +1,6 @@
 describe "Container Deployments API" do
   it "supports collect-data with OPTIONS" do
     allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
-    api_basic_authorize
     run_options container_deployments_url
     expect(response).to have_http_status(:ok)
     expect_hash_to_have_only_keys(response.parsed_body["data"], %w(deployment_types providers provision))

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -69,4 +69,12 @@ RSpec.describe "API entrypoint" do
       )
     )
   end
+
+  describe "OPTIONS /api" do
+    it "does not require a user or token" do
+      run_options(entrypoint_url)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -80,8 +80,6 @@ RSpec.describe "hosts API" do
 
     context 'OPTIONS /api/hosts' do
       it 'returns hosts node_types' do
-        api_basic_authorize
-
         expected_data = {"node_types" => Host.node_types.to_s}
 
         run_options(hosts_url)

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -699,6 +699,43 @@ describe "Querying" do
     end
   end
 
+  describe "OPTIONS /api/vms/:c_id/" do
+    it "responds OK" do
+      run_options(vms_url(vm1.id))
+
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "OPTIONS /api/vms/:c_id/snapshots" do
+    it "responds OK" do
+      run_options("#{vms_url(vm1.id)}/software")
+
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "OPTIONS /api/vms/:c_id/software/:s_id" do
+    it "responds OK" do
+      software = FactoryGirl.create(:software, :vm_or_template => vm1)
+      run_options("#{vms_url(vm1.id)}/software/#{software.id}")
+
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "OPTIONS /api/automate/custom/system" do
+    it "responds OK" do
+      run_options(automate_url("custom/system"))
+
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "with optional collection_class" do
     before { api_basic_authorize collection_action_identifier(:vms, :read, :get) }
 

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -694,8 +694,6 @@ describe "Querying" do
 
   describe 'OPTIONS /api/vms' do
     it 'returns the options information' do
-      api_basic_authorize
-
       run_options(vms_url)
       expect_options_results(:vms)
     end


### PR DESCRIPTION
This takes care of a regression that was introduced in ff3f2ab298. The
`handle_options_request` was moved and renamed to be consistent with
the other `options` actions, but these `before_action` hooks were not
updated.

@miq-bot add-label api, bug
@miq-bot assign @abellotti 