### PR TITLE
New provider provisioning for RHV

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -18,13 +18,6 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   supports :provisioning
   supports :refresh_new_target
 
-  #
-  # Hot plug of virtual memory has to be done in quanta of this size. Actually this is configurable in the
-  # engine, using the `HotPlugMemoryMultiplicationSizeMb` configuration parameter, but it is very unlikely
-  # that it will change.
-  #
-  HOT_PLUG_DIMM_SIZE = 256.megabyte.freeze
-
   def refresher
     Refresh::RefresherBuilder.new(self).build
   end
@@ -82,27 +75,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def vm_reconfigure(vm, options = {})
-    log_header = "EMS: [#{name}] #{vm.class.name}: id [#{vm.id}], name [#{vm.name}], ems_ref [#{vm.ems_ref}]"
-    spec       = options[:spec]
-
-    vm.with_provider_object do |rhevm_vm|
-      _log.info("#{log_header} Started...")
-      update_vm_memory(rhevm_vm, spec["memoryMB"] * 1.megabyte) if spec["memoryMB"]
-
-      cpu_options = {}
-      cpu_options[:cores]   = spec["numCoresPerSocket"] if spec["numCoresPerSocket"]
-      cpu_options[:sockets] = spec["numCPUs"] / (cpu_options[:cores] || vm.cpu_cores_per_socket) if spec["numCPUs"]
-
-      rhevm_vm.cpu_topology = cpu_options if cpu_options.present?
-    end
-
-    # Removing disks
-    remove_disks(spec["disksRemove"], vm) if spec["disksRemove"]
-
-    # Adding disks
-    add_disks(spec["disksAdd"], vm) if spec["disksAdd"]
-
-    _log.info("#{log_header} Completed.")
+    ovirt_services.vm_reconfigure(vm, options)
   end
 
   def add_disks(add_disks_spec, vm)
@@ -147,30 +120,6 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     end
   end
 
-  def update_vm_memory(vm, virtual)
-    # Adjust the virtual and guaranteed memory:
-    virtual = calculate_adjusted_virtual_memory(vm, virtual)
-    guaranteed = calculate_adjusted_guaranteed_memory(vm, virtual)
-
-    # If the virtual machine is running we need to update first the configuration that will be used during the
-    # next run, as the guaranteed memory can't be changed for the running virtual machine.
-    state = vm.attributes.fetch_path(:status, :state)
-    if state == 'up'
-      vm.update_memory(virtual, guaranteed, :next_run => true)
-      vm.update_memory(virtual, nil)
-    else
-      vm.update_memory(virtual, guaranteed)
-    end
-  end
-
-  def remove_disks(disks, vm)
-    with_disk_attachments_service(vm) do |service|
-      disks.each do |disk|
-        service.attachment_service(disk["disk_name"]).remove(:detach_only => !disk["delete_backing"])
-      end
-    end
-  end
-
   def vm_migrate(vm, options = {})
     host_id = URI(options[:host]).path.split('/').last
 
@@ -194,84 +143,5 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   # not be migrated together.
   def supports_migrate_for_all?(vms)
     vms.map(&:ems_cluster).uniq.compact.size == 1
-  end
-
-  private
-
-  #
-  # Adjusts the new requested virtual memory of a virtual machine so that it satisfies the constraints imposed
-  # by the engine.
-  #
-  # @param vm [Hash] The current representation of the virtual machine.
-  #
-  # @param requested [Integer] The new amount of virtual memory requested by the user.
-  #
-  # @return [Integer] The amount of virtual memory requested by the user adjusted so that it satisfies the constrains
-  #   imposed by the engine.
-  #
-  def calculate_adjusted_virtual_memory(vm, requested)
-    # Get the current state of the virtual machine, and the current amount of virtual memory:
-    attributes = vm.attributes
-    name = attributes.fetch_path(:name)
-    state = attributes.fetch_path(:status, :state)
-    current = attributes.fetch_path(:memory)
-
-    # Initially there is no need for adjustment:
-    adjusted = requested
-
-    # If the virtual machine is running then the difference in memory has to be a multiple of 256 MiB, otherwise
-    # the engine will not perform the hot plug of the new memory. The reason for this is that hot plugging of
-    # memory is performed adding a new virtual DIMM to the virtual machine, and the size of the virtual DIMM
-    # is 256 MiB. This means that we need to round the difference up to the closest multiple of 256 MiB.
-    if state == 'up'
-      delta = requested - current
-      remainder = delta % HOT_PLUG_DIMM_SIZE
-      if remainder > 0
-        adjustment = HOT_PLUG_DIMM_SIZE - remainder
-        adjusted = requested + adjustment
-        _log.info(
-          "The change in virtual memory of virtual machine '#{name}' needs to be a multiple of " \
-          "#{HOT_PLUG_DIMM_SIZE / 1.megabyte} MiB, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
-        )
-      end
-    end
-
-    # Return the adjusted memory:
-    adjusted
-  end
-
-  #
-  # Adjusts the guaranteed memory of a virtual machie so that it satisfies the constraints imposed by the
-  # engine.
-  #
-  # @param vm [Hash] The current representation of the virtual machine.
-  #
-  # @param virtual [Integer] The new amount of virtual memory requested by the user (and maybe already adjusted).
-  #
-  # @return [Integer] The amount of guarantted memory to request so that it satisfies the constraints imposed by
-  #   the engine.
-  #
-  def calculate_adjusted_guaranteed_memory(vm, virtual)
-    # Get the current amount of guaranteed memory:
-    attributes = vm.attributes
-    name = attributes.fetch_path(:name)
-    current = attributes.fetch_path(:memory_policy, :guaranteed)
-
-    # Initially there is no need for adjustment:
-    adjusted = current
-
-    # The engine requires that the virtual memory is bigger or equal than the guaranteed memory at any given
-    # time. Therefore, we need to adjust the guaranteed memory so that it is the minimum of the previous
-    # guaranteed memory and the new virtual memory.
-    if current > virtual
-      adjusted = virtual
-      _log.info(
-        "The guaranteed physical memory of virtual machine '#{name}' needs to be less or equal than the virtual " \
-        "memory, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
-      )
-    end
-
-    # Return the adjusted guaranteed memory:
-    adjusted
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -1,7 +1,8 @@
 class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
   def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.get_resource_by_ems_ref(ems_ref)
+    ovirt_services_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder
+                           .build_from_ems_or_connection(:ems => ext_management_system, :connection => connection)
+    ovirt_services_class.new(:ems => ext_management_system).get_host_proxy(self, connection)
   end
 
   def verify_credentials(auth_type = nil, options = {})

--- a/app/models/manageiq/providers/redhat/infra_manager/inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/inventory.rb
@@ -1,3 +1,3 @@
 module ManageIQ::Providers::Redhat::InfraManager::Inventory
-  require_nested :Inventory
+  require_nested :Builder
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services.rb
@@ -1,3 +1,3 @@
 module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
-  require_nested :Builder
+  require_nested :OvirtServices
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/builder.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/builder.rb
@@ -11,5 +11,14 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
       api_version = ext_management_system.highest_allowed_api_version
       "#{strategy_model}::V#{api_version}".constantize
     end
+
+    def self.build_from_ems_or_connection(args)
+      ems = args[:ems]
+      connection = args[:connection]
+      return new(ems).build if ems
+      strategy_model = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
+      api_version = connection.kind_of?(OvirtSDK4::Connection) ? 4 : 3
+      "#{strategy_model}::V#{api_version}".constantize
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/ovirt_services.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/ovirt_services.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Redhat::InfraManager::Inventory
+module ManageIQ::Providers::Redhat::InfraManager::OvirtServices
   class Error < StandardError; end
   class VmNotReadyToBoot < Error; end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v3.rb
@@ -1,10 +1,18 @@
 module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
   class V3
+    include Vmdb::Logging
+
     attr_reader :ext_management_system
 
     def initialize(args)
       @ext_management_system = args[:ems]
     end
+
+    def get
+      self
+    end
+
+    # Event parsing
 
     def username_by_href(href)
       ext_management_system.with_provider_connection do |rhevm|
@@ -16,6 +24,303 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       ext_management_system.with_provider_connection do |rhevm|
         Ovirt::Cluster.find_by_href(rhevm, href).try(:[], :name)
       end
+    end
+
+    # Provisioning
+    def get_host_proxy(host, connection)
+      connection ||= ext_management_system.connect
+      host_proxy = connection.get_resource_by_ems_ref(host.ems_ref)
+      GeneralUpdateMethodNamesDecorator.new(host_proxy)
+    end
+
+    def clone_completed?(args)
+      source = args[:source]
+      phase_context = args[:phase_context]
+      logger = args[:logger]
+      # TODO: shouldn't this error out the provision???
+      return true if phase_context[:clone_task_ref].nil?
+
+      source.with_provider_connection do |rhevm|
+        status = rhevm.status(phase_context[:clone_task_ref])
+        logger.info("Clone is #{status}")
+        status == 'complete'
+      end
+    end
+
+    def destination_image_locked?(vm)
+      vm.with_provider_object do |rhevm_vm|
+        return false if rhevm_vm.nil?
+        rhevm_vm.attributes.fetch_path(:status, :state) == "image_locked"
+      end
+    end
+
+    def populate_phase_context(phase_context, vm)
+      phase_context[:new_vm_ems_ref] = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm[:href])
+      phase_context[:clone_task_ref] = vm.creation_status_link
+    end
+
+    def nics_for_(vm)
+      vm.with_provider_object do |rhevm_vm|
+        rhevm_vm.nics.collect { |n| NicsDecorator.new(n) }
+      end
+    end
+
+    def cluster_find_network_by_name(href, network_name)
+      ext_management_system.with_provider_connection do |rhevm|
+        Ovirt::Cluster.find_by_href(rhevm, href).try(:find_network_by_name, network_name)
+      end
+    end
+
+    def configure_vnic(args)
+      vm = args[:vm]
+      mac_addr = args[:mac_addr]
+      network = args[:network]
+      nic_name = args[:nic_name]
+      interface = args[:interface]
+      vnic = args[:vnic]
+      logger = args[:logger]
+
+      options = {
+        :name        => nic_name,
+        :interface   => interface,
+        :network_id  => network[:id],
+        :mac_address => mac_addr,
+      }.delete_blanks
+
+      logger.info("with options: <#{options.inspect}>")
+
+      if vnic.nil?
+        vm.with_provider_object do |rhevm_vm|
+          rhevm_vm.create_nic(options)
+        end
+      else
+        vnic.apply_options!(options)
+      end
+    end
+
+    def powered_off_in_provider?(vm)
+      vm.with_provider_object(&:status)[:state] == "down"
+    end
+
+    def powered_on_in_provider?(vm)
+      vm.with_provider_object(&:status)[:state] == "up"
+    end
+
+    def vm_boot_from_cdrom(operation, name)
+      operation.get_provider_destination.boot_from_cdrom(name)
+    rescue Ovirt::VmNotReadyToBoot
+      raise OvirtServices::VmNotReadyToBoot
+    end
+
+    def vm_boot_from_network(operation)
+      operation.get_provider_destination.boot_from_network
+    rescue Ovirt::VmNotReadyToBoot
+      raise OvirtServices::VmNotReadyToBoot
+    end
+
+    def get_template_proxy(template, connection)
+      connection ||= ext_management_system.connect
+      template_proxy = connection.get_resource_by_ems_ref(template.ems_ref)
+      GeneralUpdateMethodNamesDecorator.new(template_proxy)
+    end
+
+    def get_vm_proxy(vm, connection)
+      connection ||= ext_management_system.connect
+      vm_proxy = connection.get_resource_by_ems_ref(vm.ems_ref)
+      GeneralUpdateMethodNamesDecorator.new(vm_proxy)
+    end
+
+    def collect_disks_by_hrefs(disks)
+      vm_disks = []
+
+      ext_management_system.try(:with_provider_connection) do |rhevm|
+        disks.each do |disk|
+          begin
+            vm_disks << Ovirt::Disk.find_by_href(rhevm, disk)
+          rescue Ovirt::MissingResourceError
+            nil
+          end
+        end
+      end
+      vm_disks
+    end
+
+    def shutdown_guest(operation)
+      operation.with_provider_object(&:shutdown)
+    rescue Ovirt::VmIsNotRunning
+    end
+
+    def start_clone(source, clone_options, phase_context)
+      source.with_provider_object do |rhevm_template|
+        vm = rhevm_template.create_vm(clone_options)
+        populate_phase_context(phase_context, vm)
+      end
+    end
+
+    def vm_start(vm, cloud_init)
+      vm.with_provider_object do |rhevm_vm|
+        rhevm_vm.start { |action| action.use_cloud_init(true) if cloud_init }
+      end
+    rescue Ovirt::VmAlreadyRunning
+    end
+
+    def vm_stop(vm)
+      vm.with_provider_object(&:stop)
+    rescue Ovirt::VmIsNotRunning
+    end
+
+    def vm_suspend(vm)
+      vm.with_provider_object(&:suspend)
+    end
+
+    def vm_reconfigure(vm, options = {})
+      log_header = "EMS: [#{ext_management_system.name}] #{vm.class.name}: id [#{vm.id}], name [#{vm.name}], ems_ref [#{vm.ems_ref}]"
+      spec = options[:spec]
+
+      _log.info("#{log_header} Started...")
+
+      vm.with_provider_object do |rhevm_vm|
+        update_vm_memory(rhevm_vm, spec["memoryMB"] * 1.megabyte) if spec["memoryMB"]
+
+        cpu_options = {}
+        cpu_options[:cores] = spec["numCoresPerSocket"] if spec["numCoresPerSocket"]
+        cpu_options[:sockets] = spec["numCPUs"] / (cpu_options[:cores] || vm.cpu_cores_per_socket) if spec["numCPUs"]
+
+        rhevm_vm.cpu_topology = cpu_options if cpu_options.present?
+      end
+
+      _log.info("#{log_header} Completed.")
+    end
+
+    class NicsDecorator < SimpleDelegator
+      def name
+        self[:name]
+      end
+
+      def network
+        id = self[:network][:id]
+        OpenStruct.new(:id => id)
+      end
+    end
+
+    class GeneralUpdateMethodNamesDecorator < SimpleDelegator
+      def method_missing(method_name, *args)
+        str_method_name = method_name.to_s
+        if str_method_name =~ /update_.*!/
+          attribute_to_update = str_method_name.split("update_")[1].delete('!')
+          send("#{attribute_to_update}=", *args)
+        else
+          # This is requied becasue of Ovirt::Vm strage behaviour - while rhevm.respond_to?(:nics)
+          # returns false, rhevm.nics actually works.
+          begin
+            __getobj__.send(method_name, *args)
+          rescue NoMethodError
+            super
+          end
+        end
+      end
+    end
+
+    private
+
+    #
+    # Hot plug of virtual memory has to be done in quanta of this size. Actually this is configurable in the
+    # engine, using the `HotPlugMemoryMultiplicationSizeMb` configuration parameter, but it is very unlikely
+    # that it will change.
+    #
+    HOT_PLUG_DIMM_SIZE = 256.megabyte.freeze
+
+    def update_vm_memory(vm, virtual)
+      # Adjust the virtual and guaranteed memory:
+      virtual = calculate_adjusted_virtual_memory(vm, virtual)
+      guaranteed = calculate_adjusted_guaranteed_memory(vm, virtual)
+
+      # If the virtual machine is running we need to update first the configuration that will be used during the
+      # next run, as the guaranteed memory can't be changed for the running virtual machine.
+      state = vm.attributes.fetch_path(:status, :state)
+      if state == 'up'
+        vm.update_memory(virtual, guaranteed, :next_run => true)
+        vm.update_memory(virtual, nil)
+      else
+        vm.update_memory(virtual, guaranteed)
+      end
+    end
+
+    #
+    # Adjusts the new requested virtual memory of a virtual machine so that it satisfies the constraints imposed
+    # by the engine.
+    #
+    # @param vm [Hash] The current representation of the virtual machine.
+    #
+    # @param requested [Integer] The new amount of virtual memory requested by the user.
+    #
+    # @return [Integer] The amount of virtual memory requested by the user adjusted so that it satisfies the constrains
+    #   imposed by the engine.
+    #
+    def calculate_adjusted_virtual_memory(vm, requested)
+      # Get the current state of the virtual machine, and the current amount of virtual memory:
+      attributes = vm.attributes
+      name = attributes.fetch_path(:name)
+      state = attributes.fetch_path(:status, :state)
+      current = attributes.fetch_path(:memory)
+
+      # Initially there is no need for adjustment:
+      adjusted = requested
+
+      # If the virtual machine is running then the difference in memory has to be a multiple of 256 MiB, otherwise
+      # the engine will not perform the hot plug of the new memory. The reason for this is that hot plugging of
+      # memory is performed adding a new virtual DIMM to the virtual machine, and the size of the virtual DIMM
+      # is 256 MiB. This means that we need to round the difference up to the closest multiple of 256 MiB.
+      if state == 'up'
+        delta = requested - current
+        remainder = delta % HOT_PLUG_DIMM_SIZE
+        if remainder > 0
+          adjustment = HOT_PLUG_DIMM_SIZE - remainder
+          adjusted = requested + adjustment
+          _log.info(
+            "The change in virtual memory of virtual machine '#{name}' needs to be a multiple of " \
+            "#{HOT_PLUG_DIMM_SIZE / 1.megabyte} MiB, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
+          )
+        end
+      end
+
+      # Return the adjusted memory:
+      adjusted
+    end
+
+    #
+    # Adjusts the guaranteed memory of a virtual machie so that it satisfies the constraints imposed by the
+    # engine.
+    #
+    # @param vm [Hash] The current representation of the virtual machine.
+    #
+    # @param virtual [Integer] The new amount of virtual memory requested by the user (and maybe already adjusted).
+    #
+    # @return [Integer] The amount of guarantted memory to request so that it satisfies the constraints imposed by
+    #   the engine.
+    #
+    def calculate_adjusted_guaranteed_memory(vm, virtual)
+      # Get the current amount of guaranteed memory:
+      attributes = vm.attributes
+      name = attributes.fetch_path(:name)
+      current = attributes.fetch_path(:memory_policy, :guaranteed)
+
+      # Initially there is no need for adjustment:
+      adjusted = current
+
+      # The engine requires that the virtual memory is bigger or equal than the guaranteed memory at any given
+      # time. Therefore, we need to adjust the guaranteed memory so that it is the minimum of the previous
+      # guaranteed memory and the new virtual memory.
+      if current > virtual
+        adjusted = virtual
+        _log.info(
+          "The guaranteed physical memory of virtual machine '#{name}' needs to be less or equal than the virtual " \
+          "memory, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
+        )
+      end
+
+      # Return the adjusted guaranteed memory:
+      adjusted
     end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -1,5 +1,9 @@
+require 'ovirtsdk4'
+
 module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
   class V4
+    include Vmdb::Logging
+
     attr_reader :ext_management_system
 
     def initialize(args)
@@ -8,7 +12,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
 
     def username_by_href(href)
       ext_management_system.with_provider_connection(:version => 4) do |connection|
-        user = connection.system_service.users_service.user_service(get_uuid_from_href(href)).get
+        user = connection.system_service.users_service.user_service(uuid_from_href(href)).get
         "#{user.name}@#{user.domain.name}"
       end
     end
@@ -19,14 +23,468 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       end
     end
 
-    private
-
-    def cluster_proxy_from_href(href, con)
-      con.system_service.clusters_service.cluster_service(get_uuid_from_href(href)).get
+    # Provisioning
+    def get_host_proxy(host, connection)
+      connection.system_service.hosts_service.host_service(host.uid_ems)
     end
 
-    def get_uuid_from_href(ems_ref)
+    def clone_completed?(args)
+      source = args[:source]
+      phase_context = args[:phase_context]
+      logger = args[:logger]
+
+      source.with_provider_connection(:version => 4) do |connection|
+        vm = vm_service_by_href(phase_context[:new_vm_ems_ref], connection).get
+        status = vm.status
+        logger.info("The Vm being cloned is #{status}")
+        status == OvirtSDK4::VmStatus::DOWN
+      end
+    end
+
+    def destination_image_locked?(vm)
+      vm.with_provider_object(:version => 4) do |vm_proxy|
+        vm_proxy.get.status == OvirtSDK4::VmStatus::IMAGE_LOCKED
+      end
+    end
+
+    def populate_phase_context(phase_context, vm)
+      phase_context[:new_vm_ems_ref] = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm.href)
+    end
+
+    def nics_for_(vm)
+      vm.with_provider_connection(:version => 4) do |connection|
+        vm_proxy = connection.system_service.vms_service.vm_service(vm.uid_ems).get
+        connection.follow_link(vm_proxy.nics)
+      end
+    end
+
+    def cluster_find_network_by_name(href, network_name)
+      ext_management_system.with_provider_connection(:version => 4) do |connection|
+        cluster_service = connection.system_service.clusters_service.cluster_service(uuid_from_href(href))
+        networks = cluster_service.networks_service.list
+        networks.detect { |n| n.name == network_name }
+      end
+    end
+
+    def configure_vnic(args)
+      vm = args[:vm]
+      mac_addr = args[:mac_addr]
+      network = args[:network]
+      nic_name = args[:nic_name]
+      interface = args[:interface]
+      vnic = args[:vnic]
+      logger = args[:logger]
+
+      vm.with_provider_connection(:version => 4) do |connection|
+        uuid = uuid_from_href(vm.ems_ref)
+        profile_id = network_profile_id(connection, network.id)
+        nics_service = connection.system_service.vms_service.vm_service(uuid).nics_service
+        options = {
+          :name         => nic_name || vnic.name,
+          :interface    => interface || vnic.interface,
+          :mac          => mac_addr ? OvirtSDK4::Mac.new(:address => mac_addr) : vnic.mac,
+          :vnic_profile => profile_id ? { :id => profile_id } : vnic.vnic_profile
+        }
+        logger.info("with options: <#{options.inspect}>")
+        if vnic
+          nics_service.nic_service(vnic.id).update(options)
+        else
+          nics_service.add(OvirtSDK4::Nic.new(options))
+        end
+      end
+    end
+
+    def powered_off_in_provider?(vm)
+      vm.with_provider_object(:version => 4) { |vm_service| vm_service.get.status } == OvirtSDK4::VmStatus::DOWN
+    end
+
+    def powered_on_in_provider?(vm)
+      vm.with_provider_object(:version => 4) { |vm_service| vm_service.get.status } == OvirtSDK4::VmStatus::UP
+    end
+
+    def vm_boot_from_cdrom(operation, name)
+      operation.get_provider_destination.vm_service.start(
+        :vm => {
+          :os     => {
+            :boot => {
+              :devices => [OvirtSDK4::BootDevice::CDROM]
+            }
+          },
+          :cdroms => [
+            {
+              :id => name
+            }
+          ]
+        }
+      )
+    rescue OvirtSDK4::Error
+      raise OvirtServices::VmNotReadyToBoot
+    end
+
+    def vm_boot_from_network(operation)
+      operation.get_provider_destination.start(
+        :vm => {
+          :os => {
+            :boot => {
+              :devices => [
+                OvirtSDK4::BootDevice::NETWORK
+              ]
+            }
+          }
+        }
+      )
+    rescue OvirtSDK4::Error
+      raise OvirtServices::VmNotReadyToBoot
+    end
+
+    def get_template_proxy(template, connection)
+      TemplateProxyDecorator.new(
+        connection.system_service.templates_service.template_service(template.uid_ems),
+        connection,
+        self
+      )
+    end
+
+    def get_vm_proxy(vm, connection)
+      VmProxyDecorator.new(connection.system_service.vms_service.vm_service(vm.uid_ems), self)
+    end
+
+    def collect_disks_by_hrefs(disks)
+      vm_disks = []
+      ext_management_system.with_provider_connection(:version => 4) do |connection|
+        disks.each do |disk|
+          parts = URI(disk).path.split('/')
+          begin
+            vm_disks << connection.system_service.storage_domains_service.storage_domain_service(parts[2]).disks_service.disk_service(parts[4]).get
+          rescue OvirtSDK4::Error
+            nil
+          end
+        end
+      end
+      vm_disks
+    end
+
+    def shutdown_guest(operation)
+      operation.with_provider_object(:version => 4, &:shutdown)
+    rescue OvirtSDK4::Error
+    end
+
+    def start_clone(source, clone_options, phase_context)
+      source.with_provider_object(:version => 4) do |rhevm_template|
+        vm = rhevm_template.create_vm(clone_options)
+        populate_phase_context(phase_context, vm)
+      end
+    end
+
+    def vm_start(vm, cloud_init)
+      opts = {}
+      vm.with_provider_object(:version => 4) do |rhevm_vm|
+        opts = {:use_cloud_init => cloud_init} if cloud_init
+        rhevm_vm.start(opts)
+      end
+    rescue OvirtSDK4::Error
+    end
+
+    def vm_stop(vm)
+      vm.with_provider_object(:version => 4, &:stop)
+    rescue OvirtSDK4::Error
+    end
+
+    def vm_suspend(vm)
+      vm.with_provider_object(:version => 4, &:suspend)
+    end
+
+    def vm_reconfigure(vm, options = {})
+      log_header = "EMS: [#{ext_management_system.name}] #{vm.class.name}: id [#{vm.id}], name [#{vm.name}], ems_ref [#{vm.ems_ref}]"
+      spec = options[:spec]
+
+      _log.info("#{log_header} Started...")
+
+      vm.with_provider_object(:version => 4) do |vm_service|
+        # Retrieve the current representation of the virtual machine:
+        vm = vm_service.get
+
+        # Update the memory:
+        memory = spec['memoryMB']
+        update_vm_memory(vm, vm_service, memory.megabytes) if memory
+
+        # Update the CPU:
+        cpu_total = spec['numCPUs']
+        cpu_cores = spec['numCoresPerSocket']
+        cpu_sockets = cpu_total / (cpu_cores || vm.cpu.topology.cores) if cpu_total
+        if cpu_cores || cpu_sockets
+          vm_service.update(
+            OvirtSDK4::Vm.new(
+              :cpu => {
+                :topology => {
+                  :cores   => cpu_cores,
+                  :sockets => cpu_sockets
+                }
+              }
+            )
+          )
+        end
+
+        # Remove disks:
+        removed_disk_specs = spec['disksRemove']
+        remove_vm_disks(vm_service, removed_disk_specs) if removed_disk_specs
+
+        # Add disks:
+        added_disk_specs = spec['disksAdd']
+        add_vm_disks(vm_service, added_disk_specs) if added_disk_specs
+      end
+
+      _log.info("#{log_header} Completed.")
+    end
+
+    class VmProxyDecorator < SimpleDelegator
+      attr_reader :service
+      def initialize(vm, service)
+        @obj = vm
+        @service = service
+        super(vm)
+      end
+
+      def update_memory_reserve!(memory_reserve_size)
+        vm = get
+        vm.memory_policy.guaranteed = memory_reserve_size
+        update(vm)
+      end
+
+      def update_description!(description)
+        vm = get
+        vm.description = description
+        update(vm)
+      end
+
+      def update_memory!(memory)
+        vm = get
+        vm.memory = memory
+        update(vm)
+      end
+
+      def update_host_affinity!(dest_host_ems_ref)
+        vm = get
+        vm.placement_policy.hosts = [OvirtSDK4::Host.new(:id => service.uuid_from_href(dest_host_ems_ref))]
+        update(vm)
+      end
+
+      def update_cpu_topology!(cpu_hash)
+        vm = get
+        vm.cpu.topology = OvirtSDK4::CpuTopology.new(cpu_hash)
+        update(vm)
+      end
+    end
+
+    class TemplateProxyDecorator < SimpleDelegator
+      attr_reader :connection, :ovirt_services
+      def initialize(template_service, connection, ovirt_services)
+        @obj = template_service
+        @connection = connection
+        @ovirt_services = ovirt_services
+        super(template_service)
+      end
+
+      def create_vm(options)
+        vms_service = connection.system_service.vms_service
+        cluster = ovirt_services.cluster_from_href(options[:cluster], connection)
+        template = get
+        vm = build_vm_from_hash(:name     => options[:name],
+                                :template => template,
+                                :cluster  => cluster)
+        vms_service.add(vm)
+      end
+
+      def build_vm_from_hash(args)
+        OvirtSDK4::Vm.new(:name     => args[:name],
+                          :template => args[:template],
+                          :cluster  => args[:cluster])
+      end
+    end
+
+    def cluster_from_href(href, connection)
+      connection.system_service.clusters_service.cluster_service(uuid_from_href(href)).get
+    end
+
+    def uuid_from_href(ems_ref)
       URI(ems_ref).path.split('/').last
+    end
+
+    private
+
+    #
+    # Hot plug of virtual memory has to be done in quanta of this size. Actually this is configurable in the
+    # engine, using the `HotPlugMemoryMultiplicationSizeMb` configuration parameter, but it is very unlikely
+    # that it will change.
+    #
+    HOT_PLUG_DIMM_SIZE = 256.megabyte.freeze
+
+    def cluster_proxy_from_href(href, connection)
+      connection.system_service.clusters_service.cluster_service(uuid_from_href(href)).get
+    end
+
+    def vm_service_by_href(href, connection)
+      vm_uuid = uuid_from_href(href)
+      connection.system_service.vms_service.vm_service(vm_uuid)
+    end
+
+    def network_profile_id(connection, network_id)
+      profiles_service = connection.system_service.vnic_profiles_service
+      profile = profiles_service.list.detect { |pr| pr.network.id == network_id }
+      profile && profile.id
+    end
+
+    #
+    # Updates the amount memory of a virtual machine.
+    #
+    # @param vm [OvirtSDK4::Vm] The current representation of the virtual machine.
+    # @param vm_service [OvirtSDK4::VmService] The service that manages the virtual machine.
+    # @param memory [Integer] The new amount of memory requested by the user.
+    #
+    def update_vm_memory(vm, vm_service, memory)
+      # Calculate the adjusted virtual and guaranteed memory:
+      virtual = calculate_adjusted_virtual_memory(vm, memory)
+      guaranteed = calculate_adjusted_guaranteed_memory(vm, memory)
+
+      # If the virtual machine is running we need to update first the configuration that will be used during the
+      # next run, as the guaranteed memory can't be changed for the running virtual machine.
+      if vm.status == OvirtSDK4::VmStatus::UP
+        vm_service.update(
+          OvirtSDK4::Vm.new(
+            :memory        => virtual,
+            :memory_policy => {
+              :guaranteed => guaranteed
+            }
+          ),
+          :next_run => true
+        )
+        vm_service.update(
+          OvirtSDK4::Vm.new(
+            :memory => virtual
+          )
+        )
+      else
+        vm_service.update(
+          OvirtSDK4::Vm.new(
+            :memory        => virtual,
+            :memory_policy => {
+              :guaranteed => guaranteed
+            }
+          )
+        )
+      end
+    end
+
+    #
+    # Adjusts the new requested virtual memory of a virtual machine so that it satisfies the constraints imposed
+    # by the engine.
+    #
+    # @param vm [OvirtSDK4::Vm] The current representation of the virtual machine.
+    # @param memory [Integer] The new amount of memory requested by the user.
+    # @return [Integer] The amount of memory requested by the user adjusted so that it satisfies the constrains
+    #   imposed by the engine.
+    #
+    def calculate_adjusted_virtual_memory(vm, memory)
+      # Initially there is no need for adjustment:
+      adjusted = memory
+
+      # If the virtual machine is running then the difference in memory has to be a multiple of 256 MiB, otherwise
+      # the engine will not perform the hot plug of the new memory. The reason for this is that hot plugging of
+      # memory is performed adding a new virtual DIMM to the virtual machine, and the size of the virtual DIMM
+      # is 256 MiB. This means that we need to round the difference up to the closest multiple of 256 MiB.
+      if vm.status == OvirtSDK4::VmStatus::UP
+        delta = memory - vm.memory
+        remainder = delta % HOT_PLUG_DIMM_SIZE
+        if remainder > 0
+          adjustment = HOT_PLUG_DIMM_SIZE - remainder
+          adjusted = memory + adjustment
+          _log.info(
+            "The change in virtual memory of virtual machine '#{vm.name}' needs to be a multiple of " \
+            "#{HOT_PLUG_DIMM_SIZE / 1.megabyte} MiB, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
+          )
+        end
+      end
+
+      # Return the adjusted memory:
+      adjusted
+    end
+
+    #
+    # Adjusts the guaranteed memory of a virtual machie so that it satisfies the constraints imposed by the
+    # engine.
+    #
+    # @param vm [OvirtSDK4::Vm] The current representation of the virtual machine.
+    # @param memory [Integer] The new amount of memory requested by the user (and maybe already adjusted).
+    # @return [Integer] The amount of guarantted memory to request so that it satisfies the constraints imposed by
+    #   the engine.
+    #
+    def calculate_adjusted_guaranteed_memory(vm, memory)
+      # Get the current amount of guaranteed memory:
+      current = vm.memory_policy.guaranteed
+
+      # Initially there is no need for adjustment:
+      adjusted = current
+
+      # The engine requires that the virtual memory is bigger or equal than the guaranteed memory at any given
+      # time. Therefore, we need to adjust the guaranteed memory so that it is the minimum of the previous
+      # guaranteed memory and the new virtual memory.
+      if current > memory
+        adjusted = memory
+        _log.info(
+          "The guaranteed physical memory of virtual machine '#{vm.name}' needs to be less or equal than the " \
+          "virtual memory, so it will be adjusted to #{adjusted / 1.megabyte} MiB."
+        )
+      end
+
+      # Return the adjusted guaranteed memory:
+      adjusted
+    end
+
+    #
+    # Adds disks to a virtual machine.
+    #
+    # @param vm_service [OvirtSDK4::VmsService] The service that manages the virtual machine.
+    # @param disk_specs [Hash] The specification of the disks to add.
+    #
+    def add_vm_disks(vm_service, disk_specs)
+      storage_spec = disk_specs[:storage]
+      attachments_service = vm_service.disk_attachments_service
+      disk_specs[:disks].each do |disk_spec|
+        attachment = prepare_vm_disk_attachment(disk_spec, storage_spec)
+        attachments_service.add(attachment)
+      end
+    end
+
+    #
+    # Prepares a disk attachment for adding a new disk to a virtual machine.
+    #
+    # @param disk_spec [Hash] The specification of the disk to add.
+    # @param storage_spec [Hash] The specification of the storage to use.
+    #
+    def prepare_vm_disk_attachment(disk_spec, storage_spec)
+      disk_spec = disk_spec.symbolize_keys
+      attachment_builder = ManageIQ::Providers::Redhat::InfraManager::DiskAttachmentBuilder.new(
+        :size_in_mb       => disk_spec[:disk_size_in_mb],
+        :storage          => storage_spec,
+        :name             => disk_spec[:disk_name],
+        :thin_provisioned => disk_spec[:thin_provisioned],
+        :bootable         => disk_spec[:bootable],
+      )
+      attachment_builder.disk_attachment
+    end
+
+    #
+    # Removes disks from a virtual machine.
+    #
+    # @param vm_service [OvirtSDK4::VmsService] The service that manages the virtual machine.
+    # @param disk_specs [Array<Hash>] The specifications of the disks to remove.
+    #
+    def remove_vm_disks(vm_service, disk_specs)
+      attachments_service = vm_service.disk_attachments_service
+      disk_specs.each do |disk_spec|
+        attachment_service = attachments_service.attachment_service(disk_spec['disk_name'])
+        attachment_service.remove(:detach_only => !disk_spec['delete_backing'])
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
 
   def configure_cloud_init
     return unless content = customization_template_content
-    get_provider_destination.cloud_init = content
+    get_provider_destination.update_cloud_init!(content)
 
     if Gem::Version.new(source.ext_management_system.api_version) >= Gem::Version.new("3.5.5.0")
       phase_context[:boot_with_cloud_init] = true
@@ -20,15 +20,15 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration
   end
 
   def configure_container
-    rhevm_vm = get_provider_destination
-
-    configure_container_description(rhevm_vm)
-    configure_memory(rhevm_vm)
-    configure_memory_reserve(rhevm_vm)
-    configure_cpu(rhevm_vm)
-    configure_host_affinity(rhevm_vm)
-    configure_network_adapters
-    configure_cloud_init
+    vm.with_provider_object(:version => vm.ext_management_system.highest_allowed_api_version) do |rhevm_vm|
+      configure_container_description(rhevm_vm)
+      configure_memory(rhevm_vm)
+      configure_memory_reserve(rhevm_vm)
+      configure_cpu(rhevm_vm)
+      configure_host_affinity(rhevm_vm)
+      configure_network_adapters
+      configure_cloud_init
+    end
   end
 
   private

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/container.rb
@@ -4,21 +4,21 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Cont
   def configure_container_description(rhevm_vm)
     description = get_option(:vm_description)
     _log.info "Setting description to:<#{description.inspect}>"
-    rhevm_vm.description = description
+    rhevm_vm.update_description!(description)
   end
 
   def configure_memory(rhevm_vm)
     vm_memory = get_option(:vm_memory).to_i * 1.megabyte
     return if vm_memory.zero?
     _log.info "Setting memory to:<#{vm_memory.inspect}>"
-    rhevm_vm.memory = vm_memory
+    rhevm_vm.update_memory!(vm_memory)
   end
 
   def configure_memory_reserve(rhevm_vm)
     memory_reserve = get_option(:memory_reserve).to_i.megabyte
     return if memory_reserve.zero?
     _log.info "Setting memory reserve to:<#{memory_reserve.inspect}>"
-    rhevm_vm.memory_reserve = memory_reserve
+    rhevm_vm.update_memory_reserve!(memory_reserve)
   end
 
   def configure_cpu(rhevm_vm)
@@ -26,12 +26,12 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Cont
     cores    = get_option(:cores_per_socket) || 1
     cpu_hash = {:cores => cores, :sockets => sockets}
     _log.info "Setting cpu to:<#{cpu_hash.inspect}>"
-    rhevm_vm.cpu_topology = cpu_hash
+    rhevm_vm.update_cpu_topology!(cpu_hash)
   end
 
   def configure_host_affinity(rhevm_vm)
     return if dest_host.nil?
     _log.info("Setting Host Affinity to: #{dest_host.name} with ID=#{dest_host.id}")
-    rhevm_vm.host_affinity = dest_host.ems_ref
+    rhevm_vm.update_host_affinity!(dest_host.ems_ref)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/configuration/network.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Network
   def configure_network_adapters
     configure_dialog_nic
-    requested_vnics   = options[:networks]
+    requested_vnics = options[:networks]
 
     if requested_vnics.nil?
       _log.info "NIC settings will be inherited from the template."
@@ -34,20 +34,22 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Netw
 
   def destination_vnics
     # Nics are not always ordered in the XML response
-    @destination_vnics ||= get_provider_destination.nics.sort_by { |n| n[:name] }
+    @destination_vnics ||= nics.sort_by(&:name)
   end
 
   def find_network_in_cluster(network_name)
-    network = source.with_provider_connection do |rhevm|
-      Ovirt::Cluster.find_by_href(rhevm, dest_cluster.ems_ref).try(:find_network_by_name, network_name)
-    end
+    network = source.ext_management_system.ovirt_services.cluster_find_network_by_name(dest_cluster.ems_ref, network_name)
 
     _log.warn "Cannot find network name=#{network_name}" if network.nil?
     network
   end
 
+  def nics
+    destination.ext_management_system.ovirt_services.nics_for_(destination)
+  end
+
   def find_nic_on_network(network)
-    nic = get_provider_destination.nics.detect { |n| n[:network][:id] == network[:id] }
+    nic = nics.detect { |n| n.network.try(:id) == network[:id] }
 
     _log.warn "Cannot find NIC with network id=#{network[:id].inspect}" if nic.nil?
     nic
@@ -68,15 +70,14 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Netw
     network   = find_network_in_cluster(network_hash[:network])
     raise MiqException::MiqProvisionError, "Unable to find specified network: <#{network_hash[:network]}>" if network.nil?
 
-    options = {
-      :name        => name,
-      :interface   => network_hash[:interface],
-      :network_id  => network[:id],
-      :mac_address => mac_addr,
-    }.delete_blanks
-
-    _log.info("with options: <#{options.inspect}>")
-
-    vnic.nil? ? get_provider_destination.create_nic(options) : vnic.apply_options!(options)
+    ems.ovirt_services.configure_vnic(
+      :vm        => destination,
+      :mac_addr  => mac_addr,
+      :network   => network,
+      :nic_name  => name,
+      :interface => network_hash[:interface],
+      :vnic      => vnic,
+      :logger    => _log
+    )
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -79,10 +79,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
   private
 
   def powered_off_in_provider?
-    destination.with_provider_object(&:status)[:state] == "down"
+    destination.ext_management_system.ovirt_services.powered_off_in_provider?(destination)
   end
 
   def powered_on_in_provider?
-    destination.with_provider_object(&:status)[:state] == "up"
+    destination.ext_management_system.ovirt_service.powered_on_in_provider?(destination)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine.rb
@@ -15,8 +15,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso::StateMachine
     update_and_notify_parent(:message => message)
 
     begin
-      get_provider_destination.boot_from_cdrom(iso_image.name)
-    rescue Ovirt::VmNotReadyToBoot
+      ext_management_system.ovirt_services.vm_boot_from_cdrom(self, iso_image.name)
+    rescue OvirtServices::VmNotReadyToBoot
       _log.info("#{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
@@ -22,8 +22,8 @@ module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine
     update_and_notify_parent(:message => message)
 
     begin
-      get_provider_destination.boot_from_network
-    rescue Ovirt::VmNotReadyToBoot
+      ext_management_system.ovirt_services.vm_boot_from_network(self)
+    rescue OvirtServices::VmNotReadyToBoot
       _log.info("#{destination_type} [#{dest_name}] is not yet ready to boot, will retry")
       requeue_phase
     else

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/host_inventory.rb
@@ -182,7 +182,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
 
         # Value provided by VC is in bytes, need to convert to MB
         memory_total_attr = inv.statistics.to_miq_a.detect { |stat| stat.name == 'memory.total' }
-        memory_total = memory_total_attr.dig(:values, :first, :datum)
+        memory_total = memory_total_attr && memory_total_attr.dig(:values, :first, :datum)
         result[:memory_mb] = memory_total.nil? ? 0 : memory_total.to_i / 1.megabyte
 
         result[:cpu_cores_per_socket] = hdw.dig(:topology, :cores) || 1

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
 
         # If the vm has a host but the refresh does not include it in the "hosts" hash
         if host.blank? && vm_inv.try(:host).present?
-          host = partial_host_hash(vm_inv.host)
+          host = partial_host_hash(vm_inv.host, ems_cluster)
           added_hosts << host if host
         end
 
@@ -87,7 +87,7 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
 
     def partial_host_hash(partial_host_inv)
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(partial_host_inv.href)
-      { :ems_ref => ems_ref, :uid_ems => partial_host_inv.id }
+      { :ems_ref => ems_ref, :uid_ems => partial_host_inv.id, :ems_cluster => ems_cluster }
     end
 
     def create_vm_hash(template, ems_ref, vm_id, name)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/strategies/api3.rb
@@ -3,7 +3,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Strategies
     def host_targeted_refresh(inventory, target)
       methods = {
         :primary   => {
-          :host => target.ems_ref,
+          :host    => target.ems_ref,
+          :network => { :networks => "network" }
         },
         :secondary => {
           :host => [:statistics, :host_nics],

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -14,7 +14,8 @@ class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers:
   end
 
   def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.get_resource_by_ems_ref(ems_ref)
+    ovirt_services_class = ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Builder
+                           .build_from_ems_or_connection(:ems => ext_management_system, :connection => connection)
+    ovirt_services_class.new(:ems => ext_management_system).get_template_proxy(self, connection)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
@@ -9,7 +9,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Guest
   end
 
   def raw_shutdown_guest
-    with_provider_object(&:shutdown)
-  rescue Ovirt::VmIsNotRunning
+    ext_management_system.ovirt_services.shutdown_guest(self)
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
@@ -5,19 +5,15 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Power
 
   def raw_start
     start_with_cloud_init = custom_attributes.find_by(:name => "miq_provision_boot_with_cloud_init")
-    with_provider_object do |rhevm_vm|
-      rhevm_vm.start { |action| action.use_cloud_init(true) if start_with_cloud_init }
-    end
+    ext_management_system.ovirt_services.vm_start(self, start_with_cloud_init)
     start_with_cloud_init.try(&:destroy)
-  rescue Ovirt::VmAlreadyRunning
   end
 
   def raw_stop
-    with_provider_object(&:stop)
-  rescue Ovirt::VmIsNotRunning
+    ext_management_system.ovirt_services.vm_stop(self)
   end
 
   def raw_suspend
-    with_provider_object(&:suspend)
+    ext_management_system.ovirt_services.vm_suspend(self)
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -7,7 +7,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
       @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address, :ipaddress => ip_address,
                                 :port => 8443)
       @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
-
       allow(@ems).to receive(:supported_api_versions).and_return([3])
       allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
     end
@@ -57,7 +56,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
       @ems.default_endpoint.path = "/ovirt-engine/api"
       allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
       allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-      ::Settings.ems.use_ovirt_engine_sdk = true
+      stub_settings_merge(:ems => { :ems_redhat => { :use_ovirt_engine_sdk => true } })
     end
 
     require 'yaml'

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -12,6 +12,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
       allow(v).to receive(:with_provider_object).and_yield(rhevm_vm)
       allow(ems).to receive(:with_disk_attachments_service).with(v).and_return(disk_attachments_service)
       allow(ems).to receive(:with_provider_connection).and_return(false)
+      # TODO: (inventory) wirte for v4
+      allow(ems).to receive(:supported_api_versions).and_return([3])
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_spec.rb
@@ -108,14 +108,22 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       end
 
       context "with a destination vm" do
+        let(:destination_vm) { FactoryGirl.create(:vm_redhat, :ext_management_system => @ems) }
         before do
+          allow(@ems).to receive(:resolve_ip_address).with(@ems.hostname).and_return("1.2.3.4")
           rhevm_vm = double(:attributes => {:status => {:state => "down"}})
           allow(@vm_prov).to receive(:get_provider_destination).and_return(rhevm_vm)
+          allow(@vm_prov).to receive(:destination).and_return(destination_vm)
+          allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:supported_api_versions)
+            .and_return([3])
+          allow(destination_vm).to receive(:provider_object).and_return(rhevm_vm)
+          allow(destination_vm).to receive(:with_provider_object)
+            .and_yield(rhevm_vm)
         end
 
         context "destination_image_locked?" do
           it "with a powered-off destination" do
-            expect(subject.destination_image_locked?).to be_falsey
+            expect(@vm_prov.destination_image_locked?).to be_falsey
           end
 
           it "with an imaged_locked destination" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine_spec.rb
@@ -7,6 +7,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
       options  = {:src_vm_id => template.id}
 
       @task = FactoryGirl.create(:miq_provision_redhat_via_iso, :source => template, :destination => vm, :state => 'pending', :status => 'Ok', :options => options)
+      allow(@task).to receive(:destination_image_locked?).and_return(false)
     end
 
     include_examples "common rhev state machine methods"

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine_spec.rb
@@ -5,9 +5,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe do
       template = FactoryGirl.create(:template_redhat, :ext_management_system => ems)
       vm       = FactoryGirl.create(:vm_redhat)
       options  = {:src_vm_id => template.id}
-
       @task = FactoryGirl.create(:miq_provision_redhat_via_pxe, :source => template, :destination => vm,
                                  :state => 'pending', :status => 'Ok', :options => options)
+      allow(@task).to receive(:destination_image_locked?).and_return(false)
     end
 
     include_examples "common rhev state machine methods"

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser_builder_spec.rb
@@ -25,13 +25,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilde
       end
 
       context "forced version 3" do
-        let(:options) { { :force_version => 3  } }
+        let(:options) { { :force_version => 3 } }
 
         it 'returns the api3 parser' do
           expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api3)
         end
       end
-
     end
 
     context "when v3 api" do
@@ -44,7 +43,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::ParserBuilde
       end
 
       context "forced version 4" do
-        let(:options) { { :force_version => 4  } }
+        let(:options) { { :force_version => 4 } }
 
         it 'returns the api4 parser' do
           expect(subject).to eq(ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies::Api4)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_4_1_spec.rb
@@ -364,7 +364,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
     expect(v.hardware.guest_devices.size).to eq(1)
     expect(v.hardware.nics.size).to eq(1)
-    nic = v.hardware.nics.find_by_device_name("nic1")
+    nic = v.hardware.nics.find_by(:device_name => "nic1")
     expect(nic).to have_attributes(
       :uid_ems         => "6a538d86-38a2-4ac9-98f5-9d401a596e93",
       :device_name     => "nic1",
@@ -498,7 +498,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
 
     expect(v.hardware.guest_devices.size).to eq(1)
     expect(v.hardware.nics.size).to eq(1)
-    nic = v.hardware.nics.find_by_device_name("nic1")
+    nic = v.hardware.nics.find_by(:device_name => "nic1")
     expect(nic).to have_attributes(
       :uid_ems         => "fdc2d708-01d1-4aa4-8b53-d64177181e2e",
       :device_name     => "nic1",
@@ -650,9 +650,9 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:hidden => true}] => {
-        [Datacenter, "dc1"] => {
+        [Datacenter, "dc1"]     => {
           [EmsFolder, "host", {:hidden => true}] => {
-            [EmsCluster, "cc1"] => {
+            [EmsCluster, "cc1"]   => {
               [ResourcePool, "Default for Cluster cc1"] => {
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm1"] => {},
                 [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"] => {},
@@ -668,16 +668,16 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
             [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm2"]                => {}
           }
         },
-        [Datacenter, "Default"]     => {
+        [Datacenter, "Default"] => {
           [EmsFolder, "host", {:hidden => true}] => {
             [EmsCluster, "Default"] => {
               [ResourcePool, "Default for Cluster Default"] => {
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-manageiq"]    => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-as"]          => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vmdc1"]                => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm3"]                  => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-yo"]          => {},
-                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-test_se121"]  => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-manageiq"]   => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-as"]         => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vmdc1"]               => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "vm3"]                 => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-yo"]         => {},
+                [ManageIQ::Providers::Redhat::InfraManager::Vm, "external-test_se121"] => {},
               }
             }
           },

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -121,7 +121,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => ip_address,
                                :ipaddress => ip_address, :port => 8443)
       ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
-      allow(ems).to receive(:supported_api_versions).and_return([3, 4])
+      # TODO: (inventory) resvisit this test and write one for V4
+      allow(ems).to receive(:supported_api_versions).and_return([3])
       allow(ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
 
       @storage = FactoryGirl.create(:storage, :ems_ref => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0")

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -56,6 +56,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:name).and_return('myvm')
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:memory).and_return(4.gigabytes)
       allow(@rhevm_vm_attrs).to receive(:fetch_path).with(:memory_policy, :guaranteed).and_return(2.gigabytes)
+      allow(@ems).to receive(:highest_allowed_api_version).and_return(3)
       @rhevm_vm = double('rhevm_vm')
       allow(@rhevm_vm).to receive(:attributes).and_return(@rhevm_vm_attrs)
       allow(@vm).to receive(:with_provider_object).and_yield(@rhevm_vm)

--- a/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
+++ b/spec/support/examples_group/shared_examples_for_provisioning_state_machine.rb
@@ -1,6 +1,7 @@
 shared_examples_for "common rhev state machine methods" do
   it "#customize_destination" do
     allow(@task).to receive(:get_provider_destination).and_return(nil)
+    allow(@task).to receive(:destination_image_locked?).and_return(false)
     allow(@task).to receive(:update_and_notify_parent)
 
     expect(@task).to receive(:configure_container)


### PR DESCRIPTION
Use OvirtSDK for the provisioning flow, this respects use_ovirt_engine_sdk setting
and will not use OvirtSDK if it is off.

~This PR is based on: https://github.com/ManageIQ/manageiq/pull/14399~
