### PR TITLE
Fix services always invisibile

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -183,15 +183,15 @@ class ServiceTemplate < ApplicationRecord
     (nh.keys - Service.column_names + %w(created_at guid service_template_id updated_at id type prov_type)).each { |key| nh.delete(key) }
 
     # Hide child services by default
-    nh[:display] = false if parent_svc
+    nh['display'] = false if parent_svc
 
     # If display is nil, set it to false
-    nh[:display] = false if nh[:display].nil?
+    nh['display'] ||= false
 
     # convert template class name to service class name by naming convention
-    nh[:type] = self.class.name.sub('Template', '')
+    nh['type'] = self.class.name.sub('Template', '')
 
-    nh[:initiator] = service_task.options[:initiator] if service_task.options[:initiator]
+    nh['initiator'] = service_task.options[:initiator] if service_task.options[:initiator]
 
     # Determine service name
     # target_name = self.get_option(:target_name)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -193,6 +193,22 @@ describe ServiceTemplate do
 
       @svc_a.create_service(sub_svc)
     end
+
+    it "should pass display attribute to created top level service" do
+      @svc_a.display = true
+      expect(@svc_a.create_service(double(:options => {:dialog => {}})).display).to eq(true)
+    end
+
+    it "should set created child service's display to false" do
+      @svc_a.display = true
+      allow(@svc_b).to receive(:add_resource!)
+      expect(@svc_a.create_service(double(:options => {:dialog => {}}), @svc_b).display).to eq(false)
+    end
+
+    it "should set created service's display to false by default" do
+      expect(@svc_a.create_service(double(:options => {:dialog => {}})).display).to eq(false)
+    end
+
     it "should return all parent services for a service" do
       add_and_save_service(@svc_a, @svc_b)
       add_and_save_service(@svc_a, @svc_c)


### PR DESCRIPTION
Fixed a bug introduced by https://github.com/ManageIQ/manageiq/pull/13800.

The existing code uses the attributes whose keys are mixed with strings and symbols. The `display` attribute was forced to set to `false` always. 

This fix eliminates the confusion by normalizing every key to string.

@miq-bot add_label bug
@miq-bot add_label automate
@miq-bot assign @gmcculloug 

cc @tinaafitz @imtayadeway 