### PR TITLE
flag required attributes for Ansible credentials

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -4,12 +4,14 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
   COMMON_ATTRIBUTES = {
     :userid => {
       :label     => N_('Access Key'),
-      :help_text => N_('AWS Access Key for this credential')
+      :help_text => N_('AWS Access Key for this credential'),
+      :required  => true
     },
     :password => {
       :type      => :password,
       :label     => N_('Secret Key'),
-      :help_text => N_('AWS Secret Key for this credential')
+      :help_text => N_('AWS Secret Key for this credential'),
+      :required  => true
     }
   }.freeze
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -4,12 +4,14 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   COMMON_ATTRIBUTES = {
     :userid => {
       :label     => N_('Username'),
-      :help_text => N_('Username for this credential')
+      :help_text => N_('Username for this credential'),
+      :required  => true
     },
     :password => {
       :type      => :password,
       :label     => N_('Password'),
-      :help_text => N_('Password for this credential')
+      :help_text => N_('Password for this credential'),
+      :required  => true
     }
   }.freeze
 
@@ -18,7 +20,8 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
       :type       => :string,
       :label      => N_('vCenter Host'),
       :help_text  => N_('The hostname or IP address of the vCenter Host'),
-      :max_length => 1024
+      :max_length => 1024,
+      :required   => true
     }
   }.freeze
 


### PR DESCRIPTION
As hint to UI to enforce some minimal checking on user input for creation.

(There is 2 more attributes not being modeled here: 
* `name` which is part of `Authentication` and it is always required for all Ansible credentials
* `organization, or team, or user` which Tower requires at least one of them.  Previously we agreed on always default to the `Default` organization that comes with vanilla Tower.  The question is who would enter that?  UI, or API, or model
@Fryguy @blomquisg what do you think on the 2nd bullet?
)