### PR TITLE
Add a concern for storing and accessing embedded ansible object ids

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
   include ManageIQ::Providers::AnsibleTower::Shared::Provider
 
+  include_concern 'DefaultAnsibleObjects'
+
   has_one :automation_manager,
           :foreign_key => "provider_id",
           :class_name  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",

--- a/app/models/manageiq/providers/embedded_ansible/provider/default_ansible_objects.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider/default_ansible_objects.rb
@@ -1,0 +1,55 @@
+module ManageIQ::Providers::EmbeddedAnsible::Provider::DefaultAnsibleObjects
+  extend ActiveSupport::Concern
+
+  ANSIBLE_OBJECT_SOURCE = "MIQ_ANSIBLE".freeze
+
+  included do
+    has_many :default_ansible_objects, -> { where(:source => ANSIBLE_OBJECT_SOURCE) }, :as => :resource, :dependent => :destroy, :class_name => "CustomAttribute"
+  end
+
+  def default_organization
+    get_default_ansible_object("organization")
+  end
+
+  def default_credential
+    get_default_ansible_object("credential")
+  end
+
+  def default_inventory
+    get_default_ansible_object("inventory")
+  end
+
+  def default_host
+    get_default_ansible_object("host")
+  end
+
+  def default_organization=(org)
+    set_default_ansible_object("organization", org)
+  end
+
+  def default_credential=(cred)
+    set_default_ansible_object("credential", cred)
+  end
+
+  def default_inventory=(inv)
+    set_default_ansible_object("inventory", inv)
+  end
+
+  def default_host=(host)
+    set_default_ansible_object("host", host)
+  end
+
+  def delete_ansible_object(name)
+    default_ansible_objects.find_by(:name => name).try(:delete)
+  end
+
+  private
+
+  def get_default_ansible_object(name)
+    default_ansible_objects.find_by(:name => name).try(:value).try(:to_i)
+  end
+
+  def set_default_ansible_object(name, value)
+    default_ansible_objects.find_or_initialize_by(:name => name).update_attributes(:value => value)
+  end
+end

--- a/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/provider_spec.rb
@@ -1,5 +1,7 @@
 require 'support/ansible_shared/provider'
 
 describe ManageIQ::Providers::AnsibleTower::Provider do
+  subject { FactoryGirl.create(:provider_ansible_tower) }
+
   it_behaves_like 'ansible provider'
 end

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -2,4 +2,44 @@ require 'support/ansible_shared/provider'
 
 describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   it_behaves_like 'ansible provider'
+
+  subject { FactoryGirl.build(:provider_embedded_ansible) }
+
+  context "DefaultAnsibleObjects concern" do
+    before do
+      subject.save
+    end
+
+    context "with no attributes" do
+      %w(organization credential inventory host).each do |obj_name|
+        it "#default_#{obj_name} returns nil" do
+          expect(subject.public_send("default_#{obj_name}")).to be_nil
+        end
+
+        it "#default_#{obj_name}= creates a new custom attribute" do
+          subject.public_send("default_#{obj_name}=", obj_name.length)
+          expect(subject.default_ansible_objects.find_by(:name => obj_name).value.to_i).to eq(obj_name.length)
+        end
+      end
+    end
+
+    context "with attributes saved" do
+      before do
+        %w(organization credential inventory host).each do |obj_name|
+          subject.default_ansible_objects.create(:name => obj_name, :value => obj_name.length)
+        end
+      end
+
+      %w(organization credential inventory host).each do |obj_name|
+        it "#default_#{obj_name} returns the saved value" do
+          expect(subject.public_send("default_#{obj_name}")).to eq(obj_name.length)
+        end
+
+        it "#default_#{obj_name}= doesn't create a second object if we pass the same value" do
+          subject.public_send("default_#{obj_name}=", obj_name.length)
+          expect(subject.default_ansible_objects.where(:name => obj_name).count).to eq(1)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -1,15 +1,11 @@
 require 'support/ansible_shared/provider'
 
 describe ManageIQ::Providers::EmbeddedAnsible::Provider do
+  subject { FactoryGirl.create(:provider_embedded_ansible) }
+
   it_behaves_like 'ansible provider'
 
-  subject { FactoryGirl.build(:provider_embedded_ansible) }
-
   context "DefaultAnsibleObjects concern" do
-    before do
-      subject.save
-    end
-
     context "with no attributes" do
       %w(organization credential inventory host).each do |obj_name|
         it "#default_#{obj_name} returns nil" do

--- a/spec/support/ansible_shared/provider.rb
+++ b/spec/support/ansible_shared/provider.rb
@@ -1,8 +1,6 @@
 require "ansible_tower_client"
 
 shared_examples_for "ansible provider" do
-  subject { FactoryGirl.build(:provider_ansible_tower) }
-
   describe "#connect" do
     let(:attrs) { {:username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER} }
 
@@ -23,16 +21,14 @@ shared_examples_for "ansible provider" do
 
   describe "#destroy" do
     it "will remove all child objects" do
-      provider = FactoryGirl.create(:provider_ansible_tower, :zone => FactoryGirl.create(:zone))
-
-      provider.automation_manager.configured_systems = [
+      subject.automation_manager.configured_systems = [
         FactoryGirl.create(:configured_system, :computer_system =>
           FactoryGirl.create(:computer_system,
                              :operating_system => FactoryGirl.create(:operating_system),
                              :hardware         => FactoryGirl.create(:hardware)))
       ]
 
-      provider.destroy
+      subject.destroy
 
       expect(Provider.count).to              eq(0)
       expect(ConfiguredSystem.count).to      eq(0)


### PR DESCRIPTION
This will allow us to determine the ansible side object to relate new objects to.

This also frees us from having to store an extra flag in our inventory to identify which objects are the "system created" ones and which are the other objects that may be artifacts of running jobs.

https://www.pivotaltracker.com/story/show/140098929