### PR TITLE
Enhanced API to have a task created for provider refreshes

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -139,8 +139,8 @@ module Api
 
     def refresh_provider(provider)
       desc = "#{provider_ident(provider)} refreshing"
-      provider.refresh_ems
-      action_result(true, desc)
+      task_id = provider.refresh_ems(:create_task => true).first
+      action_result(true, desc, :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)
     end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -400,8 +400,7 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  def refresh_ems(opts = nil)
-    opts ||= {}
+  def refresh_ems(opts = {})
     if missing_credentials?
       raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
     end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -400,14 +400,15 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  def refresh_ems
+  def refresh_ems(opts = nil)
+    opts ||= {}
     if missing_credentials?
       raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
     unless authentication_status_ok?
       raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
     end
-    EmsRefresh.queue_refresh(self)
+    EmsRefresh.queue_refresh(self, nil, opts)
   end
 
   def self.ems_infra_discovery_types

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -54,13 +54,14 @@ class Provider < ApplicationRecord
   end
   alias_method :zone_name, :my_zone
 
-  def refresh_ems
+  def refresh_ems(opts = nil)
+    opts ||= {}
     if missing_credentials?
       raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "provider")}
     end
     unless authentication_status_ok?
       raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "provider")}
     end
-    managers.each { |manager| EmsRefresh.queue_refresh(manager) }
+    managers.collect { |manager| EmsRefresh.queue_refresh(manager, nil, opts) }.flatten
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -54,14 +54,13 @@ class Provider < ApplicationRecord
   end
   alias_method :zone_name, :my_zone
 
-  def refresh_ems(opts = nil)
-    opts ||= {}
+  def refresh_ems(opts = {})
     if missing_credentials?
       raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "provider")}
     end
     unless authentication_status_ok?
       raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "provider")}
     end
-    managers.collect { |manager| EmsRefresh.queue_refresh(manager, nil, opts) }.flatten
+    managers.flat_map { |manager| EmsRefresh.queue_refresh(manager, nil, opts) }
   end
 end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -744,6 +744,36 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [failed_auth_action(p1.id), failed_auth_action(p2.id)])
     end
+
+    it "provider refresh are created with a task" do
+      api_basic_authorize collection_action_identifier(:providers, :refresh)
+
+      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      provider.update_authentication(:default => default_credentials.symbolize_keys)
+      allow_any_instance_of(provider.class).to receive_messages(:authentication_status_ok? => true)
+
+      run_post(providers_url(provider.id), gen_request(:refresh))
+
+      expect_single_action_result(:success => true,
+                                  :message => a_string_matching("Provider .* refreshing"),
+                                  :href    => providers_url(provider.id),
+                                  :task    => true)
+    end
+
+    it "provider refresh for provider_class=provider are created with a task" do
+      api_basic_authorize collection_action_identifier(:providers, :refresh)
+
+      provider = FactoryGirl.create(:provider_foreman, :zone => @zone, :url => "example.com", :verify_ssl => false)
+      provider.update_authentication(:default => default_credentials.symbolize_keys)
+      allow_any_instance_of(provider.class).to receive_messages(:authentication_status_ok? => true)
+
+      run_post(providers_url(provider.id) + '?provider_class=provider', gen_request(:refresh))
+
+      expect_single_action_result(:success => true,
+                                  :message => a_string_matching("Provider .* refreshing"),
+                                  :href    => providers_url(provider.id),
+                                  :task    => true)
+    end
   end
 
   describe 'Providers import VM' do

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -750,7 +750,7 @@ describe "Providers API" do
 
       provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
-      allow_any_instance_of(provider.class).to receive_messages(:authentication_status_ok? => true)
+      provider.authentication_type(:default).update(:status => "Valid")
 
       run_post(providers_url(provider.id), gen_request(:refresh))
 
@@ -765,7 +765,7 @@ describe "Providers API" do
 
       provider = FactoryGirl.create(:provider_foreman, :zone => @zone, :url => "example.com", :verify_ssl => false)
       provider.update_authentication(:default => default_credentials.symbolize_keys)
-      allow_any_instance_of(provider.class).to receive_messages(:authentication_status_ok? => true)
+      provider.authentication_type(:default).update(:status => "Valid")
 
       run_post(providers_url(provider.id) + '?provider_class=provider', gen_request(:refresh))
 


### PR DESCRIPTION
Enhanced API to have a task created for provider refreshes and returns the appropriate task_id and task_href in the action result.

so a successful *refresh* action now return something like:

```
  {
    "success": true,
    "message": "Provider id:2 name:'rhev36' refreshing",
    "task_id": 55,
    "task_href": "http://localhost:3000/api/tasks/55",
    "href": "http://localhost:3000/api/providers/2"
  }
```

Added spec

