### PR TITLE
Fix general CloudNetwork class_by_ems method

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -39,13 +39,9 @@ class CloudNetwork < ApplicationRecord
 
   virtual_total :total_vms, :vms, :uses => :vms
 
-  def self.class_by_ems(ext_management_system, external = false)
+  def self.class_by_ems(ext_management_system, _external = false)
     # TODO: A factory on ExtManagementSystem to return class for each provider
-    if external
-      ext_management_system && ext_management_system.class::CloudNetwork::Public
-    else
-      ext_management_system && ext_management_system.class::CloudNetwork::Private
-    end
+    ext_management_system && ext_management_system.class::CloudNetwork
   end
 
   private

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -22,6 +22,15 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
   require_nested :Private
   require_nested :Public
 
+  def self.class_by_ems(ext_management_system, external = false)
+    # TODO: A factory on ExtManagementSystem to return class for each provider
+    if external
+      ext_management_system && ext_management_system.class::CloudNetwork::Public
+    else
+      ext_management_system && ext_management_system.class::CloudNetwork::Private
+    end
+  end
+
   def self.remapping(options)
     new_options = options.dup
     new_options[:router_external] = options[:external_facing] if options[:external_facing]


### PR DESCRIPTION
Only OpenStack networks contain Public/Private versions, so class_by_ems will fail for other provider
cloud networks.  This fix remediates that.