### PR TITLE
Add ems_ref_obj to VMware folder spec factories

### DIFF
--- a/spec/factories/ems_folder.rb
+++ b/spec/factories/ems_folder.rb
@@ -20,23 +20,28 @@ FactoryGirl.define do
   #
 
   factory :vmware_folder, :parent => :ems_folder do
-    sequence(:ems_ref) { |n| "group-d#{n}" }
+    sequence(:ems_ref)     { |n| "group-d#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("group-d#{n}", "Folder", "ManagedObjectReference") }
   end
 
   factory :vmware_folder_vm, :parent => :ems_folder do
-    sequence(:ems_ref) { |n| "group-v#{n}" }
+    sequence(:ems_ref)     { |n| "group-v#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("group-v#{n}", "Folder", "ManagedObjectReference") }
   end
 
   factory :vmware_folder_host, :parent => :ems_folder do
-    sequence(:ems_ref) { |n| "group-h#{n}" }
+    sequence(:ems_ref)     { |n| "group-h#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("group-h#{n}", "Folder", "ManagedObjectReference") }
   end
 
   factory :vmware_folder_datastore, :parent => :ems_folder do
-    sequence(:ems_ref) { |n| "group-s#{n}" }
+    sequence(:ems_ref)     { |n| "group-s#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("group-s#{n}", "Folder", "ManagedObjectReference") }
   end
 
   factory :vmware_folder_network, :parent => :ems_folder do
-    sequence(:ems_ref) { |n| "group-n#{n}" }
+    sequence(:ems_ref)     { |n| "group-n#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("group-n#{n}", "Folder", "ManagedObjectReference") }
   end
 
   factory :vmware_folder_root, :parent => :vmware_folder do
@@ -66,6 +71,8 @@ FactoryGirl.define do
 
   factory :vmware_datacenter, :parent => :vmware_folder, :class => "Datacenter" do
     sequence(:name) { |n| "Test Datacenter #{seq_padded_for_sorting(n)}" }
+    sequence(:ems_ref)     { |n| "datacenter-#{n}" }
+    sequence(:ems_ref_obj) { |n| VimString.new("datacenter-#{n}", "Datacenter", "ManagedObjectReference") }
   end
 end
 


### PR DESCRIPTION
Add `ems_ref_obj` to the VMware EmsFolder factories so that they can be used in tests of code that rely on having an `ems_ref_obj`

Specifically [this new test](https://github.com/ManageIQ/manageiq-providers-vmware/pull/32/files#diff-00c41966f1addad8841ce6cd3b8f023eR11) testing `filter_vc_data` which uses the `ems_ref_obj` [here](https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb#L60-L61)