### PR TITLE
[WIP] Embedded Ansible job - undefine retire_now.

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -2,4 +2,5 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
   require_nested :Status
+  undef retire_now
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_AutomationManager_Job < MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack
     expose :manager, :association => true
+    undef retire_now
   end
 end


### PR DESCRIPTION
Ansible Playbook provisioned Services service_resources resource of type ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job cannot be retired.
The Service retirement process attempts to retire all service_resource resources that respond to retire_now. Undefining retire_now enables the Ansible Playbook service to be successfully retired.

