### PR TITLE
Add stdout_raw to ansible job

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -39,6 +39,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
     virtual_has_many :job_plays
 
+    virtual_column :stdout_raw, :type => :string
+
     class << self
       alias create_job create_stack
       alias raw_create_job raw_create_stack
@@ -132,6 +134,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
   rescue => err
     _log.error "AnsibleTower Job #{name} with id(#{id}) status error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
+
+  def stdout_raw
+    raw_stdout
   end
 
   def raw_stdout


### PR DESCRIPTION
This exposes `stdout_raw` so that it may be returned by the API when specified.

The method `stdout_raw` is added because in the future when additional arguments are added to `raw_stdout`, that method can be updated to specify that correct format, and we may add other `virtual_column`s and methods, ie: `stdout_json` 

cc: @Fryguy @bzwei @abellotti 