### PR TITLE
Provider native operations state machine

### DIFF
--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -29,14 +29,52 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
   end
 
   def refresh
+    target = target_entity
+
+    task_ids = EmsRefresh.queue_refresh_task(target)
+
+    context[:refresh_task_ids] = task_ids
+    update_attributes!(:context => context)
+
     signal(:poll_refresh)
   end
 
   def poll_refresh
-    signal(:notify)
+    refresh_finished = true
+
+    context[:refresh_task_ids].each do |task_id|
+      task = MiqTask.find(task_id)
+      if task.state != MiqTask::STATE_FINISHED
+        refresh_finished = false
+        break
+      end
+    end
+
+    if refresh_finished
+      signal(:notify)
+    else
+      # TODO use queue_signal and deliver_on
+      sleep(10)
+
+      signal(:poll_refresh)
+    end
   end
 
   def notify
+    notification_options = {
+      :target_name => target_entity.name,
+      :method      => options[:method]
+    }
+
+    if status == "ok"
+      type = :provider_operation_success
+    else
+      type = :provider_operation_failure
+      notification_options[:error] = message
+    end
+
+    Notification.create(:type => type, :options => notification_options)
+
     signal(:finish)
   end
 
@@ -45,5 +83,4 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
   alias finish       process_finished
   alias abort_job    process_abort
   alias cancel       process_cancel
-  alias error        process_error
 end

--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -18,22 +18,6 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
   #       finished <---------- notifying --------------/
   #                   :finish              :notify
   #
-  def load_transitions
-    self.state ||= 'initialize'
-
-    {
-      :initializing     => {'initialize'       => 'waiting_to_start'},
-      :start            => {'waiting_to_start' => 'running'},
-      :poll_native_task => {'running'          => 'running'},
-      :refresh          => {'running'          => 'refreshing'},
-      :poll_refresh     => {'refreshing'       => 'refreshing'},
-      :notify           => {'*'                => 'notifying'},
-      :finish           => {'*'                => 'finished'},
-      :abort_job        => {'*'                => 'aborting'},
-      :cancel           => {'*'                => 'canceling'},
-      :error            => {'*'                => '*'}
-    }
-  end
 
   def run_native_op
     raise NotImplementedError, _("run_native_op must be implemented by a subclass")
@@ -126,4 +110,23 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
   alias finish       process_finished
   alias abort_job    process_abort
   alias cancel       process_cancel
+
+  protected
+
+  def load_transitions
+    self.state ||= 'initialize'
+
+    {
+      :initializing     => {'initialize'       => 'waiting_to_start'},
+      :start            => {'waiting_to_start' => 'running'},
+      :poll_native_task => {'running'          => 'running'},
+      :refresh          => {'running'          => 'refreshing'},
+      :poll_refresh     => {'refreshing'       => 'refreshing'},
+      :notify           => {'*'                => 'notifying'},
+      :finish           => {'*'                => 'finished'},
+      :abort_job        => {'*'                => 'aborting'},
+      :cancel           => {'*'                => 'canceling'},
+      :error            => {'*'                => '*'}
+    }
+  end
 end

--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -21,11 +21,11 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
   end
 
   def run_native_op
-    signal(:poll_native_task)
+    raise NotImplementedError, _("run_native_op must be implemented by a subclass")
   end
 
   def poll_native_task
-    signal(:refresh)
+    raise NotImplementedError, _("poll_native_task must be implemented by a subclass")
   end
 
   def refresh

--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -3,6 +3,21 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
     super(name, options)
   end
 
+  #
+  # State-transition diagram:
+  #
+  #    *                          /------\
+  #    | :initialize              |      |  :poll_native_task
+  #    v               :start     v      |
+  # waiting_to_start  -------> running ----------> refreshing <-\
+  #                               |     :refresh        |       | :poll_refresh
+  #                               v                     |-------/
+  #                             error <-----------------|
+  #                               |                     |
+  #                               v                     |
+  #       finished <---------- notifying --------------/
+  #                   :finish              :notify
+  #
   def load_transitions
     self.state ||= 'initialize'
 

--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -1,0 +1,20 @@
+class ManageIQ::Providers::NativeOperationWorkflow < Job
+  def load_transitions
+    self.state ||= 'initialize'
+
+    {
+      :initializing => {'initialize'       => 'waiting_to_start'},
+      :start        => {'waiting_to_start' => 'running'},
+      :finish       => {'*'                => 'finished'},
+      :abort_job    => {'*'                => 'aborting'},
+      :cancel       => {'*'                => 'canceling'},
+      :error        => {'*'                => '*'}
+    }
+  end
+
+  alias_method :initializing, :dispatch_start
+
+  def start
+    signal(:finish)
+  end
+end

--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -65,7 +65,7 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
 
     Notification.create(:type => type, :options => notification_options)
 
-    queue_signal(:finish)
+    queue_signal(:finish, message, status)
   end
 
   def queue_signal(*args, deliver_on: nil)

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -164,4 +164,13 @@
   :expires_in: 7.days
   :level: :success
   :audience: tenant
-
+- :name: provider_operation_success
+  :message: 'The operation %{method} on %{target_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: provider_operation_failure
+  :message: 'The operation %{method} on %{target_name} failed: %{error}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-native_operation_workflow.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-native_operation_workflow.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_NativeOperationWorkflow < MiqAeServiceJob
+  end
+end

--- a/spec/models/manageiq/providers/native_operation_workflow_spec.rb
+++ b/spec/models/manageiq/providers/native_operation_workflow_spec.rb
@@ -1,0 +1,180 @@
+describe ManageIQ::Providers::NativeOperationWorkflow do
+  context '.create_job' do
+    it 'leaves job waiting to start' do
+      options = {}
+      job = described_class.create_job(options)
+
+      expect(job.state).to eq('waiting_to_start')
+    end
+  end
+
+  context 'state transitions' do
+    before do
+      @job = described_class.create_job({})
+    end
+
+    context 'waiting_to_start' do
+      before do
+        @job.state = 'waiting_to_start'
+      end
+
+      it 'allows start signal' do
+        expect(@job).to receive(:start)
+        @job.signal(:start)
+      end
+
+      it 'doesn\'t allow poll_native_task signal' do
+        expect { @job.signal(:poll_native_task) }.to raise_error(RuntimeError, /poll_native_task is not permitted at state waiting_to_start/)
+      end
+
+      it 'doesn\'t allow refresh signal' do
+        expect { @job.signal(:refresh) }.to raise_error(RuntimeError, /refresh is not permitted at state waiting_to_start/)
+      end
+
+      it 'doesn\'t allow poll_refresh signal' do
+        expect { @job.signal(:poll_refresh) }.to raise_error(RuntimeError, /poll_refresh is not permitted at state waiting_to_start/)
+      end
+    end
+
+    context 'running' do
+      before do
+        @job.state = 'running'
+      end
+
+      it 'allows poll_native_task signal' do
+        expect(@job).to receive(:poll_native_task)
+        @job.signal(:poll_native_task)
+      end
+
+      it 'allows refresh signal' do
+        expect(@job).to receive(:refresh)
+        @job.signal(:refresh)
+      end
+
+      it 'doesn\'t allow start signal' do
+        expect { @job.signal(:start) }.to raise_error(RuntimeError, /start is not permitted at state running/)
+      end
+    end
+
+    context 'refreshing' do
+      before do
+        @job.state = 'refreshing'
+      end
+
+      it 'allows poll_refresh signal' do
+        expect(@job).to receive(:poll_refresh)
+        @job.signal(:poll_refresh)
+      end
+
+      it 'allows notify signal' do
+        expect(@job).to receive(:notify)
+        @job.signal(:notify)
+      end
+
+      it 'doesn\'t allow start signal' do
+        expect { @job.signal(:start) }.to raise_error(RuntimeError, /start is not permitted at state refreshing/)
+      end
+
+      it 'doesn\'t allow poll_native_task signal' do
+        expect { @job.signal(:poll_native_task) }.to raise_error(RuntimeError, /poll_native_task is not permitted at state refreshing/)
+      end
+
+      it 'doesn\'t allow refresh signal' do
+        expect { @job.signal(:refresh) }.to raise_error(RuntimeError, /refresh is not permitted at state refreshing/)
+      end
+    end
+  end
+
+  context "refresh" do
+    before do
+      vm = FactoryGirl.create(:vm)
+
+      options = {
+        :target_id    => vm.id,
+        :target_class => vm.class.name,
+      }
+
+      @job = described_class.create_job(options)
+      @job.state = 'running'
+    end
+
+    it 'sets the refresh_task_ids in the context' do
+      refresh_task = FactoryGirl.create(:miq_task)
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([refresh_task.id])
+      expect(@job).to receive(:queue_signal).with(:poll_refresh)
+
+      @job.signal(:refresh)
+
+      expect(@job.context[:refresh_task_ids]).to eq([refresh_task.id])
+    end
+
+    it 'calls error if queuing the refresh failed' do
+      expect(EmsRefresh).to receive(:queue_refresh_task).and_return(nil)
+      expect(@job).to receive(:queue_signal).with(:error, "Failed to queue refresh", "error")
+
+      @job.signal(:refresh)
+    end
+  end
+
+  context "poll_refresh" do
+    before do
+      @job = described_class.create_job({})
+      @job.state = 'refreshing'
+    end
+
+    it 'with a refresh task that is still running' do
+      refresh_task = FactoryGirl.create(:miq_task)
+      @job.context[:refresh_task_ids] = [refresh_task.id]
+
+      expect(@job).to receive(:queue_signal).with(:poll_refresh, anything)
+
+      @job.signal(:poll_refresh)
+    end
+
+    it 'with a refresh task that failed' do
+      refresh_task = FactoryGirl.create(:miq_task, :status => MiqTask::STATUS_ERROR)
+      @job.context[:refresh_task_ids] = [refresh_task.id]
+
+      expect(@job).to receive(:queue_signal).with(:error, "Refresh failed", "error")
+
+      @job.signal(:poll_refresh)
+    end
+
+    it 'with a refresh task that is still running' do
+      refresh_task = FactoryGirl.create(:miq_task, :state => MiqTask::STATE_FINISHED)
+      @job.context[:refresh_task_ids] = [refresh_task.id]
+
+      expect(@job).to receive(:queue_signal).with(:notify)
+
+      @job.signal(:poll_refresh)
+    end
+  end
+
+  context "notify" do
+    before do
+      vm = FactoryGirl.create(:vm)
+
+      options = {
+        :target_id    => vm.id,
+        :target_class => vm.class.name,
+      }
+
+      @job = described_class.create_job(options)
+      @job.state = 'refreshing'
+    end
+
+    it 'with a successful job' do
+      @job.status = "ok"
+
+      expect(Notification).to receive(:create)
+      @job.signal(:notify)
+    end
+
+    it 'with an unsuccessful job' do
+      @job.status = "error"
+
+      expect(Notification).to receive(:create)
+      @job.signal(:notify)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/native_operation_workflow_spec.rb
+++ b/spec/models/manageiq/providers/native_operation_workflow_spec.rb
@@ -110,9 +110,12 @@ describe ManageIQ::Providers::NativeOperationWorkflow do
 
     it 'calls error if queuing the refresh failed' do
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return(nil)
-      expect(@job).to receive(:queue_signal).with(:error, "Failed to queue refresh", "error")
+      expect(@job).to receive(:queue_signal).with(:notify)
 
       @job.signal(:refresh)
+
+      expect(@job.status).to  eq("error")
+      expect(@job.message).to eq("Failed to queue refresh")
     end
   end
 
@@ -135,9 +138,12 @@ describe ManageIQ::Providers::NativeOperationWorkflow do
       refresh_task = FactoryGirl.create(:miq_task, :status => MiqTask::STATUS_ERROR)
       @job.context[:refresh_task_ids] = [refresh_task.id]
 
-      expect(@job).to receive(:queue_signal).with(:error, "Refresh failed", "error")
+      expect(@job).to receive(:queue_signal).with(:notify)
 
       @job.signal(:poll_refresh)
+
+      expect(@job.status).to  eq("error")
+      expect(@job.message).to eq("Refresh failed")
     end
 
     it 'with a refresh task that is still running' do


### PR DESCRIPTION
This provides the basics for a provider extensible CRUD state machine.

The basic workflow is:
1. Run a native operation and wait for it to complete
2. Start a refresh and wait for it to complete
3. Notify the user about the operation completing successfully or failing

State transition diagram:
```
    *                          /------\
    | :initialize              |      |  :poll_native_task
    v               :start     v      |
 waiting_to_start  -------> running ----------> refreshing <-\
                               |     :refresh        |       | :poll_refresh
                               v                     |-------/
                             error <-----------------|
                               |                     |
                               v                     |
       finished <---------- notifying --------------/
                   :finish              :notify

```

Examples of a successful and an unsuccessful notification from a NativeCrud job:
![screenshot from 2017-03-21 16-29-35](https://cloud.githubusercontent.com/assets/12851112/24169360/c2d9ffdc-0e53-11e7-85b0-352500ce5f55.png)
