### PR TITLE
Vm rollup defaults (ruby solution)

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1521,8 +1521,10 @@ class VmOrTemplate < ApplicationRecord
   # Hardware Disks/Memory storage methods
   #
 
-  virtual_delegate :allocated_disk_storage, :used_disk_storage, :provisioned_storage,
+  virtual_delegate :allocated_disk_storage, :used_disk_storage,
                    :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}
+
+  virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0
 
   def used_storage
     used_disk_storage.to_i + ram_size_in_bytes

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -147,7 +147,7 @@ module VirtualDelegates
       if allow_nil
         method_def = <<-METHOD
           def #{method_name}(#{definition})
-            return self[:#{method_name}] if has_attribute?(:#{method_name})
+            return self[:#{method_name}]#{default} if has_attribute?(:#{method_name})
             _ = #{to}
             if !_.nil? || nil.respond_to?(:#{method})
               _.#{method}(#{definition})
@@ -159,7 +159,7 @@ module VirtualDelegates
 
         method_def = <<-METHOD
           def #{method_name}(#{definition})
-            return self[:#{method_name}] if has_attribute?(:#{method_name})
+            return self[:#{method_name}]#{default} if has_attribute?(:#{method_name})
             _ = #{to}
             _.#{method}(#{definition})#{default}
           rescue NoMethodError => e

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -596,6 +596,22 @@ describe VmOrTemplate do
     end
   end
 
+  describe "#provisioned_storage" do
+    context "with no hardware" do
+      let(:vm) { FactoryGirl.create(:vm_vmware) }
+
+      it "calculates in ruby" do
+        expect(vm.provisioned_storage).to eq(0.0)
+      end
+
+      it "uses calculated (inline) attribute" do
+        vm # make sure the record is created
+        vm2 = VmOrTemplate.select(:id, :provisioned_storage).first
+        expect { expect(vm2.provisioned_storage).to eq(0) }.to match_query_limit_of(0)
+      end
+    end
+  end
+
   describe ".ram_size", ".mem_cpu" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
     let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 10) }


### PR DESCRIPTION
Fixes #14393  [Alternate to #14448 ]

Introduced by #14285, the default value for `Vm#provisioned_storage` became nil when there is no hardware record. This PR changes the default back to 0.

### Details

When delegating a column to another model, and the other model does not exist in the database, the SQL for the attribute comes back as a null. So the attribute looks like it is coming back from SQL, but in truth, it is just a null. Since there is no value, the default needs to be returned.

