### PR TITLE
Make Widget run without timezones

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -47,9 +47,7 @@ class MiqWidget < ApplicationRecord
     row_count_param.try(:to_i) || options.try(:[], :row_count) || DEFAULT_ROW_COUNT
   end
 
-  def name
-    description
-  end
+  alias_attribute :name, :description
 
   def last_run_on
     last_generated_content_on || (miq_schedule && miq_schedule.last_run_on)

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -387,10 +387,6 @@ class MiqWidget < ApplicationRecord
     end
   end
 
-  def timezones_for_users(users)
-    users.to_miq_a.collect(&:get_timezone).uniq.sort
-  end
-
   def available_for_group?(group)
     return false unless group
     has_visibility?(:roles, group.miq_user_role_name) || has_visibility?(:groups, group.description)

--- a/app/models/miq_widget/content_option_generator.rb
+++ b/app/models/miq_widget/content_option_generator.rb
@@ -1,7 +1,7 @@
 class MiqWidget::ContentOptionGenerator
-  def generate(group, users)
+  def generate(group, users, need_timezone = true)
     if group.kind_of?(MiqGroup) && !group.self_service?
-      return "MiqGroup", group.description, nil, timezones_for_users(users)
+      return "MiqGroup", group.description, nil, need_timezone ? timezones_for_users(users) : %w(UTC)
     else
       return "User", group.description, userids_for_users(users), nil
     end

--- a/app/models/miq_widget/content_option_generator.rb
+++ b/app/models/miq_widget/content_option_generator.rb
@@ -10,11 +10,7 @@ class MiqWidget::ContentOptionGenerator
   private
 
   def timezones_for_users(users)
-    timezones = users.collect do |user|
-      user.respond_to?(:get_timezone) ? user.get_timezone : nil
-    end
-
-    timezones.compact.uniq.sort
+    users.collect { |user| user.try(:get_timezone) }.compact.uniq.sort
   end
 
   def userids_for_users(users)

--- a/product/dashboard/widgets/chart_guest_os_information_any_os.yaml
+++ b/product/dashboard/widgets/chart_guest_os_information_any_os.yaml
@@ -2,6 +2,7 @@ description: chart_guest_os_information_any_os
 title: Guest OS Information
 content_type: chart
 options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/chart_vendor_and_guest_os.yaml
+++ b/product/dashboard/widgets/chart_vendor_and_guest_os.yaml
@@ -2,6 +2,7 @@ description: chart_vendor_and_guest_os
 title: Vendor and Guest OS Chart
 content_type: chart   
 options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_
@@ -14,4 +15,4 @@ miq_schedule_options:
       :value: "1"
       :unit: daily
 enabled: true        
-read_only: true  
+read_only: true

--- a/product/dashboard/widgets/report_top_storage_consumers.yaml
+++ b/product/dashboard/widgets/report_top_storage_consumers.yaml
@@ -7,6 +7,7 @@ options:
   - ems_cluster.name
   - used_disk_storage
   :row_count: 10
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -566,6 +566,8 @@ describe MiqWidget do
       MiqReport.seed_report("Vendor and Guest OS")
       MiqWidget.seed_widget("chart_vendor_and_guest_os")
 
+      # tests are written for timezone_matters = true
+      widget.options[:timezone_matters] = true if widget.options
       @role   = FactoryGirl.create(:miq_user_role)
       @group  = FactoryGirl.create(:miq_group, :miq_user_role => @role)
       @user1  = FactoryGirl.create(:user,
@@ -591,14 +593,15 @@ describe MiqWidget do
       before do
         widget.make_memberof(@ws1)
         widget.make_memberof(@ws2)
-        widget.queue_generate_content
       end
 
       it "queued based on group/TZs of User's in the group" do
+        widget.queue_generate_content
         expect(MiqQueue.count).to eq(1)
       end
 
       it "contents created for each timezone of the group" do
+        widget.queue_generate_content
         MiqQueue.first.deliver
         expect(MiqWidgetContent.count).to eq(2)
         MiqWidgetContent.all.each do |content|
@@ -608,7 +611,20 @@ describe MiqWidget do
         end
       end
 
+      it "contents created for one timezone per group with timezone_matters = false" do
+        widget.options = {:timezone_matters => false }
+        widget.queue_generate_content
+        MiqQueue.first.deliver
+        expect(MiqWidgetContent.count).to eq(1)
+        MiqWidgetContent.all.each do |content|
+          expect(content.user_id).to be_nil
+          expect(content.miq_group_id).to eq(@group.id)
+          expect(content.timezone).to eq("UTC")
+        end
+      end
+
       it "when changing to self service group" do
+        widget.queue_generate_content
         MiqQueue.first.deliver
         MiqWidgetContent.all.each do |content|
           expect(content.user_id).to be_nil

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -487,7 +487,7 @@ describe MiqWidget do
 
     before do
       allow(MiqWidget::ContentOptionGenerator).to receive(:new).and_return(content_option_generator)
-      allow(content_option_generator).to receive(:generate).with(group, users).and_return("content options")
+      allow(content_option_generator).to receive(:generate).with(group, users, true).and_return("content options")
     end
 
     it "returns the content options" do


### PR DESCRIPTION
# Summary

A `Widget` is basically a `Report` that is customized for a user's security group and time zone.

# Before

Some report data is different for each time zone.
So all reports are run for each user security group and each time zone.
Note: only time zones that are used by users in the security group are populated.

# Change

But many reports just show tallies that are the same regardless of the user's time zone.

This PR marks widgets that are not affected by time zone, so they can be run once per time zone.

# Conclusion

For my test customer:

**50% less time** is spent running these 3 reports.
The **10 minute** savings per hour is **20% less load** on the reporting worker.

# Numbers

|Widget                    | runs before | runs after | ms/run   | rows/run | before*| after*|
|--------------------------|---------:|--------:|---------:|---------:|-----------:|----------:|
|Top Storage Consumers     |  144     |  71     |  5,255.9 |    1,148 | 12.6m       | 6.2m      |
|Vendor and Guest OS Chart |  152     |  74     |  3,374.8 |    1,148 | 8.5m       | 4.2m      |
|Guest OS Information      |    7     |   3     |  4,127.8 |    2,280 |  29s       |  12s      |

\* **before** and **after** are estimated. Took too much time to run these.

# Related items

- https://bugzilla.redhat.com/show_bug.cgi?id=1251259
- https://github.com/ManageIQ/manageiq/pull/14224
- https://github.com/ManageIQ/manageiq/pull/14285