### PR TITLE
Pass event_target and event_name to Ansible

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -222,11 +222,13 @@ class MiqAction < ApplicationRecord
                     :message      => "Policy #{msg}: policy: [#{inputs[:policy].description}], event: [#{inputs[:event].description}]")
   end
 
-  def action_run_ansible_playbook(action, rec, _inputs)
+  def action_run_ansible_playbook(action, rec, inputs)
     service_template = ServiceTemplate.find(action.options[:service_template_id])
-    options = { :hosts     => target_hosts(action, rec),
-                :initiator => 'control' }
-    service_template.provision_request(target_user(rec), options)
+    dialog_options = { :hosts => target_hosts(action, rec) }
+    request_options = { :manageiq_extra_vars => { 'event_source' => rec.href_slug,
+                                                  'event_name'   => inputs[:event].try(:name) },
+                        :initiator           => 'control' }
+    service_template.provision_request(target_user(rec), dialog_options, request_options)
   end
 
   def action_snmp_trap(action, rec, inputs)

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -225,7 +225,7 @@ class MiqAction < ApplicationRecord
   def action_run_ansible_playbook(action, rec, inputs)
     service_template = ServiceTemplate.find(action.options[:service_template_id])
     dialog_options = { :hosts => target_hosts(action, rec) }
-    request_options = { :manageiq_extra_vars => { 'event_source' => rec.href_slug,
+    request_options = { :manageiq_extra_vars => { 'event_target' => rec.href_slug,
                                                   'event_name'   => inputs[:event].try(:name) },
                         :initiator           => 'control' }
     service_template.provision_request(target_user(rec), dialog_options, request_options)

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -1,5 +1,6 @@
 class ResourceActionWorkflow < MiqRequestWorkflow
   attr_accessor :dialog
+  attr_accessor :request_options
 
   def self.base_model
     ResourceActionWorkflow
@@ -55,7 +56,10 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def create_values
-    create_values_hash.tap { |value| value[:src_id] = @target.id }
+    create_values_hash.tap do |value|
+      value[:src_id] = @target.id
+      value[:request_options] = request_options unless request_options.blank?
+    end
   end
 
   def request_class

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -54,7 +54,11 @@ class ServiceAnsiblePlaybook < ServiceGeneric
       'service'   => href_slug,
       'user'      => evm_owner.href_slug,
       'action'    => action
-    }
+    }.merge(request_options_extra_vars)
+  end
+
+  def request_options_extra_vars
+    miq_request_task.options.fetch_path(:request_options, :manageiq_extra_vars) || {}
   end
 
   def get_job_options(action)

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -410,7 +410,7 @@ describe MiqAction do
     end
 
     let(:request_options) do
-      { :manageiq_extra_vars => { "event_source" => vm.href_slug, "event_name" => event_name },
+      { :manageiq_extra_vars => { "event_target" => vm.href_slug, "event_name" => event_name },
         :initiator           => 'control' }
     end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -674,9 +674,10 @@ describe ServiceTemplate do
         .with({}, user, resource_action, hash).and_return(workflow))
       expect(workflow).to receive(:submit_request)
       expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
-      expect(workflow).to receive(:set_value).with(:initiator, 'control')
+      expect(workflow).to receive(:request_options=).with(:initiator => 'control')
 
-      service_template.provision_request(user, 'ordered_by' => 'fred', :initiator => 'control')
+      service_template.provision_request(user, {'ordered_by' => 'fred'},
+                                         {:initiator => 'control'})
     end
   end
 end


### PR DESCRIPTION
Pass event_target and event_name to Ansible playbooks. The event_source is passed in as a slug

https://www.pivotaltracker.com/n/projects/1937537/stories/141706313

<img width="668" alt="screen shot 2017-03-27 at 12 36 31 pm" src="https://cloud.githubusercontent.com/assets/6452699/24367319/34980516-12ea-11e7-90eb-7af7aeec0634.png">
