### PR TITLE
Fix spec tests for ConfigurationScript

### DIFF
--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_spec.rb
@@ -1,5 +1,9 @@
 require 'support/ansible_shared/automation_manager/configuration_script'
 
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript do
+  let(:provider_with_authentication)       { FactoryGirl.create(:provider_ansible_tower, :with_authentication) }
+  let(:manager_with_authentication)        { provider_with_authentication.managers.first }
+  let(:manager_with_configuration_scripts) { FactoryGirl.create(:automation_manager_ansible_tower, :provider, :configuration_script) }
+
   it_behaves_like 'ansible configuration_script'
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -1,5 +1,9 @@
 require 'support/ansible_shared/automation_manager/configuration_script'
 
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript do
+  let(:provider_with_authentication)       { FactoryGirl.create(:provider_embedded_ansible, :with_authentication) }
+  let(:manager_with_authentication)        { provider_with_authentication.managers.first }
+  let(:manager_with_configuration_scripts) { FactoryGirl.create(:embedded_automation_manager_ansible, :provider, :configuration_script) }
+
   it_behaves_like 'ansible configuration_script'
 end

--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -6,9 +6,9 @@ shared_examples_for "ansible configuration_script" do
   let(:connection)   { double(:connection, :api => api) }
   let(:job)          { AnsibleTowerClient::Job.new(connection.api, "id" => 1) }
   let(:job_template) { AnsibleTowerClient::JobTemplate.new(connection.api, "limit" => "", "id" => 1, "url" => "api/job_templates/1/", "name" => "template", "description" => "description", "extra_vars" => {:instance_ids => ['i-3434']}) }
-  let(:manager)      { FactoryGirl.create(:automation_manager_ansible_tower, :provider, :configuration_script) }
+  let(:manager)      { manager_with_configuration_scripts }
 
-  it "belongs_to the Ansible Tower manager" do
+  it "belongs_to the manager" do
     expect(manager.configuration_scripts.size).to eq 1
     expect(manager.configuration_scripts.first.variables).to eq :instance_ids => ['i-3434']
     expect(manager.configuration_scripts.first).to be_a ConfigurationScript
@@ -85,12 +85,11 @@ shared_examples_for "ansible configuration_script" do
   end
 
   context "creates via the API" do
-    let(:provider)      { FactoryGirl.create(:provider_ansible_tower, :with_authentication) }
-    let(:manager)       { provider.managers.first }
     let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
     let(:api)           { double("AnsibleTowerClient::Api", :job_templates => job_templates) }
     let(:job_templates) { double("AnsibleTowerClient::Collection", :create! => job_template) }
     let(:job_template)  { AnsibleTowerClient::JobTemplate.new(nil, job_template_json) }
+    let(:manager)       { manager_with_authentication }
 
     let(:job_template_json) do
       params.merge(


### PR DESCRIPTION
Also fix spec tests that need to distinguish AnsibleTower from EmbeddedAnsible.

https://www.pivotaltracker.com/story/show/140972197

@miq-bot add_label enhancement
@miq-bot add_label providers/ansible_tower
@miq-bot add_label euwe/no
@miq-bot assign @gmcculloug 

cc @bdunne @jameswnl 

UPDATE:
The playbook and job_template association will be addressed by #14432 
The PR will remain to fix spec tests for AnsibleTower and EmbeddedAnsible's ConfigurationScript. Modified the PR title accordingly.