### PR TITLE
New provider event parsing

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
+  require_nested :Builder
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/builder.rb
@@ -1,0 +1,15 @@
+module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
+  class Builder
+    attr_reader :ext_management_system
+
+    def initialize(ems)
+      @ext_management_system = ems
+    end
+
+    def build
+      strategy_model = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
+      api_version = ext_management_system.highest_allowed_api_version
+      "#{strategy_model}::V#{api_version}".constantize
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -1,0 +1,21 @@
+module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
+  class V3
+    attr_reader :ext_management_system
+
+    def initialize(args)
+      @ext_management_system = args[:ems]
+    end
+
+    def username_by_href(href)
+      ext_management_system.with_provider_connection do |rhevm|
+        Ovirt::User.find_by_href(rhevm, href).try(:[], :user_name)
+      end
+    end
+
+    def cluster_name_href(href)
+      ext_management_system.with_provider_connection do |rhevm|
+        Ovirt::Cluster.find_by_href(rhevm, href).try(:[], :name)
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -1,0 +1,32 @@
+module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
+  class V4
+    attr_reader :ext_management_system
+
+    def initialize(args)
+      @ext_management_system = args[:ems]
+    end
+
+    def username_by_href(href)
+      ext_management_system.with_provider_connection(:version => 4) do |connection|
+        user = connection.system_service.users_service.user_service(get_uuid_from_href(href)).get
+        "#{user.name}@#{user.domain.name}"
+      end
+    end
+
+    def cluster_name_href(href)
+      ext_management_system.with_provider_connection(:version => 4) do |connection|
+        cluster_proxy_from_href(href, connection).name
+      end
+    end
+
+    private
+
+    def cluster_proxy_from_href(href, con)
+      con.system_service.clusters_service.cluster_service(get_uuid_from_href(href)).get
+    end
+
+    def get_uuid_from_href(ems_ref)
+      URI(ems_ref).path.split('/').last
+    end
+  end
+end

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser/response_yamls/user.yml
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser/response_yamls/user.yml
@@ -1,0 +1,41 @@
+--- !ruby/object:OvirtSDK4::User
+href: "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e"
+comment: 
+description: 
+id: 58ad9d2d-013a-00aa-018f-00000000022e
+name: admin
+department: 
+domain: !ruby/object:OvirtSDK4::Domain
+  href: "/ovirt-engine/api/domains/696E7465726E616C2D617574687A"
+  comment: 
+  description: 
+  id: 696E7465726E616C2D617574687A
+  name: internal-authz
+  groups: 
+  user: 
+  users: 
+domain_entry_id: 30663066383031392D353864322D343937302D626464302D666561323334613732663263
+email: 
+groups: 
+last_name: 
+logged_in: 
+namespace: "*"
+password: 
+permissions: !ruby/array:OvirtSDK4::List
+  internal: []
+  ivars:
+    :@href: "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e/permissions"
+principal: admin
+roles: !ruby/array:OvirtSDK4::List
+  internal: []
+  ivars:
+    :@href: "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e/roles"
+ssh_public_keys: !ruby/array:OvirtSDK4::List
+  internal: []
+  ivars:
+    :@href: "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e/sshpublickeys"
+tags: !ruby/array:OvirtSDK4::List
+  internal: []
+  ivars:
+    :@href: "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e/tags"
+user_name: admin@internal-authz

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::Redhat::InfraManager::EventParser  do
+describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
   context 'parse event using v3' do
     let(:ip_address) { '192.168.1.105' }
 
@@ -13,36 +13,99 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser  do
     end
 
     it "should parse event" do
-      event = {:id=>"414",
-               :href=>"/ovirt-engine/api/events/414",
-               :cluster=>{:id=>"00000002-0002-0002-0002-00000000017a",
-                          :href=>"/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"},
-               :data_center=>{:id=>"00000001-0001-0001-0001-000000000311",
-                              :href=>"/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"},
-               :user=>{:id=>"58ad9d2d-013a-00aa-018f-00000000022e",
-                       :href=>"/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e"},
-               :vm=>{:id=>"3a697bd0-7cea-42a1-95ef-fd292fcee721",
-                     :href=>"/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"},
-               :description=>"VM new configuration was updated by admin@internal-authz.",
-               :severity=>"normal",
-               :code=>35,
-               :time=>"2017-02-27 15:44:20 +0100",
-               :name=>"USER_UPDATE_VM"}
+      event = {:id          => "414",
+               :href        => "/ovirt-engine/api/events/414",
+               :cluster     => {:id   => "00000002-0002-0002-0002-00000000017a",
+                                :href => "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"},
+               :data_center => {:id   => "00000001-0001-0001-0001-000000000311",
+                                :href => "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"},
+               :user        => {:id   => "58ad9d2d-013a-00aa-018f-00000000022e",
+                                :href => "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e"},
+               :vm          => {:id   => "3a697bd0-7cea-42a1-95ef-fd292fcee721",
+                                :href => "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"},
+               :description => "VM new configuration was updated by admin@internal-authz.",
+               :severity    => "normal",
+               :code        => 35,
+               :time        => "2017-02-27 15:44:20 +0100",
+               :name        => "USER_UPDATE_VM"}
       allow(ManageIQ::Providers::Redhat::InfraManager).to receive(:find_by).with(:id => @ems.id).and_return(@ems)
 
       VCR.use_cassette("#{described_class.name.underscore}_parse_event", :allow_unused_http_interactions => true, :allow_playback_repeats => true, :record => :new_episodes) do
         parsed = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, @ems.id)
 
         expect(parsed).to have_attributes(
-          :event_type          => "USER_UPDATE_VM",
-          :source              => 'RHEVM',
-          :message             => "VM new configuration was updated by admin@internal-authz.",
-          :timestamp           => "2017-02-27 15:44:20 +0100",
-          :username            => "admin@internal-authz",
-          :full_data           => event,
-          :ems_id              => @ems.id,
+          :event_type => "USER_UPDATE_VM",
+          :source     => 'RHEVM',
+          :message    => "VM new configuration was updated by admin@internal-authz.",
+          :timestamp  => "2017-02-27 15:44:20 +0100",
+          :username   => "admin@internal-authz",
+          :full_data  => event,
+          :ems_id     => @ems.id,
         )
       end
+    end
+  end
+
+  context 'parse event using v4' do
+    let(:ip_address) { '192.168.1.105' }
+
+    before(:each) do
+      _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.105", :ipaddress => "192.168.1.105",
+                                :port => 8443)
+      @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
+      @ems.default_endpoint.path = "/ovirt-engine/api"
+      allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
+      allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
+      ::Settings.ems.use_ovirt_engine_sdk = true
+    end
+
+    require 'yaml'
+    def load_response_mock_for(filename)
+      prefix = described_class.name.underscore
+      YAML.load_file(File.join('spec', 'models', prefix, 'response_yamls', filename + '.yml'))
+    end
+
+    before(:each) do
+      inventory_wrapper_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
+      user_mock = load_response_mock_for('user')
+      allow_any_instance_of(inventory_wrapper_class)
+        .to receive(:username_by_href).and_return("#{user_mock.name}@#{user_mock.domain.name}")
+      allow_any_instance_of(inventory_wrapper_class).to receive(:api).and_return("4.2.0_master")
+      allow_any_instance_of(inventory_wrapper_class).to receive(:service)
+        .and_return(OpenStruct.new(:version_string => '4.2.0_master'))
+    end
+
+    it "should parse event" do
+      event = {:id          => "414",
+               :href        => "/ovirt-engine/api/events/414",
+               :cluster     => {:id   => "00000002-0002-0002-0002-00000000017a",
+                                :href => "/ovirt-engine/api/clusters/00000002-0002-0002-0002-00000000017a"},
+               :data_center => {:id   => "00000001-0001-0001-0001-000000000311",
+                                :href => "/ovirt-engine/api/datacenters/00000001-0001-0001-0001-000000000311"},
+               :user        => {:id   => "58ad9d2d-013a-00aa-018f-00000000022e",
+                                :href => "/ovirt-engine/api/users/58ad9d2d-013a-00aa-018f-00000000022e"},
+               :vm          => {:id   => "3a697bd0-7cea-42a1-95ef-fd292fcee721",
+                                :href => "/ovirt-engine/api/vms/3a697bd0-7cea-42a1-95ef-fd292fcee721"},
+               :description => "VM new configuration was updated by admin@internal-authz.",
+               :severity    => "normal",
+               :code        => 35,
+               :time        => "2017-02-27 15:44:20 +0100",
+               :name        => "USER_UPDATE_VM"}
+      allow(ManageIQ::Providers::Redhat::InfraManager).to receive(:find_by).with(:id => @ems.id).and_return(@ems)
+
+      parsed = ManageIQ::Providers::Redhat::InfraManager::EventParser.event_to_hash(event, @ems.id)
+
+      expect(parsed).to have_attributes(
+        :event_type => "USER_UPDATE_VM",
+        :source     => 'RHEVM',
+        :message    => "VM new configuration was updated by admin@internal-authz.",
+        :timestamp  => "2017-02-27 15:44:20 +0100",
+        :username   => "admin@internal-authz",
+        :full_data  => event,
+        :ems_id     => @ems.id,
+      )
     end
   end
 end


### PR DESCRIPTION
Add parsing events with OvirtSDK, this respects the setting use_ovirt_engine_sdk and will use only Ovirt gem if it is set to false.

This PR is base on: https://github.com/ManageIQ/manageiq/pull/14398


@pkliczewski @masayag  please review