### PR TITLE
Remove the `providers` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /data/
 /productization
 /plugins
+/providers
 /vmdb/
 BUILD
 ca/root


### PR DESCRIPTION
The `providers` dir was accidentally added to the repo.  I'm afraid that removing the dir from the repo will  only result in it getting added back later by someone else.
    
Adding `providers` dir back to `.gitignore` to keep it from being added to the repo until everyone has moved their `providers` dir to `plugins` (the new location for `providers`).
