### PR TITLE
Add assert_rbac stub to stub_user method

### DIFF
--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -30,6 +30,7 @@ module Spec
                       EOS
                     end
         allow(controller).to receive(:check_privileges).and_return(stub_bool)
+        allow(controller).to receive(:assert_rbac).and_return(stub_bool)
         allow(Rbac).to receive(:role_allows?).and_return(stub_bool)
 
         login_as user


### PR DESCRIPTION
This PR is needed for specs in https://github.com/ManageIQ/manageiq-ui-classic/pull/751 and for following PRs, which will come.

Make `assert_rbac` method behave same way as `assert_privileges` in specs.