### PR TITLE
[WIP] stdout from orchestration_stack

### DIFF
--- a/app/controllers/api/subcollections/orchestration_stacks.rb
+++ b/app/controllers/api/subcollections/orchestration_stacks.rb
@@ -4,6 +4,11 @@ module Api
       def orchestration_stacks_query_resource(object)
         object.orchestration_stacks
       end
+
+      def orchestration_stacks_stdout_resource(object, _type, id, _data = nil)
+        os = object.orchestration_stacks.find { |os| os.id == id }
+        { :stdout => os.raw_stdout }
+      end
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1003,15 +1003,21 @@
     :description: Orchestration Stacks
     :options:
     - :subcollection
-    :verbs: *g
+    :verbs: *gp
     :klass: OrchestrationStack
     :subcollection_actions:
       :get:
       - :name: read
         :identifier: orchestration_stack_view
+      :post:
+      - :name: stdout
+        :identifier: orchestration_stack_view
     :subresource_actions:
       :get:
       - :name: read
+        :identifier: orchestration_stack_view
+      :post:
+      - :name: stdout
         :identifier: orchestration_stack_view
   :orchestration_templates:
     :description: Orchestration Template

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -666,5 +666,17 @@ describe "Services API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'can return the stdout of an orchestration_stack' do
+      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :stdout, :post)
+      allow_any_instance_of(OrchestrationStack).to receive(:raw_stdout).and_return('stdoutput')
+      run_post("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :action => 'stdout')
+
+      expected = {
+        'stdout' => 'stdoutput'
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 end


### PR DESCRIPTION
This PR is to generate discussion about the best way to approach returning the standard output of an orchestration stack. The [method](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb#L137-L147) to return standard output currently does not accept any arguments, but will in the future. It returns a long string and is not a stream.

While the approach in this PR makes it into an action
`POST /api/services/:id/orchestration_stacks/:id`
```
{"action": "stdout"}
```
I would like to get thoughts around adding it as a *kind of* subcollection, so that the call could be
`GET /api/services/:id/orchestration_stacks/:id/stdout`
or 
`GET /api/orchestration_stacks/:id/stdout`

While exploring the above method, it will require some changes to the way things are rendered, but logically makes more sense that it be a GET request.

@miq-bot assign @abellotti 
@miq-bot add_label enhancement, api, wip

