### PR TITLE
Use the new OvirtSDK for refresh

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -230,6 +230,15 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     supported_api_versions.sort.last
   end
 
+  def highest_allowed_api_version
+    return 3 unless use_ovirt_sdk?
+    highest_supported_api_version
+  end
+
+  def use_ovirt_sdk?
+    ::Settings.ems.ems_redhat.use_ovirt_engine_sdk
+  end
+
   class_methods do
     def api3_supported_features
       []

--- a/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parser.rb
@@ -78,7 +78,7 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParser
 
   def self.parse_new_vm(vm, message, event_type, ems)
     ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm[:href])
-    parser = ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilder.new(ems).build
+    parser = ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilder.new(ems, :force_version => 3).build
     parser.create_vm_hash(ems_ref.include?('/templates/'), ems_ref, vm[:id], parse_target_name(message, event_type))
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Redhat::InfraManager::Inventory
+  require_nested :Inventory
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/builder.rb
@@ -1,0 +1,15 @@
+module ManageIQ::Providers::Redhat::InfraManager::Inventory
+  class Builder
+    attr_reader :ext_management_system
+
+    def initialize(ems)
+      @ext_management_system = ems
+    end
+
+    def build
+      strategy_model = ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
+      api_version = ext_management_system.highest_supported_api_version
+      "#{strategy_model}::V#{api_version}".constantize
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/builder.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory
 
     def build
       strategy_model = ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
-      api_version = ext_management_system.highest_supported_api_version
+      api_version = ext_management_system.highest_allowed_api_version
       "#{strategy_model}::V#{api_version}".constantize
     end
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/inventory.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Redhat::InfraManager::Inventory
+  class Error < StandardError; end
+  class VmNotReadyToBoot < Error; end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v3.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
+  class V3
+    attr_reader :ext_management_system
+
+    def initialize(args)
+      @ext_management_system = args[:ems]
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -1,0 +1,184 @@
+module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
+  class V4
+    attr_accessor :connection
+    attr_reader :ems
+
+    def initialize(args)
+      @ems = args[:ems]
+    end
+
+    def host_targeted_refresh(target)
+      @ems.with_provider_connection(:version => 4) do |connection|
+        @connection = connection
+        res = {}
+        res[:host] = collect_host(get_uuid_from_target(target))
+        res
+      end
+    end
+
+    def vm_targeted_refresh(target)
+      @ems.with_provider_connection(:version => 4) do |connection|
+        @connection = connection
+        vm_id = get_uuid_from_target(target)
+        res = {}
+        res[:cluster] = collect_clusters
+        res[:datacenter] = collect_datacenters
+        res[:vm] = collect_vm_by_uuid(vm_id)
+        res[:storage] = target.storages.empty? ? collect_storages : collect_storage(target.storages.map { |s| get_uuid_from_target(s) })
+        res[:template] = search_templates("vm.id=#{vm_id}")
+        res
+      end
+    end
+
+    def get_uuid_from_href(ems_ref)
+      URI(ems_ref).path.split('/').last
+    end
+
+    def get_uuid_from_target(object)
+      get_uuid_from_href(object.ems_ref)
+    end
+
+    def refresh
+      @ems.with_provider_connection(:version => 4) do |connection|
+        @connection = connection
+        res = {}
+        res[:cluster] = collect_clusters
+        res[:storage] = collect_storages
+        res[:host] = collect_hosts
+        res[:vm] = collect_vms
+        res[:template] = collect_templates
+        res[:network] = collect_networks
+        res[:datacenter] = collect_datacenters
+        res
+      end
+    end
+
+    def collect_clusters
+      connection.system_service.clusters_service.list
+    end
+
+    def collect_storages
+      connection.system_service.storage_domains_service.list
+    end
+
+    def collect_storage(uuids)
+      uuids.collect do |uuid|
+        connection.system_service.storage_domains_service.storage_domain_service(uuid).get
+      end
+    end
+
+    def collect_hosts
+      connection.system_service.hosts_service.list.collect do |h|
+        HostPreloadedAttributesDecorator.new(h, connection)
+      end
+    end
+
+    def collect_host(uuid)
+      host = connection.system_service.hosts_service.host_service(uuid).get
+      [HostPreloadedAttributesDecorator.new(host, connection)]
+    end
+
+    def collect_vms
+      connection.system_service.vms_service.list.collect do |vm|
+        VmPreloadedAttributesDecorator.new(vm, connection)
+      end
+    end
+
+    def collect_vm_by_uuid(uuid)
+      vm = connection.system_service.vms_service.vm_service(uuid).get
+      [VmPreloadedAttributesDecorator.new(vm, connection)]
+    end
+
+    def collect_templates
+      connection.system_service.templates_service.list.collect do |template|
+        TemplatePreloadedAttributesDecorator.new(template, connection)
+      end
+    end
+
+    def search_templates(search)
+      connection.system_service.templates_service.list(:search => search).collect do |template|
+        TemplatePreloadedAttributesDecorator.new(template, connection)
+      end
+    end
+
+    def collect_networks
+      connection.system_service.networks_service.list
+    end
+
+    def collect_datacenters
+      connection.system_service.data_centers_service.list.collect do |datacenter|
+        DatacenterPreloadedAttributesDecorator.new(datacenter, connection)
+      end
+    end
+
+    def api
+      @ems.with_provider_connection(:version => 4) do |connection|
+        connection.system_service.get.product_info.version.full_version
+      end
+    end
+
+    def service
+      @ems.with_provider_connection(:version => 4) do |connection|
+        OpenStruct.new(:version_string => connection.system_service.get.product_info.version.full_version)
+      end
+    end
+
+    class HostPreloadedAttributesDecorator < SimpleDelegator
+      attr_reader :nics, :statistics
+      def initialize(host, connection)
+        @obj = host
+        @nics = connection.follow_link(host.nics)
+        @statistics = connection.follow_link(host.statistics)
+        super(host)
+      end
+    end
+
+    class DatacenterPreloadedAttributesDecorator < SimpleDelegator
+      attr_reader :storage_domains
+      def initialize(datacenter, connection)
+        @obj = datacenter
+        @storage_domains = connection.follow_link(datacenter.storage_domains)
+        super(datacenter)
+      end
+    end
+
+    class VmPreloadedAttributesDecorator < SimpleDelegator
+      attr_reader :disks, :nics, :reported_devices, :snapshots
+      def initialize(vm, connection)
+        @obj = vm
+        @disks = self.class.get_attached_disks(vm, connection)
+        @nics = connection.follow_link(vm.nics)
+        @reported_devices = connection.follow_link(vm.reported_devices)
+        @snapshots = connection.follow_link(vm.snapshots)
+        super(vm)
+      end
+
+      def self.get_attached_disks(vm, connection)
+        AttachedDisksFetcher.get_attached_disks(vm, connection)
+      end
+    end
+
+    class AttachedDisksFetcher
+      def self.get_attached_disks(disks_owner, connection)
+        attachments = connection.follow_link(disks_owner.disk_attachments)
+        attachments.map do |attachment|
+          res = connection.follow_link(attachment.disk)
+          res.interface = attachment.interface
+          res.bootable = attachment.bootable
+          res.active = attachment.active
+          res
+        end
+      end
+    end
+
+    class TemplatePreloadedAttributesDecorator < SimpleDelegator
+      attr_reader :disks, :nics
+      def initialize(template, connection)
+        @obj = template
+        @disks = AttachedDisksFetcher.get_attached_disks(template, connection)
+        @nics = connection.follow_link(template.nics)
+        super(template)
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory/strategies/v4.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
     end
 
     def host_targeted_refresh(target)
-      @ems.with_provider_connection(:version => 4) do |connection|
+      ems.with_provider_connection(:version => 4) do |connection|
         @connection = connection
         res = {}
         res[:host] = collect_host(get_uuid_from_target(target))
@@ -17,7 +17,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
     end
 
     def vm_targeted_refresh(target)
-      @ems.with_provider_connection(:version => 4) do |connection|
+      ems.with_provider_connection(:version => 4) do |connection|
         @connection = connection
         vm_id = get_uuid_from_target(target)
         res = {}
@@ -39,7 +39,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
     end
 
     def refresh
-      @ems.with_provider_connection(:version => 4) do |connection|
+      ems.with_provider_connection(:version => 4) do |connection|
         @connection = connection
         res = {}
         res[:cluster] = collect_clusters
@@ -112,13 +112,13 @@ module ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies
     end
 
     def api
-      @ems.with_provider_connection(:version => 4) do |connection|
+      ems.with_provider_connection(:version => 4) do |connection|
         connection.system_service.get.product_info.version.full_version
       end
     end
 
     def service
-      @ems.with_provider_connection(:version => 4) do |connection|
+      ems.with_provider_connection(:version => 4) do |connection|
         OpenStruct.new(:version_string => connection.system_service.get.product_info.version.full_version)
       end
     end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder.rb
@@ -1,14 +1,15 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse
   class ParserBuilder
-    attr_reader :ext_management_system
+    attr_reader :ext_management_system, :force_version
 
-    def initialize(ems)
+    def initialize(ems, options = {})
       @ext_management_system = ems
+      @force_version = options[:force_version]
     end
 
     def build
       parse_model = ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
-      api_version = ext_management_system.highest_supported_api_version
+      api_version = force_version || ext_management_system.highest_supported_api_version
       "#{parse_model}::Api#{api_version}".constantize
     end
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse
 
     def build
       parse_model = ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
-      api_version = force_version || ext_management_system.highest_supported_api_version
+      api_version = force_version || ext_management_system.highest_allowed_api_version
       "#{parse_model}::Api#{api_version}".constantize
     end
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
@@ -1,4 +1,101 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
   class Api4 < ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
+    def self.cluster_inv_to_hashes(inv)
+      result = []
+      result_uids = {}
+      result_res_pools = []
+      return result, result_uids, result_res_pools if inv.nil?
+
+      inv.each do |data|
+        mor = data.id
+
+        # Create a default Resource Pool for the cluster
+        default_res_pool = {
+          :name         => "Default for Cluster #{data.name}",
+          :uid_ems      => "#{mor}_respool",
+          :is_default   => true,
+          :ems_children => {:vms => []}
+        }
+        result_res_pools << default_res_pool
+
+        ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(data.href)
+
+        new_result = {
+          :ems_ref       => ems_ref,
+          :ems_ref_obj   => ems_ref,
+          :uid_ems       => data.id,
+          :name          => data.name,
+
+          # Capture datacenter id so we can link up to it's sub-folders later
+          :datacenter_id => data.dig(:data_center, :id),
+
+          :ems_children  => {:resource_pools => [default_res_pool]}
+        }
+
+        result << new_result
+        result_uids[mor] = new_result
+      end
+      return result, result_uids, result_res_pools
+    end
+
+    def self.storage_inv_to_hashes(inv)
+      result = []
+      result_uids = {:storage_id => {}}
+      return result, result_uids if inv.nil?
+
+      inv.each do |storage_inv|
+        mor = storage_inv.id
+
+        storage_type = storage_inv.dig(:storage, :type).upcase
+        location = if storage_type == 'NFS' || storage_type == 'GLUSTERFS'
+                     "#{storage_inv.dig(:storage, :address)}:#{storage_inv.dig(:storage, :path)}"
+                   else
+                     # TODO this is taking only one location for some reason. Need to investigate
+                     # how this is used
+                     logical_units = storage_inv.dig(:storage, :volume_group, :logical_units)
+                     logical_unit =  logical_units && logical_units.first
+                     logical_unit && logical_unit.id
+                   end
+
+        free        = storage_inv.try(:available).to_i
+        used        = storage_inv.try(:used).to_i
+        total       = free + used
+        committed   = storage_inv.try(:committed).to_i
+        uncommitted = total - committed
+
+        ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(storage_inv.try(:href))
+
+        new_result = {
+          :ems_ref             => ems_ref,
+          :ems_ref_obj         => ems_ref,
+          :name                => storage_inv.try(:name),
+          :store_type          => storage_type,
+          :storage_domain_type => storage_inv.dig(:type, :downcase),
+          :total_space         => total,
+          :free_space          => free,
+          :uncommitted         => uncommitted,
+          :multiplehostaccess  => true,
+          :location            => location,
+          :master              => storage_inv.try(:master)
+        }
+
+        result << new_result
+        result_uids[mor] = new_result
+        result_uids[:storage_id][storage_inv.try(:id)] = new_result
+      end
+      return result, result_uids
+    end
+
+    def self.host_inv_to_hashes(inv, ems_inv, cluster_uids, storage_uids)
+      HostInventory.new(:inv => inv, :logger => _log).host_inv_to_hashes(inv, ems_inv, cluster_uids, storage_uids)
+    end
+
+    def self.vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+      VmInventory.new(:inv => inv, :logger => _log).vm_inv_to_hashes(inv, storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+    end
+
+    def self.datacenter_inv_to_hashes(inv, cluster_uids, vm_uids, storage_uids, host_uids)
+      DatacenterInventory.new(:inv => inv, :logger => _log).datacenter_inv_to_hashes(inv, cluster_uids, vm_uids, storage_uids, host_uids)
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/api4.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         location = if storage_type == 'NFS' || storage_type == 'GLUSTERFS'
                      "#{storage_inv.dig(:storage, :address)}:#{storage_inv.dig(:storage, :path)}"
                    else
-                     # TODO this is taking only one location for some reason. Need to investigate
+                     # TODO: this is taking only one location for some reason. Need to investigate
                      # how this is used
                      logical_units = storage_inv.dig(:storage, :volume_group, :logical_units)
                      logical_unit =  logical_units && logical_units.first

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/datacenter_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/datacenter_inventory.rb
@@ -1,10 +1,10 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
   class DatacenterInventory
-    attr_reader :datacenter_inv, :_log
+    attr_reader :datacenter_inv, :logger
 
     def initialize(args)
       @datacenter_inv = args[:inv]
-      @_log = args[:logger]
+      @logger = args[:logger]
     end
 
     def datacenter_inv_to_hashes(inv, cluster_uids, vm_uids, storage_uids, host_uids)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/datacenter_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/datacenter_inventory.rb
@@ -1,0 +1,63 @@
+module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
+  class DatacenterInventory
+    attr_reader :datacenter_inv, :_log
+
+    def initialize(args)
+      @datacenter_inv = args[:inv]
+      @_log = args[:logger]
+    end
+
+    def datacenter_inv_to_hashes(inv, cluster_uids, vm_uids, storage_uids, host_uids)
+      result = [{
+        :name         => 'Datacenters',
+        :type         => 'EmsFolder',
+        :uid_ems      => 'root_dc',
+        :hidden       => true,
+
+        :ems_children => {:folders => []}
+      }]
+      return result if inv.nil?
+
+      root_children = result.first[:ems_children][:folders]
+
+      inv.each do |data|
+        uid = data.id
+
+        host_folder = {:name => 'host', :type => 'EmsFolder', :uid_ems => "#{uid}_host", :hidden => true}
+        vm_folder   = {:name => 'vm',   :type => 'EmsFolder', :uid_ems => "#{uid}_vm",   :hidden => true}
+
+        # Link clusters to datacenter host folder
+        clusters = cluster_uids.values.select { |c| c[:datacenter_id] == uid }
+        host_folder[:ems_children] = {:clusters => clusters}
+
+        # Link vms to datacenter vm folder
+        vms = vm_uids.values.select { |v| v.fetch_path(:ems_cluster, :datacenter_id) == uid }
+        vm_folder[:ems_children] = {:vms => vms}
+
+        ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(data.href)
+
+        new_result = {
+          :name         => data.name,
+          :type         => 'Datacenter',
+          :ems_ref      => ems_ref,
+          :ems_ref_obj  => ems_ref,
+          :uid_ems      => uid,
+
+          :ems_children => {:folders => [host_folder, vm_folder]}
+        }
+
+        result << new_result
+        result << host_folder
+        result << vm_folder
+        root_children << new_result
+
+        # Link hosts to storages
+        hosts = host_uids.values.select { |v| v.fetch_path(:ems_cluster, :datacenter_id) == uid }
+        storage_ids = data.storage_domains.to_miq_a.collect(&:id)
+        hosts.each { |h| h[:storages] = storage_uids.values_at(*storage_ids).compact } unless storage_ids.blank?
+      end
+
+      result
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -1,0 +1,297 @@
+module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
+  class HostInventory
+    attr_reader :host_inv, :_log
+
+    def initialize(args)
+      @host_inv = args[:inv]
+      @_log = args[:logger]
+    end
+
+    def host_inv_to_hashes(inv, ems_inv, cluster_uids, _storage_uids)
+      result = []
+      result_uids = {}
+      lan_uids = {}
+      switch_uids = {}
+      guest_device_uids = {}
+      scsi_lun_uids = {}
+      return result, result_uids, lan_uids, switch_uids, guest_device_uids, scsi_lun_uids if inv.nil?
+
+      inv.each do |host_inv|
+        host_id = host_inv.id
+
+        hostname = host_inv.address
+
+        # Check connection state and log potential issues
+        power_state = host_inv.status
+        if ['down', nil, ''].include?(power_state)
+          _log.warn "Host [#{host_id}] connection state is [#{power_state.inspect}].  Inventory data may be missing."
+        end
+
+        power_state, connection_state = case power_state
+                                        when 'up'             then %w(on connected)
+                                        when 'maintenance'    then [power_state, 'connected']
+                                        when 'down'           then %w(off disconnected)
+                                        when 'non_responsive' then %w(unknown connected)
+                                        else [power_state, 'disconnected']
+                                        end
+
+        # Remove the domain suffix if it is included in the hostname
+        hostname = hostname.split(',').first
+        # Get the IP address
+        ipaddress = host_inv_to_ip(host_inv, hostname) || host_inv.address
+
+        # Collect the hardware, networking, and scsi inventories
+        switches, switch_uids[host_id], lan_uids[host_id] = host_inv_to_switch_hashes(host_inv, ems_inv)
+
+        hardware = host_inv_to_hardware_hash(host_inv)
+        hardware[:guest_devices], guest_device_uids[host_id] = host_inv_to_guest_device_hashes(host_inv, switch_uids[host_id], ems_inv)
+        hardware[:networks] = host_inv_to_network_hashes(host_inv, guest_device_uids[host_id])
+
+        ipmi_address = nil
+        if host_inv.dig(:power_management, :type).to_s.include?('ipmi')
+          ipmi_address = host_inv.dig(:power_management, :address)
+        end
+
+        host_os_version = host_inv.dig(:os, :version)
+        ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(host_inv.href)
+        new_result = {
+          :type             => 'ManageIQ::Providers::Redhat::InfraManager::Host',
+          :ems_ref          => ems_ref,
+          :ems_ref_obj      => ems_ref,
+          :name             => host_inv.name || hostname,
+          :hostname         => hostname,
+          :ipaddress        => ipaddress,
+          :uid_ems          => host_inv.id,
+          :vmm_vendor       => 'redhat',
+          :vmm_product      => host_inv.type,
+          :vmm_version      => extract_host_version(host_os_version),
+          :vmm_buildnumber  => (host_os_version.build if host_os_version),
+          :connection_state => connection_state,
+          :power_state      => power_state,
+          :operating_system => host_inv_to_os_hash(host_inv, hostname),
+          :ems_cluster      => cluster_uids[host_inv.dig(:cluster, :id)],
+          :hardware         => hardware,
+          :switches         => switches,
+        }
+        new_result[:ipmi_address] = ipmi_address unless ipmi_address.blank?
+
+        result << new_result
+        result_uids[host_id] = new_result
+      end
+      return result, result_uids, lan_uids, switch_uids, guest_device_uids, scsi_lun_uids
+    end
+
+    def extract_host_version(host_os_version)
+      return unless host_os_version && host_os_version.major
+
+      version = host_os_version.major
+      version = "#{version}.#{host_os_version.minor}" if host_os_version.minor
+      version
+    end
+
+    def host_inv_to_ip(inv, hostname = nil)
+      _log.debug("IP lookup for host in VIM inventory data...")
+      ipaddress = nil
+      inv.nics.to_miq_a.each do |nic|
+        ip_data = nic.ip
+        if !ip_data.nil? && !ip_data.gateway.blank? && !ip_data.address.blank?
+          ipaddress = ip_data.address
+          break
+        end
+      end
+
+      unless ipaddress.nil?
+        warn_msg = "IP lookup for host in VIM inventory data...Failed."
+        if [nil, "localhost", "localhost.localdomain", "127.0.0.1"].include?(hostname)
+          _log.warn warn_msg
+        else
+          _log.warn "#{warn_msg} Falling back to reverse lookup."
+          begin
+            # IPSocket.getaddress(hostname) is not used because it was appending
+            #   a ".com" to the "esxdev001.localdomain" which resolved to a real
+            #   internet address. Socket.getaddrinfo does the right thing.
+            # TODO: Can this moved to MiqSockUtil?
+
+            # _log.debug "IP lookup by hostname [#{hostname}]..."
+            ipaddress = Socket.getaddrinfo(hostname, nil)[0][3]
+            _log.debug "IP lookup by hostname [#{hostname}]...Complete: IP found: [#{ipaddress}]"
+          rescue => err
+            _log.warn "IP lookup by hostname [#{hostname}]...Failed with the following error: #{err}"
+          end
+        end
+      end
+
+      ipaddress
+    end
+
+    def host_inv_to_switch_hashes(inv, ems_inv)
+      nics = inv.nics
+
+      result = []
+      result_uids = {:pnic_id => {}}
+      lan_uids    = {}
+      return result, result_uids if nics.nil?
+
+      nics.to_miq_a.each do |data|
+        network_id = data.dig(:network, :id)
+        if network_id
+          network = ems_inv[:network].detect { |n| n.id == network_id }
+        else
+          network_name = data.dig(:network, :name)
+          cluster_id = inv.dig(:cluster, :id)
+          cluster = ems_inv[:cluster].detect { |c| c.id == cluster_id }
+          datacenter_id = cluster.dig(:data_center, :id)
+          network = ems_inv[:network].detect { |n| n.name == network_name && n.dig(:data_center, :id) == datacenter_id }
+        end
+
+        tag_value = nil
+        if network
+          uid = network.id
+          name = network.name
+          tag_value = network.try(:vlan).try(:id)
+        else
+          uid = name = network_name unless network_name.nil?
+        end
+
+        next if uid.nil?
+
+        lan = {:name => name, :uid_ems => uid, :tag => tag_value}
+        lan_uids[uid] = lan
+        new_result = {
+          :uid_ems => uid,
+          :name    => name,
+
+          :lans    => [{:name => name, :uid_ems => uid, :tag => tag_value}]
+        }
+
+        result << new_result
+        result_uids[uid] = new_result
+      end
+      return result, result_uids, lan_uids
+    end
+
+    def host_inv_to_hardware_hash(inv)
+      return nil if inv.nil?
+
+      result = {}
+
+      hdw = inv.cpu
+      unless hdw.blank?
+        result[:cpu_speed] = hdw.speed
+        result[:cpu_type] = hdw.name
+
+        # Value provided by VC is in bytes, need to convert to MB
+        memory_total_attr = inv.statistics.to_miq_a.detect { |stat| stat.name == 'memory.total' }
+        memory_total = memory_total_attr.dig(:values, :first, :datum)
+        result[:memory_mb] = memory_total.nil? ? 0 : memory_total.to_i / 1.megabyte
+
+        result[:cpu_cores_per_socket] = hdw.dig(:topology, :cores) || 1
+        result[:cpu_sockets]          = hdw.dig(:topology, :sockets) || 1
+        result[:cpu_total_cores]      = result[:cpu_sockets] * result[:cpu_cores_per_socket]
+      end
+
+      hw_info = inv.hardware_information
+      unless hw_info.blank?
+        result[:manufacturer] = hw_info.manufacturer
+        result[:model] = hw_info.product_name
+      end
+
+      result
+    end
+
+    def host_inv_to_guest_device_hashes(inv, switch_uids, ems_inv)
+      pnic = inv.nics
+
+      result = []
+      result_uids = {}
+      return result, result_uids if pnic.nil?
+      result_uids[:pnic] = {}
+      pnic.to_miq_a.each do |data|
+        # Find the switch to which this pnic is connected
+        network_id = data.dig(:network, :id)
+        if network_id
+          network = ems_inv[:network].detect { |n| n.id == network_id }
+        else
+          network_name = data.dig(:network, :name)
+          cluster_id = inv.dig(:cluster, :id)
+          cluster = ems_inv[:cluster].detect { |c| c.id == cluster_id }
+          datacenter_id = cluster.dig(:data_center, :id)
+          network = ems_inv[:network].detect { |n| n.name == network_name && n.dig(:data_center, :id) == datacenter_id }
+        end
+
+        if network
+          switch_uid = network.id
+        else
+          switch_uid = network_name unless network_name.nil?
+        end
+
+        unless switch_uid.nil?
+          switch = switch_uids[switch_uid]
+        end
+
+        location = nil
+        location = $1 if data.name =~ /(\d+)$/
+        uid = data.id
+
+        new_result = {
+          :uid_ems         => uid,
+          :device_name     => data.name,
+          :device_type     => 'ethernet',
+          :location        => location,
+          :present         => true,
+          :controller_type => 'ethernet',
+        }
+        new_result[:switch] = switch unless switch.nil?
+
+        result << new_result
+        result_uids[:pnic][uid] = new_result
+      end
+
+      return result, result_uids
+    end
+
+    def host_inv_to_os_hash(inv, hostname)
+      return nil if inv.nil?
+
+      {
+        :name         => hostname,
+        :product_type => 'linux',
+        :product_name => extract_host_os_name(inv),
+        :version      => extract_host_os_full_version(inv.os)
+      }
+    end
+
+    def extract_host_os_full_version(host_os)
+      host_os.dig(:version, :full_version)
+    end
+
+    def host_inv_to_network_hashes(inv, guest_device_uids)
+      inv = inv.nics
+      result = []
+      return result if inv.nil?
+
+      inv.to_miq_a.each do |vnic|
+        uid = vnic.id
+        guest_device = guest_device_uids.fetch_path(:pnic, uid)
+
+        # Get the ip section
+        ip = vnic.ip.presence || {}
+
+        new_result = {
+          :description => vnic.name,
+          :ipaddress   => ip.address,
+          :subnet_mask => ip.netmask,
+        }
+
+        result << new_result
+        guest_device[:network] = new_result unless guest_device.nil?
+      end
+      result
+    end
+
+    def extract_host_os_name(host_inv)
+      host_os = host_inv.os
+      host_os && host_os.type || host_inv.type
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -1,0 +1,284 @@
+module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
+  class VmInventory
+    attr_reader :host_inv, :_log
+
+    def initialize(args)
+      @host_inv = args[:inv]
+      @_log = args[:logger]
+    end
+
+    def vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)
+      result = []
+      result_uids = {}
+      guest_device_uids = {}
+      added_hosts = []
+      return result, result_uids, added_hosts if inv.nil?
+
+      inv.each do |vm_inv|
+        vm_id = vm_inv.id
+
+        # Skip the place holder template since it does not really exist and does not have a unique ID accross multiple Management Systems
+        next if vm_id == '00000000-0000-0000-0000-000000000000'
+
+        template        = vm_inv.href.include?('/templates/')
+        raw_power_state = template ? "never" : vm_inv.status
+
+        boot_time = vm_inv.try(:start_time)
+
+        storages = []
+        vm_inv.disks.to_miq_a.each do |disk|
+          disk.storage_domains.to_miq_a.each do |sd|
+            storages << storage_uids[sd.id]
+          end
+        end
+        storages.compact!
+        storages.uniq!
+        storage = storages.first
+
+        # Determine the cluster
+        ems_cluster = cluster_uids[vm_inv.cluster.id]
+
+        # If the VM is running it will have a host name in the data
+        # Otherwise if it is assigned to run on a specific host the host ID will be in the placement_policy
+        host_id = vm_inv.try(:host).try(:id)
+        host_id = vm_inv.try(:placement_policy).try(:hosts).try(:id) if host_id.blank?
+        host = host_uids.values.detect { |h| h[:uid_ems] == host_id } unless host_id.blank?
+
+        # If the vm has a host but the refresh does not include it in the "hosts" hash
+        if host.blank? && vm_inv.try(:host).present?
+          host = partial_host_hash(vm_inv.host)
+          added_hosts << host if host
+        end
+
+        host_mor = host_id
+        hardware = vm_inv_to_hardware_hash(vm_inv)
+        hardware[:disks] = vm_inv_to_disk_hashes(vm_inv, storage_uids)
+        hardware[:guest_devices], guest_device_uids[vm_id] = vm_inv_to_guest_device_hashes(vm_inv, lan_uids[host_mor])
+        hardware[:networks] = vm_inv_to_network_hashes(vm_inv, guest_device_uids[vm_id])
+
+        ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_inv.href)
+
+        new_result = create_vm_hash(template, ems_ref, vm_inv.id, URI.decode(vm_inv.name))
+
+        additional = {
+          :memory_reserve    => vm_memory_reserve(vm_inv),
+          :raw_power_state   => raw_power_state,
+          :boot_time         => boot_time,
+          :connection_state  => 'connected',
+          :host              => host,
+          :ems_cluster       => ems_cluster,
+          :storages          => storages,
+          :storage           => storage,
+          :operating_system  => vm_inv_to_os_hash(vm_inv),
+          :hardware          => hardware,
+          :custom_attributes => vm_inv_to_custom_attribute_hashes(vm_inv),
+          :snapshots         => vm_inv_to_snapshot_hashes(vm_inv),
+        }
+        new_result.merge!(additional)
+
+        # Attach to the cluster's default resource pool
+        ems_cluster[:ems_children][:resource_pools].first[:ems_children][:vms] << new_result if ems_cluster && !template
+
+        result << new_result
+        result_uids[vm_id] = new_result
+      end
+      return result, result_uids, added_hosts
+    end
+
+    def partial_host_hash(partial_host_inv)
+      ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(partial_host_inv.href)
+      { :ems_ref => ems_ref, :uid_ems => partial_host_inv.id }
+    end
+
+    def create_vm_hash(template, ems_ref, vm_id, name)
+      {
+        :type        => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
+        :ems_ref     => ems_ref,
+        :ems_ref_obj => ems_ref,
+        :uid_ems     => vm_id,
+        :vendor      => "redhat",
+        :name        => name,
+        :location    => "#{vm_id}.ovf",
+        :template    => template,
+      }
+    end
+
+    def vm_inv_to_hardware_hash(inv)
+      return nil if inv.nil?
+
+      result = {
+        :guest_os   => inv.dig(:os, :type),
+        :annotation => inv.try(:description)
+      }
+
+      hdw = inv.cpu
+      topology = hdw.topology
+      result[:cpu_cores_per_socket] = topology.try(:cores) || 1
+      result[:cpu_sockets]          = topology.try(:sockets) || 1
+      result[:cpu_total_cores]      = result[:cpu_sockets] * result[:cpu_cores_per_socket]
+
+      result[:memory_mb] = inv.memory / 1.megabyte
+
+      result
+    end
+
+    def vm_inv_to_guest_device_hashes(inv, lan_uids)
+      inv = inv.nics
+
+      result = []
+      result_uids = {}
+      return result, result_uids if inv.nil?
+
+      inv.to_miq_a.each do |data|
+        uid = data.id
+        address = data.dig(:mac, :address)
+        name = data.name
+
+        lan = lan_uids[data.dig(:network, :id)] unless lan_uids.nil?
+
+        new_result = {
+          :uid_ems         => uid,
+          :device_name     => name,
+          :device_type     => 'ethernet',
+          :controller_type => 'ethernet',
+          :address         => address,
+        }
+        new_result[:lan] = lan unless lan.nil?
+
+        result << new_result
+        result_uids[uid] = new_result
+      end
+      return result, result_uids
+    end
+
+    def vm_inv_to_network_hashes(inv, guest_device_uids)
+      reported_device = inv.respond_to?(:reported_devices) ? inv.reported_devices[0] : nil
+      inv_net = reported_device.ips if reported_device
+      result = []
+      return result if inv_net.nil?
+
+      inv_net.to_miq_a.each do |data|
+        new_result = { :ipaddress => data.address }
+        result << new_result unless new_result.blank?
+      end
+
+      # There is not data to corridnate what IPs go with what networks
+      # So if there is only 1 of each link them together.
+      if result.length == 1 && guest_device_uids.length == 1
+        guest_device = guest_device_uids[guest_device_uids.keys.first]
+        guest_device[:network] = result.first unless guest_device.nil?
+      end
+
+      result
+    end
+
+    def vm_inv_to_disk_hashes(inv, storage_uids)
+      inv = inv.try(:disks)
+
+      result = []
+      return result if inv.nil?
+      # RHEV initially orders disks by bootable status then by name. Attempt
+      # to use the disk number in the name, if available, as an ordering hint
+      # to support the case where a disk is added after initial VM creation.
+      inv = inv.to_miq_a.sort_by do |disk|
+        match = disk.try(:name).match(/disk[^\d]*(?<index>\d+)/i)
+        [disk.try(:bootable) ? 0 : 1, match ? match[:index].to_i : Float::INFINITY, disk.name]
+      end.group_by { |d| d.try(:interface) }
+
+      inv.each do |interface, devices|
+        devices.each_with_index do |device, index|
+          device_type = 'disk'
+          storage_domain = device.storage_domains && device.storage_domains.first
+          storage_mor = storage_domain && storage_domain.id
+
+          new_result = {
+            :device_name     => device.name,
+            :device_type     => device_type,
+            :controller_type => interface,
+            :present         => true,
+            :filename        => device.id,
+            :location        => index.to_s,
+            :size            => device.provisioned_size.to_i,
+            :size_on_disk    => device.actual_size.to_i,
+            :disk_type       => device.sparse == true ? 'thin' : 'thick',
+            :mode            => 'persistent',
+            :bootable        => device.try(:bootable)
+          }
+
+          new_result[:storage] = storage_uids[storage_mor] unless storage_mor.nil?
+          result << new_result
+        end
+      end
+
+      result
+    end
+
+    def vm_inv_to_os_hash(inv)
+      guest_os = inv.dig(:os, :type)
+      result = {
+        # If the data from VC is empty, default to "Other"
+        :product_name => guest_os.blank? ? "Other" : guest_os
+      }
+      result[:system_type] = inv.type unless inv.type.nil?
+      result
+    end
+
+    def vm_inv_to_snapshot_hashes(inv)
+      result = []
+      inv = inv.try(:snapshots).to_miq_a.reverse
+      return result if inv.nil?
+
+      parent_id = nil
+      inv.each_with_index do |snapshot, idx|
+        result << snapshot_inv_to_snapshot_hashes(snapshot, idx == inv.length - 1, parent_id)
+        parent_id = snapshot.id
+      end
+      result
+    end
+
+    def snapshot_inv_to_snapshot_hashes(inv, current, parent_uid = nil)
+      create_time = inv.date.getutc
+
+      # Fix case where blank description comes back as a Hash instead
+      name = description = inv.description
+      name = "Active Image" if name[0, 13] == '_ActiveImage_'
+
+      result = {
+        :uid_ems     => inv.id,
+        :uid         => inv.id,
+        :parent_uid  => parent_uid,
+        :name        => name,
+        :description => description,
+        :create_time => create_time,
+        :current     => current,
+      }
+
+      result
+    end
+
+    def vm_inv_to_custom_attribute_hashes(inv)
+      result = []
+      custom_attrs = inv.try(:custom_properties)
+      return result if custom_attrs.nil?
+
+      custom_attrs.each do |ca|
+        new_result = {
+          :section => 'custom_field',
+          :name    => ca.name,
+          :value   => ca.value.try(:truncate, 255),
+          :source  => "VC",
+        }
+        result << new_result
+      end
+
+      result
+    end
+
+    require 'ostruct'
+
+    def vm_memory_reserve(vm_inv)
+      in_bytes = vm_inv.dig(:memory_policy, :guaranteed)
+      in_bytes.nil? ? nil : in_bytes / Numeric::MEGABYTE
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -14,37 +14,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
 
         case target
         when Host
-          methods = {
-            :primary => {
-              :host        => target.ems_ref,
-            },
-            :secondary => {
-              :host        => [:statistics, :host_nics],
-            }
-          }
-          data,  = Benchmark.realtime_block(:fetch_host_data) { data = inventory.targeted_refresh(methods) }
-
+          data,  = Benchmark.realtime_block(:fetch_host_data) { host_targeted_refresh(inventory, target) }
         when VmOrTemplate
-          require 'uri'
-
-          vm = target.ems_ref
-          vm_id = URI(vm).path.split('/').last
-
-          methods = {
-            :primary => {
-              :cluster    => {:clusters => "cluster"},
-              :datacenter => {:datacenters => "data_center"},
-              :vm         => vm,
-              :template   => "/api/templates?search=vm.id=#{vm_id}",
-              :storage    => target.storages.empty? ? {:storagedomains => "storage_domain"} : target.storages.map(&:ems_ref)
-            },
-            :secondary => {
-              :vm         => [:disks, :snapshots, :nics],
-              :template   => [:disks]
-            }
-          }
-          data,  = Benchmark.realtime_block(:fetch_vm_data) { inventory.targeted_refresh(methods) }
-
+          data,  = Benchmark.realtime_block(:fetch_vm_data) { vm_targeted_refresh(inventory, target)  }
         else
           data,  = Benchmark.realtime_block(:fetch_all) { inventory.refresh }
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb
@@ -16,7 +16,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
         when Host
           data,  = Benchmark.realtime_block(:fetch_host_data) { host_targeted_refresh(inventory, target) }
         when VmOrTemplate
-          data,  = Benchmark.realtime_block(:fetch_vm_data) { vm_targeted_refresh(inventory, target)  }
+          data,  = Benchmark.realtime_block(:fetch_vm_data) { vm_targeted_refresh(inventory, target) }
         else
           data,  = Benchmark.realtime_block(:fetch_all) { inventory.refresh }
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher_builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher_builder.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh
 
     def build
       strategy_model = ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
-      api_version = ext_management_system.highest_supported_api_version
+      api_version = ext_management_system.highest_allowed_api_version
       "#{strategy_model}::Api#{api_version}".constantize
     end
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
@@ -1,4 +1,37 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
   class Api3 < ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher
+    def host_targeted_refresh(inventory, target)
+      methods = {
+        :primary => {
+          :host => target.ems_ref,
+        },
+        :secondary => {
+          :host => [:statistics, :host_nics],
+        }
+      }
+      inventory.targeted_refresh(methods)
+    end
+
+    def vm_targeted_refresh(inventory, target)
+      require 'uri'
+
+      vm = target.ems_ref
+      vm_id = URI(vm).path.split('/').last
+
+      methods = {
+        :primary => {
+          :cluster    => {:clusters => "cluster"},
+          :datacenter => {:datacenters => "data_center"},
+          :vm         => vm,
+          :template   => "/api/templates?search=vm.id=#{vm_id}",
+          :storage    => target.storages.empty? ? {:storagedomains => "storage_domain"} : target.storages.map(&:ems_ref)
+        },
+        :secondary => {
+          :vm         => [:disks, :snapshots, :nics],
+          :template   => [:disks]
+        }
+      }
+      inventory.targeted_refresh(methods)
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
   class Api3 < ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher
     def host_targeted_refresh(inventory, target)
       methods = {
-        :primary => {
+        :primary   => {
           :host => target.ems_ref,
         },
         :secondary => {
@@ -19,7 +19,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
       vm_id = URI(vm).path.split('/').last
 
       methods = {
-        :primary => {
+        :primary   => {
           :cluster    => {:clusters => "cluster"},
           :datacenter => {:datacenters => "data_center"},
           :vm         => vm,
@@ -27,8 +27,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
           :storage    => target.storages.empty? ? {:storagedomains => "storage_domain"} : target.storages.map(&:ems_ref)
         },
         :secondary => {
-          :vm         => [:disks, :snapshots, :nics],
-          :template   => [:disks]
+          :vm       => [:disks, :snapshots, :nics],
+          :template => [:disks]
         }
       }
       inventory.targeted_refresh(methods)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api4.rb
@@ -1,4 +1,20 @@
 module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
   class Api4 < ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher
+    attr_reader :ems
+
+    def host_targeted_refresh(inventory, target)
+      inventory.host_targeted_refresh(target)
+    end
+
+    def vm_targeted_refresh(inventory, target)
+      inventory.vm_targeted_refresh(target)
+    end
+
+    require 'uri'
+
+    def inventory_from_ovirt(ems)
+      @ems = ems
+      ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4.new(:ems => ems)
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -101,6 +101,7 @@
       :omit_default_port: true
       :read_timeout: 60
   :ems_redhat:
+    :use_ovirt_engine_sdk: false
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -1,0 +1,48 @@
+describe ManageIQ::Providers::Redhat::InfraManager::EventParser  do
+  context 'parse event using v3' do
+    let(:ip_address) { '192.168.1.105' }
+
+    before(:each) do
+      _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address,
+                                :port => 8443)
+      @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
+
+      allow(@ems).to receive(:supported_api_versions).and_return([3])
+      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+    end
+
+    it "should parse event" do
+      event = {:id=>"414",
+               :href=>"/ovirt-engine/api/events/414",
+               :cluster=>{:id=>"00000002-0002-0002-0002-00000000017a",
+                          :href=>"/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"},
+               :data_center=>{:id=>"00000001-0001-0001-0001-000000000311",
+                              :href=>"/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"},
+               :user=>{:id=>"58ad9d2d-013a-00aa-018f-00000000022e",
+                       :href=>"/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e"},
+               :vm=>{:id=>"3a697bd0-7cea-42a1-95ef-fd292fcee721",
+                     :href=>"/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"},
+               :description=>"VM new configuration was updated by admin@internal-authz.",
+               :severity=>"normal",
+               :code=>35,
+               :time=>"2017-02-27 15:44:20 +0100",
+               :name=>"USER_UPDATE_VM"}
+      allow(ManageIQ::Providers::Redhat::InfraManager).to receive(:find_by).with(:id => @ems.id).and_return(@ems)
+
+      VCR.use_cassette("#{described_class.name.underscore}_parse_event", :allow_unused_http_interactions => true, :allow_playback_repeats => true, :record => :new_episodes) do
+        parsed = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, @ems.id)
+
+        expect(parsed).to have_attributes(
+          :event_type          => "USER_UPDATE_VM",
+          :source              => 'RHEVM',
+          :message             => "VM new configuration was updated by admin@internal-authz.",
+          :timestamp           => "2017-02-27 15:44:20 +0100",
+          :username            => "admin@internal-authz",
+          :full_data           => event,
+          :ems_id              => @ems.id,
+        )
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilde
   subject { described_class.new(ems, options).build }
   describe 'chooses the right parsing strategy' do
     before do
-      ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = use_ovirt_engine_sdk
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => use_ovirt_engine_sdk } })
     end
 
     context "when v4 api" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
@@ -1,0 +1,55 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilder do
+  let(:ems) { FactoryGirl.build(:ems_redhat) }
+  let(:use_ovirt_engine_sdk) { true }
+  let(:options) { {} }
+  subject { described_class.new(ems, options).build }
+  describe 'chooses the right parsing strategy' do
+    before do
+      ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = use_ovirt_engine_sdk
+    end
+
+    context "when v4 api" do
+      before(:each) do
+        allow(ems).to receive(:highest_supported_api_version).and_return(4)
+      end
+
+      it 'returns the api4 parser' do
+        expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api4)
+      end
+
+      context "when use_ovirt_engine_sdk setting is turned to false" do
+        let(:use_ovirt_engine_sdk) { false }
+        it 'returns the api3 parser' do
+          expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api3)
+        end
+      end
+
+      context "forced version 3" do
+        let(:options) { { :force_version => 3  } }
+
+        it 'returns the api3 parser' do
+          expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api3)
+        end
+      end
+
+    end
+
+    context "when v3 api" do
+      before(:each) do
+        allow(ems).to receive(:highest_supported_api_version).and_return(3)
+      end
+
+      it 'returns the api3 parser' do
+        expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api3)
+      end
+
+      context "forced version 4" do
+        let(:options) { { :force_version => 4  } }
+
+        it 'returns the api4 parser' do
+          expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api4)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/clusters.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/clusters.yml
@@ -1,0 +1,470 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::Cluster
+  href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf"
+  comment: 
+  description: 
+  id: 504ae500-3476-450e-8243-f6df0f7f7acf
+  name: cc1
+  affinity_groups: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/affinitygroups"
+  ballooning_enabled: false
+  cpu: !ruby/object:OvirtSDK4::Cpu
+    href: 
+    architecture: x86_64
+    cores: 
+    cpu_tune: 
+    level: 
+    mode: 
+    name: 
+    speed: 
+    topology: 
+    type: Intel Westmere Family
+  cpu_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/cpuprofiles"
+  custom_scheduling_policy_properties: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: HighUtilization
+      value: '80'
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: CpuOverCommitDurationMinutes
+      value: '2'
+    ivars:
+      :@href: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+    comment: 
+    description: 
+    id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  error_handling: !ruby/object:OvirtSDK4::ErrorHandling
+    href: 
+    on_error: migrate
+  fencing_policy: !ruby/object:OvirtSDK4::FencingPolicy
+    href: 
+    enabled: true
+    skip_if_connectivity_broken: !ruby/object:OvirtSDK4::SkipIfConnectivityBroken
+      href: 
+      enabled: true
+      threshold: 50
+    skip_if_sd_active: !ruby/object:OvirtSDK4::SkipIfSdActive
+      href: 
+      enabled: true
+  gluster_hooks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/glusterhooks"
+  gluster_service: false
+  gluster_volumes: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/glustervolumes"
+  ha_reservation: false
+  ksm: !ruby/object:OvirtSDK4::Ksm
+    href: 
+    enabled: false
+    merge_across_nodes: true
+  maintenance_reason_required: false
+  management_network: 
+  memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+    href: 
+    ballooning: 
+    guaranteed: 
+    over_commit: !ruby/object:OvirtSDK4::MemoryOverCommit
+      href: 
+      percent: 100
+    transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+      href: 
+      enabled: true
+  migration: !ruby/object:OvirtSDK4::MigrationOptions
+    href: 
+    auto_converge: inherit
+    bandwidth: !ruby/object:OvirtSDK4::MigrationBandwidth
+      href: 
+      assignment_method: auto
+      custom_value: 
+    compressed: inherit
+    policy: !ruby/object:OvirtSDK4::MigrationPolicy
+      href: 
+      comment: 
+      description: 
+      id: 80554327-0569-496b-bdeb-fcbbf52b827b
+      name: 
+  network_filters: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/networkfilters"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/networks"
+  optional_reason: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf/permissions"
+  required_rng_sources:
+  - random
+  scheduling_policy: !ruby/object:OvirtSDK4::SchedulingPolicy
+    href: "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    comment: 
+    description: 
+    id: b4ed2332-a7ac-4d5f-9596-99a439cb2812
+    name: 
+    balances: 
+    default_policy: 
+    filters: 
+    locked: 
+    properties: 
+    weight: 
+  serial_number: 
+  supported_versions: 
+  switch_type: legacy
+  threads_as_cores: false
+  trusted_service: false
+  tunnel_migration: false
+  version: !ruby/object:OvirtSDK4::Version
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    build: 
+    full_version: 
+    major: 3
+    minor: 6
+    revision: 
+  virt_service: true
+- !ruby/object:OvirtSDK4::Cluster
+  href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610"
+  comment: 
+  description: 
+  id: 13fea00a-05fc-4024-8ed2-216cf20bf610
+  name: dccc2
+  affinity_groups: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/affinitygroups"
+  ballooning_enabled: false
+  cpu: !ruby/object:OvirtSDK4::Cpu
+    href: 
+    architecture: x86_64
+    cores: 
+    cpu_tune: 
+    level: 
+    mode: 
+    name: 
+    speed: 
+    topology: 
+    type: Intel Conroe Family
+  cpu_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/cpuprofiles"
+  custom_scheduling_policy_properties: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: HighUtilization
+      value: '80'
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: CpuOverCommitDurationMinutes
+      value: '2'
+    ivars:
+      :@href: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+    comment: 
+    description: 
+    id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  error_handling: !ruby/object:OvirtSDK4::ErrorHandling
+    href: 
+    on_error: migrate
+  fencing_policy: !ruby/object:OvirtSDK4::FencingPolicy
+    href: 
+    enabled: true
+    skip_if_connectivity_broken: !ruby/object:OvirtSDK4::SkipIfConnectivityBroken
+      href: 
+      enabled: true
+      threshold: 50
+    skip_if_sd_active: !ruby/object:OvirtSDK4::SkipIfSdActive
+      href: 
+      enabled: true
+  gluster_hooks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/glusterhooks"
+  gluster_service: false
+  gluster_volumes: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/glustervolumes"
+  ha_reservation: false
+  ksm: !ruby/object:OvirtSDK4::Ksm
+    href: 
+    enabled: false
+    merge_across_nodes: true
+  maintenance_reason_required: false
+  management_network: 
+  memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+    href: 
+    ballooning: 
+    guaranteed: 
+    over_commit: !ruby/object:OvirtSDK4::MemoryOverCommit
+      href: 
+      percent: 100
+    transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+      href: 
+      enabled: true
+  migration: !ruby/object:OvirtSDK4::MigrationOptions
+    href: 
+    auto_converge: inherit
+    bandwidth: !ruby/object:OvirtSDK4::MigrationBandwidth
+      href: 
+      assignment_method: auto
+      custom_value: 
+    compressed: inherit
+    policy: !ruby/object:OvirtSDK4::MigrationPolicy
+      href: 
+      comment: 
+      description: 
+      id: 80554327-0569-496b-bdeb-fcbbf52b827b
+      name: 
+  network_filters: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/networkfilters"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/networks"
+  optional_reason: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610/permissions"
+  required_rng_sources:
+  - random
+  scheduling_policy: !ruby/object:OvirtSDK4::SchedulingPolicy
+    href: "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    comment: 
+    description: 
+    id: b4ed2332-a7ac-4d5f-9596-99a439cb2812
+    name: 
+    balances: 
+    default_policy: 
+    filters: 
+    locked: 
+    properties: 
+    weight: 
+  serial_number: 
+  supported_versions: 
+  switch_type: legacy
+  threads_as_cores: false
+  trusted_service: false
+  tunnel_migration: false
+  version: !ruby/object:OvirtSDK4::Version
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    build: 
+    full_version: 
+    major: 3
+    minor: 6
+    revision: 
+  virt_service: true
+- !ruby/object:OvirtSDK4::Cluster
+  href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+  comment: 
+  description: The default server cluster
+  id: 00000002-0002-0002-0002-000000000092
+  name: Default
+  affinity_groups: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/affinitygroups"
+  ballooning_enabled: false
+  cpu: !ruby/object:OvirtSDK4::Cpu
+    href: 
+    architecture: x86_64
+    cores: 
+    cpu_tune: 
+    level: 
+    mode: 
+    name: 
+    speed: 
+    topology: 
+    type: Intel Westmere Family
+  cpu_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/cpuprofiles"
+  custom_scheduling_policy_properties: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: HighUtilization
+      value: '80'
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: CpuOverCommitDurationMinutes
+      value: '2'
+    ivars:
+      :@href: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f"
+    comment: 
+    description: 
+    id: 00000001-0001-0001-0001-00000000009f
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  error_handling: !ruby/object:OvirtSDK4::ErrorHandling
+    href: 
+    on_error: migrate
+  fencing_policy: !ruby/object:OvirtSDK4::FencingPolicy
+    href: 
+    enabled: true
+    skip_if_connectivity_broken: !ruby/object:OvirtSDK4::SkipIfConnectivityBroken
+      href: 
+      enabled: false
+      threshold: 50
+    skip_if_sd_active: !ruby/object:OvirtSDK4::SkipIfSdActive
+      href: 
+      enabled: false
+  gluster_hooks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/glusterhooks"
+  gluster_service: false
+  gluster_volumes: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/glustervolumes"
+  ha_reservation: false
+  ksm: !ruby/object:OvirtSDK4::Ksm
+    href: 
+    enabled: true
+    merge_across_nodes: true
+  maintenance_reason_required: false
+  management_network: 
+  memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+    href: 
+    ballooning: 
+    guaranteed: 
+    over_commit: !ruby/object:OvirtSDK4::MemoryOverCommit
+      href: 
+      percent: 100
+    transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+      href: 
+      enabled: true
+  migration: !ruby/object:OvirtSDK4::MigrationOptions
+    href: 
+    auto_converge: inherit
+    bandwidth: !ruby/object:OvirtSDK4::MigrationBandwidth
+      href: 
+      assignment_method: auto
+      custom_value: 
+    compressed: inherit
+    policy: 
+  network_filters: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/networkfilters"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/networks"
+  optional_reason: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092/permissions"
+  required_rng_sources:
+  - urandom
+  scheduling_policy: !ruby/object:OvirtSDK4::SchedulingPolicy
+    href: "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    comment: 
+    description: 
+    id: b4ed2332-a7ac-4d5f-9596-99a439cb2812
+    name: 
+    balances: 
+    default_policy: 
+    filters: 
+    locked: 
+    properties: 
+    weight: 
+  serial_number: 
+  supported_versions: 
+  switch_type: legacy
+  threads_as_cores: false
+  trusted_service: false
+  tunnel_migration: false
+  version: !ruby/object:OvirtSDK4::Version
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    build: 
+    full_version: 
+    major: 4
+    minor: 1
+    revision: 
+  virt_service: true
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/datacenters.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/datacenters.yml
@@ -1,0 +1,538 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::DatacenterPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@storage_domains
+  ? - &1 !ruby/object:OvirtSDK4::DataCenter
+      href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+      comment: 
+      description: 
+      id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+      name: dc1
+      clusters: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/clusters"
+      iscsi_bonds: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/iscsibonds"
+      local: false
+      mac_pool: 
+      networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/networks"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/permissions"
+      qoss: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/qoss"
+      quota_mode: disabled
+      quotas: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/quotas"
+      status: up
+      storage_domains: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains"
+      storage_format: v3
+      supported_versions: !ruby/array:OvirtSDK4::List
+        internal:
+        - !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 
+          major: 3
+          minor: 6
+          revision: 
+        ivars:
+          :@href: 
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 
+        full_version: 
+        major: 3
+        minor: 6
+        revision: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::StorageDomain
+        href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525"
+        comment: 
+        description: 
+        id: ef0c6712-13df-49bd-885e-d96dcaf9e525
+        name: isob1
+        available: 46170898432
+        committed: 0
+        critical_space_action_blocker: 5
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+          comment: 
+          description: 
+          id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+          name: 
+          clusters: 
+          iscsi_bonds: 
+          local: 
+          mac_pool: 
+          networks: 
+          permissions: 
+          qoss: 
+          quota_mode: 
+          quotas: 
+          status: 
+          storage_domains: 
+          storage_format: 
+          supported_versions: 
+          version: 
+        data_centers: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::DataCenter
+            href: 
+            comment: 
+            description: 
+            id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+            name: 
+            clusters: 
+            iscsi_bonds: 
+            local: 
+            mac_pool: 
+            networks: 
+            permissions: 
+            qoss: 
+            quota_mode: 
+            quotas: 
+            status: 
+            storage_domains: 
+            storage_format: 
+            supported_versions: 
+            version: 
+          ivars:
+            :@href: 
+        disk_profiles: 
+        disk_snapshots: 
+        disks: 
+        external_status: ok
+        files: 
+        host: 
+        images: 
+        import: 
+        master: false
+        permissions: 
+        status: active
+        storage: !ruby/object:OvirtSDK4::HostStorage
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          address: spider.eng.lab.tlv.redhat.com
+          host: 
+          logical_units: 
+          mount_options: 
+          nfs_retrans: 
+          nfs_timeo: 
+          nfs_version: v3
+          override_luns: 
+          password: 
+          path: "/vol/vol_bodnopoz/iso"
+          port: 
+          portal: 
+          target: 
+          type: nfs
+          username: 
+          vfs_type: 
+          volume_group: 
+        storage_connections: 
+        storage_format: v1
+        templates: 
+        type: iso
+        used: 7516192768
+        vms: 
+        warning_low_space_indicator: 10
+        wipe_after_delete: false
+      - !ruby/object:OvirtSDK4::StorageDomain
+        href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1"
+        comment: 
+        description: 
+        id: 0c55619d-4d88-4bd1-921c-5425275061d1
+        name: export
+        available: 46170898432
+        committed: 0
+        critical_space_action_blocker: 5
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+          comment: 
+          description: 
+          id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+          name: 
+          clusters: 
+          iscsi_bonds: 
+          local: 
+          mac_pool: 
+          networks: 
+          permissions: 
+          qoss: 
+          quota_mode: 
+          quotas: 
+          status: 
+          storage_domains: 
+          storage_format: 
+          supported_versions: 
+          version: 
+        data_centers: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::DataCenter
+            href: 
+            comment: 
+            description: 
+            id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+            name: 
+            clusters: 
+            iscsi_bonds: 
+            local: 
+            mac_pool: 
+            networks: 
+            permissions: 
+            qoss: 
+            quota_mode: 
+            quotas: 
+            status: 
+            storage_domains: 
+            storage_format: 
+            supported_versions: 
+            version: 
+          ivars:
+            :@href: 
+        disk_profiles: 
+        disk_snapshots: 
+        disks: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disks"
+        external_status: ok
+        files: 
+        host: 
+        images: 
+        import: 
+        master: false
+        permissions: 
+        status: active
+        storage: !ruby/object:OvirtSDK4::HostStorage
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          address: spider.eng.lab.tlv.redhat.com
+          host: 
+          logical_units: 
+          mount_options: 
+          nfs_retrans: 
+          nfs_timeo: 
+          nfs_version: v3
+          override_luns: 
+          password: 
+          path: "/vol/vol_bodnopoz/export"
+          port: 
+          portal: 
+          target: 
+          type: nfs
+          username: 
+          vfs_type: 
+          volume_group: 
+        storage_connections: 
+        storage_format: v1
+        templates: 
+        type: export
+        used: 7516192768
+        vms: 
+        warning_low_space_indicator: 10
+        wipe_after_delete: false
+      - !ruby/object:OvirtSDK4::StorageDomain
+        href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"
+        comment: 
+        description: 
+        id: 27a3bcce-c4d0-4bce-afe9-1d669d5a9d02
+        name: data1
+        available: 46170898432
+        committed: 70866960384
+        critical_space_action_blocker: 5
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+          comment: 
+          description: 
+          id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+          name: 
+          clusters: 
+          iscsi_bonds: 
+          local: 
+          mac_pool: 
+          networks: 
+          permissions: 
+          qoss: 
+          quota_mode: 
+          quotas: 
+          status: 
+          storage_domains: 
+          storage_format: 
+          supported_versions: 
+          version: 
+        data_centers: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::DataCenter
+            href: 
+            comment: 
+            description: 
+            id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+            name: 
+            clusters: 
+            iscsi_bonds: 
+            local: 
+            mac_pool: 
+            networks: 
+            permissions: 
+            qoss: 
+            quota_mode: 
+            quotas: 
+            status: 
+            storage_domains: 
+            storage_format: 
+            supported_versions: 
+            version: 
+          ivars:
+            :@href: 
+        disk_profiles: 
+        disk_snapshots: 
+        disks: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disks"
+        external_status: ok
+        files: 
+        host: 
+        images: 
+        import: 
+        master: true
+        permissions: 
+        status: active
+        storage: !ruby/object:OvirtSDK4::HostStorage
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          address: spider.eng.lab.tlv.redhat.com
+          host: 
+          logical_units: 
+          mount_options: 
+          nfs_retrans: 
+          nfs_timeo: 
+          nfs_version: v3
+          override_luns: 
+          password: 
+          path: "/vol/vol_bodnopoz/data1"
+          port: 
+          portal: 
+          target: 
+          type: nfs
+          username: 
+          vfs_type: 
+          volume_group: 
+        storage_connections: 
+        storage_format: v3
+        templates: 
+        type: data
+        used: 7516192768
+        vms: 
+        warning_low_space_indicator: 10
+        wipe_after_delete: false
+      ivars:
+        :@href: 
+  : *1
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::DatacenterPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@storage_domains
+  ? - &2 !ruby/object:OvirtSDK4::DataCenter
+      href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f"
+      comment: 
+      description: The default Data Center
+      id: 00000001-0001-0001-0001-00000000009f
+      name: Default
+      clusters: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/clusters"
+      iscsi_bonds: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/iscsibonds"
+      local: false
+      mac_pool: 
+      networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/networks"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/permissions"
+      qoss: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/qoss"
+      quota_mode: disabled
+      quotas: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/quotas"
+      status: up
+      storage_domains: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains"
+      storage_format: v3
+      supported_versions: !ruby/array:OvirtSDK4::List
+        internal:
+        - !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 
+          major: 4
+          minor: 1
+          revision: 
+        ivars:
+          :@href: 
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 
+        full_version: 
+        major: 4
+        minor: 1
+        revision: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::StorageDomain
+        href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb"
+        comment: 
+        description: 
+        id: 4672fe17-c260-4ecc-aab0-b535f4d0dbeb
+        name: data2
+        available: 46170898432
+        committed: 4294967296
+        critical_space_action_blocker: 5
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f"
+          comment: 
+          description: 
+          id: 00000001-0001-0001-0001-00000000009f
+          name: 
+          clusters: 
+          iscsi_bonds: 
+          local: 
+          mac_pool: 
+          networks: 
+          permissions: 
+          qoss: 
+          quota_mode: 
+          quotas: 
+          status: 
+          storage_domains: 
+          storage_format: 
+          supported_versions: 
+          version: 
+        data_centers: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::DataCenter
+            href: 
+            comment: 
+            description: 
+            id: 00000001-0001-0001-0001-00000000009f
+            name: 
+            clusters: 
+            iscsi_bonds: 
+            local: 
+            mac_pool: 
+            networks: 
+            permissions: 
+            qoss: 
+            quota_mode: 
+            quotas: 
+            status: 
+            storage_domains: 
+            storage_format: 
+            supported_versions: 
+            version: 
+          ivars:
+            :@href: 
+        disk_profiles: 
+        disk_snapshots: 
+        disks: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disks"
+        external_status: ok
+        files: 
+        host: 
+        images: 
+        import: 
+        master: true
+        permissions: 
+        status: active
+        storage: !ruby/object:OvirtSDK4::HostStorage
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          address: spider.eng.lab.tlv.redhat.com
+          host: 
+          logical_units: 
+          mount_options: 
+          nfs_retrans: 
+          nfs_timeo: 
+          nfs_version: 
+          override_luns: 
+          password: 
+          path: "/vol/vol_bodnopoz/data2"
+          port: 
+          portal: 
+          target: 
+          type: nfs
+          username: 
+          vfs_type: 
+          volume_group: 
+        storage_connections: 
+        storage_format: v3
+        templates: 
+        type: data
+        used: 7516192768
+        vms: 
+        warning_low_space_indicator: 10
+        wipe_after_delete: false
+      ivars:
+        :@href: 
+  : *2

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/ems_for_targeted.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/ems_for_targeted.yml
@@ -1,0 +1,857 @@
+--- !ruby/object:ManageIQ::Providers::Redhat::InfraManager
+raw_attributes:
+  id: 20
+  name: ems_0000000000001
+  created_on: '2017-02-22 08:19:27.011036'
+  updated_on: '2017-02-22 08:19:31.419674'
+  guid: 95ca03ac-f8d7-11e6-ad47-507b9def3b4a
+  zone_id: 20
+  type: ManageIQ::Providers::Redhat::InfraManager
+  api_version: 3.6.8.0
+  uid_ems: 
+  host_default_vnc_port_start: 
+  host_default_vnc_port_end: 
+  provider_region: 
+  last_refresh_error: 
+  last_refresh_date: '2017-02-22 08:19:31.414354'
+  provider_id: 
+  realm: 
+  tenant_id: 20
+  project: 
+  parent_ems_id: 
+  subscription: 
+  last_metrics_error: 
+  last_metrics_update_date: 
+  last_metrics_success_date: 
+  tenant_mapping_enabled: 
+  region_number: 
+  region_description: 
+  custom_1: 
+  custom_2: 
+  custom_3: 
+  custom_4: 
+  custom_5: 
+  custom_6: 
+  custom_7: 
+  custom_8: 
+  custom_9: 
+  last_compliance_status: 
+  last_compliance_timestamp: 
+  aggregate_cpu_speed: 
+  aggregate_cpu_total_cores: 
+  aggregate_physical_cpus: 
+  aggregate_memory: 
+  aggregate_vm_cpus: 
+  aggregate_vm_memory: 
+  aggregate_disk_capacity: 
+  authentication_status: 
+  cpu_usagemhz_rate_average_avg_over_time_period: 
+  cpu_usagemhz_rate_average_low_over_time_period: 
+  cpu_usagemhz_rate_average_high_over_time_period: 
+  derived_memory_used_avg_over_time_period: 
+  derived_memory_used_low_over_time_period: 
+  derived_memory_used_high_over_time_period: 
+  max_cpu_usage_rate_average_avg_over_time_period: 
+  max_cpu_usage_rate_average_low_over_time_period: 
+  max_cpu_usage_rate_average_high_over_time_period: 
+  max_mem_usage_absolute_average_avg_over_time_period: 
+  max_mem_usage_absolute_average_low_over_time_period: 
+  max_mem_usage_absolute_average_high_over_time_period: 
+  max_cpu_usage_rate_average_avg_over_time_period_without_overhead: 
+  max_cpu_usage_rate_average_low_over_time_period_without_overhead: 
+  max_cpu_usage_rate_average_high_over_time_period_without_overhead: 
+  max_mem_usage_absolute_average_avg_over_time_period_without_overhead: 
+  max_mem_usage_absolute_average_low_over_time_period_without_overhead: 
+  max_mem_usage_absolute_average_high_over_time_period_without_overhead: 
+  ipaddress: 
+  hostname: 
+  port: 
+  security_protocol: 
+  emstype: 
+  emstype_description: 
+  last_refresh_status: 
+  total_vms_and_templates: 
+  total_vms: 
+  total_miq_templates: 
+  total_hosts: 
+  total_storages: 
+  total_clusters: 
+  zone_name: 
+  total_vms_on: 
+  total_vms_off: 
+  total_vms_unknown: 
+  total_vms_never: 
+  total_vms_suspended: 
+  total_subnets: 
+  total_vcpus: 
+  total_memory: 
+  total_cloud_vcpus: 
+  total_cloud_memory: 
+attributes: !ruby/object:ActiveRecord::AttributeSet
+  attributes: !ruby/object:ActiveRecord::LazyAttributeHash
+    delegate_hash:
+      id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: id
+        value_before_type_cast: 20
+        type: &2 !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 8
+          range: !ruby/range
+            begin: -9223372036854775808
+            end: 9223372036854775808
+            excl: true
+        original_attribute: 
+      name: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: name
+        value_before_type_cast: ems_0000000000001
+        type: &3 !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      created_on: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: created_on
+        value_before_type_cast: '2017-02-22 08:19:27.011036'
+        type: !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          :__v2__: []
+          []: &1 !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+            precision: 
+            scale: 
+            limit: 
+        original_attribute: 
+      updated_on: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: updated_on
+        value_before_type_cast: '2017-02-22 08:19:31.419674'
+        type: !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          :__v2__: []
+          []: *1
+        original_attribute: 
+      guid: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: guid
+        value_before_type_cast: 95ca03ac-f8d7-11e6-ad47-507b9def3b4a
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 36
+        original_attribute: 
+      zone_id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: zone_id
+        value_before_type_cast: 20
+        type: *2
+        original_attribute: 
+      type: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: type
+        value_before_type_cast: ManageIQ::Providers::Redhat::InfraManager
+        type: *3
+        original_attribute: 
+      api_version: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: api_version
+        value_before_type_cast: 3.6.8.0
+        type: *3
+        original_attribute: 
+      uid_ems: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: uid_ems
+        value_before_type_cast: 
+        type: *3
+        original_attribute: 
+      host_default_vnc_port_start: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: host_default_vnc_port_start
+        value_before_type_cast: 
+        type: &4 !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      host_default_vnc_port_end: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: host_default_vnc_port_end
+        value_before_type_cast: 
+        type: *4
+        original_attribute: 
+      provider_region: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: provider_region
+        value_before_type_cast: 
+        type: *3
+        original_attribute: 
+      last_refresh_error: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: last_refresh_error
+        value_before_type_cast: 
+        type: &5 !ruby/object:ActiveModel::Type::Text
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      last_refresh_date: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: last_refresh_date
+        value_before_type_cast: '2017-02-22 08:19:31.414354'
+        type: !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          :__v2__: []
+          []: *1
+        original_attribute: 
+      provider_id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: provider_id
+        value_before_type_cast: 
+        type: *2
+        original_attribute: 
+      realm: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: realm
+        value_before_type_cast: 
+        type: *3
+        original_attribute: 
+      tenant_id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: tenant_id
+        value_before_type_cast: 20
+        type: *2
+        original_attribute: 
+      project: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: project
+        value_before_type_cast: 
+        type: *3
+        original_attribute: 
+      parent_ems_id: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: parent_ems_id
+        value_before_type_cast: 
+        type: *2
+        original_attribute: 
+      subscription: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: subscription
+        value_before_type_cast: 
+        type: *3
+        original_attribute: 
+      last_metrics_error: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: last_metrics_error
+        value_before_type_cast: 
+        type: *5
+        original_attribute: 
+      last_metrics_update_date: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: last_metrics_update_date
+        value_before_type_cast: 
+        type: !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          :__v2__: []
+          []: *1
+        original_attribute: 
+      last_metrics_success_date: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: last_metrics_success_date
+        value_before_type_cast: 
+        type: !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
+          :__v2__: []
+          []: *1
+        original_attribute: 
+      tenant_mapping_enabled: !ruby/object:ActiveRecord::Attribute::FromDatabase
+        name: tenant_mapping_enabled
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Boolean
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      region_number: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: region_number
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      region_description: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: region_description
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_1: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_1
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_2: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_2
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_3: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_3
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_4: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_4
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_5: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_5
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_6: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_6
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_7: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_7
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_8: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_8
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      custom_9: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: custom_9
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      last_compliance_status: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: last_compliance_status
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Boolean
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      last_compliance_timestamp: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: last_compliance_timestamp
+        value_before_type_cast: 
+        type: !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      aggregate_cpu_speed: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_cpu_speed
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_cpu_total_cores: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_cpu_total_cores
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_physical_cpus: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_physical_cpus
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_memory: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_memory
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_vm_cpus: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_vm_cpus
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_vm_memory: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_vm_memory
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      aggregate_disk_capacity: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: aggregate_disk_capacity
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      authentication_status: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: authentication_status
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      cpu_usagemhz_rate_average_avg_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: cpu_usagemhz_rate_average_avg_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      cpu_usagemhz_rate_average_low_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: cpu_usagemhz_rate_average_low_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      cpu_usagemhz_rate_average_high_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: cpu_usagemhz_rate_average_high_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      derived_memory_used_avg_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: derived_memory_used_avg_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      derived_memory_used_low_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: derived_memory_used_low_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      derived_memory_used_high_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: derived_memory_used_high_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_avg_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_avg_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_low_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_low_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_high_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_high_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_avg_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_avg_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_low_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_low_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_high_over_time_period: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_high_over_time_period
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_avg_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_low_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_low_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_cpu_usage_rate_average_high_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_cpu_usage_rate_average_high_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_avg_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_low_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_low_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      max_mem_usage_absolute_average_high_over_time_period_without_overhead: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: max_mem_usage_absolute_average_high_over_time_period_without_overhead
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Float
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      ipaddress: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: ipaddress
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      hostname: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: hostname
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      port: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: port
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      security_protocol: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: security_protocol
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      emstype: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: emstype
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      emstype_description: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: emstype_description
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      last_refresh_status: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: last_refresh_status
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      total_vms_and_templates: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_and_templates
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vms: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_miq_templates: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_miq_templates
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_hosts: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_hosts
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_storages: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_storages
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_clusters: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_clusters
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      zone_name: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: zone_name
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::String
+          precision: 
+          scale: 
+          limit: 
+        original_attribute: 
+      total_vms_on: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_on
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vms_off: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_off
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vms_unknown: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_unknown
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vms_never: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_never
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vms_suspended: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vms_suspended
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_subnets: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_subnets
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_vcpus: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_vcpus
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_memory: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_memory
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_cloud_vcpus: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_cloud_vcpus
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+      total_cloud_memory: !ruby/object:ActiveRecord::Attribute::Uninitialized
+        name: total_cloud_memory
+        value_before_type_cast: 
+        type: !ruby/object:ActiveModel::Type::Integer
+          precision: 
+          scale: 
+          limit: 
+          range: !ruby/range
+            begin: -2147483648
+            end: 2147483648
+            excl: true
+        original_attribute: 
+new_record: false
+active_record_yaml_version: 1

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/hosts.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/hosts.yml
@@ -1,0 +1,5048 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::HostPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@nics
+  - :@statistics
+  ? - &1 !ruby/object:OvirtSDK4::Host
+      href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+      comment: 
+      description: 
+      id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+      name: bodh1
+      address: bodh1.usersys.redhat.com
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/affinitylabels"
+      agents: 
+      auto_numa_status: disable
+      certificate: !ruby/object:OvirtSDK4::Certificate
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        content: 
+        organization: Test
+        subject: O=Test,CN=bodh1.usersys.redhat.com
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: 
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: Westmere E56xx/L56xx/X56xx (Nehalem-C)
+        speed: 2400.0
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 2
+          threads: 1
+        type: 
+      device_passthrough: !ruby/object:OvirtSDK4::HostDevicePassthrough
+        href: 
+        enabled: false
+      devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/devices"
+      display: 
+      external_host_provider: 
+      external_status: ok
+      hardware_information: !ruby/object:OvirtSDK4::HardwareInformation
+        href: 
+        family: Red Hat Enterprise Linux
+        manufacturer: Red Hat
+        product_name: RHEV Hypervisor
+        serial_number: 30353036-3837-4247-3831-303946353235
+        supported_rng_sources:
+        - random
+        uuid: 4587CAA0-8F1A-4246-838B-0F5380A7E67E
+        version: 7.2-9.el7
+      hooks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/hooks"
+      hosted_engine: 
+      iscsi: !ruby/object:OvirtSDK4::IscsiDetails
+        href: 
+        address: 
+        disk_id: 
+        initiator: iqn.1994-05.com.redhat:3a591f887a5
+        lun_mapping: 
+        password: 
+        paths: 
+        port: 
+        portal: 
+        product_id: 
+        serial: 
+        size: 
+        status: 
+        storage_domain_id: 
+        target: 
+        username: 
+        vendor_id: 
+        volume_group_id: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/katelloerrata"
+      kdump_status: disabled
+      ksm: !ruby/object:OvirtSDK4::Ksm
+        href: 
+        enabled: false
+        merge_across_nodes: 
+      libvirt_version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 17
+        full_version: libvirt-1.2.17-13.el7_2.5
+        major: 1
+        minor: 2
+        revision: 0
+      max_scheduling_memory: 3568304128
+      memory: 3973054464
+      network_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/networkattachments"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/numanodes"
+      numa_supported: false
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: 
+        cmdline: 
+        custom_kernel_cmdline: ''
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: BOOT_IMAGE=/vmlinuz-3.10.0-327.18.2.el7.x86_64 root=/dev/mapper/vg0-lv_root
+          ro rd.lvm.lv=vg0/lv_root vconsole.font=latarcyrheb-sun16 rd.lvm.lv=vg0/lv_swap
+          crashkernel=auto vconsole.keymap=us rhgb quiet LANG=en_US.UTF-8
+        type: RHEL
+        version: !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 7 - 1.1503.el7.centos.2.8
+          major: 7
+          minor: 
+          revision: 
+      override_iptables: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/permissions"
+      port: 54321
+      power_management: !ruby/object:OvirtSDK4::PowerManagement
+        href: 
+        address: 
+        agents: 
+        automatic_pm_enabled: true
+        enabled: false
+        kdump_detection: true
+        options: 
+        password: 
+        pm_proxies: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        status: 
+        type: 
+        username: 
+      protocol: stomp
+      root_password: 
+      se_linux: !ruby/object:OvirtSDK4::SeLinux
+        href: 
+        mode: enforcing
+      spm: !ruby/object:OvirtSDK4::Spm
+        href: 
+        priority: 5
+        status: spm
+      ssh: !ruby/object:OvirtSDK4::Ssh
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        authentication_method: 
+        fingerprint: SHA256:c34s0Cfo9dzBEtKX/P2gNqS6aoacuYJre2B21feC7Xk
+        port: 22
+        user: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics"
+      status: up
+      status_detail: 
+      storage_connection_extensions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/storageconnectionextensions"
+      storages: 
+      summary: !ruby/object:OvirtSDK4::VmSummary
+        href: 
+        active: 0
+        migrating: 0
+        total: 0
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/tags"
+      transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+        href: 
+        enabled: true
+      type: rhel
+      unmanaged_networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/unmanagednetworks"
+      update_available: true
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 999
+        full_version: vdsm-4.18.999-156.git7c6905e.el7.centos
+        major: 4
+        minor: 18
+        revision: 0
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::HostNic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/nics/01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd"
+        comment: 
+        description: 
+        id: 01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd
+        name: eth0
+        ad_aggregator_id: 
+        base_interface: 
+        bonding: 
+        boot_protocol: dhcp
+        bridged: true
+        check_connectivity: 
+        custom_configuration: false
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        ip: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 10.35.19.12
+          gateway: 10.35.19.254
+          netmask: 255.255.252.0
+          version: v4
+        ipv6: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 
+          gateway: "::"
+          netmask: 
+          version: v6
+        ipv6_boot_protocol: dhcp
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:23:12:8c
+        mtu: 1500
+        network: !ruby/object:OvirtSDK4::Network
+          href: "/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009"
+          comment: 
+          description: 
+          id: 00000000-0000-0000-0000-000000000009
+          name: 
+          cluster: 
+          data_center: 
+          display: 
+          ip: 
+          mtu: 
+          network_labels: 
+          permissions: 
+          profile_required: 
+          qos: 
+          required: 
+          status: 
+          stp: 
+          usages: 
+          vlan: 
+          vnic_profiles: 
+        network_labels: 
+        override_configuration: 
+        physical_function: 
+        properties: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        qos: 
+        speed: 
+        statistics: 
+        status: up
+        virtual_functions_configuration: 
+        vlan: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896"
+        comment: 
+        description: Total memory
+        id: 7816602b-c05c-3db7-a4da-3769f7ad8896
+        name: memory.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 3973054464.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08"
+        comment: 
+        description: Used memory
+        id: b7499508-c1c3-32f0-8174-c1783e57bb08
+        name: memory.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 754880348.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946"
+        comment: 
+        description: Free memory
+        id: 5a0fba9d-33d7-3cbf-addd-ba462040c946
+        name: memory.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 3218174116.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc"
+        comment: 
+        description: Shared memory
+        id: ffc0e1fd-fa34-3f85-9862-8a841c1658bc
+        name: memory.shared
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f"
+        comment: 
+        description: IO buffers
+        id: c81c86f0-bc61-3c78-a543-898b8339d03f
+        name: memory.buffers
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11"
+        comment: 
+        description: OS caches
+        id: 1b6244ee-8dbd-365d-8762-482ddc05ee11
+        name: memory.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b"
+        comment: 
+        description: Total swap
+        id: c43847d7-3bc1-3aaf-b92c-902e64bbdb5b
+        name: swap.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46"
+        comment: 
+        description: Free swap
+        id: 1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46
+        name: swap.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9"
+        comment: 
+        description: Used swap
+        id: 27686b4e-ba8d-3576-bc70-d68cbd8a2ba9
+        name: swap.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07"
+        comment: 
+        description: Swap also in memory
+        id: ea00da15-de2d-3393-a7cb-810c4b19ed07
+        name: swap.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169"
+        comment: 
+        description: KSM CPU usage
+        id: f740b9ad-14a7-3f6c-9b80-efff44777169
+        name: ksm.cpu.current
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719"
+        comment: 
+        description: User CPU usage
+        id: a1fab379-66e2-3b1d-9914-81a9e79cb719
+        name: cpu.current.user
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815"
+        comment: 
+        description: System CPU usage
+        id: a98c1e11-078c-3593-a57e-4b12c1ce9815
+        name: cpu.current.system
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac"
+        comment: 
+        description: Idle CPU usage
+        id: 4ae97794-f56d-3f05-a9e7-8798887cd1ac
+        name: cpu.current.idle
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 99.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/65860dae-c890-312e-9314-5c01f31225ab"
+        comment: 
+        description: CPU 5 minute load average
+        id: 65860dae-c890-312e-9314-5c01f31225ab
+        name: cpu.load.avg.5m
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.01
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c"
+        comment: 
+        description: Boot time of the machine
+        id: 3ceb2072-a5a5-3b21-9bb2-e966471fd81c
+        name: boot.time
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a"
+          comment: 
+          description: 
+          id: 5bf6b336-f86d-4551-ac08-d34621ec5f0a
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: none
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1474529304.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      ivars:
+        :@href: 
+  : *1
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::HostPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@nics
+  - :@statistics
+  ? - &2 !ruby/object:OvirtSDK4::Host
+      href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+      comment: 
+      description: 
+      id: 69cd8141-a6f5-4968-880d-121de26f3747
+      name: bodh2
+      address: bodh2.usersys.redhat.com
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/affinitylabels"
+      agents: 
+      auto_numa_status: disable
+      certificate: !ruby/object:OvirtSDK4::Certificate
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        content: 
+        organization: Test
+        subject: O=Test,CN=bodh2.usersys.redhat.com
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf"
+        comment: 
+        description: 
+        id: 504ae500-3476-450e-8243-f6df0f7f7acf
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: 
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: Westmere E56xx/L56xx/X56xx (Nehalem-C)
+        speed: 2400.0
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 4
+          sockets: 2
+          threads: 1
+        type: 
+      device_passthrough: !ruby/object:OvirtSDK4::HostDevicePassthrough
+        href: 
+        enabled: false
+      devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/devices"
+      display: 
+      external_host_provider: 
+      external_status: ok
+      hardware_information: !ruby/object:OvirtSDK4::HardwareInformation
+        href: 
+        family: Red Hat Enterprise Linux
+        manufacturer: Red Hat
+        product_name: RHEV Hypervisor
+        serial_number: 30353036-3837-4247-3831-303946353235
+        supported_rng_sources:
+        - random
+        uuid: 263886E9-5A74-48D4-8839-6FEAFBC380F4
+        version: 7.3-7.el7
+      hooks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/hooks"
+      hosted_engine: 
+      iscsi: !ruby/object:OvirtSDK4::IscsiDetails
+        href: 
+        address: 
+        disk_id: 
+        initiator: iqn.1994-05.com.redhat:d8ad6f214bf
+        lun_mapping: 
+        password: 
+        paths: 
+        port: 
+        portal: 
+        product_id: 
+        serial: 
+        size: 
+        status: 
+        storage_domain_id: 
+        target: 
+        username: 
+        vendor_id: 
+        volume_group_id: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/katelloerrata"
+      kdump_status: disabled
+      ksm: !ruby/object:OvirtSDK4::Ksm
+        href: 
+        enabled: false
+        merge_across_nodes: 
+      libvirt_version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 17
+        full_version: libvirt-1.2.17-13.el7_2.5
+        major: 1
+        minor: 2
+        revision: 0
+      max_scheduling_memory: 14055112704
+      memory: 16650338304
+      network_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/networkattachments"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/numanodes"
+      numa_supported: false
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: 
+        cmdline: 
+        custom_kernel_cmdline: ''
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: BOOT_IMAGE=/vmlinuz-3.10.0-327.18.2.el7.x86_64 root=/dev/mapper/vg0-lv_root
+          ro crashkernel=auto rd.lvm.lv=vg0/lv_root rd.lvm.lv=vg0/lv_swap rhgb quiet
+          LANG=en_US.UTF-8
+        type: RHEL
+        version: !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 7.2 - 9.el7
+          major: 7
+          minor: 2
+          revision: 
+      override_iptables: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/permissions"
+      port: 54321
+      power_management: !ruby/object:OvirtSDK4::PowerManagement
+        href: 
+        address: 
+        agents: 
+        automatic_pm_enabled: true
+        enabled: false
+        kdump_detection: true
+        options: 
+        password: 
+        pm_proxies: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        status: 
+        type: 
+        username: 
+      protocol: stomp
+      root_password: 
+      se_linux: !ruby/object:OvirtSDK4::SeLinux
+        href: 
+        mode: enforcing
+      spm: !ruby/object:OvirtSDK4::Spm
+        href: 
+        priority: 5
+        status: spm
+      ssh: !ruby/object:OvirtSDK4::Ssh
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        authentication_method: 
+        fingerprint: SHA256:GHC9k+DeY93GWGRpwbqgluCBmkXxFvz1FK29FCtju4Q
+        port: 22
+        user: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics"
+      status: up
+      status_detail: 
+      storage_connection_extensions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/storageconnectionextensions"
+      storages: 
+      summary: !ruby/object:OvirtSDK4::VmSummary
+        href: 
+        active: 1
+        migrating: 0
+        total: 1
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/tags"
+      transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+        href: 
+        enabled: true
+      type: rhel
+      unmanaged_networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/unmanagednetworks"
+      update_available: true
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 999
+        full_version: vdsm-4.18.999-156.git7c6905e.el7.centos
+        major: 4
+        minor: 18
+        revision: 0
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::HostNic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/nics/59646cf3-f01a-4f5f-9633-40c26ea5f938"
+        comment: 
+        description: 
+        id: 59646cf3-f01a-4f5f-9633-40c26ea5f938
+        name: eth0
+        ad_aggregator_id: 
+        base_interface: 
+        bonding: 
+        boot_protocol: dhcp
+        bridged: true
+        check_connectivity: 
+        custom_configuration: true
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        ip: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 10.35.18.214
+          gateway: 10.35.19.254
+          netmask: 255.255.252.0
+          version: v4
+        ipv6: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 
+          gateway: "::"
+          netmask: 
+          version: v6
+        ipv6_boot_protocol: dhcp
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:23:13:fe
+        mtu: 1500
+        network: !ruby/object:OvirtSDK4::Network
+          href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef"
+          comment: 
+          description: 
+          id: 6ad90f38-5496-47fb-9882-5aa55e1314ef
+          name: 
+          cluster: 
+          data_center: 
+          display: 
+          ip: 
+          mtu: 
+          network_labels: 
+          permissions: 
+          profile_required: 
+          qos: 
+          required: 
+          status: 
+          stp: 
+          usages: 
+          vlan: 
+          vnic_profiles: 
+        network_labels: 
+        override_configuration: 
+        physical_function: 
+        properties: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        qos: 
+        speed: 
+        statistics: 
+        status: up
+        virtual_functions_configuration: 
+        vlan: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896"
+        comment: 
+        description: Total memory
+        id: 7816602b-c05c-3db7-a4da-3769f7ad8896
+        name: memory.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16650338304.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08"
+        comment: 
+        description: Used memory
+        id: b7499508-c1c3-32f0-8174-c1783e57bb08
+        name: memory.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1831537213.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946"
+        comment: 
+        description: Free memory
+        id: 5a0fba9d-33d7-3cbf-addd-ba462040c946
+        name: memory.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 14818801091.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc"
+        comment: 
+        description: Shared memory
+        id: ffc0e1fd-fa34-3f85-9862-8a841c1658bc
+        name: memory.shared
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f"
+        comment: 
+        description: IO buffers
+        id: c81c86f0-bc61-3c78-a543-898b8339d03f
+        name: memory.buffers
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11"
+        comment: 
+        description: OS caches
+        id: 1b6244ee-8dbd-365d-8762-482ddc05ee11
+        name: memory.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b"
+        comment: 
+        description: Total swap
+        id: c43847d7-3bc1-3aaf-b92c-902e64bbdb5b
+        name: swap.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46"
+        comment: 
+        description: Free swap
+        id: 1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46
+        name: swap.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9"
+        comment: 
+        description: Used swap
+        id: 27686b4e-ba8d-3576-bc70-d68cbd8a2ba9
+        name: swap.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07"
+        comment: 
+        description: Swap also in memory
+        id: ea00da15-de2d-3393-a7cb-810c4b19ed07
+        name: swap.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169"
+        comment: 
+        description: KSM CPU usage
+        id: f740b9ad-14a7-3f6c-9b80-efff44777169
+        name: ksm.cpu.current
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719"
+        comment: 
+        description: User CPU usage
+        id: a1fab379-66e2-3b1d-9914-81a9e79cb719
+        name: cpu.current.user
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815"
+        comment: 
+        description: System CPU usage
+        id: a98c1e11-078c-3593-a57e-4b12c1ce9815
+        name: cpu.current.system
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac"
+        comment: 
+        description: Idle CPU usage
+        id: 4ae97794-f56d-3f05-a9e7-8798887cd1ac
+        name: cpu.current.idle
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 99.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/65860dae-c890-312e-9314-5c01f31225ab"
+        comment: 
+        description: CPU 5 minute load average
+        id: 65860dae-c890-312e-9314-5c01f31225ab
+        name: cpu.load.avg.5m
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.07
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c"
+        comment: 
+        description: Boot time of the machine
+        id: 3ceb2072-a5a5-3b21-9bb2-e966471fd81c
+        name: boot.time
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+          comment: 
+          description: 
+          id: 69cd8141-a6f5-4968-880d-121de26f3747
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: none
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1482925294.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      ivars:
+        :@href: 
+  : *2
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::HostPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@nics
+  - :@statistics
+  ? - &3 !ruby/object:OvirtSDK4::Host
+      href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+      comment: ''
+      description: 
+      id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+      name: motis
+      address: venus-vdsb.usersys.redhat.com
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/affinitylabels"
+      agents: 
+      auto_numa_status: disable
+      certificate: !ruby/object:OvirtSDK4::Certificate
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        content: 
+        organization: Test
+        subject: O=Test,CN=venus-vdsb.usersys.redhat.com
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/13fea00a-05fc-4024-8ed2-216cf20bf610"
+        comment: 
+        description: 
+        id: 13fea00a-05fc-4024-8ed2-216cf20bf610
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: 
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: Intel(R) Core(TM)2 Quad CPU    Q8400  @ 2.66GHz
+        speed: 2660.0
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 4
+          sockets: 1
+          threads: 1
+        type: 
+      device_passthrough: !ruby/object:OvirtSDK4::HostDevicePassthrough
+        href: 
+        enabled: false
+      devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/devices"
+      display: 
+      external_host_provider: 
+      external_status: ok
+      hardware_information: !ruby/object:OvirtSDK4::HardwareInformation
+        href: 
+        family: 
+        manufacturer: Dell Inc.
+        product_name: OptiPlex 780
+        serial_number: 7BL605J
+        supported_rng_sources:
+        - random
+        uuid: 44454c4c-4200-104c-8036-b7c04f30354a
+        version: 
+      hooks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/hooks"
+      hosted_engine: 
+      iscsi: !ruby/object:OvirtSDK4::IscsiDetails
+        href: 
+        address: 
+        disk_id: 
+        initiator: iqn.1994-05.com.redhat:bodnopoz-vm-2
+        lun_mapping: 
+        password: 
+        paths: 
+        port: 
+        portal: 
+        product_id: 
+        serial: 
+        size: 
+        status: 
+        storage_domain_id: 
+        target: 
+        username: 
+        vendor_id: 
+        volume_group_id: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/katelloerrata"
+      kdump_status: enabled
+      ksm: !ruby/object:OvirtSDK4::Ksm
+        href: 
+        enabled: false
+        merge_across_nodes: 
+      libvirt_version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 17
+        full_version: libvirt-1.2.17-13.el7_2.4
+        major: 1
+        minor: 2
+        revision: 0
+      max_scheduling_memory: 3463446528
+      memory: 3868196864
+      network_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/networkattachments"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/numanodes"
+      numa_supported: false
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: 
+        cmdline: 
+        custom_kernel_cmdline: ''
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: RHEL
+        version: !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 7 - 1.1503.el7.centos.2.8
+          major: 7
+          minor: 
+          revision: 
+      override_iptables: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/permissions"
+      port: 54321
+      power_management: !ruby/object:OvirtSDK4::PowerManagement
+        href: 
+        address: 
+        agents: 
+        automatic_pm_enabled: true
+        enabled: false
+        kdump_detection: true
+        options: 
+        password: 
+        pm_proxies: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        status: 
+        type: 
+        username: 
+      protocol: stomp
+      root_password: 
+      se_linux: !ruby/object:OvirtSDK4::SeLinux
+        href: 
+        mode: enforcing
+      spm: !ruby/object:OvirtSDK4::Spm
+        href: 
+        priority: 5
+        status: none
+      ssh: !ruby/object:OvirtSDK4::Ssh
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        authentication_method: 
+        fingerprint: SHA256:mm10Fxl4ZSOAYncZ68gWU9T31f8tQFHgLAvV5+2UHZ8
+        port: 22
+        user: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics"
+      status: non_responsive
+      status_detail: 
+      storage_connection_extensions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/storageconnectionextensions"
+      storages: 
+      summary: !ruby/object:OvirtSDK4::VmSummary
+        href: 
+        active: 0
+        migrating: 0
+        total: 0
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/tags"
+      transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+        href: 
+        enabled: true
+      type: rhel
+      unmanaged_networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/unmanagednetworks"
+      update_available: false
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 32
+        full_version: vdsm-4.17.32-0.el7.centos
+        major: 4
+        minor: 17
+        revision: 0
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::HostNic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/1e49055d-11e6-4c06-9dd7-0ad1e1e32f43"
+        comment: 
+        description: 
+        id: 1e49055d-11e6-4c06-9dd7-0ad1e1e32f43
+        name: enp4s0
+        ad_aggregator_id: 
+        base_interface: 
+        bonding: 
+        boot_protocol: none
+        bridged: false
+        check_connectivity: 
+        custom_configuration: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        ip: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: ''
+          gateway: 
+          netmask: ''
+          version: v4
+        ipv6: 
+        ipv6_boot_protocol: none
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:07:e9:11:0d:e5
+        mtu: 1500
+        network: 
+        network_labels: 
+        override_configuration: 
+        physical_function: 
+        properties: 
+        qos: 
+        speed: 
+        statistics: 
+        status: down
+        virtual_functions_configuration: 
+        vlan: 
+      - !ruby/object:OvirtSDK4::HostNic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/nics/192e4fce-7237-49bd-8e75-13ac27bd8349"
+        comment: 
+        description: 
+        id: 192e4fce-7237-49bd-8e75-13ac27bd8349
+        name: enp0s25
+        ad_aggregator_id: 
+        base_interface: 
+        bonding: 
+        boot_protocol: dhcp
+        bridged: true
+        check_connectivity: 
+        custom_configuration: true
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        ip: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 10.35.0.154
+          gateway: 10.35.1.254
+          netmask: 255.255.254.0
+          version: v4
+        ipv6: !ruby/object:OvirtSDK4::Ip
+          href: 
+          address: 
+          gateway: "::"
+          netmask: 
+          version: v6
+        ipv6_boot_protocol: none
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 84:2b:2b:bf:60:43
+        mtu: 1500
+        network: !ruby/object:OvirtSDK4::Network
+          href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef"
+          comment: 
+          description: 
+          id: 6ad90f38-5496-47fb-9882-5aa55e1314ef
+          name: 
+          cluster: 
+          data_center: 
+          display: 
+          ip: 
+          mtu: 
+          network_labels: 
+          permissions: 
+          profile_required: 
+          qos: 
+          required: 
+          status: 
+          stp: 
+          usages: 
+          vlan: 
+          vnic_profiles: 
+        network_labels: 
+        override_configuration: 
+        physical_function: 
+        properties: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        qos: 
+        speed: 100000000
+        statistics: 
+        status: up
+        virtual_functions_configuration: 
+        vlan: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896"
+        comment: 
+        description: Total memory
+        id: 7816602b-c05c-3db7-a4da-3769f7ad8896
+        name: memory.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 3868196864.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08"
+        comment: 
+        description: Used memory
+        id: b7499508-c1c3-32f0-8174-c1783e57bb08
+        name: memory.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946"
+        comment: 
+        description: Free memory
+        id: 5a0fba9d-33d7-3cbf-addd-ba462040c946
+        name: memory.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 3868196864.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc"
+        comment: 
+        description: Shared memory
+        id: ffc0e1fd-fa34-3f85-9862-8a841c1658bc
+        name: memory.shared
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f"
+        comment: 
+        description: IO buffers
+        id: c81c86f0-bc61-3c78-a543-898b8339d03f
+        name: memory.buffers
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11"
+        comment: 
+        description: OS caches
+        id: 1b6244ee-8dbd-365d-8762-482ddc05ee11
+        name: memory.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b"
+        comment: 
+        description: Total swap
+        id: c43847d7-3bc1-3aaf-b92c-902e64bbdb5b
+        name: swap.total
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46"
+        comment: 
+        description: Free swap
+        id: 1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46
+        name: swap.free
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 16776167424.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9"
+        comment: 
+        description: Used swap
+        id: 27686b4e-ba8d-3576-bc70-d68cbd8a2ba9
+        name: swap.used
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07"
+        comment: 
+        description: Swap also in memory
+        id: ea00da15-de2d-3393-a7cb-810c4b19ed07
+        name: swap.cached
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: bytes
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169"
+        comment: 
+        description: KSM CPU usage
+        id: f740b9ad-14a7-3f6c-9b80-efff44777169
+        name: ksm.cpu.current
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719"
+        comment: 
+        description: User CPU usage
+        id: a1fab379-66e2-3b1d-9914-81a9e79cb719
+        name: cpu.current.user
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815"
+        comment: 
+        description: System CPU usage
+        id: a98c1e11-078c-3593-a57e-4b12c1ce9815
+        name: cpu.current.system
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac"
+        comment: 
+        description: Idle CPU usage
+        id: 4ae97794-f56d-3f05-a9e7-8798887cd1ac
+        name: cpu.current.idle
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/65860dae-c890-312e-9314-5c01f31225ab"
+        comment: 
+        description: CPU 5 minute load average
+        id: 65860dae-c890-312e-9314-5c01f31225ab
+        name: cpu.load.avg.5m
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: decimal
+        unit: percent
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 0.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      - !ruby/object:OvirtSDK4::Statistic
+        href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa/statistics/3ceb2072-a5a5-3b21-9bb2-e966471fd81c"
+        comment: 
+        description: Boot time of the machine
+        id: 3ceb2072-a5a5-3b21-9bb2-e966471fd81c
+        name: boot.time
+        brick: 
+        disk: 
+        gluster_volume: 
+        host: !ruby/object:OvirtSDK4::Host
+          href: "/ovirt-engine/api/hosts/2d0f658b-37fe-4692-b0d7-7d18b18eadaa"
+          comment: 
+          description: 
+          id: 2d0f658b-37fe-4692-b0d7-7d18b18eadaa
+          name: 
+          address: 
+          affinity_labels: 
+          agents: 
+          auto_numa_status: 
+          certificate: 
+          cluster: 
+          cpu: 
+          device_passthrough: 
+          devices: 
+          display: 
+          external_host_provider: 
+          external_status: 
+          hardware_information: 
+          hooks: 
+          hosted_engine: 
+          iscsi: 
+          katello_errata: 
+          kdump_status: 
+          ksm: 
+          libvirt_version: 
+          max_scheduling_memory: 
+          memory: 
+          network_attachments: 
+          nics: 
+          numa_nodes: 
+          numa_supported: 
+          os: 
+          override_iptables: 
+          permissions: 
+          port: 
+          power_management: 
+          protocol: 
+          root_password: 
+          se_linux: 
+          spm: 
+          ssh: 
+          statistics: 
+          status: 
+          status_detail: 
+          storage_connection_extensions: 
+          storages: 
+          summary: 
+          tags: 
+          transparent_huge_pages: 
+          type: 
+          unmanaged_networks: 
+          update_available: 
+          version: 
+        host_nic: 
+        host_numa_node: 
+        kind: gauge
+        nic: 
+        step: 
+        type: integer
+        unit: none
+        values: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Value
+            href: 
+            datum: 1464607249.0
+            detail: 
+          ivars:
+            :@href: 
+        vm: 
+      ivars:
+        :@href: 
+  : *3

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/networks.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/networks.yml
@@ -1,0 +1,127 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::Network
+  href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef"
+  comment: 
+  description: Default Management Network
+  id: 6ad90f38-5496-47fb-9882-5aa55e1314ef
+  name: ovirtmgmt
+  cluster: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1"
+    comment: 
+    description: 
+    id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  ip: 
+  mtu: 0
+  network_labels: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/networklabels"
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/permissions"
+  profile_required: 
+  qos: !ruby/object:OvirtSDK4::Qos
+    href: "/ovirt-engine/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1/qoss/9e1a73ff-2598-4474-b24f-42d683f56d14"
+    comment: 
+    description: 
+    id: 9e1a73ff-2598-4474-b24f-42d683f56d14
+    name: 
+    cpu_limit: 
+    data_center: 
+    inbound_average: 
+    inbound_burst: 
+    inbound_peak: 
+    max_iops: 
+    max_read_iops: 
+    max_read_throughput: 
+    max_throughput: 
+    max_write_iops: 
+    max_write_throughput: 
+    outbound_average: 
+    outbound_average_linkshare: 
+    outbound_average_realtime: 
+    outbound_average_upperlimit: 
+    outbound_burst: 
+    outbound_peak: 
+    type: 
+  required: 
+  status: 
+  stp: false
+  usages:
+  - vm
+  vlan: 
+  vnic_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/6ad90f38-5496-47fb-9882-5aa55e1314ef/vnicprofiles"
+- !ruby/object:OvirtSDK4::Network
+  href: "/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009"
+  comment: 
+  description: Management Network
+  id: 00000000-0000-0000-0000-000000000009
+  name: ovirtmgmt
+  cluster: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-00000000009f"
+    comment: 
+    description: 
+    id: 00000001-0001-0001-0001-00000000009f
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  ip: 
+  mtu: 0
+  network_labels: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/networklabels"
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/permissions"
+  profile_required: 
+  qos: 
+  required: 
+  status: 
+  stp: false
+  usages:
+  - vm
+  vlan: 
+  vnic_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009/vnicprofiles"
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/storages.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/storages.yml
@@ -1,0 +1,451 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"
+  comment: 
+  description: 
+  id: 27a3bcce-c4d0-4bce-afe9-1d669d5a9d02
+  name: data1
+  available: 46170898432
+  committed: 70866960384
+  critical_space_action_blocker: 5
+  data_center: 
+  data_centers: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::DataCenter
+      href: 
+      comment: 
+      description: 
+      id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+      name: 
+      clusters: 
+      iscsi_bonds: 
+      local: 
+      mac_pool: 
+      networks: 
+      permissions: 
+      qoss: 
+      quota_mode: 
+      quotas: 
+      status: 
+      storage_domains: 
+      storage_format: 
+      supported_versions: 
+      version: 
+    ivars:
+      :@href: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disksnapshots"
+  disks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/disks"
+  external_status: ok
+  files: 
+  host: 
+  images: 
+  import: 
+  master: true
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/permissions"
+  status: 
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: spider.eng.lab.tlv.redhat.com
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: v3
+    override_luns: 
+    password: 
+    path: "/vol/vol_bodnopoz/data1"
+    port: 
+    portal: 
+    target: 
+    type: nfs
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/storageconnections"
+  storage_format: v3
+  templates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/templates"
+  type: data
+  used: 7516192768
+  vms: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02/vms"
+  warning_low_space_indicator: 10
+  wipe_after_delete: false
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb"
+  comment: 
+  description: 
+  id: 4672fe17-c260-4ecc-aab0-b535f4d0dbeb
+  name: data2
+  available: 46170898432
+  committed: 4294967296
+  critical_space_action_blocker: 5
+  data_center: 
+  data_centers: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::DataCenter
+      href: 
+      comment: 
+      description: 
+      id: 00000001-0001-0001-0001-00000000009f
+      name: 
+      clusters: 
+      iscsi_bonds: 
+      local: 
+      mac_pool: 
+      networks: 
+      permissions: 
+      qoss: 
+      quota_mode: 
+      quotas: 
+      status: 
+      storage_domains: 
+      storage_format: 
+      supported_versions: 
+      version: 
+    ivars:
+      :@href: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disksnapshots"
+  disks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/disks"
+  external_status: ok
+  files: 
+  host: 
+  images: 
+  import: 
+  master: true
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/permissions"
+  status: 
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: spider.eng.lab.tlv.redhat.com
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: 
+    override_luns: 
+    password: 
+    path: "/vol/vol_bodnopoz/data2"
+    port: 
+    portal: 
+    target: 
+    type: nfs
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/storageconnections"
+  storage_format: v3
+  templates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/templates"
+  type: data
+  used: 7516192768
+  vms: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb/vms"
+  warning_low_space_indicator: 10
+  wipe_after_delete: false
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1"
+  comment: 
+  description: 
+  id: 0c55619d-4d88-4bd1-921c-5425275061d1
+  name: export
+  available: 46170898432
+  committed: 0
+  critical_space_action_blocker: 5
+  data_center: 
+  data_centers: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::DataCenter
+      href: 
+      comment: 
+      description: 
+      id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+      name: 
+      clusters: 
+      iscsi_bonds: 
+      local: 
+      mac_pool: 
+      networks: 
+      permissions: 
+      qoss: 
+      quota_mode: 
+      quotas: 
+      status: 
+      storage_domains: 
+      storage_format: 
+      supported_versions: 
+      version: 
+    ivars:
+      :@href: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disksnapshots"
+  disks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/disks"
+  external_status: ok
+  files: 
+  host: 
+  images: 
+  import: 
+  master: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/permissions"
+  status: 
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: spider.eng.lab.tlv.redhat.com
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: v3
+    override_luns: 
+    password: 
+    path: "/vol/vol_bodnopoz/export"
+    port: 
+    portal: 
+    target: 
+    type: nfs
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/storageconnections"
+  storage_format: v1
+  templates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/templates"
+  type: export
+  used: 7516192768
+  vms: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/0c55619d-4d88-4bd1-921c-5425275061d1/vms"
+  warning_low_space_indicator: 10
+  wipe_after_delete: false
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525"
+  comment: 
+  description: 
+  id: ef0c6712-13df-49bd-885e-d96dcaf9e525
+  name: isob1
+  available: 46170898432
+  committed: 0
+  critical_space_action_blocker: 5
+  data_center: 
+  data_centers: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::DataCenter
+      href: 
+      comment: 
+      description: 
+      id: b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1
+      name: 
+      clusters: 
+      iscsi_bonds: 
+      local: 
+      mac_pool: 
+      networks: 
+      permissions: 
+      qoss: 
+      quota_mode: 
+      quotas: 
+      status: 
+      storage_domains: 
+      storage_format: 
+      supported_versions: 
+      version: 
+    ivars:
+      :@href: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525/disksnapshots"
+  disks: 
+  external_status: ok
+  files: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525/files"
+  host: 
+  images: 
+  import: 
+  master: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525/permissions"
+  status: 
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: spider.eng.lab.tlv.redhat.com
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: v3
+    override_luns: 
+    password: 
+    path: "/vol/vol_bodnopoz/iso"
+    port: 
+    portal: 
+    target: 
+    type: nfs
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/ef0c6712-13df-49bd-885e-d96dcaf9e525/storageconnections"
+  storage_format: v1
+  templates: 
+  type: iso
+  used: 7516192768
+  vms: 
+  warning_low_space_indicator: 10
+  wipe_after_delete: false
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74"
+  comment: 
+  description: 
+  id: 072fbaa1-08f3-4a40-9f34-a5ca22dd1d74
+  name: ovirt-image-repository
+  available: 
+  committed: 0
+  critical_space_action_blocker: 0
+  data_center: 
+  data_centers: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/disksnapshots"
+  disks: 
+  external_status: ok
+  files: 
+  host: 
+  images: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/images"
+  import: 
+  master: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/permissions"
+  status: unattached
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: 
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: 
+    override_luns: 
+    password: 
+    path: 
+    port: 
+    portal: 
+    target: 
+    type: glance
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: 
+  storage_format: v1
+  templates: 
+  type: image
+  used: 
+  vms: 
+  warning_low_space_indicator: 0
+  wipe_after_delete: false
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/templates.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/templates.yml
@@ -1,0 +1,979 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  ? - &1 !ruby/object:OvirtSDK4::Template
+      href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+      comment: 
+      description: Blank template
+      id: 00000000-0000-0000-0000-000000000000
+      name: Blank
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: undefined
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2008-04-01 00:00:00.000000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments"
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions"
+      status: ok
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags"
+      version: !ruby/object:OvirtSDK4::TemplateVersion
+        href: 
+        base_template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+          comment: 
+          description: 
+          id: 00000000-0000-0000-0000-000000000000
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          cdroms: 
+          disk_attachments: 
+          graphics_consoles: 
+          nics: 
+          permissions: 
+          status: 
+          tags: 
+          version: 
+          vm: 
+          watchdogs: 
+        version_name: ''
+        version_number: 0
+      vm: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+  : *1
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  ? - &2 !ruby/object:OvirtSDK4::Template
+      href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79"
+      comment: 
+      description: 
+      id: 785e845e-baa0-4812-8a8c-467f37ad6c79
+      name: template_cd1
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: true
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf"
+        comment: 
+        description: 
+        id: 504ae500-3476-450e-8243-f6df0f7f7acf
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 4
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d"
+        comment: 
+        description: 
+        id: c34525ea-072c-452d-baa1-0c5efe643e4d
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-07-12 10:57:38.356000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: !ruby/object:OvirtSDK4::Initialization
+        href: 
+        active_directory_ou: 
+        authorized_ssh_keys: ''
+        cloud_init: 
+        configuration: 
+        custom_script: ''
+        dns_search: 
+        dns_servers: 
+        domain: 
+        host_name: 
+        input_locale: 
+        nic_configurations: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        org_name: 
+        regenerate_ids: 
+        regenerate_ssh_keys: false
+        root_password: 
+        system_locale: 
+        timezone: 
+        ui_language: 
+        user_locale: 
+        user_name: 
+        windows_license_key: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 4219469824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 4219469824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/diskattachments"
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/graphicsconsoles"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/nics"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/permissions"
+      status: ok
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/tags"
+      version: !ruby/object:OvirtSDK4::TemplateVersion
+        href: 
+        base_template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79"
+          comment: 
+          description: 
+          id: 785e845e-baa0-4812-8a8c-467f37ad6c79
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          cdroms: 
+          disk_attachments: 
+          graphics_consoles: 
+          nics: 
+          permissions: 
+          status: 
+          tags: 
+          version: 
+          vm: 
+          watchdogs: 
+        version_name: base version
+        version_number: 1
+      vm: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6"
+        comment: 
+        description: 
+        id: 7917730e-39fb-4da4-9256-da652c33e5b6
+        name: vm1_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 1838448640
+        alias_: vm1_Disk1
+        bootable: true
+        disk_profile: !ruby/object:OvirtSDK4::DiskProfile
+          href: "/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"
+          comment: 
+          description: 
+          id: 0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486
+          name: 
+          permissions: 
+          qos: 
+          storage_domain: 
+        format: raw
+        image_id: cea4905b-0d4a-4d10-9943-1721ddc454eb
+        interface: virtio
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/permissions"
+        propagate_errors: false
+        provisioned_size: 6442450944
+        quota: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/7917730e-39fb-4da4-9256-da652c33e5b6/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"
+            comment: 
+            description: 
+            id: 27a3bcce-c4d0-4bce-afe9-1d669d5a9d02
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Nic
+        href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79/nics/b2761a52-fdfb-4424-8ef9-8ec49335bfb4"
+        comment: 
+        description: 
+        id: b2761a52-fdfb-4424-8ef9-8ec49335bfb4
+        name: nic1
+        instance_type: 
+        template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79"
+          comment: 
+          description: 
+          id: 785e845e-baa0-4812-8a8c-467f37ad6c79
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          cdroms: 
+          disk_attachments: 
+          graphics_consoles: 
+          nics: 
+          permissions: 
+          status: 
+          tags: 
+          version: 
+          vm: 
+          watchdogs: 
+        vm: 
+        vms: 
+        boot_protocol: 
+        interface: virtio
+        linked: true
+        mac: 
+        network: 
+        network_attachments: 
+        network_labels: 
+        on_boot: 
+        plugged: true
+        reported_devices: 
+        statistics: 
+        virtual_function_allowed_labels: 
+        virtual_function_allowed_networks: 
+        vnic_profile: !ruby/object:OvirtSDK4::VnicProfile
+          href: "/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903"
+          comment: 
+          description: 
+          id: 361634d2-4975-4ef7-8429-c009871ce903
+          name: 
+          custom_properties: 
+          network: 
+          network_filter: 
+          pass_through: 
+          permissions: 
+          port_mirroring: 
+          qos: 
+      ivars:
+        :@href: 
+  : *2
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  ? - &3 !ruby/object:OvirtSDK4::Template
+      href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b"
+      comment: 
+      description: 
+      id: 187e40e6-dfff-453c-9433-066ac1b14e5b
+      name: template_ex_default
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-07-12 10:58:45.436000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/diskattachments"
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/graphicsconsoles"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/nics"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/permissions"
+      status: ok
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/tags"
+      version: !ruby/object:OvirtSDK4::TemplateVersion
+        href: 
+        base_template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b"
+          comment: 
+          description: 
+          id: 187e40e6-dfff-453c-9433-066ac1b14e5b
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          cdroms: 
+          disk_attachments: 
+          graphics_consoles: 
+          nics: 
+          permissions: 
+          status: 
+          tags: 
+          version: 
+          vm: 
+          watchdogs: 
+        version_name: base version
+        version_number: 1
+      vm: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/187e40e6-dfff-453c-9433-066ac1b14e5b/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+  : *3

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/vms.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/response_yamls/vms.yml
@@ -1,0 +1,5523 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &1 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb"
+      comment: 
+      description: 
+      id: 63978315-2d17-4e67-b393-2ea60a8aeacb
+      name: external-as
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-06-28 12:08:47.228000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: external
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-06-28 12:08:47.232000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/63978315-2d17-4e67-b393-2ea60a8aeacb/snapshots/45a18e0d-7564-4e0b-9c18-ae06cf69d048"
+        comment: 
+        description: Active VM
+        id: 45a18e0d-7564-4e0b-9c18-ae06cf69d048
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-06-28 12:08:47.238000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *1
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &2 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b"
+      comment: 
+      description: 
+      id: ed7f875f-4518-4618-aec6-e04d0034475b
+      name: external-manageiq
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 4
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-06-28 12:08:46.888000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 6410993664
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 6410993664
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: external
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-06-28 12:08:46.890000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/ed7f875f-4518-4618-aec6-e04d0034475b/snapshots/0b304821-d2d5-4de0-82b2-de8d18e51e00"
+        comment: 
+        description: Active VM
+        id: 0b304821-d2d5-4de0-82b2-de8d18e51e00
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-06-28 12:08:46.897000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *2
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &3 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27"
+      comment: 
+      description: 
+      id: 5aa608f3-1e02-4aca-8db5-445ec2170a27
+      name: external-test_se121
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-06-28 12:07:48.904000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: external
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-06-28 12:07:48.913000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/5aa608f3-1e02-4aca-8db5-445ec2170a27/snapshots/4c39e12b-030c-427e-98bd-877bd80a279d"
+        comment: 
+        description: Active VM
+        id: 4c39e12b-030c-427e-98bd-877bd80a279d
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-06-28 12:07:48.967000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *3
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &4 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe"
+      comment: 
+      description: 
+      id: f664d87c-6a0d-4207-b6e5-d418247cecbe
+      name: external-yo
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-06-28 12:08:47.070000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: external
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-07-12 10:58:45.464000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/f664d87c-6a0d-4207-b6e5-d418247cecbe/snapshots/dddc0532-12c3-42bc-935f-57127a08f63b"
+        comment: 
+        description: Active VM
+        id: dddc0532-12c3-42bc-935f-57127a08f63b
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-06-28 12:08:47.077000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *4
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &5 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f"
+      comment: 
+      description: 
+      id: 3a9401a0-bf3d-4496-8acf-edd3e903511f
+      name: vm1
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: true
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf"
+        comment: 
+        description: 
+        id: 504ae500-3476-450e-8243-f6df0f7f7acf
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 4
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d"
+        comment: 
+        description: 
+        id: c34525ea-072c-452d-baa1-0c5efe643e4d
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-06-28 13:31:17.000000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 10.35.18.214
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 5900
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: !ruby/object:OvirtSDK4::Initialization
+        href: 
+        active_directory_ou: 
+        authorized_ssh_keys: ''
+        cloud_init: 
+        configuration: 
+        custom_script: ''
+        dns_search: 
+        dns_servers: 
+        domain: 
+        host_name: 
+        input_locale: 
+        nic_configurations: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: 
+        org_name: 
+        regenerate_ids: 
+        regenerate_ssh_keys: false
+        root_password: 
+        system_locale: 
+        timezone: 
+        ui_language: 
+        user_locale: 
+        user_name: 
+        windows_license_key: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 2122317824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 2122317824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: vm-18-82.eng.lab.tlv.redhat.com
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/graphicsconsoles"
+      guest_operating_system: !ruby/object:OvirtSDK4::GuestOperatingSystem
+        href: 
+        architecture: x86_64
+        codename: Core
+        distribution: CentOS Linux
+        family: Linux
+        kernel: !ruby/object:OvirtSDK4::Kernel
+          href: 
+          version: !ruby/object:OvirtSDK4::Version
+            href: 
+            comment: 
+            description: 
+            id: 
+            name: 
+            build: 0
+            full_version: 3.10.0-123.el7.x86_64
+            major: 3
+            minor: 10
+            revision: 123
+        version: !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 1406
+          full_version: 7.0.1406
+          major: 7
+          minor: 0
+          revision: 
+      guest_time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Asia/Jerusalem
+        utc_offset: "+02:00"
+      host: !ruby/object:OvirtSDK4::Host
+        href: "/ovirt-engine/api/hosts/69cd8141-a6f5-4968-880d-121de26f3747"
+        comment: 
+        description: 
+        id: 69cd8141-a6f5-4968-880d-121de26f3747
+        name: 
+        address: 
+        affinity_labels: 
+        agents: 
+        auto_numa_status: 
+        certificate: 
+        cluster: 
+        cpu: 
+        device_passthrough: 
+        devices: 
+        display: 
+        external_host_provider: 
+        external_status: 
+        hardware_information: 
+        hooks: 
+        hosted_engine: 
+        iscsi: 
+        katello_errata: 
+        kdump_status: 
+        ksm: 
+        libvirt_version: 
+        max_scheduling_memory: 
+        memory: 
+        network_attachments: 
+        nics: 
+        numa_nodes: 
+        numa_supported: 
+        os: 
+        override_iptables: 
+        permissions: 
+        port: 
+        power_management: 
+        protocol: 
+        root_password: 
+        se_linux: 
+        spm: 
+        ssh: 
+        statistics: 
+        status: 
+        status_detail: 
+        storage_connection_extensions: 
+        storages: 
+        summary: 
+        tags: 
+        transparent_huge_pages: 
+        type: 
+        unmanaged_networks: 
+        update_available: 
+        version: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices"
+      run_once: false
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots"
+      start_time: !ruby/object:DateTime 2016-12-28 13:59:55.602000000 +02:00
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/statistics"
+      status: up
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-12-28 12:36:24.611000000 +02:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec"
+        comment: 
+        description: 
+        id: af578e0e-b222-4754-aefc-879bf37eacec
+        name: vm1_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 2987851776
+        alias_: vm1_Disk1
+        bootable: true
+        disk_profile: !ruby/object:OvirtSDK4::DiskProfile
+          href: "/ovirt-engine/api/diskprofiles/0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486"
+          comment: 
+          description: 
+          id: 0be3e43c-1d7a-4c2c-b0b5-8e9c894b0486
+          name: 
+          permissions: 
+          qos: 
+          storage_domain: 
+        format: cow
+        image_id: 54a3215e-1cde-4912-8b85-b9908c519983
+        interface: virtio
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/permissions"
+        propagate_errors: false
+        provisioned_size: 6442450944
+        quota: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/af578e0e-b222-4754-aefc-879bf37eacec/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"
+            comment: 
+            description: 
+            id: 27a3bcce-c4d0-4bce-afe9-1d669d5a9d02
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Nic
+        href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93"
+        comment: 
+        description: 
+        id: 6a538d86-38a2-4ac9-98f5-9d401a596e93
+        name: nic1
+        instance_type: 
+        template: 
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f"
+          comment: 
+          description: 
+          id: 3a9401a0-bf3d-4496-8acf-edd3e903511f
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: 
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: 
+          payloads: 
+          permissions: 
+          placement_policy: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: 
+          status_detail: 
+          stop_reason: 
+          stop_time: 
+          tags: 
+          template: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+        vms: 
+        boot_protocol: 
+        interface: virtio
+        linked: true
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:16:01:51
+        network: 
+        network_attachments: 
+        network_labels: 
+        on_boot: 
+        plugged: true
+        reported_devices: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::ReportedDevice
+            href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a"
+            comment: 
+            description: guest reported data
+            id: 65746830-3030-3a31-613a-34613a31363a
+            name: eth0
+            ips: !ruby/array:OvirtSDK4::List
+              internal:
+              - !ruby/object:OvirtSDK4::Ip
+                href: 
+                address: 10.35.18.3
+                gateway: 
+                netmask: 
+                version: v4
+              - !ruby/object:OvirtSDK4::Ip
+                href: 
+                address: fe80::21a:4aff:fe16:151
+                gateway: 
+                netmask: 
+                version: v6
+              - !ruby/object:OvirtSDK4::Ip
+                href: 
+                address: 2620:52:0:2310:21a:4aff:fe16:151
+                gateway: 
+                netmask: 
+                version: v6
+              ivars:
+                :@href: 
+            mac: !ruby/object:OvirtSDK4::Mac
+              href: 
+              address: 00:1a:4a:16:01:51
+            type: network
+            vm: !ruby/object:OvirtSDK4::Vm
+              href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f"
+              comment: 
+              description: 
+              id: 3a9401a0-bf3d-4496-8acf-edd3e903511f
+              name: 
+              bios: 
+              cluster: 
+              console: 
+              cpu: 
+              cpu_profile: 
+              cpu_shares: 
+              creation_time: 
+              custom_compatibility_version: 
+              custom_cpu_model: 
+              custom_emulated_machine: 
+              custom_properties: 
+              delete_protected: 
+              display: 
+              domain: 
+              high_availability: 
+              initialization: 
+              io: 
+              large_icon: 
+              memory: 
+              memory_policy: 
+              migration: 
+              migration_downtime: 
+              origin: 
+              os: 
+              quota: 
+              rng_device: 
+              serial_number: 
+              small_icon: 
+              soundcard_enabled: 
+              sso: 
+              start_paused: 
+              stateless: 
+              storage_domain: 
+              time_zone: 
+              tunnel_migration: 
+              type: 
+              usb: 
+              virtio_scsi: 
+              affinity_labels: 
+              applications: 
+              cdroms: 
+              disk_attachments: 
+              external_host_provider: 
+              floppies: 
+              fqdn: 
+              graphics_consoles: 
+              guest_operating_system: 
+              guest_time_zone: 
+              host: 
+              host_devices: 
+              instance_type: 
+              katello_errata: 
+              next_run_configuration_exists: 
+              nics: 
+              numa_nodes: 
+              numa_tune_mode: 
+              payloads: 
+              permissions: 
+              placement_policy: 
+              reported_devices: 
+              run_once: 
+              sessions: 
+              snapshots: 
+              start_time: 
+              statistics: 
+              status: 
+              status_detail: 
+              stop_reason: 
+              stop_time: 
+              tags: 
+              template: 
+              use_latest_template_version: 
+              vm_pool: 
+              watchdogs: 
+          ivars:
+            :@href: 
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/nics/6a538d86-38a2-4ac9-98f5-9d401a596e93/statistics"
+        virtual_function_allowed_labels: 
+        virtual_function_allowed_networks: 
+        vnic_profile: !ruby/object:OvirtSDK4::VnicProfile
+          href: "/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903"
+          comment: 
+          description: 
+          id: 361634d2-4975-4ef7-8429-c009871ce903
+          name: 
+          custom_properties: 
+          network: 
+          network_filter: 
+          pass_through: 
+          permissions: 
+          port_mirroring: 
+          qos: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::ReportedDevice
+        href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/reporteddevices/65746830-3030-3a31-613a-34613a31363a"
+        comment: 
+        description: guest reported data
+        id: 65746830-3030-3a31-613a-34613a31363a
+        name: eth0
+        ips: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Ip
+            href: 
+            address: 10.35.18.3
+            gateway: 
+            netmask: 
+            version: v4
+          - !ruby/object:OvirtSDK4::Ip
+            href: 
+            address: fe80::21a:4aff:fe16:151
+            gateway: 
+            netmask: 
+            version: v6
+          - !ruby/object:OvirtSDK4::Ip
+            href: 
+            address: 2620:52:0:2310:21a:4aff:fe16:151
+            gateway: 
+            netmask: 
+            version: v6
+          ivars:
+            :@href: 
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:16:01:51
+        type: network
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f"
+          comment: 
+          description: 
+          id: 3a9401a0-bf3d-4496-8acf-edd3e903511f
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: 
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: 
+          payloads: 
+          permissions: 
+          placement_policy: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: 
+          status_detail: 
+          stop_reason: 
+          stop_time: 
+          tags: 
+          template: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/e13fc61c-c566-4264-9a75-0e62fe5d7a30"
+        comment: 
+        description: Active VM
+        id: e13fc61c-c566-4264-9a75-0e62fe5d7a30
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-07-05 13:14:08.116000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510"
+        comment: 
+        description: vm1_snap
+        id: 05ff445a-0bfc-44c3-90d1-a338e9095510
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/cdroms"
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f/snapshots/05ff445a-0bfc-44c3-90d1-a338e9095510/nics"
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-12-15 09:51:43.247000000 +02:00
+        persist_memorystate: true
+        snapshot_status: ok
+        snapshot_type: regular
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: 
+          comment: 
+          description: 
+          id: 3a9401a0-bf3d-4496-8acf-edd3e903511f
+          name: vm1
+          bios: !ruby/object:OvirtSDK4::Bios
+            href: 
+            boot_menu: !ruby/object:OvirtSDK4::BootMenu
+              href: 
+              enabled: true
+          cluster: !ruby/object:OvirtSDK4::Cluster
+            href: 
+            comment: 
+            description: 
+            id: 504ae500-3476-450e-8243-f6df0f7f7acf
+            name: 
+            affinity_groups: 
+            ballooning_enabled: 
+            cpu: 
+            cpu_profiles: 
+            custom_scheduling_policy_properties: 
+            data_center: 
+            display: 
+            error_handling: 
+            fencing_policy: 
+            gluster_hooks: 
+            gluster_service: 
+            gluster_volumes: 
+            ha_reservation: 
+            ksm: 
+            maintenance_reason_required: 
+            management_network: 
+            memory_policy: 
+            migration: 
+            network_filters: 
+            networks: 
+            optional_reason: 
+            permissions: 
+            required_rng_sources: 
+            scheduling_policy: 
+            serial_number: 
+            supported_versions: 
+            switch_type: 
+            threads_as_cores: 
+            trusted_service: 
+            tunnel_migration: 
+            version: 
+            virt_service: 
+          console: 
+          cpu: !ruby/object:OvirtSDK4::Cpu
+            href: 
+            architecture: x86_64
+            cores: 
+            cpu_tune: 
+            level: 
+            mode: 
+            name: 
+            speed: 
+            topology: !ruby/object:OvirtSDK4::CpuTopology
+              href: 
+              cores: 1
+              sockets: 4
+              threads: 1
+            type: 
+          cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+            href: 
+            comment: 
+            description: 
+            id: c34525ea-072c-452d-baa1-0c5efe643e4d
+            name: 
+            cluster: 
+            permissions: 
+            qos: 
+          cpu_shares: 0
+          creation_time: !ruby/object:DateTime 2016-06-28 13:31:17.000000000 +03:00
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: false
+          display: !ruby/object:OvirtSDK4::Display
+            href: 
+            address: 10.35.18.214
+            allow_override: false
+            certificate: 
+            copy_paste_enabled: true
+            disconnect_action: LOCK_SCREEN
+            file_transfer_enabled: true
+            keyboard_layout: 
+            monitors: 1
+            port: 
+            proxy: 
+            secure_port: 5900
+            single_qxl_pci: false
+            smartcard_enabled: false
+            type: spice
+          domain: 
+          high_availability: !ruby/object:OvirtSDK4::HighAvailability
+            href: 
+            enabled: false
+            priority: 1
+          initialization: !ruby/object:OvirtSDK4::Initialization
+            href: 
+            active_directory_ou: 
+            authorized_ssh_keys: 
+            cloud_init: 
+            configuration: 
+            custom_script: 
+            dns_search: 
+            dns_servers: 
+            domain: 
+            host_name: 
+            input_locale: 
+            nic_configurations: 
+            org_name: 
+            regenerate_ids: 
+            regenerate_ssh_keys: 
+            root_password: 
+            system_locale: 
+            timezone: 
+            ui_language: 
+            user_locale: 
+            user_name: 
+            windows_license_key: 
+          io: !ruby/object:OvirtSDK4::Io
+            href: 
+            threads: 0
+          large_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+            name: 
+            data: 
+            media_type: 
+          memory: 2122317824
+          memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+            href: 
+            ballooning: 
+            guaranteed: 2122317824
+            over_commit: 
+            transparent_huge_pages: 
+          migration: !ruby/object:OvirtSDK4::MigrationOptions
+            href: 
+            auto_converge: inherit
+            bandwidth: 
+            compressed: inherit
+            policy: 
+          migration_downtime: -1
+          origin: ovirt
+          os: !ruby/object:OvirtSDK4::OperatingSystem
+            href: 
+            boot: !ruby/object:OvirtSDK4::Boot
+              href: 
+              devices:
+              - hd
+            cmdline: 
+            custom_kernel_cmdline: 
+            initrd: 
+            kernel: 
+            reported_kernel_cmdline: 
+            type: other
+            version: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+            name: 
+            data: 
+            media_type: 
+          soundcard_enabled: 
+          sso: !ruby/object:OvirtSDK4::Sso
+            href: 
+            methods: !ruby/array:OvirtSDK4::List
+              internal:
+              - !ruby/object:OvirtSDK4::Method
+                href: 
+                id: guest_agent
+              ivars:
+                :@href: 
+          start_paused: false
+          stateless: false
+          storage_domain: 
+          time_zone: !ruby/object:OvirtSDK4::TimeZone
+            href: 
+            name: Etc/GMT
+            utc_offset: 
+          tunnel_migration: 
+          type: desktop
+          usb: !ruby/object:OvirtSDK4::Usb
+            href: 
+            enabled: false
+            type: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: vm-18-82.eng.lab.tlv.redhat.com
+          graphics_consoles: 
+          guest_operating_system: !ruby/object:OvirtSDK4::GuestOperatingSystem
+            href: 
+            architecture: x86_64
+            codename: Core
+            distribution: CentOS Linux
+            family: Linux
+            kernel: !ruby/object:OvirtSDK4::Kernel
+              href: 
+              version: !ruby/object:OvirtSDK4::Version
+                href: 
+                comment: 
+                description: 
+                id: 
+                name: 
+                build: 0
+                full_version: 3.10.0-123.el7.x86_64
+                major: 3
+                minor: 10
+                revision: 123
+            version: !ruby/object:OvirtSDK4::Version
+              href: 
+              comment: 
+              description: 
+              id: 
+              name: 
+              build: 1406
+              full_version: 7.0.1406
+              major: 7
+              minor: 0
+              revision: 
+          guest_time_zone: !ruby/object:OvirtSDK4::TimeZone
+            href: 
+            name: Asia/Jerusalem
+            utc_offset: "+02:00"
+          host: !ruby/object:OvirtSDK4::Host
+            href: 
+            comment: 
+            description: 
+            id: 69cd8141-a6f5-4968-880d-121de26f3747
+            name: 
+            address: 
+            affinity_labels: 
+            agents: 
+            auto_numa_status: 
+            certificate: 
+            cluster: 
+            cpu: 
+            device_passthrough: 
+            devices: 
+            display: 
+            external_host_provider: 
+            external_status: 
+            hardware_information: 
+            hooks: 
+            hosted_engine: 
+            iscsi: 
+            katello_errata: 
+            kdump_status: 
+            ksm: 
+            libvirt_version: 
+            max_scheduling_memory: 
+            memory: 
+            network_attachments: 
+            nics: 
+            numa_nodes: 
+            numa_supported: 
+            os: 
+            override_iptables: 
+            permissions: 
+            port: 
+            power_management: 
+            protocol: 
+            root_password: 
+            se_linux: 
+            spm: 
+            ssh: 
+            statistics: 
+            status: 
+            status_detail: 
+            storage_connection_extensions: 
+            storages: 
+            summary: 
+            tags: 
+            transparent_huge_pages: 
+            type: 
+            unmanaged_networks: 
+            update_available: 
+            version: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: false
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: interleave
+          payloads: 
+          permissions: 
+          placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+            href: 
+            affinity: migratable
+            hosts: 
+          reported_devices: 
+          run_once: false
+          sessions: 
+          snapshots: 
+          start_time: !ruby/object:DateTime 2016-12-28 13:59:55.602000000 +02:00
+          statistics: 
+          status: up
+          status_detail: 
+          stop_reason: 
+          stop_time: !ruby/object:DateTime 2016-12-28 12:36:24.611000000 +02:00
+          tags: 
+          template: !ruby/object:OvirtSDK4::Template
+            href: 
+            comment: 
+            description: 
+            id: 00000000-0000-0000-0000-000000000000
+            name: 
+            bios: 
+            cluster: 
+            console: 
+            cpu: 
+            cpu_profile: 
+            cpu_shares: 
+            creation_time: 
+            custom_compatibility_version: 
+            custom_cpu_model: 
+            custom_emulated_machine: 
+            custom_properties: 
+            delete_protected: 
+            display: 
+            domain: 
+            high_availability: 
+            initialization: 
+            io: 
+            large_icon: 
+            memory: 
+            memory_policy: 
+            migration: 
+            migration_downtime: 
+            origin: 
+            os: 
+            quota: 
+            rng_device: 
+            serial_number: 
+            small_icon: 
+            soundcard_enabled: 
+            sso: 
+            start_paused: 
+            stateless: 
+            storage_domain: 
+            time_zone: 
+            tunnel_migration: 
+            type: 
+            usb: 
+            virtio_scsi: 
+            cdroms: 
+            disk_attachments: 
+            graphics_consoles: 
+            nics: 
+            permissions: 
+            status: 
+            tags: 
+            version: 
+            vm: 
+            watchdogs: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+      ivars:
+        :@href: 
+  : *5
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &6 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf"
+      comment: 
+      description: 
+      id: 072093dc-3492-4cb1-b240-dbf88a8f4fbf
+      name: vm2
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: true
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/504ae500-3476-450e-8243-f6df0f7f7acf"
+        comment: 
+        description: 
+        id: 504ae500-3476-450e-8243-f6df0f7f7acf
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/c34525ea-072c-452d-baa1-0c5efe643e4d"
+        comment: 
+        description: 
+        id: c34525ea-072c-452d-baa1-0c5efe643e4d
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-07-05 14:48:58.000000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - network
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/statistics"
+      status: down
+      status_detail: 
+      stop_reason: ''
+      stop_time: !ruby/object:DateTime 2016-11-17 17:24:40.816000000 +02:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d"
+        comment: 
+        description: 
+        id: 9a3e866c-4497-46df-801a-d1739c31c69d
+        name: vm2_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 204800
+        alias_: vm2_Disk1
+        bootable: true
+        disk_profile: 
+        format: cow
+        image_id: b181984a-e625-48c7-895c-f2cbac41d5db
+        interface: virtio
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/permissions"
+        propagate_errors: false
+        provisioned_size: 5368709120
+        quota: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/9a3e866c-4497-46df-801a-d1739c31c69d/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02"
+            comment: 
+            description: 
+            id: 27a3bcce-c4d0-4bce-afe9-1d669d5a9d02
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Nic
+        href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e"
+        comment: 
+        description: 
+        id: fdc2d708-01d1-4aa4-8b53-d64177181e2e
+        name: nic1
+        instance_type: 
+        template: 
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf"
+          comment: 
+          description: 
+          id: 072093dc-3492-4cb1-b240-dbf88a8f4fbf
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: 
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: 
+          payloads: 
+          permissions: 
+          placement_policy: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: 
+          status_detail: 
+          stop_reason: 
+          stop_time: 
+          tags: 
+          template: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+        vms: 
+        boot_protocol: 
+        interface: virtio
+        linked: true
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:16:01:52
+        network: 
+        network_attachments: 
+        network_labels: 
+        on_boot: 
+        plugged: true
+        reported_devices: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/reporteddevices"
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/nics/fdc2d708-01d1-4aa4-8b53-d64177181e2e/statistics"
+        virtual_function_allowed_labels: 
+        virtual_function_allowed_networks: 
+        vnic_profile: !ruby/object:OvirtSDK4::VnicProfile
+          href: "/ovirt-engine/api/vnicprofiles/361634d2-4975-4ef7-8429-c009871ce903"
+          comment: 
+          description: 
+          id: 361634d2-4975-4ef7-8429-c009871ce903
+          name: 
+          custom_properties: 
+          network: 
+          network_filter: 
+          pass_through: 
+          permissions: 
+          port_mirroring: 
+          qos: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912"
+        comment: 
+        description: '22'
+        id: 677a1c40-8112-4e4a-bd03-c430e7505912
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/cdroms"
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/677a1c40-8112-4e4a-bd03-c430e7505912/nics"
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-08-02 14:42:19.378000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: regular
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: 
+          comment: 
+          description: 
+          id: 072093dc-3492-4cb1-b240-dbf88a8f4fbf
+          name: vm2
+          bios: !ruby/object:OvirtSDK4::Bios
+            href: 
+            boot_menu: !ruby/object:OvirtSDK4::BootMenu
+              href: 
+              enabled: true
+          cluster: !ruby/object:OvirtSDK4::Cluster
+            href: 
+            comment: 
+            description: 
+            id: 504ae500-3476-450e-8243-f6df0f7f7acf
+            name: 
+            affinity_groups: 
+            ballooning_enabled: 
+            cpu: 
+            cpu_profiles: 
+            custom_scheduling_policy_properties: 
+            data_center: 
+            display: 
+            error_handling: 
+            fencing_policy: 
+            gluster_hooks: 
+            gluster_service: 
+            gluster_volumes: 
+            ha_reservation: 
+            ksm: 
+            maintenance_reason_required: 
+            management_network: 
+            memory_policy: 
+            migration: 
+            network_filters: 
+            networks: 
+            optional_reason: 
+            permissions: 
+            required_rng_sources: 
+            scheduling_policy: 
+            serial_number: 
+            supported_versions: 
+            switch_type: 
+            threads_as_cores: 
+            trusted_service: 
+            tunnel_migration: 
+            version: 
+            virt_service: 
+          console: 
+          cpu: !ruby/object:OvirtSDK4::Cpu
+            href: 
+            architecture: x86_64
+            cores: 
+            cpu_tune: 
+            level: 
+            mode: 
+            name: 
+            speed: 
+            topology: !ruby/object:OvirtSDK4::CpuTopology
+              href: 
+              cores: 1
+              sockets: 1
+              threads: 1
+            type: 
+          cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+            href: 
+            comment: 
+            description: 
+            id: c34525ea-072c-452d-baa1-0c5efe643e4d
+            name: 
+            cluster: 
+            permissions: 
+            qos: 
+          cpu_shares: 0
+          creation_time: !ruby/object:DateTime 2016-07-05 14:48:58.000000000 +03:00
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: false
+          display: !ruby/object:OvirtSDK4::Display
+            href: 
+            address: 
+            allow_override: false
+            certificate: 
+            copy_paste_enabled: true
+            disconnect_action: LOCK_SCREEN
+            file_transfer_enabled: true
+            keyboard_layout: 
+            monitors: 1
+            port: 
+            proxy: 
+            secure_port: 
+            single_qxl_pci: false
+            smartcard_enabled: false
+            type: 
+          domain: 
+          high_availability: !ruby/object:OvirtSDK4::HighAvailability
+            href: 
+            enabled: false
+            priority: 1
+          initialization: !ruby/object:OvirtSDK4::Initialization
+            href: 
+            active_directory_ou: 
+            authorized_ssh_keys: 
+            cloud_init: 
+            configuration: 
+            custom_script: 
+            dns_search: 
+            dns_servers: 
+            domain: 
+            host_name: 
+            input_locale: 
+            nic_configurations: 
+            org_name: 
+            regenerate_ids: 
+            regenerate_ssh_keys: 
+            root_password: 
+            system_locale: 
+            timezone: 
+            ui_language: 
+            user_locale: 
+            user_name: 
+            windows_license_key: 
+          io: !ruby/object:OvirtSDK4::Io
+            href: 
+            threads: 0
+          large_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+            name: 
+            data: 
+            media_type: 
+          memory: 1073741824
+          memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+            href: 
+            ballooning: 
+            guaranteed: 1073741824
+            over_commit: 
+            transparent_huge_pages: 
+          migration: !ruby/object:OvirtSDK4::MigrationOptions
+            href: 
+            auto_converge: inherit
+            bandwidth: 
+            compressed: inherit
+            policy: 
+          migration_downtime: -1
+          origin: ovirt
+          os: !ruby/object:OvirtSDK4::OperatingSystem
+            href: 
+            boot: !ruby/object:OvirtSDK4::Boot
+              href: 
+              devices:
+              - network
+              - hd
+            cmdline: 
+            custom_kernel_cmdline: 
+            initrd: 
+            kernel: 
+            reported_kernel_cmdline: 
+            type: other
+            version: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+            name: 
+            data: 
+            media_type: 
+          soundcard_enabled: 
+          sso: !ruby/object:OvirtSDK4::Sso
+            href: 
+            methods: !ruby/array:OvirtSDK4::List
+              internal:
+              - !ruby/object:OvirtSDK4::Method
+                href: 
+                id: guest_agent
+              ivars:
+                :@href: 
+          start_paused: false
+          stateless: false
+          storage_domain: 
+          time_zone: !ruby/object:OvirtSDK4::TimeZone
+            href: 
+            name: Etc/GMT
+            utc_offset: 
+          tunnel_migration: 
+          type: desktop
+          usb: !ruby/object:OvirtSDK4::Usb
+            href: 
+            enabled: false
+            type: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: false
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: interleave
+          payloads: 
+          permissions: 
+          placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+            href: 
+            affinity: migratable
+            hosts: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: down
+          status_detail: 
+          stop_reason: ''
+          stop_time: !ruby/object:DateTime 2016-11-17 17:24:40.816000000 +02:00
+          tags: 
+          template: !ruby/object:OvirtSDK4::Template
+            href: 
+            comment: 
+            description: 
+            id: 00000000-0000-0000-0000-000000000000
+            name: 
+            bios: 
+            cluster: 
+            console: 
+            cpu: 
+            cpu_profile: 
+            cpu_shares: 
+            creation_time: 
+            custom_compatibility_version: 
+            custom_cpu_model: 
+            custom_emulated_machine: 
+            custom_properties: 
+            delete_protected: 
+            display: 
+            domain: 
+            high_availability: 
+            initialization: 
+            io: 
+            large_icon: 
+            memory: 
+            memory_policy: 
+            migration: 
+            migration_downtime: 
+            origin: 
+            os: 
+            quota: 
+            rng_device: 
+            serial_number: 
+            small_icon: 
+            soundcard_enabled: 
+            sso: 
+            start_paused: 
+            stateless: 
+            storage_domain: 
+            time_zone: 
+            tunnel_migration: 
+            type: 
+            usb: 
+            virtio_scsi: 
+            cdroms: 
+            disk_attachments: 
+            graphics_consoles: 
+            nics: 
+            permissions: 
+            status: 
+            tags: 
+            version: 
+            vm: 
+            watchdogs: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf/snapshots/ef7b7d35-c7b8-4270-8ec7-b85047a50bdc"
+        comment: 
+        description: Active VM
+        id: ef7b7d35-c7b8-4270-8ec7-b85047a50bdc
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-11-17 17:24:11.967000000 +02:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *6
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &7 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761"
+      comment: 
+      description: 
+      id: 7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761
+      name: vm3
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-08-02 14:27:54.349000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2016-08-02 14:27:54.353000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/15bf929f-5935-4e66-91e3-12a1c362aab0"
+        comment: 
+        description: 
+        id: 15bf929f-5935-4e66-91e3-12a1c362aab0
+        name: vm3_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 0
+        alias_: vm3_Disk1
+        bootable: false
+        disk_profile: !ruby/object:OvirtSDK4::DiskProfile
+          href: "/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e"
+          comment: 
+          description: 
+          id: b1f0065e-9aef-4eb1-8939-aaad13eee28e
+          name: 
+          permissions: 
+          qos: 
+          storage_domain: 
+        format: raw
+        image_id: 9df4ba4f-66d2-4018-baf5-728e7306d5d7
+        interface: virtio
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/15bf929f-5935-4e66-91e3-12a1c362aab0/permissions"
+        propagate_errors: false
+        provisioned_size: 1073741824
+        quota: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/15bf929f-5935-4e66-91e3-12a1c362aab0/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb"
+            comment: 
+            description: 
+            id: 4672fe17-c260-4ecc-aab0-b535f4d0dbeb
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/7c0f1dfc-ffd5-48b1-b9f8-bfb492b39761/snapshots/d19294eb-adde-4795-a1ad-cb7552fa4a91"
+        comment: 
+        description: Active VM
+        id: d19294eb-adde-4795-a1ad-cb7552fa4a91
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-08-02 14:27:54.388000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *7
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &8 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba"
+      comment: 
+      description: 
+      id: 9a3d9765-1a23-41f0-a578-50013a8ad5ba
+      name: vmdc1
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-000000000092"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-000000000092
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000384"
+        comment: 
+        description: 
+        id: 0000000e-000e-000e-000e-000000000384
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2016-07-12 10:53:13.985000000 +03:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/db8d96f8-75cd-475a-b2f5-c37d75a288b1"
+        comment: 
+        description: 
+        id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c947ca42-629e-46cf-aeeb-ef949fae52c0"
+        comment: 
+        description: 
+        id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/statistics"
+      status: down
+      status_detail: 
+      stop_reason: ''
+      stop_time: !ruby/object:DateTime 2016-07-18 17:34:44.729000000 +03:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/1e9668b0-0054-4afd-8ae3-970346ebe513"
+        comment: 
+        description: 
+        id: 1e9668b0-0054-4afd-8ae3-970346ebe513
+        name: vmdc1_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 204800
+        alias_: vmdc1_Disk1
+        bootable: false
+        disk_profile: !ruby/object:OvirtSDK4::DiskProfile
+          href: "/ovirt-engine/api/diskprofiles/b1f0065e-9aef-4eb1-8939-aaad13eee28e"
+          comment: 
+          description: 
+          id: b1f0065e-9aef-4eb1-8939-aaad13eee28e
+          name: 
+          permissions: 
+          qos: 
+          storage_domain: 
+        format: cow
+        image_id: 7a9246c6-c600-4755-afd9-48551b807372
+        interface: virtio
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/1e9668b0-0054-4afd-8ae3-970346ebe513/permissions"
+        propagate_errors: false
+        provisioned_size: 1073741824
+        quota: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/1e9668b0-0054-4afd-8ae3-970346ebe513/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb"
+            comment: 
+            description: 
+            id: 4672fe17-c260-4ecc-aab0-b535f4d0dbeb
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/snapshots/3bccd9d6-484d-48a6-9d90-0d018d045d32"
+        comment: 
+        description: Active VM
+        id: 3bccd9d6-484d-48a6-9d90-0d018d045d32
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-07-12 10:53:14.025000000 +03:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/snapshots/fc550453-c7d4-4146-ad23-4298c0b8defa"
+        comment: 
+        description: tests1
+        id: fc550453-c7d4-4146-ad23-4298c0b8defa
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/snapshots/fc550453-c7d4-4146-ad23-4298c0b8defa/cdroms"
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/9a3d9765-1a23-41f0-a578-50013a8ad5ba/snapshots/fc550453-c7d4-4146-ad23-4298c0b8defa/nics"
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2016-07-13 13:28:42.963000000 +03:00
+        persist_memorystate: true
+        snapshot_status: ok
+        snapshot_type: regular
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: 
+          comment: 
+          description: 
+          id: 9a3d9765-1a23-41f0-a578-50013a8ad5ba
+          name: vmdc1
+          bios: !ruby/object:OvirtSDK4::Bios
+            href: 
+            boot_menu: !ruby/object:OvirtSDK4::BootMenu
+              href: 
+              enabled: false
+          cluster: !ruby/object:OvirtSDK4::Cluster
+            href: 
+            comment: 
+            description: 
+            id: 00000002-0002-0002-0002-000000000092
+            name: 
+            affinity_groups: 
+            ballooning_enabled: 
+            cpu: 
+            cpu_profiles: 
+            custom_scheduling_policy_properties: 
+            data_center: 
+            display: 
+            error_handling: 
+            fencing_policy: 
+            gluster_hooks: 
+            gluster_service: 
+            gluster_volumes: 
+            ha_reservation: 
+            ksm: 
+            maintenance_reason_required: 
+            management_network: 
+            memory_policy: 
+            migration: 
+            network_filters: 
+            networks: 
+            optional_reason: 
+            permissions: 
+            required_rng_sources: 
+            scheduling_policy: 
+            serial_number: 
+            supported_versions: 
+            switch_type: 
+            threads_as_cores: 
+            trusted_service: 
+            tunnel_migration: 
+            version: 
+            virt_service: 
+          console: 
+          cpu: !ruby/object:OvirtSDK4::Cpu
+            href: 
+            architecture: x86_64
+            cores: 
+            cpu_tune: 
+            level: 
+            mode: 
+            name: 
+            speed: 
+            topology: !ruby/object:OvirtSDK4::CpuTopology
+              href: 
+              cores: 1
+              sockets: 1
+              threads: 1
+            type: 
+          cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+            href: 
+            comment: 
+            description: 
+            id: 0000000e-000e-000e-000e-000000000384
+            name: 
+            cluster: 
+            permissions: 
+            qos: 
+          cpu_shares: 0
+          creation_time: !ruby/object:DateTime 2016-07-12 10:53:13.000000000 +03:00
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: false
+          display: !ruby/object:OvirtSDK4::Display
+            href: 
+            address: 
+            allow_override: false
+            certificate: 
+            copy_paste_enabled: true
+            disconnect_action: LOCK_SCREEN
+            file_transfer_enabled: true
+            keyboard_layout: 
+            monitors: 1
+            port: 
+            proxy: 
+            secure_port: 
+            single_qxl_pci: false
+            smartcard_enabled: false
+            type: 
+          domain: 
+          high_availability: !ruby/object:OvirtSDK4::HighAvailability
+            href: 
+            enabled: false
+            priority: 1
+          initialization: !ruby/object:OvirtSDK4::Initialization
+            href: 
+            active_directory_ou: 
+            authorized_ssh_keys: 
+            cloud_init: 
+            configuration: 
+            custom_script: 
+            dns_search: 
+            dns_servers: 
+            domain: 
+            host_name: 
+            input_locale: 
+            nic_configurations: 
+            org_name: 
+            regenerate_ids: 
+            regenerate_ssh_keys: 
+            root_password: 
+            system_locale: 
+            timezone: 
+            ui_language: 
+            user_locale: 
+            user_name: 
+            windows_license_key: 
+          io: !ruby/object:OvirtSDK4::Io
+            href: 
+            threads: 0
+          large_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: db8d96f8-75cd-475a-b2f5-c37d75a288b1
+            name: 
+            data: 
+            media_type: 
+          memory: 1073741824
+          memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+            href: 
+            ballooning: 
+            guaranteed: 1073741824
+            over_commit: 
+            transparent_huge_pages: 
+          migration: !ruby/object:OvirtSDK4::MigrationOptions
+            href: 
+            auto_converge: inherit
+            bandwidth: 
+            compressed: inherit
+            policy: 
+          migration_downtime: -1
+          origin: ovirt
+          os: !ruby/object:OvirtSDK4::OperatingSystem
+            href: 
+            boot: !ruby/object:OvirtSDK4::Boot
+              href: 
+              devices:
+              - hd
+            cmdline: 
+            custom_kernel_cmdline: 
+            initrd: 
+            kernel: 
+            reported_kernel_cmdline: 
+            type: other
+            version: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: !ruby/object:OvirtSDK4::Icon
+            href: 
+            comment: 
+            description: 
+            id: c947ca42-629e-46cf-aeeb-ef949fae52c0
+            name: 
+            data: 
+            media_type: 
+          soundcard_enabled: 
+          sso: !ruby/object:OvirtSDK4::Sso
+            href: 
+            methods: !ruby/array:OvirtSDK4::List
+              internal:
+              - !ruby/object:OvirtSDK4::Method
+                href: 
+                id: guest_agent
+              ivars:
+                :@href: 
+          start_paused: false
+          stateless: false
+          storage_domain: 
+          time_zone: !ruby/object:OvirtSDK4::TimeZone
+            href: 
+            name: Etc/GMT
+            utc_offset: 
+          tunnel_migration: 
+          type: desktop
+          usb: !ruby/object:OvirtSDK4::Usb
+            href: 
+            enabled: false
+            type: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: false
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: interleave
+          payloads: 
+          permissions: 
+          placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+            href: 
+            affinity: migratable
+            hosts: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: down
+          status_detail: 
+          stop_reason: ''
+          stop_time: !ruby/object:DateTime 2016-07-18 17:34:44.729000000 +03:00
+          tags: 
+          template: !ruby/object:OvirtSDK4::Template
+            href: 
+            comment: 
+            description: 
+            id: 00000000-0000-0000-0000-000000000000
+            name: 
+            bios: 
+            cluster: 
+            console: 
+            cpu: 
+            cpu_profile: 
+            cpu_shares: 
+            creation_time: 
+            custom_compatibility_version: 
+            custom_cpu_model: 
+            custom_emulated_machine: 
+            custom_properties: 
+            delete_protected: 
+            display: 
+            domain: 
+            high_availability: 
+            initialization: 
+            io: 
+            large_icon: 
+            memory: 
+            memory_policy: 
+            migration: 
+            migration_downtime: 
+            origin: 
+            os: 
+            quota: 
+            rng_device: 
+            serial_number: 
+            small_icon: 
+            soundcard_enabled: 
+            sso: 
+            start_paused: 
+            stateless: 
+            storage_domain: 
+            time_zone: 
+            tunnel_migration: 
+            type: 
+            usb: 
+            virtio_scsi: 
+            cdroms: 
+            disk_attachments: 
+            graphics_consoles: 
+            nics: 
+            permissions: 
+            status: 
+            tags: 
+            version: 
+            vm: 
+            watchdogs: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+      ivars:
+        :@href: 
+  : *8

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/clusters.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/clusters.yml
@@ -1,0 +1,161 @@
+--- !ruby/array:OvirtSDK4::List
+internal:
+- !ruby/object:OvirtSDK4::Cluster
+  href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"
+  comment: 
+  description: The default server cluster
+  id: 00000002-0002-0002-0002-00000000017a
+  name: Default
+  affinity_groups: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/affinitygroups"
+  ballooning_enabled: false
+  cpu: !ruby/object:OvirtSDK4::Cpu
+    href: 
+    architecture: x86_64
+    cores: 
+    cpu_tune: 
+    level: 
+    mode: 
+    name: 
+    speed: 
+    topology: 
+    type: Intel SandyBridge Family
+  cpu_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/cpuprofiles"
+  custom_scheduling_policy_properties: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: HighUtilization
+      value: '80'
+    - !ruby/object:OvirtSDK4::Property
+      href: 
+      name: CpuOverCommitDurationMinutes
+      value: '2'
+    ivars:
+      :@href: 
+  data_center: !ruby/object:OvirtSDK4::DataCenter
+    href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"
+    comment: 
+    description: 
+    id: 00000001-0001-0001-0001-000000000311
+    name: 
+    clusters: 
+    iscsi_bonds: 
+    local: 
+    mac_pool: 
+    networks: 
+    permissions: 
+    qoss: 
+    quota_mode: 
+    quotas: 
+    status: 
+    storage_domains: 
+    storage_format: 
+    supported_versions: 
+    version: 
+  display: 
+  error_handling: !ruby/object:OvirtSDK4::ErrorHandling
+    href: 
+    on_error: migrate
+  fencing_policy: !ruby/object:OvirtSDK4::FencingPolicy
+    href: 
+    enabled: true
+    skip_if_connectivity_broken: !ruby/object:OvirtSDK4::SkipIfConnectivityBroken
+      href: 
+      enabled: false
+      threshold: 50
+    skip_if_sd_active: !ruby/object:OvirtSDK4::SkipIfSdActive
+      href: 
+      enabled: false
+  gluster_hooks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/glusterhooks"
+  gluster_service: false
+  gluster_volumes: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/glustervolumes"
+  ha_reservation: false
+  ksm: !ruby/object:OvirtSDK4::Ksm
+    href: 
+    enabled: true
+    merge_across_nodes: true
+  maintenance_reason_required: false
+  management_network: 
+  memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+    href: 
+    ballooning: 
+    guaranteed: 
+    over_commit: !ruby/object:OvirtSDK4::MemoryOverCommit
+      href: 
+      percent: 100
+    transparent_huge_pages: !ruby/object:OvirtSDK4::TransparentHugePages
+      href: 
+      enabled: true
+  migration: !ruby/object:OvirtSDK4::MigrationOptions
+    href: 
+    auto_converge: inherit
+    bandwidth: !ruby/object:OvirtSDK4::MigrationBandwidth
+      href: 
+      assignment_method: auto
+      custom_value: 
+    compressed: inherit
+    policy: !ruby/object:OvirtSDK4::MigrationPolicy
+      href: 
+      comment: 
+      description: 
+      id: 00000000-0000-0000-0000-000000000000
+      name: 
+  network_filters: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/networkfilters"
+  networks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/networks"
+  optional_reason: false
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a/permissions"
+  required_rng_sources:
+  - urandom
+  scheduling_policy: !ruby/object:OvirtSDK4::SchedulingPolicy
+    href: "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    comment: 
+    description: 
+    id: b4ed2332-a7ac-4d5f-9596-99a439cb2812
+    name: 
+    balances: 
+    default_policy: 
+    filters: 
+    locked: 
+    properties: 
+    weight: 
+  serial_number: 
+  supported_versions: 
+  switch_type: legacy
+  threads_as_cores: false
+  trusted_service: false
+  tunnel_migration: false
+  version: !ruby/object:OvirtSDK4::Version
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    build: 
+    full_version: 
+    major: 4
+    minor: 1
+    revision: 
+  virt_service: true
+ivars:
+  :@href: 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/datacenters.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/datacenters.yml
@@ -1,0 +1,173 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::DatacenterPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@storage_domains
+  ? - &1 !ruby/object:OvirtSDK4::DataCenter
+      href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"
+      comment: 
+      description: The default Data Center
+      id: 00000001-0001-0001-0001-000000000311
+      name: Default
+      clusters: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/clusters"
+      iscsi_bonds: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/iscsibonds"
+      local: false
+      mac_pool: 
+      networks: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/networks"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/permissions"
+      qoss: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/qoss"
+      quota_mode: disabled
+      quotas: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/quotas"
+      status: up
+      storage_domains: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/storagedomains"
+      storage_format: v4
+      supported_versions: !ruby/array:OvirtSDK4::List
+        internal:
+        - !ruby/object:OvirtSDK4::Version
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          build: 
+          full_version: 
+          major: 4
+          minor: 1
+          revision: 
+        ivars:
+          :@href: 
+      version: !ruby/object:OvirtSDK4::Version
+        href: 
+        comment: 
+        description: 
+        id: 
+        name: 
+        build: 
+        full_version: 
+        major: 4
+        minor: 1
+        revision: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::StorageDomain
+        href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500"
+        comment: 
+        description: 
+        id: 6cc26c9d-e1a7-43ba-95d3-c744442c7500
+        name: data
+        available: 9663676416
+        committed: 1073741824
+        critical_space_action_blocker: 5
+        data_center: !ruby/object:OvirtSDK4::DataCenter
+          href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"
+          comment: 
+          description: 
+          id: 00000001-0001-0001-0001-000000000311
+          name: 
+          clusters: 
+          iscsi_bonds: 
+          local: 
+          mac_pool: 
+          networks: 
+          permissions: 
+          qoss: 
+          quota_mode: 
+          quotas: 
+          status: 
+          storage_domains: 
+          storage_format: 
+          supported_versions: 
+          version: 
+        data_centers: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::DataCenter
+            href: 
+            comment: 
+            description: 
+            id: 00000001-0001-0001-0001-000000000311
+            name: 
+            clusters: 
+            iscsi_bonds: 
+            local: 
+            mac_pool: 
+            networks: 
+            permissions: 
+            qoss: 
+            quota_mode: 
+            quotas: 
+            status: 
+            storage_domains: 
+            storage_format: 
+            supported_versions: 
+            version: 
+          ivars:
+            :@href: 
+        disk_profiles: 
+        disk_snapshots: 
+        disks: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/disks"
+        external_status: ok
+        files: 
+        host: 
+        images: 
+        import: 
+        master: true
+        permissions: 
+        status: active
+        storage: !ruby/object:OvirtSDK4::HostStorage
+          href: 
+          comment: 
+          description: 
+          id: 
+          name: 
+          address: 192.168.1.107
+          host: 
+          logical_units: 
+          mount_options: 
+          nfs_retrans: 
+          nfs_timeo: 
+          nfs_version: auto
+          override_luns: 
+          password: 
+          path: "/export/data"
+          port: 
+          portal: 
+          target: 
+          type: nfs
+          username: 
+          vfs_type: 
+          volume_group: 
+        storage_connections: 
+        storage_format: v4
+        templates: 
+        type: data
+        used: 42949672960
+        vms: 
+        warning_low_space_indicator: 10
+        wipe_after_delete: false
+      ivars:
+        :@href: 
+  : *1

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/storages.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/storages.yml
@@ -1,0 +1,98 @@
+---
+- !ruby/object:OvirtSDK4::StorageDomain
+  href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500"
+  comment: 
+  description: 
+  id: 6cc26c9d-e1a7-43ba-95d3-c744442c7500
+  name: data
+  available: 849329782784
+  committed: 15032385536
+  critical_space_action_blocker: 5
+  data_center: 
+  data_centers: !ruby/array:OvirtSDK4::List
+    internal:
+    - !ruby/object:OvirtSDK4::DataCenter
+      href: 
+      comment: 
+      description: 
+      id: 00000001-0001-0001-0001-000000000311
+      name: 
+      clusters: 
+      iscsi_bonds: 
+      local: 
+      mac_pool: 
+      networks: 
+      permissions: 
+      qoss: 
+      quota_mode: 
+      quotas: 
+      status: 
+      storage_domains: 
+      storage_format: 
+      supported_versions: 
+      version: 
+    ivars:
+      :@href: 
+  disk_profiles: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/diskprofiles"
+  disk_snapshots: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/disksnapshots"
+  disks: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/disks"
+  external_status: ok
+  files: 
+  host: 
+  images: 
+  import: 
+  master: true
+  permissions: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/permissions"
+  status: 
+  storage: !ruby/object:OvirtSDK4::HostStorage
+    href: 
+    comment: 
+    description: 
+    id: 
+    name: 
+    address: 192.168.1.107
+    host: 
+    logical_units: 
+    mount_options: 
+    nfs_retrans: 
+    nfs_timeo: 
+    nfs_version: auto
+    override_luns: 
+    password: 
+    path: "/export/data"
+    port: 
+    portal: 
+    target: 
+    type: nfs
+    username: 
+    vfs_type: 
+    volume_group: 
+  storage_connections: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/storageconnections"
+  storage_format: v4
+  templates: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/templates"
+  type: data
+  used: 140660178944
+  vms: !ruby/array:OvirtSDK4::List
+    internal: []
+    ivars:
+      :@href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500/vms"
+  warning_low_space_indicator: 10
+  wipe_after_delete: false

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/templates.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/templates.yml
@@ -1,0 +1,229 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::TemplatePreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  ? - &1 !ruby/object:OvirtSDK4::Template
+      href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+      comment: 
+      description: Blank template
+      id: 00000000-0000-0000-0000-000000000000
+      name: Blank
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: undefined
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2008-03-31 23:00:00.000000000 +02:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 0
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/b2e0f4dc-5458-4d8c-ad97-1bd7f4198014"
+        comment: 
+        description: 
+        id: b2e0f4dc-5458-4d8c-ad97-1bd7f4198014
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: 
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c0e111ec-3df0-4c60-ba57-9600ea05a993"
+        comment: 
+        description: 
+        id: c0e111ec-3df0-4c60-ba57-9600ea05a993
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/diskattachments"
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/graphicsconsoles"
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics"
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions"
+      status: ok
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/tags"
+      version: !ruby/object:OvirtSDK4::TemplateVersion
+        href: 
+        base_template: !ruby/object:OvirtSDK4::Template
+          href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+          comment: 
+          description: 
+          id: 00000000-0000-0000-0000-000000000000
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          cdroms: 
+          disk_attachments: 
+          graphics_consoles: 
+          nics: 
+          permissions: 
+          status: 
+          tags: 
+          version: 
+          vm: 
+          watchdogs: 
+        version_name: ''
+        version_number: 0
+      vm: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/watchdogs"
+    - []
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+  : *1

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/vms.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher/target_response_yamls/vms.yml
@@ -1,0 +1,664 @@
+---
+- !ruby/marshalable:ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4::VmPreloadedAttributesDecorator
+  :__v2__:
+  - :@obj
+  - :@disks
+  - :@nics
+  - :@reported_devices
+  - :@snapshots
+  ? - &1 !ruby/object:OvirtSDK4::Vm
+      href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"
+      comment: 
+      description: '12345'
+      id: 3a697bd0-7cea-42a1-95ef-fd292fcee721
+      name: new
+      bios: !ruby/object:OvirtSDK4::Bios
+        href: 
+        boot_menu: !ruby/object:OvirtSDK4::BootMenu
+          href: 
+          enabled: false
+      cluster: !ruby/object:OvirtSDK4::Cluster
+        href: "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"
+        comment: 
+        description: 
+        id: 00000002-0002-0002-0002-00000000017a
+        name: 
+        affinity_groups: 
+        ballooning_enabled: 
+        cpu: 
+        cpu_profiles: 
+        custom_scheduling_policy_properties: 
+        data_center: 
+        display: 
+        error_handling: 
+        fencing_policy: 
+        gluster_hooks: 
+        gluster_service: 
+        gluster_volumes: 
+        ha_reservation: 
+        ksm: 
+        maintenance_reason_required: 
+        management_network: 
+        memory_policy: 
+        migration: 
+        network_filters: 
+        networks: 
+        optional_reason: 
+        permissions: 
+        required_rng_sources: 
+        scheduling_policy: 
+        serial_number: 
+        supported_versions: 
+        switch_type: 
+        threads_as_cores: 
+        trusted_service: 
+        tunnel_migration: 
+        version: 
+        virt_service: 
+      console: 
+      cpu: !ruby/object:OvirtSDK4::Cpu
+        href: 
+        architecture: x86_64
+        cores: 
+        cpu_tune: 
+        level: 
+        mode: 
+        name: 
+        speed: 
+        topology: !ruby/object:OvirtSDK4::CpuTopology
+          href: 
+          cores: 1
+          sockets: 1
+          threads: 1
+        type: 
+      cpu_profile: !ruby/object:OvirtSDK4::CpuProfile
+        href: "/ovirt-engine/api/cpuprofiles/58ad9d13-0251-012f-01d4-0000000001c0"
+        comment: 
+        description: 
+        id: 58ad9d13-0251-012f-01d4-0000000001c0
+        name: 
+        cluster: 
+        permissions: 
+        qos: 
+      cpu_shares: 0
+      creation_time: !ruby/object:DateTime 2017-02-23 15:58:22.984000000 +01:00
+      custom_compatibility_version: 
+      custom_cpu_model: 
+      custom_emulated_machine: 
+      custom_properties: 
+      delete_protected: false
+      display: !ruby/object:OvirtSDK4::Display
+        href: 
+        address: 
+        allow_override: false
+        certificate: 
+        copy_paste_enabled: true
+        disconnect_action: LOCK_SCREEN
+        file_transfer_enabled: true
+        keyboard_layout: 
+        monitors: 1
+        port: 
+        proxy: 
+        secure_port: 
+        single_qxl_pci: false
+        smartcard_enabled: false
+        type: spice
+      domain: 
+      high_availability: !ruby/object:OvirtSDK4::HighAvailability
+        href: 
+        enabled: false
+        priority: 1
+      initialization: 
+      io: !ruby/object:OvirtSDK4::Io
+        href: 
+        threads: 0
+      large_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/b2e0f4dc-5458-4d8c-ad97-1bd7f4198014"
+        comment: 
+        description: 
+        id: b2e0f4dc-5458-4d8c-ad97-1bd7f4198014
+        name: 
+        data: 
+        media_type: 
+      memory: 1073741824
+      memory_policy: !ruby/object:OvirtSDK4::MemoryPolicy
+        href: 
+        ballooning: true
+        guaranteed: 1073741824
+        over_commit: 
+        transparent_huge_pages: 
+      migration: !ruby/object:OvirtSDK4::MigrationOptions
+        href: 
+        auto_converge: inherit
+        bandwidth: 
+        compressed: inherit
+        policy: 
+      migration_downtime: -1
+      origin: ovirt
+      os: !ruby/object:OvirtSDK4::OperatingSystem
+        href: 
+        boot: !ruby/object:OvirtSDK4::Boot
+          href: 
+          devices:
+          - hd
+        cmdline: 
+        custom_kernel_cmdline: 
+        initrd: 
+        kernel: 
+        reported_kernel_cmdline: 
+        type: other
+        version: 
+      quota: !ruby/object:OvirtSDK4::Quota
+        href: 
+        comment: 
+        description: 
+        id: 58ad9d24-00d3-00c3-01e2-00000000035b
+        name: 
+        cluster_hard_limit_pct: 
+        cluster_soft_limit_pct: 
+        data_center: 
+        disks: 
+        permissions: 
+        quota_cluster_limits: 
+        quota_storage_limits: 
+        storage_hard_limit_pct: 
+        storage_soft_limit_pct: 
+        users: 
+        vms: 
+      rng_device: 
+      serial_number: 
+      small_icon: !ruby/object:OvirtSDK4::Icon
+        href: "/ovirt-engine/api/icons/c0e111ec-3df0-4c60-ba57-9600ea05a993"
+        comment: 
+        description: 
+        id: c0e111ec-3df0-4c60-ba57-9600ea05a993
+        name: 
+        data: 
+        media_type: 
+      soundcard_enabled: 
+      sso: !ruby/object:OvirtSDK4::Sso
+        href: 
+        methods: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::Method
+            href: 
+            id: guest_agent
+          ivars:
+            :@href: 
+      start_paused: false
+      stateless: false
+      storage_domain: 
+      time_zone: !ruby/object:OvirtSDK4::TimeZone
+        href: 
+        name: Etc/GMT
+        utc_offset: 
+      tunnel_migration: 
+      type: desktop
+      usb: !ruby/object:OvirtSDK4::Usb
+        href: 
+        enabled: false
+        type: 
+      virtio_scsi: 
+      affinity_labels: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/affinitylabels"
+      applications: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/applications"
+      cdroms: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/cdroms"
+      disk_attachments: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/diskattachments"
+      external_host_provider: 
+      floppies: 
+      fqdn: 
+      graphics_consoles: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/graphicsconsoles"
+      guest_operating_system: 
+      guest_time_zone: 
+      host: 
+      host_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/hostdevices"
+      instance_type: 
+      katello_errata: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/katelloerrata"
+      next_run_configuration_exists: false
+      nics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/nics"
+      numa_nodes: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/numanodes"
+      numa_tune_mode: interleave
+      payloads: 
+      permissions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/permissions"
+      placement_policy: !ruby/object:OvirtSDK4::VmPlacementPolicy
+        href: 
+        affinity: migratable
+        hosts: 
+      reported_devices: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/reporteddevices"
+      run_once: 
+      sessions: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/sessions"
+      snapshots: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/snapshots"
+      start_time: 
+      statistics: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/statistics"
+      status: down
+      status_detail: 
+      stop_reason: 
+      stop_time: !ruby/object:DateTime 2017-02-23 15:58:22.990000000 +01:00
+      tags: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/tags"
+      template: !ruby/object:OvirtSDK4::Template
+        href: "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000"
+        comment: 
+        description: 
+        id: 00000000-0000-0000-0000-000000000000
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        cdroms: 
+        disk_attachments: 
+        graphics_consoles: 
+        nics: 
+        permissions: 
+        status: 
+        tags: 
+        version: 
+        vm: 
+        watchdogs: 
+      use_latest_template_version: 
+      vm_pool: 
+      watchdogs: !ruby/array:OvirtSDK4::List
+        internal: []
+        ivars:
+          :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/watchdogs"
+    - - !ruby/object:OvirtSDK4::Disk
+        href: "/ovirt-engine/api/disks/c413aff6-e988-4830-8b24-f74af66ced5a"
+        comment: 
+        description: 
+        id: c413aff6-e988-4830-8b24-f74af66ced5a
+        name: new_Disk1
+        instance_type: 
+        template: 
+        vm: 
+        vms: 
+        active: true
+        actual_size: 0
+        alias_: new_Disk1
+        bootable: true
+        disk_profile: !ruby/object:OvirtSDK4::DiskProfile
+          href: "/ovirt-engine/api/diskprofiles/5ea19cf2-37fa-45fd-9034-87fe4c4d1c0a"
+          comment: 
+          description: 
+          id: 5ea19cf2-37fa-45fd-9034-87fe4c4d1c0a
+          name: 
+          permissions: 
+          qos: 
+          storage_domain: 
+        format: raw
+        image_id: 7c702634-a9e5-4107-8bb1-b0c3d900096d
+        initial_size: 
+        interface: virtio_scsi
+        logical_name: 
+        lun_storage: 
+        openstack_volume_type: 
+        permissions: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/c413aff6-e988-4830-8b24-f74af66ced5a/permissions"
+        propagate_errors: false
+        provisioned_size: 1073741824
+        quota: !ruby/object:OvirtSDK4::Quota
+          href: 
+          comment: 
+          description: 
+          id: 58ad9d24-00d3-00c3-01e2-00000000035b
+          name: 
+          cluster_hard_limit_pct: 
+          cluster_soft_limit_pct: 
+          data_center: 
+          disks: 
+          permissions: 
+          quota_cluster_limits: 
+          quota_storage_limits: 
+          storage_hard_limit_pct: 
+          storage_soft_limit_pct: 
+          users: 
+          vms: 
+        read_only: 
+        sgio: 
+        shareable: false
+        snapshot: 
+        sparse: true
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/disks/c413aff6-e988-4830-8b24-f74af66ced5a/statistics"
+        status: ok
+        storage_domain: 
+        storage_domains: !ruby/array:OvirtSDK4::List
+          internal:
+          - !ruby/object:OvirtSDK4::StorageDomain
+            href: "/ovirt-engine/api/storagedomains/6cc26c9d-e1a7-43ba-95d3-c744442c7500"
+            comment: 
+            description: 
+            id: 6cc26c9d-e1a7-43ba-95d3-c744442c7500
+            name: 
+            available: 
+            committed: 
+            critical_space_action_blocker: 
+            data_center: 
+            data_centers: 
+            disk_profiles: 
+            disk_snapshots: 
+            disks: 
+            external_status: 
+            files: 
+            host: 
+            images: 
+            import: 
+            master: 
+            permissions: 
+            status: 
+            storage: 
+            storage_connections: 
+            storage_format: 
+            templates: 
+            type: 
+            used: 
+            vms: 
+            warning_low_space_indicator: 
+            wipe_after_delete: 
+          ivars:
+            :@href: 
+        storage_type: image
+        uses_scsi_reservation: 
+        wipe_after_delete: false
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Nic
+        href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/nics/bec92d4f-9b9e-462f-9cd4-7d6b99948a81"
+        comment: 
+        description: 
+        id: bec92d4f-9b9e-462f-9cd4-7d6b99948a81
+        name: nic1
+        instance_type: 
+        template: 
+        vm: !ruby/object:OvirtSDK4::Vm
+          href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"
+          comment: 
+          description: 
+          id: 3a697bd0-7cea-42a1-95ef-fd292fcee721
+          name: 
+          bios: 
+          cluster: 
+          console: 
+          cpu: 
+          cpu_profile: 
+          cpu_shares: 
+          creation_time: 
+          custom_compatibility_version: 
+          custom_cpu_model: 
+          custom_emulated_machine: 
+          custom_properties: 
+          delete_protected: 
+          display: 
+          domain: 
+          high_availability: 
+          initialization: 
+          io: 
+          large_icon: 
+          memory: 
+          memory_policy: 
+          migration: 
+          migration_downtime: 
+          origin: 
+          os: 
+          quota: 
+          rng_device: 
+          serial_number: 
+          small_icon: 
+          soundcard_enabled: 
+          sso: 
+          start_paused: 
+          stateless: 
+          storage_domain: 
+          time_zone: 
+          tunnel_migration: 
+          type: 
+          usb: 
+          virtio_scsi: 
+          affinity_labels: 
+          applications: 
+          cdroms: 
+          disk_attachments: 
+          external_host_provider: 
+          floppies: 
+          fqdn: 
+          graphics_consoles: 
+          guest_operating_system: 
+          guest_time_zone: 
+          host: 
+          host_devices: 
+          instance_type: 
+          katello_errata: 
+          next_run_configuration_exists: 
+          nics: 
+          numa_nodes: 
+          numa_tune_mode: 
+          payloads: 
+          permissions: 
+          placement_policy: 
+          reported_devices: 
+          run_once: 
+          sessions: 
+          snapshots: 
+          start_time: 
+          statistics: 
+          status: 
+          status_detail: 
+          stop_reason: 
+          stop_time: 
+          tags: 
+          template: 
+          use_latest_template_version: 
+          vm_pool: 
+          watchdogs: 
+        vms: 
+        boot_protocol: 
+        interface: virtio
+        linked: true
+        mac: !ruby/object:OvirtSDK4::Mac
+          href: 
+          address: 00:1a:4a:16:01:51
+        network: 
+        network_attachments: 
+        network_labels: 
+        on_boot: 
+        plugged: true
+        reported_devices: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/nics/bec92d4f-9b9e-462f-9cd4-7d6b99948a81/reporteddevices"
+        statistics: !ruby/array:OvirtSDK4::List
+          internal: []
+          ivars:
+            :@href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/nics/bec92d4f-9b9e-462f-9cd4-7d6b99948a81/statistics"
+        virtual_function_allowed_labels: 
+        virtual_function_allowed_networks: 
+        vnic_profile: !ruby/object:OvirtSDK4::VnicProfile
+          href: "/ovirt-engine/api/vnicprofiles/0000000a-000a-000a-000a-000000000398"
+          comment: 
+          description: 
+          id: 0000000a-000a-000a-000a-000000000398
+          name: 
+          custom_properties: 
+          network: 
+          network_filter: 
+          pass_through: 
+          permissions: 
+          port_mirroring: 
+          qos: 
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal: []
+      ivars:
+        :@href: 
+    - !ruby/array:OvirtSDK4::List
+      internal:
+      - !ruby/object:OvirtSDK4::Snapshot
+        href: "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721/snapshots/4af35c92-7c6e-4c23-b25e-e05cb29bed49"
+        comment: 
+        description: Active VM
+        id: 4af35c92-7c6e-4c23-b25e-e05cb29bed49
+        name: 
+        bios: 
+        cluster: 
+        console: 
+        cpu: 
+        cpu_profile: 
+        cpu_shares: 
+        creation_time: 
+        custom_compatibility_version: 
+        custom_cpu_model: 
+        custom_emulated_machine: 
+        custom_properties: 
+        delete_protected: 
+        display: 
+        domain: 
+        high_availability: 
+        initialization: 
+        io: 
+        large_icon: 
+        memory: 
+        memory_policy: 
+        migration: 
+        migration_downtime: 
+        origin: 
+        os: 
+        quota: 
+        rng_device: 
+        serial_number: 
+        small_icon: 
+        soundcard_enabled: 
+        sso: 
+        start_paused: 
+        stateless: 
+        storage_domain: 
+        time_zone: 
+        tunnel_migration: 
+        type: 
+        usb: 
+        virtio_scsi: 
+        affinity_labels: 
+        applications: 
+        cdroms: 
+        disk_attachments: 
+        external_host_provider: 
+        floppies: 
+        fqdn: 
+        graphics_consoles: 
+        guest_operating_system: 
+        guest_time_zone: 
+        host: 
+        host_devices: 
+        instance_type: 
+        katello_errata: 
+        next_run_configuration_exists: 
+        nics: 
+        numa_nodes: 
+        numa_tune_mode: 
+        payloads: 
+        permissions: 
+        placement_policy: 
+        reported_devices: 
+        run_once: 
+        sessions: 
+        snapshots: 
+        start_time: 
+        statistics: 
+        status: 
+        status_detail: 
+        stop_reason: 
+        stop_time: 
+        tags: 
+        template: 
+        use_latest_template_version: 
+        vm_pool: 
+        watchdogs: 
+        date: !ruby/object:DateTime 2017-02-23 15:58:23.054000000 +01:00
+        persist_memorystate: false
+        snapshot_status: ok
+        snapshot_type: active
+        vm: 
+      ivars:
+        :@href: 
+  : *1

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
                               :port => 8443)
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
-    ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = true
+    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -5,6 +5,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
                               :port => 8443)
     @ems.update_authentication(:default => {:userid => "admin@internal", :password => "123456"})
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+    ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = true
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -11,8 +11,35 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(described_class.ems_type).to eq(:rhevm)
   end
 
+  require 'yaml'
+  def load_response_mock_for(filename)
+    prefix = described_class.name.underscore
+    YAML.load_file(File.join('spec', 'models', prefix, 'response_yamls', filename + '.yml'))
+  end
+
+  before(:each) do
+    inventory_wrapper_class = ManageIQ::Providers::Redhat::InfraManager::Inventory::Strategies::V4
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_clusters).and_return(load_response_mock_for('clusters'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_storages).and_return(load_response_mock_for('storages'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_hosts).and_return(load_response_mock_for('hosts'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_vms).and_return(load_response_mock_for('vms'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_templates).and_return(load_response_mock_for('templates'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_networks).and_return(load_response_mock_for('networks'))
+    allow_any_instance_of(inventory_wrapper_class)
+      .to receive(:collect_datacenters).and_return(load_response_mock_for('datacenters'))
+    allow_any_instance_of(inventory_wrapper_class).to receive(:api).and_return("4.2.0_master")
+    allow_any_instance_of(inventory_wrapper_class).to receive(:service)
+      .and_return(OpenStruct.new(:version_string => '4.2.0_master'))
+  end
+
   it "will perform a full refresh on v4.1" do
-    VCR.use_cassette("#{described_class.name.underscore}_4_1", :allow_unused_http_interactions => true) do
+    VCR.use_cassette("#{described_class.name.underscore}_4_1", :allow_unused_http_interactions => true, :allow_playback_repeats => true, :record => :new_episodes) do
       EmsRefresh.refresh(@ems)
     end
     @ems.reload
@@ -21,11 +48,11 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     assert_ems
     assert_specific_cluster
     assert_specific_storage
-    # assert_specific_host
-    # assert_specific_vm_powered_on
-    # assert_specific_vm_powered_off
-    # assert_specific_template
-    # assert_relationship_tree
+    assert_specific_host
+    assert_specific_vm_powered_on
+    assert_specific_vm_powered_off
+    assert_specific_template
+    assert_relationship_tree
   end
 
   def assert_table_counts
@@ -42,14 +69,14 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(CustomAttribute.count).to eq(0) # TODO: 3.0 spec has values for this
     expect(CustomizationSpec.count).to eq(0)
     expect(Disk.count).to eq(5)
-    expect(GuestDevice.count).to eq(6)
+    expect(GuestDevice.count).to eq(7)
     expect(Hardware.count).to eq(13)
     expect(Lan.count).to eq(3)
     expect(MiqScsiLun.count).to eq(0)
     expect(MiqScsiTarget.count).to eq(0)
-    expect(Network.count).to eq(4)
+    expect(Network.count).to eq(7)
     expect(OperatingSystem.count).to eq(13)
-    expect(Snapshot.count).to eq(12)
+    expect(Snapshot.count).to eq(11)
     expect(Switch.count).to eq(3)
     expect(SystemService.count).to eq(0)
 
@@ -59,7 +86,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
   def assert_ems
     expect(@ems).to have_attributes(
-      :api_version => "4.1.0_master.",
+      :api_version => "4.2.0_master",
       :uid_ems     => nil
     )
 
@@ -119,9 +146,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :ems_ref_obj                   => "/api/storagedomains/27a3bcce-c4d0-4bce-afe9-1d669d5a9d02",
       :name                          => "data1",
       :store_type                    => "NFS",
-      :total_space                   => 53687091200,
-      :free_space                    => 49392123904,
-      :uncommitted                   => 36507222016,
+      :total_space                   => 53_687_091_200,
+      :free_space                    => 46_170_898_432,
+      :uncommitted                   => -17_179_869_184,
       :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
       :location                      => "spider.eng.lab.tlv.redhat.com:/vol/vol_bodnopoz/data1",
       :directory_hierarchy_supported => nil,
@@ -134,8 +161,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :ems_ref_obj                   => "/api/storagedomains/4672fe17-c260-4ecc-aab0-b535f4d0dbeb",
       :name                          => "data2",
       :store_type                    => "NFS",
-      :total_space                   => 53687091200,
-      :free_space                    => 49392123904,
+      :total_space                   => 53_687_091_200,
+      :free_space                    => 46_170_898_432,
       :uncommitted                   => 49392123904,
       :multiplehostaccess            => 1, # TODO: Should this be a boolean column?
       :location                      => "spider.eng.lab.tlv.redhat.com:/vol/vol_bodnopoz/data2",
@@ -146,41 +173,43 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   end
 
   def assert_specific_host
-    @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "per410-rh1")
+    @host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh1")
     expect(@host).to have_attributes(
-      :ems_ref          => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
-      :ems_ref_obj      => "/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db",
-      :name             => "per410-rh1",
-      :hostname         => "192.168.252.232",
-      :ipaddress        => "192.168.252.232",
-      :uid_ems          => "2f1d11cc-e269-11e2-839c-005056a217db",
+      :ems_ref          => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
+      :ems_ref_obj      => "/api/hosts/5bf6b336-f86d-4551-ac08-d34621ec5f0a",
+      :name             => "bodh1",
+      :hostname         => "bodh1.usersys.redhat.com",
+      :ipaddress        => "10.35.19.12",
+      :uid_ems          => "5bf6b336-f86d-4551-ac08-d34621ec5f0a",
       :vmm_vendor       => "redhat",
-      :vmm_version      => nil,
+      :vmm_version      => "7",
       :vmm_product      => "rhel",
       :vmm_buildnumber  => nil,
       :power_state      => "on",
       :connection_state => "connected"
     )
 
-    expect(@host.ems_cluster).to eq(@cluster)
-    expect(@host.storages.size).to eq(4)
-    expect(@host.storages).to      include(@storage)
+    @host_cluster = EmsCluster.find_by(:ems_ref => "/api/clusters/00000002-0002-0002-0002-000000000092")
+
+    expect(@host.ems_cluster).to eq(@host_cluster)
+    expect(@host.storages.size).to eq(1)
+    expect(@host.storages).to      include(@storage2)
 
     expect(@host.operating_system).to have_attributes(
-      :name         => "192.168.252.232", # TODO: ?????
-      :product_name => "rhel",
-      :version      => nil,
+      :name         => "bodh1.usersys.redhat.com", # TODO: ?????
+      :product_name => "RHEL",
+      :version      => "7 - 1.1503.el7.centos.2.8",
       :build_number => nil,
       :product_type => "linux"
     )
 
     expect(@host.system_services.size).to eq(0)
 
-    expect(@host.switches.size).to eq(3)
-    switch = @host.switches.find_by(:name => "rhevm")
+    expect(@host.switches.size).to eq(1)
+    switch = @host.switches.first
     expect(switch).to have_attributes(
       :uid_ems           => "00000000-0000-0000-0000-000000000009",
-      :name              => "rhevm",
+      :name              => "ovirtmgmt",
       :ports             => nil,
       :allow_promiscuous => nil,
       :forged_transmits  => nil,
@@ -188,10 +217,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     )
 
     expect(switch.lans.size).to eq(1)
-    @lan = switch.lans.find_by(:name => "rhevm")
+    @lan = switch.lans.first
     expect(@lan).to have_attributes(
       :uid_ems                    => "00000000-0000-0000-0000-000000000009",
-      :name                       => "rhevm",
+      :name                       => "ovirtmgmt",
       :tag                        => nil,
       :allow_promiscuous          => nil,
       :forged_transmits           => nil,
@@ -202,16 +231,16 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     )
 
     expect(@host.hardware).to have_attributes(
-      :cpu_speed            => 1995,
-      :cpu_type             => "Intel(R) Xeon(R) CPU           E5504  @ 2.00GHz",
-      :manufacturer         => "",
-      :model                => "",
+      :cpu_speed            => 2400,
+      :cpu_type             => "Westmere E56xx/L56xx/X56xx (Nehalem-C)",
+      :manufacturer         => "Red Hat",
+      :model                => "RHEV Hypervisor",
       :number_of_nics       => nil,
-      :memory_mb            => 56333,
+      :memory_mb            => 3789,
       :memory_console       => nil,
       :cpu_sockets          => 2,
-      :cpu_total_cores      => 8,
-      :cpu_cores_per_socket => 4,
+      :cpu_total_cores      => 2,
+      :cpu_cores_per_socket => 1,
       :guest_os             => nil,
       :guest_os_full_name   => nil,
       :vmotion_enabled      => nil,
@@ -219,33 +248,25 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :memory_usage         => nil
     )
 
-    expect(@host.hardware.networks.size).to eq(3)
-    network = @host.hardware.networks.find_by(:description => "em1")
+    expect(@host.hardware.networks.size).to eq(1)
+    network = @host.hardware.networks.find_by(:description => "eth0")
     expect(network).to have_attributes(
-      :description  => "em1",
+      :description  => "eth0",
       :dhcp_enabled => nil,
-      :ipaddress    => "192.168.252.232",
-      :subnet_mask  => "255.255.254.0"
-    )
-
-    nic_without_ip = @host.hardware.networks.find_by(:description => "em3")
-    expect(nic_without_ip).to have_attributes(
-      :description  => "em3",
-      :dhcp_enabled => nil,
-      :ipaddress    => nil,
-      :subnet_mask  => nil
+      :ipaddress    => "10.35.19.12",
+      :subnet_mask  => "255.255.252.0"
     )
 
     # TODO: Verify this host should have 3 nics, 2 cdroms, 1 floppy, any storage adapters?
-    expect(@host.hardware.guest_devices.size).to eq(3)
+    expect(@host.hardware.guest_devices.size).to eq(1)
 
-    expect(@host.hardware.nics.size).to eq(3)
-    nic = @host.hardware.nics.find_by_device_name("em1")
+    expect(@host.hardware.nics.size).to eq(1)
+    nic = @host.hardware.nics.first
     expect(nic).to have_attributes(
-      :uid_ems         => "1e783be8-fe80-456e-9a19-42329b03f28c",
-      :device_name     => "em1",
+      :uid_ems         => "01c2d4a8-5d7a-4960-bfc4-ca1b400a9bdd",
+      :device_name     => "eth0",
       :device_type     => "ethernet",
-      :location        => "1",
+      :location        => "0",
       :present         => true,
       :controller_type => "ethernet"
     )
@@ -256,22 +277,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   end
 
   def assert_specific_vm_powered_on
-    v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "EmsRefreshSpec-PoweredOn")
+    v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "vm1")
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
-      :ems_ref_obj           => "/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876",
-      :uid_ems               => "fe052832-2350-48ce-8e56-c24b4cd91876",
+      :ems_ref               => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
+      :ems_ref_obj           => "/api/vms/3a9401a0-bf3d-4496-8acf-edd3e903511f",
+      :uid_ems               => "3a9401a0-bf3d-4496-8acf-edd3e903511f",
       :vendor                => "redhat",
       :raw_power_state       => "up",
       :power_state           => "on",
-      :location              => "fe052832-2350-48ce-8e56-c24b4cd91876.ovf",
+      :location              => "3a9401a0-bf3d-4496-8acf-edd3e903511f.ovf",
       :tools_status          => nil,
-      :boot_time             => Time.parse("2014-10-07T21:01:24.183000Z"),
+      :boot_time             => Time.zone.parse("2016-12-28T11:59:55.6020000Z"),
       :standby_action        => nil,
       :connection_state      => "connected",
       :cpu_affinity          => nil,
-      :memory_reserve        => 682,
+      :memory_reserve        => 2024,
       :memory_reserve_expand => nil,
       :memory_limit          => nil,
       :memory_shares         => nil,
@@ -286,106 +307,82 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.ext_management_system).to eq(@ems)
     expect(v.ems_cluster).to eq(@cluster)
     expect(v.parent_resource_pool).to eq(@default_rp)
-    expect(v.host).to eq(@host)
+    host = ManageIQ::Providers::Redhat::InfraManager::Host.find_by(:name => "bodh2")
+    expect(v.host).to eq(host)
     expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "rhel_6x64"
+      :product_name => "other"
     )
 
     expect(v.custom_attributes.size).to eq(0)
 
-    expect(v.snapshots.size).to eq(1)
+    expect(v.snapshots.size).to eq(2)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
     expect(snapshot).to have_attributes(
-      :uid         => "d7db04c1-9030-4c39-8618-3978787c3278",
-      :parent_uid  => nil,
-      :uid_ems     => "d7db04c1-9030-4c39-8618-3978787c3278",
+      :uid         => "e13fc61c-c566-4264-9a75-0e62fe5d7a30",
+      :parent_uid  => "05ff445a-0bfc-44c3-90d1-a338e9095510",
+      :uid_ems     => "e13fc61c-c566-4264-9a75-0e62fe5d7a30",
       :name        => "Active VM",
       :description => "Active VM",
       :current     => 1,
       :total_size  => nil,
       :filename    => nil
     )
-    expect(snapshot.parent).to be_nil
+    snapshot_parent = ManageIQ::Providers::Redhat::InfraManager::Snapshot.find_by(:name => "vm1_snap")
+    expect(snapshot.parent).to eq(snapshot_parent)
 
     expect(v.hardware).to have_attributes(
-      :guest_os             => "rhel_6x64",
+      :guest_os             => "other",
       :guest_os_full_name   => nil,
       :bios                 => nil,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 2,
-      :cpu_sockets          => 2,
-      :annotation           => "Powered On VM for EmsRefresh testing with DirectLUN Disk",
-      :memory_mb            => 1024
+      :cpu_total_cores      => 4,
+      :cpu_sockets          => 4,
+      :annotation           => nil,
+      :memory_mb            => 2024
     )
 
-    expect(v.hardware.disks.size).to eq(3)
-    disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec-PoweredOn_Disk1")
+    expect(v.hardware.disks.size).to eq(1)
+    disk = v.hardware.disks.find_by(:device_name => "vm1_Disk1")
     expect(disk).to have_attributes(
-      :device_name     => "EmsRefreshSpec-PoweredOn_Disk1",
+      :device_name     => "vm1_Disk1",
       :device_type     => "disk",
-      :controller_type => "ide",
+      :controller_type => "virtio",
       :present         => true,
-      :filename        => "5fc5484d-1730-42bc-adc3-262592ea595a",
+      :filename        => "af578e0e-b222-4754-aefc-879bf37eacec",
       :location        => "0",
-      :size            => 5.gigabytes,
-      :size_on_disk    => 1.gigabytes,
+      :size            => 6.gigabytes,
+      :size_on_disk    => 2_987_851_776,
       :mode            => "persistent",
       :disk_type       => "thin",
       :start_connected => true
     )
     expect(disk.storage).to eq(@storage)
 
-    # DirectLUN disk
-    disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec-PoweredOn_Disk3")
-    expect(disk).to have_attributes(
-      :device_name     => "EmsRefreshSpec-PoweredOn_Disk3",
-      :device_type     => "disk",
-      :controller_type => "virtio",
-      :present         => true,
-      :filename        => "b7139a48-854b-49b4-b4a0-92ef88261b7b",
-      :location        => "1",
-      :size            => 1.gigabytes,
-      :size_on_disk    => 1.gigabytes,
-      :mode            => "persistent",
-      :disk_type       => "thick",
-      :start_connected => true
-    )
-    expect(disk.storage).to eq(@storage)
-
-    expect(v.hardware.guest_devices.size).to eq(3)
-    expect(v.hardware.nics.size).to eq(3)
+    expect(v.hardware.guest_devices.size).to eq(1)
+    expect(v.hardware.nics.size).to eq(1)
     nic = v.hardware.nics.find_by_device_name("nic1")
     expect(nic).to have_attributes(
-      :uid_ems         => "98610918-86f6-45a9-b96f-b9849ab3ad7d",
+      :uid_ems         => "6a538d86-38a2-4ac9-98f5-9d401a596e93",
       :device_name     => "nic1",
       :device_type     => "ethernet",
       :controller_type => "ethernet",
       :present         => true,
       :start_connected => true,
-      :address         => "00:1a:4a:a8:fc:12"
+      :address         => "00:1a:4a:16:01:51"
     )
     # nic.lan.should == @lan # TODO: Hook up this connection
 
-    expect(v.hardware.networks.size).to eq(1)
-    network = v.hardware.networks.first
-    expect(network).to have_attributes(
-      :hostname    => nil, # TODO: Should be miq-winxpsp3 (or something like that)?
-      :ipaddress   => "192.168.253.45",
-      :ipv6address => nil
-    )
-    # nic.network.should == network # TODO: Hook up this connection
-
     expect(v.parent_datacenter).to have_attributes(
-      :ems_ref     => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :ems_ref_obj => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db",
-      :name        => "Default",
+      :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :name        => "dc1",
       :type        => "Datacenter",
 
-      :folder_path => "Datacenters/Default"
+      :folder_path => "Datacenters/dc1"
     )
 
     expect(v.parent_folder).to have_attributes(
@@ -401,31 +398,31 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.parent_blue_folder).to have_attributes(
       :ems_ref     => nil,
       :ems_ref_obj => nil,
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
       :name        => "vm",
       :type        => nil,
 
-      :folder_path => "Datacenters/Default/vm"
+      :folder_path => "Datacenters/dc1/vm"
     )
   end
 
   def assert_specific_vm_powered_off
-    v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "EmsRefreshSpec-PoweredOff")
+    v = ManageIQ::Providers::Redhat::InfraManager::Vm.find_by(:name => "vm2")
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
-      :ems_ref_obj           => "/api/vms/26a050fb-62c3-4645-9088-be6efec860e1",
-      :uid_ems               => "26a050fb-62c3-4645-9088-be6efec860e1",
+      :ems_ref               => "/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf",
+      :ems_ref_obj           => "/api/vms/072093dc-3492-4cb1-b240-dbf88a8f4fbf",
+      :uid_ems               => "072093dc-3492-4cb1-b240-dbf88a8f4fbf",
       :vendor                => "redhat",
       :raw_power_state       => "down",
       :power_state           => "off",
-      :location              => "26a050fb-62c3-4645-9088-be6efec860e1.ovf",
+      :location              => "072093dc-3492-4cb1-b240-dbf88a8f4fbf.ovf",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
       :connection_state      => "connected",
       :cpu_affinity          => nil,
-      :memory_reserve        => 512,
+      :memory_reserve        => 1024,
       :memory_reserve_expand => nil,
       :memory_limit          => nil,
       :memory_shares         => nil,
@@ -441,83 +438,74 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.ems_cluster).to eq(@cluster)
     expect(v.parent_resource_pool).to eq(@default_rp)
     expect(v.host).to be_nil
-    expect(v.storages).to eq([@storage2])
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "rhel_6x64"
+      :product_name => "other"
     )
 
     expect(v.custom_attributes.size).to eq(0)
 
-    expect(v.snapshots.size).to eq(3)
+    expect(v.snapshots.size).to eq(2)
     snapshot = v.snapshots.detect { |s| s.current == 1 } # TODO: Fix this boolean column
     expect(snapshot).to have_attributes(
-      :uid         => "a49102de-1e2a-45b7-b464-185f959dbfbb",
-      :parent_uid  => "edbc4501-23a6-45c9-a736-b378f45a2aec",
-      :uid_ems     => "a49102de-1e2a-45b7-b464-185f959dbfbb",
-      :name        => "Active VM",
-      :description => "Active VM",
+      :uid         => "677a1c40-8112-4e4a-bd03-c430e7505912",
+      :parent_uid  => "ef7b7d35-c7b8-4270-8ec7-b85047a50bdc",
+      :uid_ems     => "677a1c40-8112-4e4a-bd03-c430e7505912",
+      :name        => "22",
+      :description => "22",
       :current     => 1,
       :total_size  => nil,
       :filename    => nil
     )
     snapshot = snapshot.parent # TODO: THIS IS COMPLETELY WRONG
     expect(snapshot).to have_attributes(
-      :uid         => "edbc4501-23a6-45c9-a736-b378f45a2aec",
-      :parent_uid  => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
-      :uid_ems     => "edbc4501-23a6-45c9-a736-b378f45a2aec",
-      :name        => "Snapshot1",
-      :description => "Snapshot1",
-      :current     => 0
-    )
-    snapshot = snapshot.parent
-    expect(snapshot).to have_attributes(
-      :uid         => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
+      :uid         => "ef7b7d35-c7b8-4270-8ec7-b85047a50bdc",
       :parent_uid  => nil,
-      :uid_ems     => "f5990c3f-c608-4fc7-b50d-17fe1d389757",
-      :name        => "Snapshot2",
-      :description => "Snapshot2",
+      :uid_ems     => "ef7b7d35-c7b8-4270-8ec7-b85047a50bdc",
+      :name        => "Active VM",
+      :description => "Active VM",
       :current     => 0
     )
     expect(snapshot.parent).to be_nil
 
     expect(v.hardware).to have_attributes(
-      :guest_os           => "rhel_6x64",
+      :guest_os           => "other",
       :guest_os_full_name => nil,
       :bios               => nil,
-      :cpu_sockets        => 2,
-      :annotation         => "Powered Off VM for EmsRefresh testing",
+      :cpu_sockets        => 1,
+      :annotation         => nil,
       :memory_mb          => 1024
     )
 
-    expect(v.hardware.disks.size).to eq(2)
-    disk = v.hardware.disks.find_by_device_name("Disk 1")
+    expect(v.hardware.disks.size).to eq(1)
+    disk = v.hardware.disks.find_by(:device_name => "vm2_Disk1")
     expect(disk).to have_attributes(
-      :device_name     => "Disk 1",
+      :device_name     => "vm2_Disk1",
       :device_type     => "disk",
       :controller_type => "virtio",
       :present         => true,
-      :filename        => "21fc55f7-2775-4fec-8442-fa546e06fabc",
+      :filename        => "9a3e866c-4497-46df-801a-d1739c31c69d",
       :location        => "0",
-      :size            => 1.gigabytes,
+      :size            => 5.gigabytes,
       :mode            => "persistent",
       :disk_type       => "thin",
       :start_connected => true
     )
-    expect(disk.storage).to eq(@storage2)
+    expect(disk.storage).to eq(@storage)
 
-    expect(v.hardware.guest_devices.size).to eq(3)
-    expect(v.hardware.nics.size).to eq(3)
+    expect(v.hardware.guest_devices.size).to eq(1)
+    expect(v.hardware.nics.size).to eq(1)
     nic = v.hardware.nics.find_by_device_name("nic1")
     expect(nic).to have_attributes(
-      :uid_ems         => "f2b9d3dc-e948-4ec9-a746-b03c409cfd18",
+      :uid_ems         => "fdc2d708-01d1-4aa4-8b53-d64177181e2e",
       :device_name     => "nic1",
       :device_type     => "ethernet",
       :controller_type => "ethernet",
       :present         => true,
       :start_connected => true,
-      :address         => "00:1a:4a:a8:fc:0c"
+      :address         => "00:1a:4a:16:01:52"
     )
     expect(nic.lan).to     be_nil
     expect(nic.network).to be_nil
@@ -525,13 +513,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.hardware.networks.size).to eq(0)
 
     expect(v.parent_datacenter).to have_attributes(
-      :ems_ref     => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :ems_ref_obj => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db",
-      :name        => "Default",
+      :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :name        => "dc1",
       :type        => "Datacenter",
 
-      :folder_path => "Datacenters/Default"
+      :folder_path => "Datacenters/dc1"
     )
 
     expect(v.parent_folder).to have_attributes(
@@ -547,30 +535,30 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.parent_blue_folder).to have_attributes(
       :ems_ref     => nil,
       :ems_ref_obj => nil,
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
       :name        => "vm",
       :type        => nil,
 
-      :folder_path => "Datacenters/Default/vm"
+      :folder_path => "Datacenters/dc1/vm"
     )
   end
 
   def assert_specific_template
-    v = ManageIQ::Providers::Redhat::InfraManager::Template.find_by(:name => "EmsRefreshSpec-Template")
+    v = ManageIQ::Providers::Redhat::InfraManager::Template.find_by(:name => "template_cd1")
     expect(v).to have_attributes(
       :template              => true,
-      :ems_ref               => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
-      :ems_ref_obj           => "/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613",
-      :uid_ems               => "7a6db798-9df9-40ca-8cc3-3baab32e7613",
+      :ems_ref               => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
+      :ems_ref_obj           => "/api/templates/785e845e-baa0-4812-8a8c-467f37ad6c79",
+      :uid_ems               => "785e845e-baa0-4812-8a8c-467f37ad6c79",
       :vendor                => "redhat",
       :power_state           => "never",
-      :location              => "7a6db798-9df9-40ca-8cc3-3baab32e7613.ovf",
+      :location              => "785e845e-baa0-4812-8a8c-467f37ad6c79.ovf",
       :tools_status          => nil,
       :boot_time             => nil,
       :standby_action        => nil,
       :connection_state      => "connected",
       :cpu_affinity          => nil,
-      :memory_reserve        => nil,
+      :memory_reserve        => 4024,
       :memory_reserve_expand => nil,
       :memory_limit          => nil,
       :memory_shares         => nil,
@@ -586,55 +574,55 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.ems_cluster).to eq(@cluster)
     expect(v.parent_resource_pool).to  be_nil
     expect(v.host).to                  be_nil
-    expect(v.storages).to eq([@storage2])
+    expect(v.storages).to eq([@storage])
     # v.storage  # TODO: Fix bug where duplication location GUIDs could cause the wrong value to appear.
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "rhel_6x64"
+      :product_name => "other"
     )
 
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(0)
 
     expect(v.hardware).to have_attributes(
-      :guest_os             => "rhel_6x64",
+      :guest_os             => "other",
       :guest_os_full_name   => nil,
       :bios                 => nil,
-      :cpu_sockets          => 2,
+      :cpu_sockets          => 4,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 2,
-      :annotation           => "Template for EmsRefresh testing",
-      :memory_mb            => 1024
+      :cpu_total_cores      => 4,
+      :annotation           => nil,
+      :memory_mb            => 4024
     )
 
-    expect(v.hardware.disks.size).to eq(2)
-    disk = v.hardware.disks.find_by_device_name("EmsRefreshSpec_Disk1")
+    expect(v.hardware.disks.size).to eq(1)
+    disk = v.hardware.disks.first
     expect(disk).to have_attributes(
-      :device_name     => "EmsRefreshSpec_Disk1",
+      :device_name     => "vm1_Disk1",
       :device_type     => "disk",
       :controller_type => "virtio",
       :present         => true,
-      :filename        => "95a35764-4e49-4d6c-895f-33948f30ea69",
+      :filename        => "7917730e-39fb-4da4-9256-da652c33e5b6",
       :location        => "0",
-      :size            => 1.gigabytes,
+      :size            => 6.gigabytes,
       :mode            => "persistent",
       :disk_type       => "thin",
       :start_connected => true
     )
-    expect(disk.storage).to eq(@storage2)
+    expect(disk.storage).to eq(@storage)
 
-    expect(v.hardware.guest_devices.size).to eq(0) # TODO: Should this be 3 like the other tests?
-    expect(v.hardware.nics.size).to eq(0)
+    expect(v.hardware.guest_devices.size).to eq(1)
+    expect(v.hardware.nics.size).to eq(1)
     expect(v.hardware.networks.size).to eq(0)
 
     expect(v.parent_datacenter).to have_attributes(
-      :ems_ref     => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :ems_ref_obj => "/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db",
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db",
-      :name        => "Default",
+      :ems_ref     => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :ems_ref_obj => "/api/datacenters/b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1",
+      :name        => "dc1",
       :type        => "Datacenter",
 
-      :folder_path => "Datacenters/Default"
+      :folder_path => "Datacenters/dc1"
     )
 
     expect(v.parent_folder).to have_attributes(
@@ -650,100 +638,56 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     expect(v.parent_blue_folder).to have_attributes(
       :ems_ref     => nil,
       :ems_ref_obj => nil,
-      :uid_ems     => "45b5a710-eccd-11e1-bc2c-005056a217db_vm",
+      :uid_ems     => "b60b3daa-dcbd-40c9-8d09-3fc08c91f5d1_vm",
       :name        => "vm",
       :type        => nil,
 
-      :folder_path => "Datacenters/Default/vm"
+      :folder_path => "Datacenters/dc1/vm"
     )
   end
 
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:hidden => true}] => {
-        [Datacenter, "Default"] => {
+        [Datacenter, "dc1"] => {
           [EmsFolder, "host", {:hidden => true}] => {
-            [EmsCluster, "iSCSI"] => {
-              [ResourcePool, "Default for Cluster iSCSI"] => {
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "BD-F17-Desktop"]                => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "EVM-DHS-Test"]                  => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-NoDisks-NoNics"] => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-PoweredOff"]     => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-PoweredOn"]      => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "abc123"]                        => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "abc1234"]                       => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-isotest-14-ir"]              => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-isotest-14-pr"]              => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-wintest"]                    => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-wintest-01-18-c"]            => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bill-t1"]                       => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "evm-5012"]                      => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy-test"]                     => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu"]                      => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu7"]                     => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu8"]                     => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "miqutil"]                       => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "rmtest06"]                      => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-evm-iscsi"]                 => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-test1"]                     => {},
+            [EmsCluster, "cc1"] => {
+              [ResourcePool, "Default for Cluster cc1"] => {
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm1"] => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"] => {},
               }
+            },
+            [EmsCluster, "dccc2"] => {
+              [ResourcePool, "Default for Cluster dccc2"] => {},
             }
           },
           [EmsFolder, "vm", {:hidden => true}]   => {
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "CFME_Base"]               => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-v50017"]              => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "EVM-v50025"]              => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "EmsRefreshSpec-Template"] => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "PxeRhelRhevm31"]          => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "evm-v5012"]               => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "rmrhel"]                  => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "BD-F17-Desktop"]                => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "EVM-DHS-Test"]                  => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-NoDisks-NoNics"] => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-PoweredOff"]     => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "EmsRefreshSpec-PoweredOn"]      => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "abc123"]                        => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "abc1234"]                       => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-isotest-14-ir"]              => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-isotest-14-pr"]              => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-wintest"]                    => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-wintest-01-18-c"]            => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bill-t1"]                       => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "evm-5012"]                      => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy-test"]                     => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu"]                      => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu7"]                     => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "lucy_cpu8"]                     => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "miqutil"]                       => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "rmtest06"]                      => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-evm-iscsi"]                 => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-test1"]                     => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Template, "template_cd1"] => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm1"]                => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"]                => {}
           }
         },
-        [Datacenter, "NFS"]     => {
+        [Datacenter, "Default"]     => {
           [EmsFolder, "host", {:hidden => true}] => {
-            [EmsCluster, "NFS"] => {
-              [ResourcePool, "Default for Cluster NFS"] => {
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "MK_AUG_05_003_DELETE"] => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "aab_demo_vm"]          => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "aab_test_vm"]          => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-testiso1"]          => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd1"]                  => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-test2"]            => {},
+            [EmsCluster, "Default"] => {
+              [ResourcePool, "Default for Cluster Default"] => {
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-manageiq"]    => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-as"]          => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vmdc1"]                => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm3"]                  => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-yo"]          => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-test_se121"]  => {},
               }
             }
           },
           [EmsFolder, "vm", {:hidden => true}]   => {
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "757e824d-6d97-4568-be29-9346c354e802"] => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "bd-clone-template"]                    => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "bd-temp1"]                             => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Template, "prov-template"]                        => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "MK_AUG_05_003_DELETE"]                       => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "aab_demo_vm"]                                => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "aab_test_vm"]                                => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd-testiso1"]                                => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "bd1"]                                        => {},
-            [ManageIQ::Providers::Redhat::InfraManager::Vm, "rpo-test2"]                                  => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Template, "template_ex_default"] => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-manageiq"]         => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-as"]               => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "vmdc1"]                     => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm3"]                       => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-yo"]               => {},
+            [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-test_se121"]       => {},
           },
         }
       }

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_spec.rb
@@ -1,6 +1,11 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   let(:ems) { FactoryGirl.build(:ems_redhat) }
+  let(:use_ovirt_engine_sdk) { true }
   describe 'chooses the right refresher strategy' do
+    before do
+      ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = use_ovirt_engine_sdk
+    end
+
     context "when v4 api" do
       before(:each) do
         allow(ems).to receive(:highest_supported_api_version).and_return(4)
@@ -8,6 +13,13 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
       it 'returns the api4 refresher' do
         expect(ems.refresher).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies::Api4)
+      end
+
+      context "when use_ovirt_engine_sdk setting is turned to false" do
+        let(:use_ovirt_engine_sdk) { false }
+        it 'returns the api4 refresher' do
+          expect(ems.refresher).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies::Api3)
+        end
       end
     end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   let(:use_ovirt_engine_sdk) { true }
   describe 'chooses the right refresher strategy' do
     before do
-      ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = use_ovirt_engine_sdk
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => use_ovirt_engine_sdk } })
     end
 
     context "when v4 api" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -9,6 +9,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.default_endpoint.path = "/ovirt-engine/api"
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
     allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+    ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = true
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
     @ems.default_endpoint.path = "/ovirt-engine/api"
     allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
     allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-    ::Settings.ems.ems_redhat.use_ovirt_engine_sdk = true
+    stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
   end
 
   it ".ems_type" do

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/event_parser_parse_event.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/event_parser_parse_event.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://192.168.1.105:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '68'
+      Date:
+      - Tue, 28 Feb 2017 10:15:18 GMT
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Error</title></head><body>Not Found</body></html>"
+    http_version: 
+  recorded_at: Tue, 28 Feb 2017 10:15:18 GMT
+- request:
+    method: get
+    uri: https://192.168.1.105:8443/ovirt-engine/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="RESTAPI"
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '71'
+      Date:
+      - Tue, 28 Feb 2017 10:15:18 GMT
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
+    http_version: 
+  recorded_at: Tue, 28 Feb 2017 10:15:18 GMT
+- request:
+    method: get
+    uri: https://admin%40internal:engine@192.168.1.105:8443/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - JSESSIONID=QJK8swbFaOknhBCfP5oyVbvBzcin5FjUaFT2xxt_.f24; path=/ovirt-engine/api;
+        HttpOnly
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '373'
+      Correlation-Id:
+      - 9666e3b2-8329-4ea7-8ee7-7537704076c9
+      Date:
+      - Tue, 28 Feb 2017 12:14:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAK2T0U6DMBSG73kK0ksTBHqgQAJM4+YT6PVSabc1K4W0bHE+
+        vWWV4Ew0XtCk8Pc/h36ncChX7630z1wb0akKxfcR8rlqOibUvkKvL89Bjnwz
+        UMWo7BSv0IUbtKq98mS49g+a7yoUdmehh4CrvVA8pL0Ix6AJ05yygmEWRDHQ
+        IIqovcT5zqqvgTFHvmAV+ldm7fl2lIq2vKasFaoMr9rZUqjjAvWEupP2hL7m
+        skJOhwsTeq5bYcb3PXG+O0vTBrqfMFe59P7GHPrTmxTNkV8m0K03EVnXUqF+
+        ZbqwCUlBNllC0gyTDYnJE16TOEutk2ePrlv+zHCwuVOEGrhWVAb0NBw+blrm
+        C3lT3parQV+2gtUQEXKdOUQQQ4HXkEJOEsBWJVBABpElY5JYb1SEpCQGDACJ
+        vWeA7bOYwISZd5772PS04fWdq8otXHD8ANu50x9+nmKOu/xeC9WInsrpz5gN
+        z2XX3idpxb9H6wMAAA==
+    http_version: 
+  recorded_at: Tue, 28 Feb 2017 12:14:00 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
If the ovirt provider supports version 4 of the api use the new
OvirtSDK to do refresh and targeted refresh.

(This is a first in a series of PRs that will allow using the OvirtSDK with providers that support version 4 for refresh, event handling and provisioning.)