### PR TITLE
Added test to make sure none of our tables include an href or href_slug attribute

### DIFF
--- a/spec/replication/util/api_attributes_spec.rb
+++ b/spec/replication/util/api_attributes_spec.rb
@@ -1,0 +1,33 @@
+describe "all tables" do
+  let(:connection) { ApplicationRecord.connection }
+
+  it "do not have an attribute called href" do
+    href_tables = []
+    connection.tables.each do |t|
+      next if %w(schema_migrations ar_internal_metadata).include?(t)
+      href_tables << t if connection.columns(t).collect(&:name).include?("href")
+    end
+    expect(href_tables.size).to eq(0), <<-EOS.gsub!(/^ +/, "")
+      Attribute "href" was found for the following table(s):
+
+      #{href_tables.join("\n")}
+
+      The "href" attribute is reserved for the ManageIQ API.
+    EOS
+  end
+
+  it "do not have an attribute called href_slug" do
+    href_slug_tables = []
+    connection.tables.each do |t|
+      next if %w(schema_migrations ar_internal_metadata).include?(t)
+      href_slug_tables << t if connection.columns(t).collect(&:name).include?("href_slug")
+    end
+    expect(href_slug_tables.size).to eq(0), <<-EOS.gsub!(/^ +/, "")
+      Attribute "href_slug" was found for the following table(s):
+
+      #{href_slug_tables.join("\n")}
+
+      The "href_slug" attribute is reserved for ManageIQ API.
+    EOS
+  end
+end

--- a/spec/replication/util/api_attributes_spec.rb
+++ b/spec/replication/util/api_attributes_spec.rb
@@ -1,33 +1,27 @@
 describe "all tables" do
   let(:connection) { ApplicationRecord.connection }
 
+  def api_invalid_tables_message(invalid_tables, attr)
+    <<-EOS
+Attribute "#{attr}" was found for the following tables(s):
+
+#{invalid_tables.join("\n")}
+
+The "#{attr}" attribute is reserved for the ManageIQ API.
+EOS
+  end
+
   it "do not have an attribute called href" do
-    href_tables = []
-    connection.tables.each do |t|
-      next if %w(schema_migrations ar_internal_metadata).include?(t)
-      href_tables << t if connection.columns(t).collect(&:name).include?("href")
+    href_tables = connection.tables.select do |t|
+      !%w(schema_migrations ar_internal_metadata).include?(t) && connection.columns(t).any? { |c| c.name == "href" }
     end
-    expect(href_tables.size).to eq(0), <<-EOS.gsub!(/^ +/, "")
-      Attribute "href" was found for the following table(s):
-
-      #{href_tables.join("\n")}
-
-      The "href" attribute is reserved for the ManageIQ API.
-    EOS
+    expect(href_tables.size).to eq(0), api_invalid_tables_message(href_tables, "href")
   end
 
   it "do not have an attribute called href_slug" do
-    href_slug_tables = []
-    connection.tables.each do |t|
-      next if %w(schema_migrations ar_internal_metadata).include?(t)
-      href_slug_tables << t if connection.columns(t).collect(&:name).include?("href_slug")
+    href_slug_tables = connection.tables.select do |t|
+      !%w(schema_migrations ar_internal_metadata).include?(t) && connection.columns(t).any? { |c| c.name == "href_slug" }
     end
-    expect(href_slug_tables.size).to eq(0), <<-EOS.gsub!(/^ +/, "")
-      Attribute "href_slug" was found for the following table(s):
-
-      #{href_slug_tables.join("\n")}
-
-      The "href_slug" attribute is reserved for ManageIQ API.
-    EOS
+    expect(href_slug_tables.size).to eq(0), api_invalid_tables_message(href_slug_tables, "href_slug")
   end
 end


### PR DESCRIPTION
Added a replication test to make sure none of our tables include either an "href" or "href_slug" attribute as they are reserved for the API.
