### PR TITLE
Fix new specific-entity label->tag mappings

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -59,8 +59,10 @@ class ContainerLabelTagMapping < ApplicationRecord
   def self.map_label(cache, type, label)
     # Apply both specific-type and any-type, independently.
     # TODO: separate provider/type better to support "Kubernetes Any" vs "Amazon Any".
-    (map_name_type_value(cache, label[:name], split_provider_entity(type), label[:value]) +
-     map_name_type_value(cache, label[:name], nil,                         label[:value]))
+    provider_entity = type.split('::')
+    raise ArgumentError, "Not in Provider::Entity format: '#{type}'" unless provider_entity.size == 2
+    (map_name_type_value(cache, label[:name], provider_entity, label[:value]) +
+     map_name_type_value(cache, label[:name], nil,             label[:value]))
   end
 
   def self.map_name_type_value(cache, name, type, value)

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -217,7 +217,7 @@ module ManageIQ::Providers::Kubernetes
         :type           => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
         :identity_infra => node.spec.providerID,
         :labels         => labels,
-        :tags           => map_labels('ContainerNode', labels),
+        :tags           => map_labels('Kubernetes::ContainerNode', labels),
         :lives_on_id    => nil,
         :lives_on_type  => nil
       )
@@ -286,7 +286,7 @@ module ManageIQ::Providers::Kubernetes
         :session_affinity => service.spec.sessionAffinity,
         :service_type     => service.spec.type,
         :labels           => labels,
-        :tags             => map_labels('ContainerService', labels),
+        :tags             => map_labels('Kubernetes::ContainerService', labels),
         :selector_parts   => parse_selector_parts(service),
         :container_groups => container_groups
       )
@@ -364,7 +364,7 @@ module ManageIQ::Providers::Kubernetes
       new_result[:container_conditions] = parse_conditions(pod)
 
       new_result[:labels] = parse_labels(pod)
-      new_result[:tags] = map_labels('ContainerGroup', new_result[:labels])
+      new_result[:tags] = map_labels('Kubernetes::ContainerGroup', new_result[:labels])
       new_result[:node_selector_parts] = parse_node_selector_parts(pod)
       new_result[:container_volumes] = parse_volumes(pod)
       new_result
@@ -392,7 +392,7 @@ module ManageIQ::Providers::Kubernetes
     def parse_namespace(namespace)
       new_result = parse_base_item(namespace).except(:namespace)
       new_result[:labels] = parse_labels(namespace)
-      new_result[:tags] = map_labels('ContainerProject', new_result[:labels])
+      new_result[:tags] = map_labels('Kubernetes::ContainerProject', new_result[:labels])
       new_result
     end
 
@@ -549,7 +549,7 @@ module ManageIQ::Providers::Kubernetes
         :replicas         => container_replicator.spec.replicas,
         :current_replicas => container_replicator.status.replicas,
         :labels           => labels,
-        :tags             => map_labels('ContainerReplicator', labels),
+        :tags             => map_labels('Kubernetes::ContainerReplicator', labels),
         :selector_parts   => parse_selector_parts(container_replicator)
       )
 

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -77,7 +77,7 @@ module ManageIQ::Providers
           # TODO: persist tls
           :host_name => route.spec.try(:host),
           :labels    => labels,
-          :tags      => map_labels('ContainerRoute', labels),
+          :tags      => map_labels('Kubernetes::ContainerRoute', labels),
           :path      => route.path
         )
 
@@ -105,7 +105,7 @@ module ManageIQ::Providers
         labels = parse_labels(build)
         new_result.merge!(
           :labels                      => labels,
-          :tags                        => map_labels('ContainerBuild', labels),
+          :tags                        => map_labels('Kubernetes::ContainerBuild', labels),
           :service_account             => build.spec.serviceAccount,
           :completion_deadline_seconds => build.spec.try(:completionDeadlineSeconds),
           :output_name                 => build.spec.try(:output).try(:to).try(:name)

--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     label_name 'name'
 
     trait :only_nodes do
-      labeled_resource_type 'ContainerNode'
+      labeled_resource_type 'Kubernetes::ContainerNode'
     end
   end
 end

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -56,7 +56,6 @@ describe ContainerLabelTagMapping do
         {:tag_id => tag1.id},
         {:tag_id => tag2.id}
       )
-      expect(map_to_tags('ContainerNode', 'name' => 'value-1')).to contain_exactly(tag1, tag2)
       expect(map_to_tags('Kubernetes::ContainerNode', 'name' => 'value-1')).to contain_exactly(tag1, tag2)
     end
   end

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -37,7 +37,7 @@ describe ContainerLabelTagMapping do
   context "with empty mapping" do
     it "does nothing" do
       expect(ContainerLabelTagMapping.cache).to be_empty
-      expect(map_labels('ContainerNode',
+      expect(map_labels('Kubernetes::ContainerNode',
                         'foo'  => 'bar',
                         'quux' => 'whatever')).to be_empty
     end
@@ -52,7 +52,7 @@ describe ContainerLabelTagMapping do
     end
 
     it "map_labels returns 2 tags" do
-      expect(map_labels('ContainerNode', 'name' => 'value-1')).to contain_exactly(
+      expect(map_labels('Kubernetes::ContainerNode', 'name' => 'value-1')).to contain_exactly(
         {:tag_id => tag1.id},
         {:tag_id => tag2.id}
       )
@@ -71,7 +71,7 @@ describe ContainerLabelTagMapping do
     end
 
     it "prefers specific-value" do
-      expect(map_to_tags('ContainerNode', 'name' => 'value-1')).to contain_exactly(tag1, tag2)
+      expect(map_to_tags('Kubernetes::ContainerNode', 'name' => 'value-1')).to contain_exactly(tag1, tag2)
     end
 
     it "creates tag for new value" do
@@ -80,7 +80,7 @@ describe ContainerLabelTagMapping do
       expect(ContainerLabelTagMapping.controls_tag?(tag_in_another_cat)).to be false
 
       cached1 = ContainerLabelTagMapping.cache
-      tags = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'ContainerNode', labels('name' => 'value-2')))
+      tags = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'Kubernetes::ContainerNode', labels('name' => 'value-2')))
       expect(tags.size).to eq(1)
       expect(tags[0].name).to eq(cat_tag.name + '/value_2')
       expect(tags[0].classification.description).to eq('value-2')
@@ -91,7 +91,7 @@ describe ContainerLabelTagMapping do
 
       # But nothing changes when called again, the previously created tag is re-used.
 
-      tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'ContainerNode', labels('name' => 'value-2')))
+      tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'Kubernetes::ContainerNode', labels('name' => 'value-2')))
       expect(tags2).to contain_exactly(tags[0])
 
       expect(ContainerLabelTagMapping.controls_tag?(tag1)).to be true
@@ -102,7 +102,7 @@ describe ContainerLabelTagMapping do
 
       cached2 = ContainerLabelTagMapping.cache
 
-      tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'ContainerNode', labels('name' => 'value-2')))
+      tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'Kubernetes::ContainerNode', labels('name' => 'value-2')))
       expect(tags2).to contain_exactly(tags[0])
 
       expect(ContainerLabelTagMapping.controls_tag?(tag1)).to be true
@@ -115,8 +115,8 @@ describe ContainerLabelTagMapping do
       # (but the optional domain prefix must be lowercase).
       FactoryGirl.create(:container_label_tag_mapping,
                          :label_name => 'Name_Case', :label_value => 'value', :tag => tag2)
-      tags = map_to_tags('ContainerNode', 'name_case' => 'value')
-      tags2 = map_to_tags('ContainerNode', 'Name_Case' => 'value', 'naME_caSE' => 'value')
+      tags = map_to_tags('Kubernetes::ContainerNode', 'name_case' => 'value')
+      tags2 = map_to_tags('Kubernetes::ContainerNode', 'Name_Case' => 'value', 'naME_caSE' => 'value')
       expect(tags).to be_empty
       expect(tags2).to contain_exactly(tag2)
 
@@ -125,9 +125,9 @@ describe ContainerLabelTagMapping do
     end
 
     it "handles values that differ only by case / punctuation" do
-      tags = map_to_tags('ContainerNode', 'name' => 'value-case.punct')
-      tags2 = map_to_tags('ContainerNode', 'name' => 'VaLuE-CASE.punct')
-      tags3 = map_to_tags('ContainerNode', 'name' => 'value-case/punct')
+      tags = map_to_tags('Kubernetes::ContainerNode', 'name' => 'value-case.punct')
+      tags2 = map_to_tags('Kubernetes::ContainerNode', 'name' => 'VaLuE-CASE.punct')
+      tags3 = map_to_tags('Kubernetes::ContainerNode', 'name' => 'value-case/punct')
       # TODO: They get mapped to the same tag, is this desired?
       # TODO: What do we want the description to be?
       expect(tags2).to eq(tags)
@@ -135,9 +135,9 @@ describe ContainerLabelTagMapping do
     end
 
     it "handles values that differ only past 50th character" do
-      tags = map_to_tags('ContainerNode', 'name' => 'x' * 50)
-      tags2 = map_to_tags('ContainerNode', 'name' => 'x' * 50 + 'y')
-      tags3 = map_to_tags('ContainerNode', 'name' => 'x' * 50 + 'z')
+      tags = map_to_tags('Kubernetes::ContainerNode', 'name' => 'x' * 50)
+      tags2 = map_to_tags('Kubernetes::ContainerNode', 'name' => 'x' * 50 + 'y')
+      tags3 = map_to_tags('Kubernetes::ContainerNode', 'name' => 'x' * 50 + 'z')
       # TODO: They get mapped to the same tag, is this desired?
       # TODO: What do we want the description to be?
       expect(tags2).to eq(tags)
@@ -150,8 +150,8 @@ describe ContainerLabelTagMapping do
       it "handle known value simultaneously" do
         cached1 = ContainerLabelTagMapping.cache
         cached2 = ContainerLabelTagMapping.cache
-        tags1 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'ContainerNode', labels('name' => 'value-1')))
-        tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'ContainerNode', labels('name' => 'value-1')))
+        tags1 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'Kubernetes::ContainerNode', labels('name' => 'value-1')))
+        tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'Kubernetes::ContainerNode', labels('name' => 'value-1')))
         expect(tags1).to contain_exactly(tag1, tag2)
         expect(tags2).to contain_exactly(tag1, tag2)
       end
@@ -159,8 +159,8 @@ describe ContainerLabelTagMapping do
       it "handle new value encountered simultaneously" do
         cached1 = ContainerLabelTagMapping.cache
         cached2 = ContainerLabelTagMapping.cache
-        tags1 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'ContainerNode', labels('name' => 'value-2')))
-        tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'ContainerNode', labels('name' => 'value-2')))
+        tags1 = to_tags(ContainerLabelTagMapping.map_labels(cached1, 'Kubernetes::ContainerNode', labels('name' => 'value-2')))
+        tags2 = to_tags(ContainerLabelTagMapping.map_labels(cached2, 'Kubernetes::ContainerNode', labels('name' => 'value-2')))
         expect(tags1.size).to eq(1)
         expect(tags1).to eq(tags2)
       end
@@ -174,7 +174,7 @@ describe ContainerLabelTagMapping do
     end
 
     it "maps same new value in both into 1 new tag" do
-      tags = map_to_tags('ContainerNode', 'name1' => 'value', 'name2' => 'value')
+      tags = map_to_tags('Kubernetes::ContainerNode', 'name1' => 'value', 'name2' => 'value')
       expect(tags.size).to eq(1)
       expect(ContainerLabelTagMapping.controls_tag?(tags[0])).to be true
     end
@@ -183,15 +183,15 @@ describe ContainerLabelTagMapping do
   context "given a label with empty value" do
     it "any-value mapping is ignored" do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
-      expect(map_to_tags('ContainerNode', 'name' => '')).to be_empty
+      expect(map_to_tags('Kubernetes::ContainerNode', 'name' => '')).to be_empty
     end
 
     it "honors specific mapping for the empty value" do
       FactoryGirl.create(:container_label_tag_mapping, :label_value => '', :tag => empty_tag_under_cat)
-      expect(map_to_tags('ContainerNode', 'name' => '')).to contain_exactly(empty_tag_under_cat)
+      expect(map_to_tags('Kubernetes::ContainerNode', 'name' => '')).to contain_exactly(empty_tag_under_cat)
       # same with both any-value and specific-value mappings
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
-      expect(map_to_tags('ContainerNode', 'name' => '')).to contain_exactly(empty_tag_under_cat)
+      expect(map_to_tags('Kubernetes::ContainerNode', 'name' => '')).to contain_exactly(empty_tag_under_cat)
     end
   end
 
@@ -206,11 +206,11 @@ describe ContainerLabelTagMapping do
     end
 
     it "applies both independently" do
-      expect(map_to_tags('ContainerNode', 'name' => 'value')).to contain_exactly(tag1, tag2)
+      expect(map_to_tags('Kubernetes::ContainerNode', 'name' => 'value')).to contain_exactly(tag1, tag2)
     end
 
     it "skips specific-type when type doesn't match" do
-      expect(map_to_tags('ContainerProject', 'name' => 'value')).to contain_exactly(tag2)
+      expect(map_to_tags('Kubernetes::ContainerProject', 'name' => 'value')).to contain_exactly(tag2)
     end
   end
 
@@ -221,7 +221,7 @@ describe ContainerLabelTagMapping do
     end
 
     it "resolves them independently" do
-      tags = map_to_tags('ContainerNode', 'name' => 'value')
+      tags = map_to_tags('Kubernetes::ContainerNode', 'name' => 'value')
       expect(tags.size).to eq(2)
       expect(tags).to include(tag2)
     end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -22,10 +22,17 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
   # Smoke test the use of ContainerLabelTagMapping during refresh.
   before :each do
     @name_category = FactoryGirl.create(:classification, :name => 'name', :description => 'Name')
-    @label_tag_mapping = FactoryGirl.create(
+    @name_mapping = FactoryGirl.create(
       :container_label_tag_mapping,
       :label_name => 'name', :tag => @name_category.tag
     )
+    @hostname_category = FactoryGirl.create(:classification, :name => 'hostname', :description => 'Hostname')
+    @hostname_mapping = FactoryGirl.create(
+      :container_label_tag_mapping, :only_nodes,
+      :label_name => 'kubernetes.io/hostname', :tag => @hostname_category.tag
+    )
+    # Verify we're testing with labeled_resource_type column matching what UI would create.
+    expect(ContainerLabelTagMapping::MAPPABLE_ENTITIES).to include(@hostname_mapping.labeled_resource_type)
   end
 
   it "will perform a full refresh on k8s" do
@@ -208,6 +215,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
 
     expect(@containernode.labels).to contain_exactly(
       label_with_name_value("kubernetes.io/hostname", "10.35.0.169")
+    )
+    expect(@containernode.tags).to contain_exactly(
+      tag_in_category_with_description(@hostname_category, "10.35.0.169")
     )
 
     expect(@containernode.computer_system.operating_system).to have_attributes(


### PR DESCRIPTION
Followup to #14288 and https://github.com/ManageIQ/manageiq-ui-classic/pull/666
After these PRs new label->tag mappings will be created with a prefixed `Provider::Entity` format, but container refresh calls map_labels() with unprefixed `Entity` format and these mappings would never apply.
(`<Any>` mappings were unaffected.)

Added function to split [provider, entity], almost as if they were separate columns (which is probably your next step).
Most mapping code still treats them as one thing.

Extended mapping "smoke test" within container refresher spec to (1) test a specific-entity mapping too (2) hopefully catch future mismatches between UI creation vs / test factory.

@djberg96 @blomquisg @bronaghs Please review.

Steps for Testing/QA
-------------------------------

Create a type-specific e.g. "Kubernetes/ContainerNode" mapping in the UI
(Configuration -> Region -> Map Labels tab)
and check that it works (creates a corresponding tag) on refresh.