### PR TITLE
Don't allow selecting resources from another region when creating a catalog item

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -288,7 +288,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     rails_logger('allowed_templates', 0)
-    vms = VmOrTemplate.all
+    vms = VmOrTemplate.in_my_region.all
     condition = allowed_template_condition
 
     unless options[:tag_filters].blank?
@@ -309,7 +309,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
       unless tag_conditions.blank?
         _log.info "Filtering VM templates with the following tag_filters: <#{tag_conditions.inspect}>"
-        vms = MiqTemplate.where(condition).find_tags_by_grouping(tag_conditions, :ns => "/managed")
+        vms = MiqTemplate.in_my_region.where(condition).find_tags_by_grouping(tag_conditions, :ns => "/managed")
       end
     end
 

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -320,4 +320,23 @@ describe MiqProvisionVirtWorkflow do
       expect(request.source_id).to eq(template.id)
     end
   end
+
+  context "#allowed_templates" do
+    let(:external_region_id) do
+      remote_region_number = ApplicationRecord.my_region_number + 1
+      ApplicationRecord.region_to_range(remote_region_number).first
+    end
+
+    let(:remote_vmware) { FactoryGirl.create(:ems_vmware_with_authentication, :id => external_region_id) }
+    let(:local_vmware)  { FactoryGirl.create(:ems_vmware_with_authentication) }
+
+    it "only returns records from its region" do
+      EvmSpecHelper.local_guid_miq_server_zone # Because there is no default timezone in settings
+      FactoryGirl.create(:template_vmware, :ext_management_system => remote_vmware, :id => external_region_id)
+      FactoryGirl.create(:template_vmware, :ext_management_system => local_vmware)
+
+      expect(MiqTemplate.count).to eq(2)
+      expect(workflow.allowed_templates.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When creating a catalog item, only allow selecting resources from the current region.

https://bugzilla.redhat.com/show_bug.cgi?id=1398725