### PR TITLE
[DARGA] Backport Change the range of captured metric data on initialization

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/metrics_capture.rb
@@ -33,7 +33,7 @@ class ManageIQ::Providers::Redhat::InfraManager::MetricsCapture < ManageIQ::Prov
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
     log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
 
-    start_time ||= 1.week.ago
+    start_time ||= Metric::Capture.historical_start_time
 
     begin
       Benchmark.realtime_block(:rhevm_connect) { perf_init_rhevm }

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -35,4 +35,8 @@ FactoryGirl.define do
     auth_key    nil
     status      "SomeMockedStatus"
   end
+
+  factory :authentication_redhat_metric, :parent => :authentication do
+    authtype "metrics"
+  end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -92,6 +92,13 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_redhat_with_metrics_authentication,
+          :parent => :ems_redhat do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication_redhat_metric)
+    end
+  end
+
   factory :ems_openstack_infra,
           :aliases => ["manageiq/providers/openstack/infra_manager"],
           :class   => "ManageIQ::Providers::Openstack::InfraManager",

--- a/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/metrics_capture_spec.rb
@@ -1,0 +1,16 @@
+describe ManageIQ::Providers::Redhat::InfraManager::MetricsCapture do
+  require 'ovirt_metrics'
+  context '#perf_collect_metrics' do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_metrics_authentication) }
+    let(:host) { FactoryGirl.create(:host_redhat, :ems_id => ems.id) }
+    let(:start_time) { 4.hours.ago }
+    it 'collects historical metric data according to the value of historical_start_time' do
+      allow(Metric::Capture).to receive(:historical_start_time).and_return(start_time)
+      allow(OvirtMetrics).to receive(:establish_connection).and_return(true)
+      allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:history_database_name)
+        .and_return('stuff')
+      expect(OvirtMetrics).to receive(:host_realtime).with(host.uid_ems, start_time, nil)
+      host.perf_collect_metrics("realtime")
+    end
+  end
+end


### PR DESCRIPTION
Attempt to hotfix the bug: https://bugzilla.redhat.com/show_bug.cgi?id=1432719
By back porting commit e3e19a9660ed8db07f34a6ad7b669343e7e79cd3
From the PR https://github.com/ManageIQ/manageiq/pull/10828