### PR TITLE
Add retire_now to Embedded Ansible job.

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -2,4 +2,9 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
   require_nested :Status
+
+  def retire_now(requester = nil)
+    update_attributes(:retirement_requester => requester)
+    finish_retirement
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -1,5 +1,12 @@
 require 'support/ansible_shared/automation_manager/job'
 
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
+  let(:job) { FactoryGirl.create(:embedded_ansible_job) }
+
   it_behaves_like 'ansible job'
+
+  it 'processes retire_now properly' do
+    expect(job).to receive(:finish_retirement).once
+    job.retire_now
+  end
 end


### PR DESCRIPTION
Use retire_now to mark the job as retired.

Set the Ansible Playbook provisioned Services service_resources resource of type ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job to retired with retire_now.

https://www.pivotaltracker.com/story/show/141719033