### PR TITLE
[EUWE] Create spec examples for enabled/disabled button

### DIFF
--- a/app/helpers/application_helper/button/set_ownership.rb
+++ b/app/helpers/application_helper/button/set_ownership.rb
@@ -2,8 +2,11 @@ class ApplicationHelper::Button::SetOwnership < ApplicationHelper::Button::Basic
   needs :@record
 
   def disabled?
-    @error_message = _('Ownership is controlled by tenant mapping') if
-      @record.ext_management_system.tenant_mapping_enabled?
-    @error_message.present?
+    @record.ext_management_system.tenant_mapping_enabled?
+  end
+
+  def calculate_properties
+    super
+    self[:title] = _('Ownership is controlled by tenant mapping') if disabled?
   end
 end

--- a/spec/helpers/application_helper/buttons/set_ownership_spec.rb
+++ b/spec/helpers/application_helper/buttons/set_ownership_spec.rb
@@ -14,7 +14,7 @@ describe ApplicationHelper::Button::SetOwnership do
 
     context 'when provider has tenant mapping enabled' do
       let(:tenant_mapping_enabled) { true }
-      it_behaves_like 'a disabled button', 'Ownership is controlled by tenant mapping'
+      it_behaves_like 'a disabled button'
     end
 
     context 'when provider has tenant mapping disabled' do

--- a/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
@@ -1,0 +1,6 @@
+shared_examples_for 'a disabled button' do |err_msg|
+  subject { button }
+  it do
+    expect(subject[:enabled]).to be_falsey
+  end
+end

--- a/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_disabled_buttons.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a disabled button' do |err_msg|
+shared_examples_for 'a disabled button' do
   subject { button }
   it do
     expect(subject[:enabled]).to be_falsey

--- a/spec/support/examples_group/shared_examples_for_enabled_buttons.rb
+++ b/spec/support/examples_group/shared_examples_for_enabled_buttons.rb
@@ -1,0 +1,6 @@
+shared_examples_for 'an enabled button' do
+  subject { button }
+  it do
+    expect(subject[:enabled]).to be_truthy
+  end
+end


### PR DESCRIPTION
caused by backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/649 

there were missing shared examples 
https://github.com/ManageIQ/manageiq-ui-classic/pull/649/commits/dc3fa4e3bf38a86b95c7b1d5d92dc01ca77ac1a6#diff-4a5795a2580c6484b3f302bbb8322226R17

from @vecerek's https://github.com/ManageIQ/manageiq-ui-classic/pull/174 
 
I pulled-out only these shared examples 
cc @martinpovolny 
@miq-bot add_label test

@miq-bot assign @simaishi



