### PR TITLE
Prepare parameter hash before passing to Tower API credential CU

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -31,4 +31,5 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
     :label      => N_('Amazon'),
     :attributes => API_ATTRIBUTES
   }.freeze
+  TOWER_KIND = 'aws'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   module ClassMethods
     def provider_params(params)
       params[:username] = params.delete(:userid) if params.include?(:userid)
+      params[:kind] = self::TOWER_KIND
       params
     end
 
@@ -82,4 +83,5 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  # TOWER_KIND = 'ssh'.freeze # default to `ssh` just like Tower does
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -4,6 +4,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   module ClassMethods
     def provider_params(params)
       params[:username] = params.delete(:userid) if params.include?(:userid)
+      params[:username] = params.delete('userid') if params.include?('userid')
       params[:kind] = self::TOWER_KIND
       params
     end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -2,7 +2,13 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def provider_params(params)
+      params[:username] = params.delete(:userid) if params.include?(:userid)
+      params
+    end
+
     def create_in_provider(manager_id, params)
+      params = provider_params(params)
       manager = ExtManagementSystem.find(manager_id)
       credential = manager.with_provider_connection do |connection|
         connection.api.credentials.create!(params)
@@ -48,6 +54,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
 
   def update_in_provider(params)
     params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
+    params = self.class.provider_params(params)
     resource.with_provider_connection do |connection|
       connection.api.credentials.find(manager_ref).update_attributes!(params)
     end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -83,5 +83,4 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
-  # TOWER_KIND = 'ssh'.freeze # default to `ssh` just like Tower does
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -58,4 +58,5 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
     :type       => 'machine',
     :attributes => API_ATTRIBUTES
   }.freeze
+  TOWER_KIND = 'ssh'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -34,4 +34,5 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
     :type       => 'scm',
     :attributes => API_ATTRIBUTES
   }.freeze
+  TOWER_KIND = 'scm'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -32,4 +32,5 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
     :type       => 'cloud',
     :attributes => API_ATTRIBUTES
   }.freeze
+  TOWER_KIND = 'vmware'.freeze
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -2,6 +2,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
 
   def self.provider_params(params)
-    super.merge(:organization => 1)
+    super.merge(:organization_id => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -1,4 +1,7 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential <
-  ManageIQ::Providers::EmbeddedAutomationManager::Authentication
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
+
+  def self.provider_params(params)
+    super.merge(:organization => 1)
+  end
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
@@ -1,5 +1,5 @@
 require 'support/ansible_shared/automation_manager/credential'
 
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::Credential do
-  it_behaves_like 'ansible credential'
+  it_behaves_like 'ansible credential', :provider_ansible_tower
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
@@ -1,5 +1,9 @@
 require 'support/ansible_shared/automation_manager/credential'
 
 describe ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential do
-  it_behaves_like 'ansible credential', :provider_ansible_tower
+  let(:manager) do
+    FactoryGirl.create(:provider_ansible_tower, :with_authentication).managers.first
+  end
+
+  it_behaves_like 'ansible credential'
 end

--- a/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/ansible_tower/automation_manager/credential_spec.rb
@@ -1,5 +1,5 @@
 require 'support/ansible_shared/automation_manager/credential'
 
-describe ManageIQ::Providers::AnsibleTower::AutomationManager::Credential do
+describe ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential do
   it_behaves_like 'ansible credential', :provider_ansible_tower
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,5 +1,9 @@
 require 'support/ansible_shared/automation_manager/credential'
 
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential do
-  it_behaves_like 'ansible credential', :provider_embedded_ansible
+  let(:manager) do
+    FactoryGirl.create(:provider_embedded_ansible, :with_authentication, :default_organization => 1).managers.first
+  end
+
+  it_behaves_like 'ansible credential'
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,5 +1,5 @@
 require 'support/ansible_shared/automation_manager/credential'
 
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
-  it_behaves_like 'ansible credential'
+  it_behaves_like 'ansible credential', :provider_embedded_ansible
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,5 +1,5 @@
 require 'support/ansible_shared/automation_manager/credential'
 
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential do
   it_behaves_like 'ansible credential', :provider_embedded_ansible
 end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -97,7 +97,8 @@ shared_examples_for "ansible credential" do |ansible_provider|
     it "#update_in_provider" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
-      expect(ansible_cred.update_in_provider({})).to be_a(described_class)
+      expect(credential).to receive(:update_attributes!).with({:username => 'john'})
+      expect(ansible_cred.update_in_provider({:userid => 'john'})).to be_a(described_class)
     end
 
     it "#update_in_provider_queue" do

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -1,8 +1,8 @@
 require 'ansible_tower_client'
 
-shared_examples_for "ansible credential" do
+shared_examples_for "ansible credential" do |ansible_provider|
   let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
-  let(:manager)       { FactoryGirl.create(:provider_ansible_tower, :with_authentication).managers.first }
+  let(:manager)       { FactoryGirl.create(ansible_provider, :with_authentication).managers.first }
   let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
   let(:api)           { double("AnsibleTowerClient::Api", :credentials => credentials) }
 

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -1,8 +1,7 @@
 require 'ansible_tower_client'
 
-shared_examples_for "ansible credential" do |ansible_provider|
+shared_examples_for "ansible credential" do
   let(:finished_task) { FactoryGirl.create(:miq_task, :state => "Finished") }
-  let(:manager)       { FactoryGirl.create(ansible_provider, :with_authentication).managers.first }
   let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
   let(:api)           { double("AnsibleTowerClient::Api", :credentials => credentials) }
 
@@ -33,7 +32,7 @@ shared_examples_for "ansible credential" do |ansible_provider|
         :username     => "john",
         :kind         => described_class::TOWER_KIND
       }
-      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expected_params[:organization_id] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_credential(credential, manager)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
@@ -108,11 +107,11 @@ shared_examples_for "ansible credential" do |ansible_provider|
         :username => 'john',
         :kind     => described_class::TOWER_KIND
       }
-      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expected_params[:organization_id] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
       expect(credential).to receive(:update_attributes!).with(expected_params)
-      expect(ansible_cred.update_in_provider(:userid => 'john')).to be_a(described_class)
+      expect(ansible_cred.update_in_provider('userid' => 'john')).to be_a(described_class)
     end
 
     it "#update_in_provider_queue" do

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -97,7 +97,10 @@ shared_examples_for "ansible credential" do |ansible_provider|
     it "#update_in_provider" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
-      expect(credential).to receive(:update_attributes!).with({:username => 'john'})
+      expect(credential).to receive(:update_attributes!).with({
+        :username => 'john',
+        :kind     => 'scm' # described_class::TOWER_KIND
+      })
       expect(ansible_cred.update_in_provider({:userid => 'john'})).to be_a(described_class)
     end
 


### PR DESCRIPTION
* convert `:userid` to `:username`
* add `:kind`
* add `:organization => 1` if it's the `EmbeddedAnsible`. I.e. assign to `Default` organization in Tower