### PR TITLE
Remove method MiqPolicy#action_result_for_event

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -103,11 +103,6 @@ class MiqPolicy < ApplicationRecord
     end.compact
   end
 
-  def action_result_for_event(action, event)
-    pe = miq_policy_contents.find_by(:miq_action => action, :miq_event_definition => event)
-    pe.qualifier == "success"
-  end
-
   def delete_event(event)
     MiqPolicyContent.where(:miq_policy => self, :miq_event_definition => event).destroy_all
   end

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -139,12 +139,6 @@ describe MiqPolicy do
       end
     end
 
-    describe "#action_result_for_event" do
-      it "finds the action result to be true or false" do
-        expect(policy.action_result_for_event(action, event)).to be true
-      end
-    end
-
     describe "#copy, .clean_attrs" do
       it "creates new instance based on the existing one" do
         new_policy = policy.copy(:name => 'newname', :description => 'newdesc')


### PR DESCRIPTION
Removing the method as we don't use it anymore - the last usage of the method was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/754

Marking the PR as WIP - as we need to merge the PR from manageiq-ui-classic first.
