### PR TITLE
Destroy Ansible Playbook job templates

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -151,4 +151,14 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     end
     super
   end
+
+  def destroy
+    auth_user = User.current_userid || 'system'
+    resource_actions.where.not(:configuration_template_id => nil).each do |resource_action|
+      job_template = resource_action.configuration_template
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript
+        .delete_in_provider_queue(job_template.manager.id, { :manager_ref => job_template.manager_ref }, auth_user)
+    end
+    super
+  end
 end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -20,7 +20,8 @@ describe ServiceTemplateAnsiblePlaybook do
 
   let(:job_template) do
     FactoryGirl.create(:configuration_script,
-                       :variables => catalog_item_options.fetch_path(:config_info, :provision, :extra_vars))
+                       :variables => catalog_item_options.fetch_path(:config_info, :provision, :extra_vars),
+                       :manager   => ems)
   end
 
   let(:catalog_item_options) do
@@ -237,14 +238,41 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
     end
+  end
 
-    def prebuild_service_template
-      expect(described_class)
-        .to receive(:create_job_templates).and_return(:provision => {:configuration_template => job_template})
-      service_template = described_class.create_catalog_item(catalog_item_options_two, user)
-      expect(service_template).to receive(:job_template)
-        .and_return(job_template).at_least(:once)
-      service_template
+  describe '#destroy' do
+    it 'destroys a job template if there is an associated configuration_template' do
+      service_template = prebuild_service_template(:job_template => false)
+      adjust_resource_actions(service_template, job_template.id)
+
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
+        .to receive(:delete_in_provider_queue)
+      service_template.destroy
+    end
+
+    it 'does not destroy a job template if there is no associated configuration_template' do
+      service_template = prebuild_service_template(:job_template => false)
+      adjust_resource_actions(service_template, nil)
+
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
+        .to receive(:delete_in_provider_queue).never
+      service_template.destroy
+    end
+
+    def adjust_resource_actions(service_template, item)
+      service_template.resource_actions.first.tap do |resource_action|
+        resource_action.configuration_template_id = item
+      end.save
+    end
+  end
+
+  def prebuild_service_template(options = { :job_template => true })
+    ret = {:provision => {:configuration_template => job_template}}
+    expect(described_class).to receive(:create_job_templates).and_return(ret).at_least(:once)
+    described_class.create_catalog_item(catalog_item_options_two, user).tap do |service_template|
+      if options[:job_template]
+        expect(service_template).to receive(:job_template).and_return(job_template).at_least(:once)
+      end
     end
   end
 end


### PR DESCRIPTION
If an associated `configuration_template` exists then delete the associated `JobTemplate`

Otherwise simply delete the `ServiceTemplateAnsiblePlaybook`

https://www.pivotaltracker.com/story/show/140761595

