### PR TITLE
Delegate custom attributes to images in ChargebackContainerImage

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -60,7 +60,7 @@ class Chargeback < ActsAsArModel
     self.start_date, self.end_date, self.display_range = options.report_step_range(consumption.timestamp)
     self.interval_name = options.interval
     self.chargeback_rates = ''
-    self.entity = consumption.resource
+    self.entity ||= consumption.resource
   end
 
   def calculate_costs(consumption, rates)


### PR DESCRIPTION
Custom attributes in this report would turn out nil since they actually belong to the container image.

@lpichler Please review
cc @simon3z 

@miq-bot add_label bug, chargeback, providers/containers
