### PR TITLE
Drop 'jobs.agent_class' column

### DIFF
--- a/db/migrate/20170317134007_remove_agent_class_from_jobs.rb
+++ b/db/migrate/20170317134007_remove_agent_class_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveAgentClassFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :agent_class, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1578,7 +1578,6 @@ jobs:
 - type
 - process
 - agent_id
-- agent_class
 - agent_message
 - started_on
 - dispatch_status


### PR DESCRIPTION
All references to 'jobs.agent_class' were removed in #14356, and this column not in use.
Dropping it will make future merging of `Job` and `MiqTask` models simpler.

@miq-bot add-label core, technical debt

@Fryguy