### PR TITLE
Remove MiqQueue rows containing a class removed in Rails 5.

### DIFF
--- a/db/migrate/20170320195659_remove_oid_integer_args_from_miq_queue.rb
+++ b/db/migrate/20170320195659_remove_oid_integer_args_from_miq_queue.rb
@@ -1,0 +1,8 @@
+class RemoveOidIntegerArgsFromMiqQueue < ActiveRecord::Migration[5.0]
+  class MiqQueue < ActiveRecord::Base; end
+  def up
+    say_with_time("Removing MiqQueue rows with args column values containing a class removed from Rails 5: PostgreSQL::OID::Integer.") do
+      MiqQueue.where("args LIKE '%PostgreSQL::OID::Integer%'").delete_all
+    end
+  end
+end

--- a/spec/migrations/20170320195659_remove_oid_integer_args_from_miq_queue_spec.rb
+++ b/spec/migrations/20170320195659_remove_oid_integer_args_from_miq_queue_spec.rb
@@ -1,0 +1,27 @@
+require_migration
+
+describe RemoveOidIntegerArgsFromMiqQueue do
+  let(:queue_stub) { migration_stub(:MiqQueue) }
+
+  migration_context :up do
+    it 'deletes rows with PostgreSQL::OID:Integer class serialized in args' do
+      args = <<-EOS
+---
+- !ruby/object:ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer
+    precision:
+    scale:
+    limit: 8
+    range: !ruby/range
+      begin: -9223372036854775808
+      end: 9223372036854775808
+      excl: true
+EOS
+      queue_stub.create(:state => "ready", :args => args)
+      queue_stub.create(:state => "ready", :method_name => "stuff")
+      migrate
+
+      expect(queue_stub.count).to eq(1)
+      expect(queue_stub.where(:method_name => "stuff").count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1434454

The PostgreSQL::OID::Integer class was removed in:
rails/rails@aafee23

It's possible that old Rails 4.2 versions of objects could have been
serialized in the MiqQueue in the args column and we won't be able to
deserialize them with Rails 5+, so we need to remove these rows.

Related to ManageIQ#14365
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1429747