### PR TITLE
Remove 'retired' column from the services list

### DIFF
--- a/product/views/Service.yaml
+++ b/product/views/Service.yaml
@@ -22,7 +22,6 @@ cols:
 - name
 - description
 - created_at
-- retired
 - v_total_vms
 - aggregate_all_vm_cpus
 - aggregate_all_vm_memory
@@ -44,7 +43,6 @@ col_order:
 - name
 - description
 - created_at
-- retired
 - v_total_vms
 - aggregate_all_vm_cpus
 - aggregate_all_vm_memory
@@ -59,7 +57,6 @@ headers:
 - Name
 - Description
 - Created On
-- Retired
 - Total VMs
 - Total CPUs
 - Total Memory
@@ -67,12 +64,6 @@ headers:
 - Total VM Disk Space Allocated
 - Total VM Disk Space Used
 - Total VM Memory on Disk
-
-col_formats:
--
--
--
-- :boolean_yes_no
 
 # Condition(s) string for the SQL query
 conditions: 


### PR DESCRIPTION
Follow up for https://github.com/ManageIQ/manageiq-ui-classic/pull/632 - remove the 'Retired' column from the services list, as the retired services are listed in a separate node.

Links 
----------------

https://github.com/ManageIQ/manageiq-ui-classic/pull/632


![screenshot from 2017-03-17 09-02-06](https://cloud.githubusercontent.com/assets/12769982/24044151/6cb18758-0af0-11e7-9721-e524f2c2b706.png)
