### PR TITLE
Exclude chargeback lookup tables

### DIFF
--- a/config/default_replication_exclude_tables.yml
+++ b/config/default_replication_exclude_tables.yml
@@ -4,6 +4,9 @@
   - audit_events
   - binary_blobs
   - binary_blob_parts
+  - chargeable_fields
+  - chargeback_rate_detail_currencies
+  - chargeback_rate_detail_measures
   - chargeback_rate_details
   - chargeback_rates
   - conditions


### PR DESCRIPTION
An AR validation which was being enforced during seeding was preventing the global server from starting up with failing rows in the database.

This situation happens when the seeded rows get replicated up from a remote region and then the global appliance runs through seeding again.

https://bugzilla.redhat.com/show_bug.cgi?id=1435004