### PR TITLE
Revert "Remove unneeded include from reports"

### DIFF
--- a/product/views/CloudObjectStoreContainer-cloud_object_store_containers.yaml
+++ b/product/views/CloudObjectStoreContainer-cloud_object_store_containers.yaml
@@ -23,6 +23,19 @@ cols:
 - bytes
 - object_count
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_tenant:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreContainer.yaml
+++ b/product/views/CloudObjectStoreContainer.yaml
@@ -23,6 +23,19 @@ cols:
 - bytes
 - object_count
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_tenant:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
+++ b/product/views/CloudObjectStoreObject-cloud_object_store_objects.yaml
@@ -24,6 +24,21 @@ cols:
 - last_modified
 - etag
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_object_store_container:
+    columns:
+    - key
+  cloud_tenant:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudObjectStoreObject.yaml
+++ b/product/views/CloudObjectStoreObject.yaml
@@ -24,6 +24,21 @@ cols:
 - last_modified
 - etag
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_object_store_container:
+    columns:
+    - key
+  cloud_tenant:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - key

--- a/product/views/CloudSubnet.yaml
+++ b/product/views/CloudSubnet.yaml
@@ -26,6 +26,15 @@ cols:
 - dns_nameservers_show
 - total_vms
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudTenant.yaml
+++ b/product/views/CloudTenant.yaml
@@ -22,6 +22,15 @@ cols:
 - name
 - total_vms
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolume-based_volumes.yaml
+++ b/product/views/CloudVolume-based_volumes.yaml
@@ -25,6 +25,19 @@ cols:
 - volume_type
 - bootable
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  availability_zone:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolume.yaml
+++ b/product/views/CloudVolume.yaml
@@ -25,6 +25,18 @@ cols:
 - volume_type
 - bootable
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  availability_zone:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolumeBackup-cloud_volume_backups.yaml
+++ b/product/views/CloudVolumeBackup-cloud_volume_backups.yaml
@@ -23,6 +23,19 @@ cols:
 - size
 - status
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_volume:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+# include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/CloudVolumeBackup.yaml
+++ b/product/views/CloudVolumeBackup.yaml
@@ -23,6 +23,16 @@ cols:
 - size
 - status
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_volume:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+++ b/product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
@@ -24,6 +24,16 @@ cols:
 - status
 - total_based_volumes
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_volume:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/CloudVolumeSnapshot.yaml
+++ b/product/views/CloudVolumeSnapshot.yaml
@@ -24,6 +24,16 @@ cols:
 - status
 - total_based_volumes
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  cloud_volume:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
 # Included tables and columns for query performance
 # include_for_find:
 

--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -22,6 +22,18 @@ cols:
 - name
 - state
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_group:
+    columns:
+    - name
+  container_image:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerBuild.yaml
+++ b/product/views/ContainerBuild.yaml
@@ -24,6 +24,19 @@ cols:
 - output_name
 - completion_deadline_seconds
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerGroup.yaml
+++ b/product/views/ContainerGroup.yaml
@@ -26,6 +26,18 @@ cols:
 - dns_policy
 - running_containers_summary
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerImage.yaml
+++ b/product/views/ContainerImage.yaml
@@ -24,6 +24,15 @@ cols:
 - image_ref
 - display_registry
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerImageRegistry.yaml
+++ b/product/views/ContainerImageRegistry.yaml
@@ -22,6 +22,14 @@ cols:
 - host
 - port
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - host

--- a/product/views/ContainerNode.yaml
+++ b/product/views/ContainerNode.yaml
@@ -25,6 +25,15 @@ cols:
 - kernel_version
 - container_runtime_version
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerProject.yaml
+++ b/product/views/ContainerProject.yaml
@@ -28,6 +28,15 @@ cols:
 - containers_count
 - images_count
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ContainerReplicator.yaml
+++ b/product/views/ContainerReplicator.yaml
@@ -23,6 +23,18 @@ cols:
 - replicas
 - current_replicas
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerRoute.yaml
+++ b/product/views/ContainerRoute.yaml
@@ -21,6 +21,18 @@ db: ContainerRoute
 cols:
 - name
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerService.yaml
+++ b/product/views/ContainerService.yaml
@@ -25,6 +25,18 @@ cols:
 - session_affinity
 - container_groups_count
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/ContainerTemplate.yaml
+++ b/product/views/ContainerTemplate.yaml
@@ -21,6 +21,18 @@ db: ContainerTemplate
 cols:
 - name
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  container_project:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/FloatingIp.yaml
+++ b/product/views/FloatingIp.yaml
@@ -22,6 +22,18 @@ cols:
 - address
 - fixed_ip_address
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+  vm:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - address

--- a/product/views/LoadBalancer.yaml
+++ b/product/views/LoadBalancer.yaml
@@ -23,6 +23,15 @@ cols:
 - description
 - total_vms
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_AutomationManager.yaml
@@ -26,6 +26,18 @@ cols:
 - authentication_status
 - total_configured_systems
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+  provider:
+    columns:
+    - url
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
@@ -27,6 +27,15 @@ cols:
 - total_security_groups
 - total_cloud_networks
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -26,6 +26,18 @@ cols:
 - authentication_status
 - total_configured_systems
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+  provider:
+    columns:
+    - url
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -27,6 +27,18 @@ cols:
 - total_configuration_profiles
 - total_configured_systems
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+  provider:
+    columns:
+    - url
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ManageIQ_Providers_StorageManager.yaml
+++ b/product/views/ManageIQ_Providers_StorageManager.yaml
@@ -24,6 +24,12 @@ cols:
 - port
 - region_description
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}

--- a/product/views/MiddlewareDatasource.yaml
+++ b/product/views/MiddlewareDatasource.yaml
@@ -21,6 +21,17 @@ db: MiddlewareDatasource
 cols:
 - name
 
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  middleware_server:
+    columns:
+    - name
+    - hostname
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareDeployment.yaml
+++ b/product/views/MiddlewareDeployment.yaml
@@ -22,6 +22,17 @@ cols:
 - name
 - status
 
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  middleware_server:
+    columns:
+    - name
+    - hostname
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareDomain.yaml
+++ b/product/views/MiddlewareDomain.yaml
@@ -22,6 +22,16 @@ cols:
 - name
 - feed
 
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareMessaging.yaml
+++ b/product/views/MiddlewareMessaging.yaml
@@ -22,6 +22,16 @@ cols:
 - name
 - messaging_type
 
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  middleware_server:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareServer.yaml
+++ b/product/views/MiddlewareServer.yaml
@@ -30,6 +30,15 @@ include:
     columns:
       - name
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/MiddlewareServerGroup.yaml
+++ b/product/views/MiddlewareServerGroup.yaml
@@ -23,6 +23,16 @@ cols:
 - name
 - profile
 
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  middleware_domain:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/NetworkPort.yaml
+++ b/product/views/NetworkPort.yaml
@@ -24,6 +24,18 @@ cols:
 - ipaddresses
 - cloud_subnets_names
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+#  device:
+#    columns:
+#    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/NetworkRouter.yaml
+++ b/product/views/NetworkRouter.yaml
@@ -23,6 +23,15 @@ cols:
 - status
 - total_vms
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/SecurityGroup.yaml
+++ b/product/views/SecurityGroup.yaml
@@ -23,6 +23,15 @@ cols:
 - description
 - total_vms
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+
 # Order of columns (from all tables)
 col_order:
 - name

--- a/product/views/ServiceTemplateCatalog.yaml
+++ b/product/views/ServiceTemplateCatalog.yaml
@@ -22,6 +22,15 @@ cols:
 - name
 - description
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  tenant:
+    columns:
+      - name
+
+# Included tables and columns for query performance
+include_for_find:
+  
 # Order of columns (from all tables)
 col_order: 
 - name

--- a/product/views/VmdbDatabaseConnection.yaml
+++ b/product/views/VmdbDatabaseConnection.yaml
@@ -28,6 +28,18 @@ cols:
 - wait_time
 - command
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+  miq_server:
+    columns:
+    - name
+  miq_worker:
+    columns:
+    - type
+
 # Order of columns (from all tables)
 col_order:
 - zone.name

--- a/product/views/ems_block_storage.yaml
+++ b/product/views/ems_block_storage.yaml
@@ -24,6 +24,12 @@ cols:
 - port
 - region_description
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}

--- a/product/views/ems_object_storage.yaml
+++ b/product/views/ems_object_storage.yaml
@@ -24,6 +24,12 @@ cols:
 - port
 - region_description
 
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+
 # Included tables and columns for query performance
 include_for_find:
   :tags: {}


### PR DESCRIPTION
This reverts commit 3af1aeba691d9cd778889d12b8325057537d890c (from #13675 )

#13675 was not working properly with `MiqReport#build_reportable_data`. Columns were missing from the UI [BZ 1422584](https://bugzilla.redhat.com/show_bug.cgi?id=1422584) #14115 

This PR adds the removed `include` values back into the report definitions.
They will be removed in the future once `build_reportable_data` has been fixed to read `sort_cols` or `includes`

/cc @gtanzillo @martinpovolny 

links: https://www.pivotaltracker.com/n/projects/1619581