### PR TITLE
add_resource to Service api

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -20,14 +20,17 @@ module Api
 
     def add_resource_resource(type, id, data)
       svc = resource_search(id, type, collection_class(type))
-      data['resources'].each do |resource_ref|
-        resource_type, resource_id = parse_href(resource_ref['href'])
-        resource = resource_search(resource_id, resource_type, collection_class(resource_type))
-        raise "Cannot assign #{resource_type} to #{service_ident(svc)}" unless resource.respond_to? :add_to_service
-        resource.add_to_service(svc)
+      data['resources'].collect do |resource_ref|
+        begin
+          resource_type, resource_id = parse_href(resource_ref['href'])
+          resource = resource_search(resource_id, resource_type, collection_class(resource_type))
+          raise "Cannot assign #{resource_type} to #{service_ident(svc)}" unless resource.respond_to? :add_to_service
+          resource.add_to_service(svc)
+          action_result(true, "Assigned resource #{resource_type} id:#{resource_id} to #{service_ident(svc)}")
+        rescue => err
+          action_result(false, err.to_s)
+        end
       end
-      svc.save!
-      action_result(true, "Assigned resources to #{service_ident(svc)}")
     rescue => err
       action_result(false, err.to_s)
     end

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -23,7 +23,8 @@ module Api
       data['resources'].each do |resource_ref|
         resource_type, resource_id = parse_href(resource_ref['href'])
         resource = resource_search(resource_id, resource_type, collection_class(resource_type))
-        svc.add_resource(resource)
+        raise "Cannot assign #{resource_type} to #{service_ident(svc)}" unless resource.respond_to? :add_to_service
+        resource.add_to_service(svc)
       end
       svc.save!
       action_result(true, "Assigned resources to #{service_ident(svc)}")

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -18,6 +18,19 @@ module Api
       super(type, id, attributes)
     end
 
+    def add_resource_resource(type, id, data)
+      svc = resource_search(id, type, collection_class(type))
+      data['resources'].each do |resource_ref|
+        resource_type, resource_id = parse_href(resource_ref['href'])
+        resource = resource_search(resource_id, resource_type, collection_class(resource_type))
+        svc.add_resource(resource)
+      end
+      svc.save!
+      action_result(true, "Assigned resources to #{service_ident(svc)}")
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def reconfigure_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -1936,6 +1936,8 @@
         :identifier: service_admin
       - :name: delete
         :identifier: service_delete
+      - :name: add_resource
+        :identifier: service_edit
       :delete:
       - :name: delete
         :identifier: service_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -1911,6 +1911,8 @@
         :identifier: service_tag
       - :name: unassign_tags
         :identifier: service_tag
+      - :name: add_resource
+        :identifier: service_edit
     :resource_actions:
       :get:
       - :name: read
@@ -1934,6 +1936,8 @@
         :identifier: service_admin
       - :name: delete
         :identifier: service_delete
+      - :name: add_resource
+        :identifier: service_edit
       :delete:
       - :name: delete
         :identifier: service_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -1936,8 +1936,6 @@
         :identifier: service_admin
       - :name: delete
         :identifier: service_delete
-      - :name: add_resource
-        :identifier: service_edit
       :delete:
       - :name: delete
         :identifier: service_delete

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -75,7 +75,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource))
     end
   end
 
@@ -91,7 +91,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource))
     end
 
     it "supports the custom_actions attribute" do

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -75,7 +75,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit))
     end
   end
 
@@ -91,7 +91,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3))
     end
 
     it "supports the custom_actions attribute" do

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -671,15 +671,14 @@ describe "Services API" do
   describe 'add_resource' do
     let(:vm1) { FactoryGirl.create(:vm_vmware) }
     let(:vm2) { FactoryGirl.create(:vm_vmware) }
-    let(:vm3) { FactoryGirl.create(:vm_vmware) }
 
-    it 'can add multiple vms to multiple services by href with an appropriate role' do
+    it 'can add vm to services by href with an appropriate role' do
       api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => services_url(svc.id), 'resources' => [{'href' => vms_url(vm1.id)}, {'href' => vms_url(vm2.id)}] },
-          { 'href' => services_url(svc1.id), 'resources' => [{'href' => vms_url(vm3.id)}] }
+          { 'href' => services_url(svc.id), 'resource' => {'href' => vms_url(vm1.id)} },
+          { 'href' => services_url(svc1.id), 'resource' => {'href' => vms_url(vm2.id)} }
         ]
       }
 
@@ -688,15 +687,14 @@ describe "Services API" do
       expected = {
         'results' => [
           { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"},
-          { 'success' => true, 'message' => "Assigned resource vms id:#{vm2.id} to Service id:#{svc.id} name:'#{svc.name}'"},
-          { 'success' => true, 'message' => "Assigned resource vms id:#{vm3.id} to Service id:#{svc1.id} name:'#{svc1.name}'"}
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm2.id} to Service id:#{svc1.id} name:'#{svc1.name}'"}
         ]
       }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq(expected)
-      expect(svc.reload.vms).to eq([vm1, vm2])
-      expect(svc1.reload.vms).to eq([vm3])
+      expect(svc.reload.vms).to eq([vm1])
+      expect(svc1.reload.vms).to eq([vm2])
     end
 
     it 'returns individual success and failures' do
@@ -705,8 +703,8 @@ describe "Services API" do
       request = {
         'action'    => 'add_resource',
         'resources' => [
-          { 'href' => services_url(svc.id), 'resources' => [{'href' => vms_url(vm1.id)}, {'href' => users_url(user.id)}] },
-          { 'href' => services_url(svc1.id), 'resources' => [{'href' => vms_url(vm3.id)}] }
+          { 'href' => services_url(svc.id), 'resource' => {'href' => vms_url(vm1.id)} },
+          { 'href' => services_url(svc1.id), 'resource' => {'href' => users_url(user.id)} }
         ]
       }
 
@@ -715,15 +713,75 @@ describe "Services API" do
       expected = {
         'results' => [
           { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"},
-          { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"},
-          { 'success' => true, 'message' => "Assigned resource vms id:#{vm3.id} to Service id:#{svc1.id} name:'#{svc1.name}'"}
+          { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc1.id} name:'#{svc1.name}'"}
         ]
       }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq(expected)
       expect(svc.reload.vms).to eq([vm1])
-      expect(svc1.reload.vms).to eq([vm3])
+    end
+
+    it 'requires a valid resource' do
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'   => 'add_resource',
+        'resource' => { 'resource' => { 'href' => '1' } }
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = { 'success' => false, 'message' => "Invalid resource href specified 1"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+    end
+
+    it 'requires the resource to respond to add_to_service' do
+      user = FactoryGirl.create(:user)
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'   => 'add_resource',
+        'resource' => { 'resource' => { 'href' => users_url(user.id) } }
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+    end
+
+    it 'requires a resource reference' do
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'   => 'add_resource',
+        'resource' => { 'resource' => {} }
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = { 'success' => false, 'message' => "Must specify a resource reference"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+    end
+
+    it 'can add a vm to a resource with appropriate role' do
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'   => 'add_resource',
+        'resource' => { 'resource' => {'href' => vms_url(vm1.id)} }
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"}
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+      expect(svc.reload.vms).to eq([vm1])
     end
 
     it 'cannot add multiple vms to multiple services by href without an appropriate role' do

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -673,37 +673,8 @@ describe "Services API" do
     let(:vm2) { FactoryGirl.create(:vm_vmware) }
     let(:vm3) { FactoryGirl.create(:vm_vmware) }
 
-    it 'can add multiple vms by href with an appropriate role' do
-      api_basic_authorize(action_identifier(:services, :add_resource))
-      request = {
-        'action'    => 'add_resource',
-        'resources' => [
-          { 'href' => vms_url(vm1.id) },
-          { 'href' => vms_url(vm2.id) }
-        ]
-      }
-
-      run_post(services_url(svc.id), request)
-
-      expected = {
-        'success' => true,
-        'message' => "Assigned resources to Service id:#{svc.id} name:'#{svc.name}'"
-      }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq(expected)
-      expect(svc.reload.vms).to eq([vm1, vm2])
-    end
-
-    it 'cannot add multiple vms by href without an appropriate role' do
-      api_basic_authorize
-
-      run_post(services_url(svc.id), 'action' => 'add_resource')
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
     it 'can add multiple vms to multiple services by href with an appropriate role' do
-      api_basic_authorize(action_identifier(:services, :add_resource))
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
       request = {
         'action'    => 'add_resource',
         'resources' => [
@@ -716,13 +687,42 @@ describe "Services API" do
 
       expected = {
         'results' => [
-          { 'success' => true, 'message' => "Assigned resources to Service id:#{svc.id} name:'#{svc.name}'"},
-          { 'success' => true, 'message' => "Assigned resources to Service id:#{svc1.id} name:'#{svc1.name}'"}
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"},
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm2.id} to Service id:#{svc.id} name:'#{svc.name}'"},
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm3.id} to Service id:#{svc1.id} name:'#{svc1.name}'"}
         ]
       }
+
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq(expected)
       expect(svc.reload.vms).to eq([vm1, vm2])
+      expect(svc1.reload.vms).to eq([vm3])
+    end
+
+    it 'returns individual success and failures' do
+      user = FactoryGirl.create(:user)
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'    => 'add_resource',
+        'resources' => [
+          { 'href' => services_url(svc.id), 'resources' => [{'href' => vms_url(vm1.id)}, {'href' => users_url(user.id)}] },
+          { 'href' => services_url(svc1.id), 'resources' => [{'href' => vms_url(vm3.id)}] }
+        ]
+      }
+
+      run_post(services_url, request)
+
+      expected = {
+        'results' => [
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm1.id} to Service id:#{svc.id} name:'#{svc.name}'"},
+          { 'success' => false, 'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"},
+          { 'success' => true, 'message' => "Assigned resource vms id:#{vm3.id} to Service id:#{svc1.id} name:'#{svc1.name}'"}
+        ]
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+      expect(svc.reload.vms).to eq([vm1])
       expect(svc1.reload.vms).to eq([vm3])
     end
 
@@ -732,26 +732,6 @@ describe "Services API" do
       run_post(services_url, 'action' => 'add_resource')
 
       expect(response).to have_http_status(:forbidden)
-    end
-
-    it 'raises an error if the service cannot be added' do
-      user = FactoryGirl.create(:user)
-      api_basic_authorize(action_identifier(:services, :add_resource))
-      request = {
-        'action'    => 'add_resource',
-        'resources' => [
-          { 'href' => users_url(user.id) }
-        ]
-      }
-
-      run_post(services_url(svc.id), request)
-
-      expected = {
-        'success' => false,
-        'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"
-      }
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq(expected)
     end
   end
 end

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -733,5 +733,25 @@ describe "Services API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'raises an error if the service cannot be added' do
+      user = FactoryGirl.create(:user)
+      api_basic_authorize(action_identifier(:services, :add_resource))
+      request = {
+        'action'    => 'add_resource',
+        'resources' => [
+          { 'href' => users_url(user.id) }
+        ]
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = {
+        'success' => false,
+        'message' => "Cannot assign users to Service id:#{svc.id} name:'#{svc.name}'"
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Adds "add_resource" action to Service resources
```
POST /api/services
{
  "action" : "add_resource",
  "resources" : [
    { "href": "http://localhost:3000/api/services/1" , "resources" : [ {"href" : "http://localhost:3000/api/vms/11" }, { "href" : "http://localhost:3000/api/vms/12" } ],
    {  "href": "http://localhost:3000/api/services/1" , "resources" : [ {"href" : "http://localhost:3000/api/vms/11" }, { "href" : "http://localhost:3000/api/vms/12" } ]}
    ...
  ]
}
```

https://www.pivotaltracker.com/story/show/142057167

@miq-bot add_label enhancement, api, service
@miq-bot assign @abellotti 
cc: @mkanoor 
