### PR TITLE
[DARGA] Call changeAuthTab from more miq_tab_header()s

### DIFF
--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -5,29 +5,29 @@
   %h3
     = legendtext
   %ul.nav.nav-tabs
-    = miq_tab_header('default') do
+    = miq_tab_header('default', nil, {'ng-click' => "changeAuthTab('default')"}) do
       %i{"error-on-tab" => "default", :style => "color:#cc0000"}
       = _("Default")
     - if %w(ems_cloud ems_infra).include?(controller_name)
-      = miq_tab_header('metrics') do
+      = miq_tab_header('metrics', nil, {'ng-click' => "changeAuthTab('metrics')"}) do
         %i{"error-on-tab" => "metrics", :style => "color:#cc0000"}
         = _("C & U Database")
-      = miq_tab_header('amqp') do
+      = miq_tab_header('amqp', nil, {'ng-click' => "changeAuthTab('amqp')"}) do
         %i{"error-on-tab" => "amqp", :style => "color:#cc0000"}
         = _("Events")
-      = miq_tab_header('ssh_keypair') do
+      = miq_tab_header('ssh_keypair', nil, {'ng-click' => "changeAuthTab('ssh_keypair')"}) do
         %i{"error-on-tab" => "ssh_keypair", :style => "color:#cc0000"}
         = _("RSA key pair")
     - elsif controller_name == "ems_container"
-      = miq_tab_header('hawkular') do
+      = miq_tab_header('hawkular', nil, {'ng-click' => "changeAuthTab('hawkular')"}) do
         %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
         = _("Hawkular")
     - else
-      = miq_tab_header('remote') do
+      = miq_tab_header('remote', nil, {'ng-click' => "changeAuthTab('remote')"}) do
         = _("Remote Login")
-      = miq_tab_header('ws') do
+      = miq_tab_header('ws', nil, {'ng-click' => "changeAuthTab('ws')"}) do
         = _("Web Services")
-      = miq_tab_header('ipmi') do
+      = miq_tab_header('ipmi', nil, {'ng-click' => "changeAuthTab('ipmi')"}) do
         = _("IPMI")
 
   .tab-content


### PR DESCRIPTION
@simaishi For your convenience.  ManageIQ/manageiq-ui-classic#706 changes actually apply cleanly, but there was one `else`/`elsif` change in an adjusted line, at least `patch` was unhappy (not sure about `git cherry-pick`, I'm not skilled enough with it across repos :wink:).
Tested carefully.

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1434848 (darga)
clone of https://bugzilla.redhat.com/show_bug.cgi?id=1434064 (master)

----

Call changeAuthTab from more miq_tab_header()s

miq_tab_header() once did this automatically, that was disabled by
https://github.com/ManageIQ/manageiq-ui-classic/commit/2b1da75e4d389b1212f3db1b2885016a047846ee
[backported to darga as commit e66e26ae5f228353f227dbc15c1363cf4c8fcdf0 in #13471]
and explicit ng-click was added to some tab headers but not all,
this adds some more.
