### PR TITLE
Fix an issue in Condition where fields of virtual associations can't be evaluated.

### DIFF
--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -148,7 +148,7 @@ module ActsAsTaggable
         relationship = "self"
         macro = :has_one
       else
-        macro = subject.class.reflect_on_association(relationship.to_sym).macro
+        macro = subject.class.reflection_with_virtual(relationship.to_sym).macro
       end
       if macro == :has_one || macro == :belongs_to
         value = subject.public_send(relationship).public_send(attr)

--- a/spec/lib/extensions/ar_taggable_spec.rb
+++ b/spec/lib/extensions/ar_taggable_spec.rb
@@ -123,6 +123,12 @@ describe ActsAsTaggable do
       expect(@vm1).to be_is_tagged_with("/test/tags/red", :ns => "none")
       expect(@vm1).to be_is_tagged_with("/test/tags/red", :ns => :none)
     end
+
+    it "with virtual reflections" do
+      lan = FactoryGirl.create(:lan, :name => "VM NFS Network")
+      vm  = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :guest_devices => [FactoryGirl.create(:guest_device_nic, :lan => lan)]))
+      expect(vm).to be_is_tagged_with("/virtual/lans/name/VM NFS Network", :ns => "*")
+    end
   end
 
   it "#tag_list" do


### PR DESCRIPTION
Virtual associations are not checked when navigating down the relationships.

https://bugzilla.redhat.com/show_bug.cgi?id=1434553

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, euwe/yes, control