### PR TITLE
Descriptive custom attribute columns

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1173,10 +1173,10 @@ class MiqExpression
 
     klass.custom_keys.each do |custom_key|
       custom_detail_column = [model, CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX + custom_key].join("-")
-      custom_detail_name = custom_key
+      custom_detail_name = _("Labels: %{custom_key}") % { :custom_key => custom_key }
       if options[:include_model]
         model_name = Dictionary.gettext(model, :type => :model, :notfound => :titleize)
-        custom_detail_name = [model_name, custom_key].join(" : ")
+        custom_detail_name = [model_name, custom_detail_name].join(" : ")
       end
       custom_attributes_details.push([custom_detail_name, custom_detail_column])
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1958,7 +1958,7 @@ describe MiqExpression do
       custom_attr1
       custom_attr2
 
-      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
+      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Labels: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
   end
 


### PR DESCRIPTION
update of #11916
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1416220
Completed on the UI side by https://github.com/ManageIQ/manageiq-ui-classic/pull/733
does `version` -> `Labels: version` in report columns.

@lpichler Please review
cc @simon3z 

@miq-bot add_label euwe/yes, chargeback, providers/containers