### PR TITLE
The Service model href_slug

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -33,6 +33,10 @@ describe MiqAeMethodService::MiqAeServiceVm do
     expect(@ae_vm.associations).to be_kind_of(Array)
   end
 
+  it "href_slug" do
+    expect(@vm.href_slug).to eq(@ae_vm.href_slug)
+  end
+
   describe "#tag_assign" do
     let(:category)    { FactoryGirl.create(:classification) }
     let(:tag)         { FactoryGirl.create(:classification_tag, :parent_id => category.id) }


### PR DESCRIPTION
Spec to test that the Service Model href_slug is the same
as the one for the model

The base service model automatically exposes this attribute.

Links
-----

* PR #14344

Notes:
-------
Automate methods, the ones that list dialog items can now use the href_slug to uniquely identify a object.