### PR TITLE
Skip relationship query when we know there are none

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -126,7 +126,8 @@ module RelationshipMixin
   # Returns all of the relationships of the parents of the record, [] for a root node
   def parent_rels(*args)
     options = args.extract_options!
-    rels = Relationship.where(:id => parent_rel_ids)
+    pri = parent_rel_ids
+    rels = pri.kind_of?(Array) && pri.empty? ? Relationship.none : Relationship.where(:id => parent_rel_ids)
     Relationship.filter_by_resource_type(rels, options)
   end
 


### PR DESCRIPTION
```ruby
# when parent_rel_ids = []

def parent_rels
  Relationships.where(:id => parent_rel_ids)
end

# => SELECT * from "relationships" WHERE 1=0
```

When `parent_rel_ids` is an empty array, we perform a no-op query. This PR removes this extra query.


### numbers

|       ms |   bytes | objects |queries | query (ms) |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  3,418.4 | 77,412,641* | 4,659,232 |   81 |   363.0 |    2,941 |before
|  3,305.5 | 76,674,581* | 4,375,785 |   67 |   409.2 |    2,941 |after
| 3% | n/a | 6% | 17% | n/a | 0 | diff

\* Memory usage does not reflect 1,550,176 freed objects.
\* Memory usage does not reflect 1,274,302 freed objects.

### analysis

Typically, the widget report `"Host Summary for VMs"`, shows a number of skipped queries. But results are data dependent, and some data sets show the same query count for the before and after cases.

Since only non-result queries are skipped, row counts will be identical and timings will only show modest savings. (runtime variances actually showed this query time as higher)