### PR TITLE
Delete Container/AWS labels that no longer exist on the provider.

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -404,14 +404,9 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
 
     entity.send(attribute_name).reset
-    deletes = if target.kind_of?(ExtManagementSystem)
-                :use_association
-              else
-                []
-              end
 
     save_inventory_multi(entity.send(attribute_name),
-                         hashes, deletes, [:section, :name])
+                         hashes, :use_association, [:section, :name])
     store_ids_for_new_records(entity.send(attribute_name),
                               hashes, [:section, :name])
   end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -401,6 +401,8 @@ module EmsRefresh::SaveInventoryContainer
   end
 
   def save_custom_attribute_attribute_inventory(entity, attribute_name, hashes, target = nil)
+    # This serves the AWS labels refresh also.
+
     return if hashes.nil?
 
     entity.send(attribute_name).reset
@@ -412,6 +414,8 @@ module EmsRefresh::SaveInventoryContainer
   end
 
   def save_labels_inventory(entity, hashes, target = nil)
+    # This serves the AWS labels refresh also.
+
     save_custom_attribute_attribute_inventory(entity, :labels, hashes, target)
   end
 


### PR DESCRIPTION
When a label (tag) has been deleted on a resource on AWS, that label should be deleted in the MIQ database too but instead it persists.

**Steps to reproduce:**

1. Execute an EMS refresh in MIQ
2. Open an instance in MIQ and observe the contents of the Labels box in the Summary page
3. Delete one of the tags on the instance using the AWS console
4. Execute an EMS refresh in MIQ
5. Observe the tag deleted in step 3) still persists.

@cben -
1. Does this bug also apply to labels in Containers too?
2. Will this fix break anything on the Containers side?

