### PR TITLE
Drop 'jobs.agent_name' column

### DIFF
--- a/db/migrate/20170321171945_remove_agent_name_from_jobs.rb
+++ b/db/migrate/20170321171945_remove_agent_name_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveAgentNameFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :agent_name, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1584,7 +1584,6 @@ jobs:
 - sync_key
 - miq_server_id
 - zone
-- agent_name
 - options
 - context
 - miq_task_id


### PR DESCRIPTION
**blocked:** https://github.com/ManageIQ/manageiq/pull/14426

All references to 'jobs.agent_name' were removed in #14426, and this column not in use.
Dropping it will make future merging of `Job` and `MiqTask` models simpler.

@miq-bot add-label core, technical debt, wip

\cc @Fryguy