### PR TITLE
Add policy checking for request_host_scan.

### DIFF
--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -622,4 +622,34 @@ describe Host do
       expect(Host.non_clustered).to eq([host])
     end
   end
+
+  describe "#scan" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @host = FactoryGirl.create(:host_vmware)
+      FactoryGirl.create(:miq_event_definition, :name => :request_host_scan)
+      # admin user is needed to process Events
+      User.super_admin || FactoryGirl.create(:user_with_group, :userid => "admin")
+    end
+
+    it "policy passes" do
+      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Host).to receive(:scan_queue)
+
+      allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+      @host.scan
+      status, message, result = MiqQueue.first.deliver
+      MiqQueue.first.delivered(status, message, result)
+    end
+
+    it "policy prevented" do
+      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Host).to_not receive(:scan_queue)
+
+      event = {:attributes => {"full_data" => {:policy => {:prevented => true}}}}
+      allow_any_instance_of(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:get_obj_from_path).with("/").and_return(:event_stream => event)
+      allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+      @host.scan
+      status, message, _result = MiqQueue.first.deliver
+      MiqQueue.first.delivered(status, message, MiqAeEngine::MiqAeWorkspaceRuntime.new)
+    end
+  end
 end


### PR DESCRIPTION
All events are sent to automate for processing since [Event Switchboard PR](https://github.com/ManageIQ/manageiq/pull/4328).
Since then the policy checking for prevent action has changed from a sync process to an async process.

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, control, darga/yes, euwe/yes