### PR TITLE
[WIP] Assign the relationship between Physical server and host

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -46,9 +46,8 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    servers = save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref])
-    
-    #Assign the physical server to host relationship
+    servers = save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref]) 
+    # Assign the physical server to host relationship
     servers.map do |s|
       host = Host.where(:service_tag => s.serial_number)
       host.physical_server = s

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -46,7 +46,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    servers = save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref]) 
+    servers = save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref])
     # Assign the physical server to host relationship
     servers.map do |s|
       host = Host.where(:service_tag => s.serial_number)

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -46,7 +46,15 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref])
+    servers = save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref])
+    
+    #Assign the physical server to host relationship
+    servers.map do |s|
+      host = Host.where(:service_tag => s.serial_number)
+      host.physical_server = s
+      host.save!
+    end
+
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end
 end


### PR DESCRIPTION
Change the `save_phsyical_server_inventory` method to:

1. find a host which has the `service_tag` equal to physical server `serial_number`.
2. Assign physical server to host which was found in the previous step.


NOTICE: **This routine still is in test using LXCA appliance, but it should work to any physical server.**