### PR TITLE
ansible refresh job_template -> playbook connection

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -33,7 +33,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
       inventory_object.variables = job_template.extra_vars_hash
       inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
       inventory_object.parent = persister.configuration_script_payloads.lazy_find(
-        "#{job_template.project_id}__#{job_template.playbook}"
+        :configuration_script_source => job_template.project_id,
+        :manager_ref                 => job_template.playbook
       )
 
       inventory_object.authentications = []

--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -32,6 +32,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
       inventory_object.survey_spec = job_template.survey_spec_hash
       inventory_object.variables = job_template.extra_vars_hash
       inventory_object.inventory_root_group = persister.inventory_root_groups.lazy_find(job_template.inventory_id.to_s)
+      inventory_object.parent = persister.configuration_script_payloads.lazy_find(
+        "#{job_template.project_id}__#{job_template.playbook}"
+      )
 
       inventory_object.authentications = []
       %w(credential_id cloud_credential_id network_credential_id).each do |credential_attr|

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -18,7 +18,7 @@ module ManagerRefresh::Inventory::Core
       has_inventory({
         :model_class                 => ::ConfigurationScript,
         :manager_ref                 => [:manager_ref],
-        :inventory_object_attributes => %i(name description survey_spec variables inventory_root_group authentications),
+        :inventory_object_attributes => %i(name description survey_spec variables inventory_root_group authentications parent),
       }.merge(options))
     end
 

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -441,7 +441,7 @@ module ManagerRefresh
       when :local_db_find_missing_references
         data_index[manager_uuid] || find_in_db(manager_uuid)
       else
-        data_index[manager_uuid]
+        manager_uuid.kind_of?(Hash) ? find_by(manager_uuid) : data_index[manager_uuid]
       end
     end
 

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -151,6 +151,8 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :variables   => {'abc' => 123},
     )
     expect(expected_configuration_script.inventory_root_group).to have_attributes(:ems_ref => "2")
+    expect(expected_configuration_script.parent.name).to eq('hello_world.yml')
+    expect(expected_configuration_script.parent.configuration_script_source.manager_ref).to eq('37')
   end
 
   def assert_configuration_script_with_survey_spec

--- a/spec/support/ansible_shared/automation_manager/refresher_v2.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher_v2.rb
@@ -108,6 +108,8 @@ shared_examples_for "ansible refresher_v2" do |ansible_provider, manager_class, 
       :variables   => {'abc' => 123},
     )
     expect(expected_configuration_script.inventory_root_group).to have_attributes(:ems_ref => "2")
+    expect(expected_configuration_script.parent.name).to eq('language_features/group_commands.yml')
+    expect(expected_configuration_script.parent.configuration_script_source.manager_ref).to eq('75')
   end
 
   def assert_configuration_script_with_survey_spec


### PR DESCRIPTION
attaches Playbook (ConfigurationScriptPayload) to JobTemplate (ConfigurationScript) via `.parent` during refresh

do what https://github.com/ManageIQ/manageiq/pull/14419 did in refresh
