### PR TITLE
[EUWE] Display the same services in the tree as in the right-side list

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -21,7 +21,7 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    all_services = Rbac.filtered(Service.where(:display => true))
+    all_services = Rbac.filtered(Service.where(:ancestry => [nil, ""]))
     if count_only
       all_services.size
     else

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -5,16 +5,11 @@ describe TreeBuilderServices do
     create_deep_tree
 
     expect(root_nodes).to eq(
-      @service => {
-        @service_c1 => {
-          @service_c11 => {},
-          @service_c12 => {
-            @service_c121 => {}
-          }
-        },
-        @service_c2 => {}
-      }
-    )
+      @service => {},
+      @service_c1 => {},
+      @service_c2 => {},
+      @service_c3 => {}
+      )
   end
 
   private
@@ -29,12 +24,11 @@ describe TreeBuilderServices do
 
   def create_deep_tree
     @service      = FactoryGirl.create(:service, :display => true)
-    @service_c1   = FactoryGirl.create(:service, :service => @service, :display => true)
+    @service_c1   = FactoryGirl.create(:service, :display => true)
     @service_c11  = FactoryGirl.create(:service, :service => @service_c1, :display => true)
     @service_c12  = FactoryGirl.create(:service, :service => @service_c1, :display => true)
     @service_c121 = FactoryGirl.create(:service, :service => @service_c12, :display => true)
-    @service_c2   = FactoryGirl.create(:service, :service => @service, :display => true)
-    # hidden
-    @service_c3   = FactoryGirl.create(:service, :service => @service, :display => false)
+    @service_c2   = FactoryGirl.create(:service, :display => true)
+    @service_c3   = FactoryGirl.create(:service, :display => false)
   end
 end


### PR DESCRIPTION
Display all services in the tree that are now displayed in the right-side list: services with no ancestry, regardless of the display field value,.
Links

https://bugzilla.redhat.com/show_bug.cgi?id=1431271

![screenshot from 2017-03-20 14-50-38](https://cloud.githubusercontent.com/assets/12769982/24116269/9d17647e-0d7c-11e7-81c7-847b617cf0cd.png)
