### PR TITLE
Enable scm_credential type in refresh

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -77,7 +77,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
                                 when 'net' then "#{provider_module}::AutomationManager::NetworkCredential"
                                 when 'ssh' then "#{provider_module}::AutomationManager::MachineCredential"
                                 when 'vmware' then "#{provider_module}::AutomationManager::VmwareCredential"
-                                # when 'scm' then "#{provider_module}::AutomationManager::???Credential"
+                                when 'scm' then "#{provider_module}::AutomationManager::ScmCredential"
                                 when 'aws' then "#{provider_module}::AutomationManager::AmazonCredential"
                                 when 'rax' then "#{provider_module}::AutomationManager::RackspaceCredential"
                                 when 'satellite6' then "#{provider_module}::AutomationManager::Satellite6Credential"

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_v2_spec.rb
@@ -1,7 +1,7 @@
-require 'support/ansible_shared/automation_manager/refresher'
+require 'support/ansible_shared/automation_manager/refresher_v2'
 
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher do
-  it_behaves_like 'ansible refresher',
+  it_behaves_like 'ansible refresher_v2',
                   :provider_ansible_tower,
                   described_class.parent,
                   :ansible_tower_automation,

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/refresher_v2_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/refresher_v2_spec.rb
@@ -1,4 +1,4 @@
-require 'support/ansible_shared/automation_manager/refresher'
+require 'support/ansible_shared/automation_manager/refresher_v2'
 
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Refresher do
   it_behaves_like 'ansible refresher_v2',

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -107,6 +107,13 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :userid => "MiqAnsibleUser@vsphere.local",
     )
     expect(cloud_credential.options.keys).to match_array(cloud_credential.class::EXTRA_ATTRIBUTES.keys)
+
+    scm_credential = expected_configuration_script_source.authentication
+    expect(scm_credential).to have_attributes(
+      :name   => "db-github",
+      :userid => "syncrou"
+    )
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
   end
 
   def assert_playbooks

--- a/spec/support/ansible_shared/automation_manager/refresher_v2.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher_v2.rb
@@ -64,6 +64,7 @@ shared_examples_for "ansible refresher_v2" do |ansible_provider, manager_class, 
       :name   => "appliance",
       :userid => "root",
     )
+
     cloud_credential = expected_configuration_script.authentications.find_by(
       :type => manager_class::AmazonCredential
     )
@@ -71,6 +72,13 @@ shared_examples_for "ansible refresher_v2" do |ansible_provider, manager_class, 
       :name   => "AWS",
       :userid => "065ZMGNV5WNKPMX4FF82",
     )
+
+    scm_credential = expected_configuration_script_source.authentication
+    expect(scm_credential).to have_attributes(
+      :name   => "db-github",
+      :userid => "syncrou"
+    )
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
   end
 
   def assert_playbooks


### PR DESCRIPTION
The `scm_credential` was not being inventoried with most accurate class type. 

Also fixing a test `shared_examples` being directed to wrong file.

