### PR TITLE
Do not use Job.agent name attribute

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -174,7 +174,6 @@ class JobProxyDispatcher
   def assign_proxy_to_job(proxy, job)
     job.agent_id        = proxy.id
     job.miq_server_id   = proxy.id
-    job.agent_name      = proxy.name
     job.started_on      = Time.now.utc
     job.dispatch_status = "active"
     job.save

--- a/product/views/Job.yaml
+++ b/product/views/Job.yaml
@@ -27,13 +27,15 @@ cols:
 - message
 - name
 - userid
-- agent_name
 - agent_message
 - target_class
 - target_id
 
 # Included tables (joined, has_one, has_many) and columns
 include:
+  miq_server:
+    columns:
+    - name
 
 # Order of columns (from all tables)
 col_order:
@@ -44,7 +46,7 @@ col_order:
 - message
 - name
 - userid
-- agent_name
+- miq_server.name
 - agent_message
 
 # Column titles, in order


### PR DESCRIPTION
Part of ManageIQ/manageiq#14030 - merging `MiqTask` and `Job`.

Agent is instance of `MiqServer` and instead of duplicating `MiqServer#name` in `jobs.agent_name` we can use `MiqServer#name` directly

This PR:
- removes references to the `jobs.agent_name`
- modifies `Job.yaml` to show in UI `miq_servers.name` instead of `jobs.agent_name`

BEFORE and AFTER looks the same in UI:

<img width="1124" alt="screen shot 2017-03-21 at 9 56 42 am" src="https://cloud.githubusercontent.com/assets/6556758/24151131/38517afa-0e1e-11e7-8cb0-1982a9419958.png">

@miq-bot add-label core, refactoring

\cc @martinpovolny  @Fryguy 