### PR TITLE
Consistent naming of Azure models

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -830,7 +830,7 @@ en:
       ManageIQ::Providers::Azure::CloudManager::OrchestrationStack:         Orchestration Stack (Microsoft Azure)
       ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack:        Orchestration Stack (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::NetworkPort:             Network Port (Amazon)
-      ManageIQ::Providers::Azure::NetworkManager:                           Network Manager (Azure)
+      ManageIQ::Providers::Azure::NetworkManager:                           Network Manager (Microsoft Azure)
       ManageIQ::Providers::Azure::NetworkManager::NetworkPort:              Network Port (Microsoft Azure)
       ManageIQ::Providers::Openstack::NetworkManager::NetworkPort:          Network Port (OpenStack)
       ManageIQ::Providers::StorageManager:                                  Storage Manager


### PR DESCRIPTION
`Azure` -> `Microsoft Azure`, which we use everywhere else.

https://bugzilla.redhat.com/show_bug.cgi?id=1421684