### PR TITLE
Fix EmsRefresh miq_callback when merging queue items

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -181,7 +181,7 @@ module EmsRefresh
         :task_id      => task_id,
         :msg_timeout  => queue_timeout,
         :miq_callback => {
-          :class_name  => task.class.name,
+          :class_name  => 'MiqTask',
           :method_name => :queue_callback,
           :instance_id => task_id,
           :args        => ['Finished']

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -76,6 +76,14 @@ describe EmsRefresh do
         expect(task_ids2.length).to eq(1)
         expect(task_ids.first).to   eq(task_ids2.first)
       end
+
+      it "sets the queue callback correctly" do
+        task_ids = described_class.queue_refresh_task(target1)
+        described_class.queue_refresh_task(target2)
+
+        queue_item = MiqQueue.find_by(:task_id => task_ids.first.to_s)
+        expect(queue_item.miq_callback[:class_name]).to eq("MiqTask")
+      end
     end
 
     context "with Vms on different EMSs" do


### PR DESCRIPTION
When merging an EmsRefresh queue item the class_name in the miq_callback was getting set to NilClass causing the callback to fail and the task to never get marked as finished.

The `miq_callback[:class_name]` was set with `task.class.name`, but the `task` variable was only valid when [creating a task](https://github.com/agrare/manageiq/blob/ca60048be6fff03c2db8535afd228c151a94c25f/app/models/ems_refresh.rb#L174-L177).  If we were reusing an [existing task](https://github.com/agrare/manageiq/blob/ca60048be6fff03c2db8535afd228c151a94c25f/app/models/ems_refresh.rb#L172-L173) then `task` was nil.