### PR TITLE
Fixes tag control multi-value

### DIFF
--- a/app/models/dialog_field_tag_control.rb
+++ b/app/models/dialog_field_tag_control.rb
@@ -29,6 +29,10 @@ class DialogFieldTagControl < DialogFieldSortedItem
     options[:force_single_value] = setting
   end
 
+  def force_multi_value
+    !single_value?
+  end
+
   def self.allowed_tag_categories
     tag_cats = Classification.where(:show => true, :parent_id => 0, :read_only => false).includes(:tag).to_a
 

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -36,6 +36,13 @@ describe DialogFieldTagControl do
       expect(@df.single_value?).to be_truthy
     end
 
+    it "#force_multi_value" do
+      expect(@df.force_multi_value).to be_truthy
+
+      @df.force_single_value = true
+      expect(@df.force_multi_value).to be_falsey
+    end
+
     it "#automate_key_name" do
       expect(@df.automate_key_name).to eq("Array::dialog_#{@df.name}")
     end


### PR DESCRIPTION
Drop-downs have multi-select functionality as of https://github.com/ManageIQ/manageiq-ui-classic/pull/114. This fixes an issue where tag control, which is sub-classed from the same base as drop-down, lacks the necessary method for multiple items on the same field. 

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/729 
