### PR TITLE
Adding support for a format_attributes parameter

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -35,6 +35,14 @@ module Api
         search_options.map(&:downcase).include?(what.to_s)
       end
 
+      def format_attributes
+        params['format_attributes'].to_s.split(",").map { |af| af.split("=").map(&:strip) }
+      end
+
+      def attribute_format(attr)
+        format_attributes.detect { |af| af.first == attr }.try(:second)
+      end
+
       def attribute_selection
         if !@req.attributes.empty? || @additional_attributes
           @req.attributes | Array(@additional_attributes) | ID_ATTRS

--- a/app/controllers/api/subcollections/orchestration_stacks.rb
+++ b/app/controllers/api/subcollections/orchestration_stacks.rb
@@ -4,6 +4,13 @@ module Api
       def orchestration_stacks_query_resource(object)
         object.orchestration_stacks
       end
+
+      #
+      # Virtual attribute accessors
+      #
+      def fetch_orchestration_stacks_stdout(resource)
+        resource.stdout(attribute_format("stdout"))
+      end
     end
   end
 end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -80,7 +80,7 @@ class OrchestrationStack < ApplicationRecord
   end
 
   def stdout(format = nil)
-    try(:raw_stdout, format)
+    format.nil? ? try(:raw_stdout) : try(:raw_stdout, format)
   end
 
   private :directs_and_indirects

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -41,6 +41,8 @@ class OrchestrationStack < ApplicationRecord
   virtual_total :total_security_groups, :security_groups
   virtual_total :total_cloud_networks, :cloud_networks
 
+  virtual_column :stdout, :type => :string
+
   alias_method :orchestration_stack_parameters, :parameters
   alias_method :orchestration_stack_outputs,    :outputs
   alias_method :orchestration_stack_resources,  :resources
@@ -76,6 +78,11 @@ class OrchestrationStack < ApplicationRecord
   def directs_and_indirects(direct_attrs)
     MiqPreloader.preload_and_map(subtree, direct_attrs)
   end
+
+  def stdout(format = nil)
+    try(:raw_stdout, format)
+  end
+
   private :directs_and_indirects
 
   def self.create_stack(orchestration_manager, stack_name, template, options = {})

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -659,6 +659,34 @@ describe "Services API" do
       expect(response.parsed_body).to include(expected)
     end
 
+    it 'can query a specific orchestration stack asking for stdout' do
+      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
+
+      allow_any_instance_of(OrchestrationStack).to receive(:stdout).with(nil).and_return("default text stdout")
+      run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout")
+
+      expected = {
+        'id'     => os.id,
+        'stdout' => "default text stdout"
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can query a specific orchestration stack asking for stdout in alternate format' do
+      api_basic_authorize subcollection_action_identifier(:services, :orchestration_stacks, :read, :get)
+
+      allow_any_instance_of(OrchestrationStack).to receive(:stdout).with("json").and_return("json stdout")
+      run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout", :format_attributes => "stdout=json")
+
+      expected = {
+        'id'     => os.id,
+        'stdout' => "json stdout"
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it 'will not return orchestration stacks without an appropriate role' do
       api_basic_authorize
 

--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -45,7 +45,7 @@ class RestApi
     SCRIPTDIR_ACTIONS    = %w(ls run).freeze
     SUB_COMMANDS         = ACTIONS + %w(edit vi) + SCRIPTDIR_ACTIONS
     API_PARAMETERS       = %w(expand hide attributes decorators limit offset
-                              depth search_options
+                              depth search_options format_attributes
                               sort_by sort_order sort_options
                               filter by_tag provider_class collection_class requester_type).freeze
 


### PR DESCRIPTION
Adding support for a format_attributes parameter with syntax:

```
  format_attributes=attr1=format1,attr2=format2,attr3=format3,....
```
Implementation to support an stdout virtual attribute on orchestration_stacks with optional attribute rendering as follows:

```
  GET /api/services/:id/orchestration_stacks
      ?expand=resources
      &attributes=stdout
      &format_attributes=stdout=raw
```

