### PR TITLE
Remove the policy checking for request_host_vmotion_enabled.

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -487,7 +487,7 @@ class Host < ApplicationRecord
   def vmotion_enabled?
     msg = validate_vmotion_enabled?
     if msg[:available] && respond_to?(:vim_vmotion_enabled?)
-      check_policy_prevent("request_host_vmotion_enabled", "vim_vmotion_enabled?")
+      vim_vmotion_enabled?
     else
       _log.warn("Cannot check if vmotion is enabled because <#{msg[:message]}>")
     end


### PR DESCRIPTION
There are events ```request_host_enable_vmotion``` and ```request_host_disable_vmotion``` defined in db/fixtures/miq_event_definitions.csv.
But ```request_host_vmotion_enabled``` is not a defined event.

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, control, darga/yes, euwe/yes