### PR TITLE
Yardoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ node_modules/
 
 # ignore included plugins in bundler.d
 bundler.d/*
+
+# yardoc
+/doc/
+.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+app/models/mixins/supports_feature_mixin.rb
+app/models/manager_refresh/inventory_collection.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,2 @@
 app/models/mixins/supports_feature_mixin.rb
-app/models/manager_refresh/inventory_collection.rb
+app/models/manager_refresh

--- a/Gemfile
+++ b/Gemfile
@@ -198,6 +198,7 @@ unless ENV["APPLIANCE"]
     gem "haml_lint",        "~>0.20.0", :require => false
     gem "rubocop",          "~>0.47.0", :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
+    gem "yard"
   end
 
   group :test do

--- a/app/models/manager_refresh/inventory/collector.rb
+++ b/app/models/manager_refresh/inventory/collector.rb
@@ -2,7 +2,7 @@ class ManagerRefresh::Inventory::Collector
   attr_reader :manager, :target
 
   # @param manager [ManageIQ::Providers::BaseManager] A manager object
-  # @param target [Object] A refresh Target object
+  # @param refresh_target [Object] A refresh Target object
   def initialize(manager, refresh_target)
     @manager = manager
     @target  = refresh_target

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -1,3 +1,50 @@
+# Usage:
+####################################################################################################################
+# Example 1, storing Vm model data into the DB:
+####################################################################################################################
+#   ################################################################################################################
+#   # Example 1.1 Starting with no vms, lets add vm1 and vm2
+#   @ems = ManageIQ::Providers::BaseManager.first
+#   puts @ems.vms.collect(&:ems_ref) # => []
+#   # Init InventoryCollection
+#   vms_inventory_collection = ::ManagerRefresh::InventoryCollection.new(
+#     :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms
+#   )
+#
+#   # Fill InventoryCollection with data
+#   vms_inventory_collection.build(:ems_ref => "vm1", :name => "vm1")
+#   vms_inventory_collection.build(:ems_ref => "vm2", :name => "vm2")
+#
+#   # Save InventoryCollection to the db
+#   ManagerRefresh::SaveInventory.save_inventory(@ems, [vms_inventory_collection])
+#
+#   # The result in the DB is that vm1 and vm2 were created
+#   puts @ems.vms.collect(&:ems_ref) # => ["vm1", "vm2"]
+#
+#   ################################################################################################################
+#   # Example 1.2 In another refresh, vm1 does not exist anymore and vm3 was added
+#   # Init InventoryCollection
+#   vms_inventory_collection = ::ManagerRefresh::InventoryCollection.new(
+#     :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms
+#   )
+#   # Fill InventoryCollection with data
+#   vms_inventory_collection.build(:ems_ref => "vm2", :name => "vm2")
+#   vms_inventory_collection.build(:ems_ref => "vm3", :name => "vm3")
+#
+#   # Save InventoryCollection to the db
+#   ManagerRefresh::SaveInventory.save_inventory(@ems, [vms_inventory_collection])
+#
+#   # The result in the DB is that vm1 was deleted, vm2 was updated and vm3 was created
+#   puts @ems.vms.collect(&:ems_ref) # => ["vm2", "vm3"]
+#
+####################################################################################################################
+#
+# For more usage examples please follow spec examples in:
+# spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+# spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+# spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
+# spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+# spec/models/manager_refresh/save_inventory/strategies_and_references_spec.rb
 module ManagerRefresh
   class InventoryCollection
     # @return [Boolean] Says whether this collection is already saved into the DB , e.g. InventoryCollections with
@@ -49,54 +96,6 @@ module ManagerRefresh
 
     delegate :each, :size, :to => :to_a
 
-    # Usage:
-    ####################################################################################################################
-    # Example 1, storing Vm model data into the DB:
-    ####################################################################################################################
-    #   ################################################################################################################
-    #   # Example 1.1 Starting with no vms, lets add vm1 and vm2
-    #   @ems = ManageIQ::Providers::BaseManager.first
-    #   puts @ems.vms.collect(&:ems_ref) # => []
-    #   # Init InventoryCollection
-    #   vms_inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-    #     :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms
-    #   )
-    #
-    #   # Fill InventoryCollection with data
-    #   vms_inventory_collection.build(:ems_ref => "vm1", :name => "vm1")
-    #   vms_inventory_collection.build(:ems_ref => "vm2", :name => "vm2")
-    #
-    #   # Save InventoryCollection to the db
-    #   ManagerRefresh::SaveInventory.save_inventory(@ems, [vms_inventory_collection])
-    #
-    #   # The result in the DB is that vm1 and vm2 were created
-    #   puts @ems.vms.collect(&:ems_ref) # => ["vm1", "vm2"]
-    #
-    #   ################################################################################################################
-    #   # Example 1.2 In another refresh, vm1 does not exist anymore and vm3 was added
-    #   # Init InventoryCollection
-    #   vms_inventory_collection = ::ManagerRefresh::InventoryCollection.new(
-    #     :model_class => ManageIQ::Providers::CloudManager::Vm, :parent => @ems, :association => :vms
-    #   )
-    #   # Fill InventoryCollection with data
-    #   vms_inventory_collection.build(:ems_ref => "vm2", :name => "vm2")
-    #   vms_inventory_collection.build(:ems_ref => "vm3", :name => "vm3")
-    #
-    #   # Save InventoryCollection to the db
-    #   ManagerRefresh::SaveInventory.save_inventory(@ems, [vms_inventory_collection])
-    #
-    #   # The result in the DB is that vm1 was deleted, vm2 was updated and vm3 was created
-    #   puts @ems.vms.collect(&:ems_ref) # => ["vm2", "vm3"]
-    #
-    ####################################################################################################################
-    #
-    # For more usage examples please follow spec examples in:
-    # spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
-    # spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
-    # spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
-    # spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
-    # spec/models/manager_refresh/save_inventory/strategies_and_references_spec.rb
-    #
     # @param model_class [Class] A class of an ApplicationRecord model, that we want to persist into the DB or load from
     #        the DB.
     # @param manager_ref [Array] Array of Symbols, that are keys of the InventoryObject's data, inserted into this

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -149,7 +149,7 @@ module ManagerRefresh
     #              }
     #            })
     #
-    #        And the labmda is defined as:
+    #        And the lambda is defined as:
     #
     #            orchestration_stack_ancestry_save_block = lambda do |_ems, inventory_collection|
     #              stacks_inventory_collection = inventory_collection.dependency_attributes[:orchestration_stacks].try(:first)
@@ -182,7 +182,7 @@ module ManagerRefresh
     #              :custom_reconnect_block => vms_custom_reconnect_block,
     #            })
     #
-    #        And the labmda is defined as:
+    #        And the lambda is defined as:
     #
     #            vms_custom_reconnect_block = lambda do |inventory_collection, inventory_objects_index, attributes_index|
     #              inventory_objects_index.each_slice(1000) do |batch|

--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -42,10 +42,10 @@ module ManagerRefresh
     end
 
     # Returns targets in a format:
-    # {
-    #   :vms => {:ems_ref => Set.new(["vm_ref_1", "vm_ref2"])}
-    #   :network_ports => {:ems_ref => Set.new(["network_port_1", "network_port2"])
-    # }
+    #   {
+    #     :vms => {:ems_ref => Set.new(["vm_ref_1", "vm_ref2"])},
+    #     :network_ports => {:ems_ref => Set.new(["network_port_1", "network_port2"])
+    #   }
     #
     # Then we can quickly access all objects affected by:
     #   NetworkPort.where(target_collection.manager_refs_by_association[:network_ports].to_a) =>

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -1,60 +1,60 @@
+#
+# Including this in a model gives you a DSL to make features supported or not
+#
+#   class Post
+#     include SupportsFeatureMixin
+#     supports :publish
+#     supports_not :fake, :reason => 'We keep it real'
+#     supports :archive do
+#       unsupported_reason_add(:archive, 'Its too good') if featured?
+#     end
+#   end
+#
+# To make a feature conditionally supported, pass a block to the +supports+ method.
+# The block is evaluated in the context of the instance.
+# If you call the private method +unsupported_reason_add+ with the feature
+# and a reason, then the feature will be unsupported and the reason will be
+# accessible through
+#
+#   instance.unsupported_reason(:feature)
+#
+# The above allows you to call +supports_feature?+ or +supports?(feature) :methods
+# on the Class and Instance
+#
+#   Post.supports_publish?                       # => true
+#   Post.supports?(:publish)                     # => true
+#   Post.new.supports_publish?                   # => true
+#   Post.supports_fake?                          # => false
+#   Post.supports_archive?                       # => true
+#   Post.new(featured: true).supports_archive?   # => false
+#
+# To get a reason why a feature is unsupported use the +unsupported_reason+ method
+#
+#   Post.unsupported_reason(:publish)                     # => "Feature not supported"
+#   Post.unsupported_reason(:fake)                        # => "We keep it real"
+#   Post.new(featured: true).unsupported_reason(:archive) # => "Its too good"
+#
+# To query for known features you can ask the class or the instance via +feature_known?+
+#
+#   Post.feature_known?('fake')     # => true
+#   Post.new.feature_known?(:fake)  # => true
+#   Post.new.feature_known?(:alert) # => false
+#
+# If you include this concern in a Module that gets included by the Model
+# you have to extend that model with +ActiveSupport::Concern+ and wrap the
+# +supports+ calls in an +included+ block. This is also true for modules in between!
+#
+#   module Operations
+#     extend ActiveSupport::Concern
+#     module Power
+#       extend ActiveSupport::Concern
+#       included do
+#         supports :operation
+#       end
+#     end
+#   end
+#
 module SupportsFeatureMixin
-  #
-  # Including this in a model gives you a DSL to make features supported or not
-  #
-  #   class Post
-  #     include SupportsFeatureMixin
-  #     supports :publish
-  #     supports_not :fake, :reason => 'We keep it real'
-  #     supports :archive do
-  #       unsupported_reason_add(:archive, 'Its too good') if featured?
-  #     end
-  #   end
-  #
-  # To make a feature conditionally supported, pass a block to the +supports+ method.
-  # The block is evaluated in the context of the instance.
-  # If you call the private method +unsupported_reason_add+ with the feature
-  # and a reason, then the feature will be unsupported and the reason will be
-  # accessible through
-  #
-  #   instance.unsupported_reason(:feature)
-  #
-  # The above allows you to call +supports_feature?+ or +supports?(feature) :methods
-  # on the Class and Instance
-  #
-  #   Post.supports_publish?                       # => true
-  #   Post.supports?(:publish)                     # => true
-  #   Post.new.supports_publish?                   # => true
-  #   Post.supports_fake?                          # => false
-  #   Post.supports_archive?                       # => true
-  #   Post.new(featured: true).supports_archive?   # => false
-  #
-  # To get a reason why a feature is unsupported use the +unsupported_reason+ method
-  #
-  #   Post.unsupported_reason(:publish)                     # => "Feature not supported"
-  #   Post.unsupported_reason(:fake)                        # => "We keep it real"
-  #   Post.new(featured: true).unsupported_reason(:archive) # => "Its too good"
-  #
-  # To query for known features you can ask the class or the instance via +feature_known?+
-  #
-  #   Post.feature_known?('fake')     # => true
-  #   Post.new.feature_known?(:fake)  # => true
-  #   Post.new.feature_known?(:alert) # => false
-  #
-  # If you include this concern in a Module that gets included by the Model
-  # you have to extend that model with +ActiveSupport::Concern+ and wrap the
-  # +supports+ calls in an +included+ block. This is also true for modules in between!
-  #
-  #   module Operations
-  #     extend ActiveSupport::Concern
-  #     module Power
-  #       extend ActiveSupport::Concern
-  #       included do
-  #         supports :operation
-  #       end
-  #     end
-  #   end
-  #
   extend ActiveSupport::Concern
 
   QUERYABLE_FEATURES = {


### PR DESCRIPTION
This is an initial stab at putting the scarce but existent documentation in the source code into a browsable format. I think having something thats actually visible and accessible encourages people to read and _write_ docs.

I've opted for http://yardoc.org/ because I know it.

To add files to the documentation, simply add them to `.yardopts`
To build the documentation run `bundle exec yard` and point your w3c to `doc/index.html`

Maybe we can run this periodically and publish it somewhere.

If this is something we want to do, I would continue with cleaning up docs those 2 files and scan for additional stuff we want to include

@miq-bot add_label documentation

cc @hayesr @Fryguy @chessbyte @blomquisg 