### PR TITLE
New folder targeted refresh [Depends on vmware/32]

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -101,7 +101,7 @@ module EmsRefresh
   def self.refresh_new_target(target_hash, ems_id)
     ems = ExtManagementSystem.find(ems_id)
 
-    target = save_new_target(target_hash)
+    target = save_new_target(ems, target_hash)
     if target.nil?
       _log.warn "Unknown target for event data: #{target_hash}."
       return

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -354,15 +354,14 @@ module EmsRefresh::SaveInventory
     save_inventory_multi(os.event_logs, hashes, :use_association, [:uid])
   end
 
-  def save_new_target(target_hash)
-    unless target_hash[:vm].nil?
+  def save_new_target(ems, target_hash)
+    if target_hash[:vm]
       vm_hash = target_hash[:vm]
       existing_vm = VmOrTemplate.find_by(:ems_ref => vm_hash[:ems_ref], :ems_id => target_hash[:ems_id])
       unless existing_vm.nil?
         return existing_vm
       end
 
-      ems = ExtManagementSystem.find_by(:id => target_hash[:ems_id])
       old_cluster = get_cluster(ems, target_hash[:cluster], target_hash[:resource_pools], target_hash[:folders])
 
       vm_hash[:ems_cluster_id] = old_cluster[:id]
@@ -379,6 +378,8 @@ module EmsRefresh::SaveInventory
       resource_pool.save!
 
       new_vm
+    elsif target_hash[:folder]
+      ems.ems_folders.create!(target_hash[:folder])
     end
   end
 

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -39,7 +39,7 @@ module EmsRefresh::SaveInventoryInfra
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
-    if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank?)
+    if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank? && hashes[:folders].blank?)
       target.disconnect_inv
       return
     end

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -162,9 +162,13 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   }.freeze
 
   def on_create_event(ems_id, event)
-    # TODO: Implement
-    _log.debug("Ignoring refresh for EMS id: [#{ems_id}] on event [#{event[:objType]}-create]")
-    nil
+    target_hash = ManageIQ::Providers::Vmware::InfraManager::EventParser.obj_update_to_hash(event)
+    if target_hash.nil?
+      _log.debug("Ignoring refresh for EMS id: [#{ems_id}] on event [#{event[:objType]}-create]")
+    else
+      ems = ExtManagementSystem.find(ems_id)
+      EmsRefresh.queue_refresh_new_target(target_hash, ems)
+    end
   end
 
   def on_delete_event(ems_id, event)


### PR DESCRIPTION
This implements the `MiqVimBrokerWorker::Runner#on_create_event` by parsing the event sent by [MiqVimUpdate](https://github.com/ManageIQ/manageiq-gems-pending/blob/master/lib/gems/pending/VMwareWebService/MiqVimUpdate.rb#L302-L312) and call `EmsRefresh.queue_refresh_new_target`.

https://github.com/ManageIQ/manageiq-providers-vmware/pull/32 implements the event parser and folder inventory filter.

Depends:
* ~~https://github.com/ManageIQ/manageiq-providers-vmware/pull/32~~

https://bugzilla.redhat.com/show_bug.cgi?id=1378984