### PR TITLE
Use embedded tower default objects for ManageIQ

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -102,8 +102,10 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   def create_inventory_with_hosts(action, hosts)
-    manager(action).with_provider_connection do |connection|
-      connection.api.inventories.create!(:name => inventory_name(action), :organization => 1).tap do |inventory|
+    tower = manager(action)
+    tower.with_provider_connection do |connection|
+      miq_org = tower.provider.default_organization
+      connection.api.inventories.create!(:name => inventory_name(action), :organization => miq_org).tap do |inventory|
         hosts.split(',').each do |host|
           connection.api.hosts.create!(:name => host, :inventory => inventory.id)
         end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -91,7 +91,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :description              => description || '',
       :project                  => playbook.configuration_script_source.manager_ref,
       :playbook                 => playbook.name,
-      :inventory                => tower.inventory_root_groups.find_by!(:name => 'Demo Inventory').ems_ref,
+      :inventory                => tower.provider.default_inventory,
       :ask_variables_on_launch  => true,
       :ask_limit_on_launch      => true,
       :ask_inventory_on_launch  => true,

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -5,17 +5,14 @@ describe ServiceTemplateAnsiblePlaybook do
 
   let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
 
-  let(:inventory_root_group) { FactoryGirl.create(:inventory_root_group, :name => 'Demo Inventory') }
   let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
-  let(:ems) do
-    FactoryGirl.create(:automation_manager_ansible_tower, :inventory_root_groups => [inventory_root_group])
-  end
+  let(:provider) { FactoryGirl.create(:provider_embedded_ansible, :default_inventory => 1) }
+  let(:ems)      { FactoryGirl.create(:automation_manager_ansible_tower, :provider => provider) }
 
   let(:playbook) do
     FactoryGirl.create(:embedded_playbook,
                        :configuration_script_source => script_source,
-                       :manager                     => ems,
-                       :inventory_root_group        => inventory_root_group)
+                       :manager                     => ems)
   end
 
   let(:job_template) do


### PR DESCRIPTION
Use default inventory for service catalog item creation.
Use default organization for template inventory creation when launching a job.

https://www.pivotaltracker.com/story/show/141875335

@miq-bot add_label enhancement
@miq-bot add_label providers/ansible_tower
@miq-bot add_label services
@miq-bot add_label euwe/no
@miq-bot assign @gmcculloug 