### PR TITLE
Link jobs and miq_server tables (make job belongs_to miq_server)

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -4,6 +4,7 @@ class Job < ApplicationRecord
   include FilterableMixin
 
   belongs_to :miq_task, :dependent => :delete
+  belongs_to :miq_server
 
   serialize :options
   serialize :context

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -173,6 +173,7 @@ class JobProxyDispatcher
 
   def assign_proxy_to_job(proxy, job)
     job.agent_id        = proxy.id
+    job.miq_server_id   = proxy.id
     job.agent_name      = proxy.name
     job.started_on      = Time.now.utc
     job.dispatch_status = "active"

--- a/db/migrate/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table.rb
+++ b/db/migrate/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table.rb
@@ -1,0 +1,17 @@
+class CopyAgentIdToMiqServerIdInJobsTable < ActiveRecord::Migration[5.0]
+  class Job < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("copying data from agent_id column to miq_server_id column on jobs table") do
+      Job.update_all("miq_server_id = agent_id")
+    end
+  end
+
+  def down
+    say_with_time("nullifying miq_server_id column on jobs table") do
+      Job.update_all(:miq_server_id => nil)
+    end
+  end
+end

--- a/spec/migrations/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table_spec.rb
+++ b/spec/migrations/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table_spec.rb
@@ -1,0 +1,21 @@
+require_migration
+
+describe CopyAgentIdToMiqServerIdInJobsTable do
+  let(:jobs_stub) { migration_stub(:Job) }
+
+  migration_context :up do
+    it "copies data from 'agent_id' to 'miq_server_id' column on jobs table" do
+      jobs_stub.create!(:name => "Hello Test Job", :agent_id => 111)
+      migrate
+      expect(Job.find_by(:name => "Hello Test Job").miq_server_id).to eq 111
+    end
+  end
+
+  migration_context :down do
+    it "nullifies 'miq_server_id' column on jobs table" do
+      jobs_stub.create!(:name => "Hello Test Job", :miq_server_id => 111)
+      migrate
+      expect(Job.find_by(:name => "Hello Test Job").miq_server_id).to be nil
+    end
+  end
+end

--- a/spec/migrations/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table_spec.rb
+++ b/spec/migrations/20170317153953_copy_agent_id_to_miq_server_id_in_jobs_table_spec.rb
@@ -1,21 +1,22 @@
 require_migration
 
 describe CopyAgentIdToMiqServerIdInJobsTable do
-  let(:jobs_stub) { migration_stub(:Job) }
+  let(:job_stub) { migration_stub(:Job) }
+  let(:job_name) { "Hello Test Job" }
 
   migration_context :up do
     it "copies data from 'agent_id' to 'miq_server_id' column on jobs table" do
-      jobs_stub.create!(:name => "Hello Test Job", :agent_id => 111)
+      job_stub.create!(:name => job_name, :agent_id => 111)
       migrate
-      expect(Job.find_by(:name => "Hello Test Job").miq_server_id).to eq 111
+      expect(Job.find_by(:name => job_name).miq_server_id).to eq 111
     end
   end
 
   migration_context :down do
     it "nullifies 'miq_server_id' column on jobs table" do
-      jobs_stub.create!(:name => "Hello Test Job", :miq_server_id => 111)
+      job_stub.create!(:name => job_name, :miq_server_id => 111)
       migrate
-      expect(Job.find_by(:name => "Hello Test Job").miq_server_id).to be nil
+      expect(Job.find_by(:name => job_name).miq_server_id).to be nil
     end
   end
 end


### PR DESCRIPTION
Part of ManageIQ/manageiq#14030 - merging `MiqTask` and `Job`

Linking `MiqServer` and `Job` will:
- allow to drop `jobs.agent_name` column and use `miq_server.name` instead. 
- allow to use `miq_server_id` column instead of `agent_id` and drop redundant column

`jobs.miq_server_id` column already exists, it is just was not used before.

@miq-bot add-label core, refactoring

\cc @Fryguy @jrafanie 

