### PR TITLE
Tower API CUD operations of configuration_script_source and credential to share a concern

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script_source.rb
@@ -2,4 +2,5 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptS
   ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptSource
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 end

--- a/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/credential.rb
@@ -1,3 +1,11 @@
 class ManageIQ::Providers::AnsibleTower::AutomationManager::Credential < ManageIQ::Providers::ExternalAutomationManager::Authentication
+  # Authentication is associated with EMS through resource_id/resource_type
+  # Alias is to make the AutomationManager code more uniformly as those
+  # CUD operations in the TowerApi concern
+
+  alias_attribute :manager_id, :resource_id
+  alias_attribute :manager, :resource
+
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -1,78 +1,17 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource
   extend ActiveSupport::Concern
 
+  include ProviderObjectMixin
+
   module ClassMethods
-    def create_in_provider(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
-      project = manager.with_provider_connection do |connection|
-        connection.api.projects.create!(params)
+    def provider_collection(manager)
+      manager.with_provider_connection do |connection|
+        connection.api.projects
       end
-
-      refresh(manager)
-      find_by!(:manager_id => manager.id, :manager_ref => project.id)
-    end
-
-    def create_in_provider_queue(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
-      action = "Creating #{name} with name=#{params[:name]}"
-      queue(manager.my_zone, nil, "create_in_provider", [manager_id, params], action)
-    end
-
-    def provider_object(connection = nil)
-      (connection || connection_source.connect).api.projects.find(manager_ref)
-    end
-
-    private
-
-    def refresh(manager)
-      # Get the record in our database
-      # TODO: This needs to be targeted refresh so it doesn't take too long
-      task_ids = EmsRefresh.queue_refresh_task(manager)
-      task_ids.each { |tid| MiqTask.wait_for_taskid(tid) }
-    end
-
-    def queue(zone, instance_id, method_name, args, action)
-      task_opts = {
-        :action => action,
-        :userid => "system"
-      }
-
-      queue_opts = {
-        :args        => args,
-        :class_name  => name,
-        :method_name => method_name,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => zone
-      }
-      queue_opts[:instance_id] = instance_id if instance_id
-      MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
   end
 
-  def update_in_provider(params)
-    params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
-    manager.with_provider_connection do |connection|
-      connection.api.projects.find(manager_ref).update_attributes!(params)
-    end
-    self.class.send('refresh', manager)
-    reload
-  end
-
-  def update_in_provider_queue(params)
-    action = "Updating #{self.class.name} with manager_ref=#{manager_ref}"
-    self.class.send('queue', manager.my_zone, id, "update_in_provider", [params], action)
-  end
-
-  def delete_in_provider
-    manager.with_provider_connection do |connection|
-      connection.api.projects.find(manager_ref).destroy!
-    end
-    self.class.send('refresh', manager)
-  end
-
-  def delete_in_provider_queue
-    action = "Deleting #{self.class.name} with manager_ref=#{manager_ref}"
-    self.class.send('queue', manager.my_zone, id, "delete_in_provider", [], action)
+  def provider_object(connection = nil)
+    (connection || connection_source.connect).api.projects.find(manager_ref)
   end
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -1,84 +1,25 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   extend ActiveSupport::Concern
 
+  include ProviderObjectMixin
+
   module ClassMethods
+    def provider_collection(manager)
+      manager.with_provider_connection do |connection|
+        connection.api.credentials
+      end
+    end
+
     def provider_params(params)
       params[:username] = params.delete(:userid) if params.include?(:userid)
       params[:username] = params.delete('userid') if params.include?('userid')
       params[:kind] = self::TOWER_KIND
       params
     end
-
-    def create_in_provider(manager_id, params)
-      params = provider_params(params)
-      manager = ExtManagementSystem.find(manager_id)
-      credential = manager.with_provider_connection do |connection|
-        connection.api.credentials.create!(params)
-      end
-
-      refresh(manager)
-      find_by!(:resource_id => manager.id, :manager_ref => credential.id)
-    end
-
-    def create_in_provider_queue(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
-      action = "Creating #{name} with name=#{params[:name]}"
-      queue(manager.my_zone, nil, "create_in_provider", [manager_id, params], action)
-    end
-
-    private
-
-    def refresh(manager)
-      # Get the record in our database
-      # TODO: This needs to be targeted refresh so it doesn't take too long
-      task_ids = EmsRefresh.queue_refresh_task(manager)
-      task_ids.each { |tid| MiqTask.wait_for_taskid(tid) }
-    end
-
-    def queue(zone, instance_id, method_name, args, action)
-      task_opts = {
-        :action => action,
-        :userid => "system"
-      }
-
-      queue_opts = {
-        :args        => args,
-        :class_name  => name,
-        :method_name => method_name,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => zone
-      }
-      queue_opts[:instance_id] = instance_id if instance_id
-      MiqTask.generic_action_with_callback(task_opts, queue_opts)
-    end
   end
 
-  def update_in_provider(params)
-    params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
-    params = self.class.provider_params(params)
-    resource.with_provider_connection do |connection|
-      connection.api.credentials.find(manager_ref).update_attributes!(params)
-    end
-    self.class.send('refresh', resource)
-    reload
-  end
-
-  def update_in_provider_queue(params)
-    action = "Updating #{self.class.name} with manager_ref=#{manager_ref}"
-    self.class.send('queue', resource.my_zone, id, "update_in_provider", [params], action)
-  end
-
-  def delete_in_provider
-    resource.with_provider_connection do |connection|
-      connection.api.credentials.find(manager_ref).destroy!
-    end
-    self.class.send('refresh', resource)
-  end
-
-  def delete_in_provider_queue
-    action = "Deleting #{self.class.name} with manager_ref=#{manager_ref}"
-    self.class.send('queue', resource.my_zone, id, "delete_in_provider", [], action)
+  def provider_object(connection = nil)
+    (connection || connection_source.connect).api.credentials.find(manager_ref)
   end
 
   COMMON_ATTRIBUTES = {}.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -1,0 +1,72 @@
+module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def create_in_provider(manager_id, params)
+      params = provider_params(params) if respond_to? :provider_params
+      manager = ExtManagementSystem.find(manager_id)
+      tower_object = provider_collection(manager).create!(params)
+
+      refresh(manager)
+      find_by!(:manager_id => manager.id, :manager_ref => tower_object.id)
+    end
+
+    def create_in_provider_queue(manager_id, params)
+      manager = ExtManagementSystem.find(manager_id)
+      action = "Creating #{name} with name=#{params[:name]}"
+      queue(manager.my_zone, nil, "create_in_provider", [manager_id, params], action)
+    end
+
+    private
+
+    def refresh(manager)
+      # Get the record in our database
+      # TODO: This needs to be targeted refresh so it doesn't take too long
+      task_ids = EmsRefresh.queue_refresh_task(manager)
+      task_ids.each { |tid| MiqTask.wait_for_taskid(tid) }
+    end
+
+    def queue(zone, instance_id, method_name, args, action)
+      task_opts = {
+        :action => action,
+        :userid => "system"
+      }
+
+      queue_opts = {
+        :args        => args,
+        :class_name  => name,
+        :method_name => method_name,
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :role        => "ems_operations",
+        :zone        => zone
+      }
+      queue_opts[:instance_id] = instance_id if instance_id
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+  end
+
+  def update_in_provider(params)
+    params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
+    params = self.class.provider_params(params) if self.class.respond_to? :provider_params
+    with_provider_object do |provider_object|
+      provider_object.update_attributes!(params)
+    end
+    self.class.send('refresh', manager)
+    reload
+  end
+
+  def update_in_provider_queue(params)
+    action = "Updating #{self.class.name} with manager_ref=#{manager_ref}"
+    self.class.send('queue', manager.my_zone, id, "update_in_provider", [params], action)
+  end
+
+  def delete_in_provider
+    with_provider_object(&:destroy!)
+    self.class.send('refresh', manager)
+  end
+
+  def delete_in_provider_queue
+    action = "Deleting #{self.class.name} with manager_ref=#{manager_ref}"
+    self.class.send('queue', manager.my_zone, id, "delete_in_provider", [], action)
+  end
+end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,5 +1,5 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource <
-  ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -1,5 +1,13 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
+  # Authentication is associated with EMS through resource_id/resource_type
+  # Alias is to make the AutomationManager code more uniformly as those
+  # CUD operations in the TowerApi concern
+
+  alias_attribute :manager_id, :resource_id
+  alias_attribute :manager, :resource
+
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
   def self.provider_params(params)
     super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)


### PR DESCRIPTION
To eliminate those 99% duplicated code.

Next step is to make `configuration_script` to include the `tower_api` concern as well.