### PR TITLE
Add API_OPTIONS for additional cloud credential types

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/azure_credential.rb
@@ -1,4 +1,5 @@
 # This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential.  We are not modeling the deprecated Azure classic
 class ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential <
   ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/google_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::GoogleCredential
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/openstack_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::OpenstackCredential
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/rackspace_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/rackspace_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::RackspaceCredential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::RackspaceCredential
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/satellite6_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/satellite6_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential < ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Satellite6Credential
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/azure_credential.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
+  extend ActiveSupport::Concern
+
+  COMMON_ATTRIBUTES = {
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Azure'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/google_credential.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::GoogleCredential
+  extend ActiveSupport::Concern
+
+  COMMON_ATTRIBUTES = {
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Google'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/openstack_credential.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::OpenstackCredential
+  extend ActiveSupport::Concern
+
+  COMMON_ATTRIBUTES = {
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Openstack'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/rackspace_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/rackspace_credential.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::RackspaceCredential
+  extend ActiveSupport::Concern
+
+  COMMON_ATTRIBUTES = {
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Rackspace'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/satellite6_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/satellite6_credential.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Satellite6Credential
+  extend ActiveSupport::Concern
+
+  COMMON_ATTRIBUTES = {
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Satellite6'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+end


### PR DESCRIPTION
Adds `API_OPTIONS` to other cloud credential types. For now, only including `:type` and `:label`

@miq-bot assign @gmcculloug 
cc: @jameswnl @h-kataria 
@miq-bot add_label enhancement, services