### PR TITLE
Map Amazon labels to tags

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -188,9 +188,13 @@ module EmsRefresh::SaveInventory
   #
   # {:category_tag_id=>139, :entry_name=>"foo", :entry_description=>"bar"}
   #
+  # The +hash+ argument can either be a Hash, in which case the argument should
+  # have a single :tags key, or a simple Array of hashes.
+  #
   def save_tags_inventory(object, hash, _target = nil)
     return if hash.blank?
-    ContainerLabelTagMapping.retag_entity(object, hash[:tags])
+    tags = hash.is_a?(Hash) ? hash[:tags] : hash
+    ContainerLabelTagMapping.retag_entity(object, tags)
   rescue => err
     raise if EmsRefresh.debug_failures
     _log.error("Auto-tagging failed on #{object.class} [#{object.name}] with error [#{err}].")

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -188,12 +188,8 @@ module EmsRefresh::SaveInventory
   #
   # {:category_tag_id=>139, :entry_name=>"foo", :entry_description=>"bar"}
   #
-  # For now, the object must be a VmOrTemplate object.
-  #
-  def save_tags_inventory(object, hash)
+  def save_tags_inventory(object, hash, _target = nil)
     return if hash.blank?
-    return unless object.kind_of?(VmOrTemplate)
-
     ContainerLabelTagMapping.retag_entity(object, hash[:tags])
   rescue => err
     raise if EmsRefresh.debug_failures

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -182,18 +182,18 @@ module EmsRefresh::SaveInventory
   end
 
   # Convert all mapped hashes into actual tags and associate them with the object.
-  # The hash[:tags] object should be an array of hashes, probably created by
-  # the ContainerLabelTagMapping.map_labels method. Each hash in the array should
-  # have the following basic structure:
+  # The collection or collection[:tags] object should be an array of hashes, probably
+  # created by the ContainerLabelTagMapping.map_labels method. Each hash in the array
+  # should have the following basic structure:
   #
   # {:category_tag_id=>139, :entry_name=>"foo", :entry_description=>"bar"}
   #
-  # The +hash+ argument can either be a Hash, in which case the argument should
-  # have a single :tags key, or a simple Array of hashes.
+  # The +collection+ argument can either be a Hash, in which case the argument
+  # should have a single :tags key, or a simple Array of hashes.
   #
-  def save_tags_inventory(object, hash, _target = nil)
-    return if hash.blank?
-    tags = hash.is_a?(Hash) ? hash[:tags] : hash
+  def save_tags_inventory(object, collection, _target = nil)
+    return if collection.blank?
+    tags = collection.is_a?(Hash) ? collection[:tags] : collection
     ContainerLabelTagMapping.retag_entity(object, tags)
   rescue => err
     raise if EmsRefresh.debug_failures

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -193,7 +193,7 @@ module EmsRefresh::SaveInventory
   #
   def save_tags_inventory(object, collection, _target = nil)
     return if collection.blank?
-    tags = collection.is_a?(Hash) ? collection[:tags] : collection
+    tags = collection.kind_of?(Hash) ? collection[:tags] : collection
     ContainerLabelTagMapping.retag_entity(object, tags)
   rescue => err
     raise if EmsRefresh.debug_failures

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -230,7 +230,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_node_id] = h.fetch_path(:container_node, :id)
       h[:container_replicator_id] = h.fetch_path(:container_replicator, :id)
       h[:container_project_id] = h.fetch_path(:project, :id)
-      h[:container_build_pod_id] = ems.container_build_pods.find_by(:name => 
+      h[:container_build_pod_id] = ems.container_build_pods.find_by(:name =>
         h[:build_pod_name]).try(:id)
     end
 
@@ -422,16 +422,6 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_docker_labels_inventory(entity, hashes, target = nil)
     save_custom_attribute_attribute_inventory(entity, :docker_labels, hashes, target)
-  end
-
-  def save_tags_inventory(entity, hashes, _target = nil)
-    return if hashes.nil?
-
-    ContainerLabelTagMapping.retag_entity(entity, hashes) # Keeps user-assigned tags.
-  rescue => err
-    raise if EmsRefresh.debug_failures
-    _log.error("Auto-tagging failed on #{entity.class} [#{entity.name}] with error [#{err}].")
-    _log.log_backtrace(err)
   end
 
   def save_selector_parts_inventory(entity, hashes, target = nil)

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -230,8 +230,7 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_node_id] = h.fetch_path(:container_node, :id)
       h[:container_replicator_id] = h.fetch_path(:container_replicator, :id)
       h[:container_project_id] = h.fetch_path(:project, :id)
-      h[:container_build_pod_id] = ems.container_build_pods.find_by(:name =>
-        h[:build_pod_name]).try(:id)
+      h[:container_build_pod_id] = ems.container_build_pods.find_by(:name => h[:build_pod_name]).try(:id)
     end
 
     save_inventory_multi(ems.container_groups, hashes, deletes, [:ems_ref],

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -20,8 +20,8 @@ context "save_tags_inventory" do
   # creation here, the assumption is that these were the generated mappings.
   #
   let(:data) do
-    {:tags =>
-      [
+    {
+      :tags => [
         {
           :category_tag_id   => @cat1.tag_id,
           :entry_name        => 'owner',

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -55,16 +55,16 @@ context "save_tags_inventory" do
   it "creates the expected taggings for a VM" do
     EmsRefresh.save_tags_inventory(@vm, data)
     taggings = Tagging.all
-    expect(taggings.all?{ |e| e.taggable_id == @vm.id }).to be true
-    expect(taggings.map(&:taggable_type).all?{ |e| e == 'VmOrTemplate' }).to be true
+    expect(taggings.all? { |e| e.taggable_id == @vm.id }).to be true
+    expect(taggings.map(&:taggable_type).all? { |e| e == 'VmOrTemplate' }).to be true
     expect(@vm.tags.map(&:id).sort).to eql(taggings.map(&:tag_id).sort)
   end
 
   it "creates the expected taggings for a container node" do
     EmsRefresh.save_tags_inventory(@node, data)
     taggings = Tagging.all
-    expect(taggings.all?{ |e| e.taggable_id == @node.id }).to be true
-    expect(taggings.map(&:taggable_type).all?{ |e| e == 'ContainerNode' }).to be true
+    expect(taggings.all? { |e| e.taggable_id == @node.id }).to be true
+    expect(taggings.map(&:taggable_type).all? { |e| e == 'ContainerNode' }).to be true
     expect(@node.tags.map(&:id).sort).to eql(taggings.map(&:tag_id).sort)
   end
 end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,0 +1,56 @@
+context "save_vms_inventory mapping tags" do
+  before(:each) do
+    @zone = FactoryGirl.create(:zone)
+    @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
+    @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
+
+    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
+    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
+    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:foo') # All
+
+    @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
+    @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
+    @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
+
+    @map1 = FactoryGirl.create(
+      :container_label_tag_mapping,
+      :labeled_resource_type => 'Vm',
+      :label_name            => 'owner',
+      :tag                   => @tag1
+    )
+
+=begin
+    @map2 = FactoryGirl.create(
+      :container_label_tag_mapping,
+      :labeled_resource_type => 'ContainerNode',
+      :label_name            => 'owner',
+      :tag                   => @tag2
+    )
+
+    @map3 = FactoryGirl.create(
+      :container_label_tag_mapping,
+      :labeled_resource_type => nil,
+      :label_name            => 'owner',
+      :tag                   => @tag3
+    )
+=end
+  end
+
+  let(:data) do
+    {:tags =>
+      [
+        {
+          :category_tag_id   => @cat1.tag_id,
+          :entry_name        => 'amazon_vm_owner',
+          :entry_description => 'Daniel'
+        }
+      ]
+    }
+  end
+
+  it "creates the expected number of taggings" do
+    EmsRefresh.save_tags_inventory(@vm, data)
+    taggings = Tagging.all
+    expect(taggings.size).to eql(1)
+  end
+end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,8 +1,10 @@
-context "save_vms_inventory mapping tags" do
+context "save_tags_inventory" do
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
+
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
+    @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
     @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
     @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
@@ -11,46 +13,58 @@ context "save_vms_inventory mapping tags" do
     @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
     @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
     @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
-
-    @map1 = FactoryGirl.create(
-      :container_label_tag_mapping,
-      :labeled_resource_type => 'Vm',
-      :label_name            => 'owner',
-      :tag                   => @tag1
-    )
-
-=begin
-    @map2 = FactoryGirl.create(
-      :container_label_tag_mapping,
-      :labeled_resource_type => 'ContainerNode',
-      :label_name            => 'owner',
-      :tag                   => @tag2
-    )
-
-    @map3 = FactoryGirl.create(
-      :container_label_tag_mapping,
-      :labeled_resource_type => nil,
-      :label_name            => 'owner',
-      :tag                   => @tag3
-    )
-=end
   end
 
+  # This is what ContainerLabelTagMapping.map_labels(cache, 'Type', labels) would
+  # return in the refresh parser. Note that we don't explicitly test the mapping
+  # creation here, the assumption is that these were the generated mappings.
+  #
   let(:data) do
     {:tags =>
       [
         {
           :category_tag_id   => @cat1.tag_id,
-          :entry_name        => 'amazon_vm_owner',
+          :entry_name        => 'owner',
           :entry_description => 'Daniel'
+        },
+        {
+          :category_tag_id   => @cat2.tag_id,
+          :entry_name        => 'stuff',
+          :entry_description => 'Ladas'
+        },
+        {
+          :category_tag_id   => @cat3.tag_id,
+          :entry_name        => 'foo',
+          :entry_description => 'Bronagh'
         }
       ]
     }
   end
 
+  # Note that in these tests we're explicitly passing the object, so that's
+  # why the object type may not match what you would expect from the tag
+  # name type above.
+
   it "creates the expected number of taggings" do
     EmsRefresh.save_tags_inventory(@vm, data)
     taggings = Tagging.all
-    expect(taggings.size).to eql(1)
+    expect(taggings.size).to eql(3)
+    expect(@vm.tags.size).to eql(3)
+  end
+
+  it "creates the expected taggings for a VM" do
+    EmsRefresh.save_tags_inventory(@vm, data)
+    taggings = Tagging.all
+    expect(taggings.all?{ |e| e.taggable_id == @vm.id }).to be true
+    expect(taggings.map(&:taggable_type).all?{ |e| e == 'VmOrTemplate' }).to be true
+    expect(@vm.tags.map(&:id).sort).to eql(taggings.map(&:tag_id).sort)
+  end
+
+  it "creates the expected taggings for a container node" do
+    EmsRefresh.save_tags_inventory(@node, data)
+    taggings = Tagging.all
+    expect(taggings.all?{ |e| e.taggable_id == @node.id }).to be true
+    expect(taggings.map(&:taggable_type).all?{ |e| e == 'ContainerNode' }).to be true
+    expect(@node.tags.map(&:id).sort).to eql(taggings.map(&:tag_id).sort)
   end
 end


### PR DESCRIPTION
This PR maps custom attributes on the AWS side to tags on the ManageIQ side based on mappings that have been setup by a user.

See also https://github.com/ManageIQ/manageiq-providers-amazon/pull/183 which sets the :tags attribute on Vm's and Images, which you will need for this PR to have any noticeable effect.

Once you have your Gemfile pointing at that fork and the "aws_tags3" branch, you can perform the following steps to see it in action:

Within ManageIQ go to Configuration -> Region -> Map Tags. Add an entry, selecting "Amazon::Vm" as the entity, type in "owner" as the resource label, and whatever you want for the category, e.g. "amazon_vm_owner". Then refresh your Amazon provider (or add one if you haven't already). Any VM with a custom attribute of "owner" will now show up as a company tag on the instance view.

Use the "US East - Northern Virginia" region from our Dev environment if you want to make sure you get some VM's with an "owner" attribute.

