### PR TITLE
[WIP] Remove sensitive data from container deployment OPTIONS

### DIFF
--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -6,7 +6,7 @@ module Api
     end
 
     def options
-      render_options(:container_deployments, ContainerDeploymentService.new.all_data)
+      render_options(:container_deployments, :deployment_types => ContainerDeployment::DEPLOYMENT_TYPES)
     end
   end
 end

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -1,10 +1,11 @@
 describe "Container Deployments API" do
   it "supports collect-data with OPTIONS" do
-    allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
     api_basic_authorize
+
     run_options container_deployments_url
+
     expect(response).to have_http_status(:ok)
-    expect_hash_to_have_only_keys(response.parsed_body["data"], %w(deployment_types providers provision))
+    expect(response.parsed_body).to include("data" => {"deployment_types" => ContainerDeployment::DEPLOYMENT_TYPES})
   end
 
   it "creates container deployment with POST" do

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -811,6 +811,106 @@ describe "Providers API" do
         expect_query_result(:providers, 1, 1)
       end
     end
+
+    it "can return all the relevant info for possible provision providers for container deployment and their templates" do
+      amazon_disk = FactoryGirl.create(:disk, :size => 1024)
+      amazon_hardware = FactoryGirl.create(:hardware, :disks => [amazon_disk], :cpu_total_cores => 1, :memory_mb => 256)
+      amazon_template = FactoryGirl.create(:template_amazon, :hardware => amazon_hardware)
+      amazon_ems = FactoryGirl.create(:ems_amazon, :miq_templates => [amazon_template])
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get(
+        providers_url,
+        :expand     => "resources",
+        :attributes => "miq_templates,hardwares,disks",
+        :filter     => [
+          "type='ManageIQ::Providers::Amazon::CloudManager'",
+          "or type='ManageIQ::Providers::Redhat::InfraManager'"
+        ]
+      )
+
+      expected = {
+        "resources" => a_collection_containing_exactly(
+          a_hash_including(
+            "miq_templates" => [
+              a_hash_including(
+                "id"     => amazon_template.id,
+                "ems_id" => amazon_ems.id,
+              )
+            ],
+            "disks"         => [
+              a_hash_including(
+                "size"        => 1024,
+                "hardware_id" => amazon_hardware.id
+              )
+            ],
+            "hardwares"     => [
+              a_hash_including(
+                "vm_or_template_id" => amazon_template.id,
+                "cpu_total_cores"   => 1,
+                "memory_mb"         => 256
+              )
+            ]
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to be_success
+    end
+
+    it "can return all the relevant info for possible providers for container deployment and their vms" do
+      amazon_disk = FactoryGirl.create(:disk, :size => 1024)
+      amazon_hardware = FactoryGirl.create(:hardware, :disks => [amazon_disk], :cpu_total_cores => 1, :memory_mb => 256)
+      amazon_vm = FactoryGirl.create(:vm_amazon, :name => "Alice's VM", :hardware => amazon_hardware)
+      amazon_ems = FactoryGirl.create(:ems_amazon, :vms => [amazon_vm])
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get(
+        providers_url,
+        :expand     => "resources",
+        :attributes => "vms,disks,hardwares",
+        :filter     => [
+          "type='ManageIQ::Providers::Google::CloudManager'",
+          "or type='ManageIQ::Providers::Openstack::CloudManager'",
+          "or type='ManageIQ::Providers::Amazon::CloudManager'",
+          "or type='ManageIQ::Providers::Azure::CloudManager'",
+          "or type='ManageIQ::Providers::Vmware::CloudManager'",
+          "or type='ManageIQ::Providers::Redhat::InfraManager'",
+          "or type='ManageIQ::Providers::Microsoft::InfraManager'",
+          "or type='ManageIQ::Providers::Vmware::InfraManager'",
+          "or type='ManageIQ::Providers::Openstack::InfraManager'"
+        ]
+      )
+
+      expected = {
+        "resources" => a_collection_containing_exactly(
+          a_hash_including(
+            "vms"       => [
+              a_hash_including(
+                "id"     => amazon_vm.id,
+                "name"   => "Alice's VM",
+                "ems_id" => amazon_ems.id,
+              )
+            ],
+            "disks"     => [
+              a_hash_including(
+                "size"        => 1024,
+                "hardware_id" => amazon_hardware.id
+              )
+            ],
+            "hardwares" => [
+              a_hash_including(
+                "vm_or_template_id" => amazon_vm.id,
+                "cpu_total_cores"   => 1,
+                "memory_mb"         => 256
+              )
+            ]
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to be_success
+    end
   end
 
   context 'load balancers subcollection' do


### PR DESCRIPTION
DO NOT MERGE - it will break things in the classic UI - opening for discussion

This is problematic for a few reasons:

1. It's currently "protected" because this request requires
authentication, but we can't do that because it violates the CORS
protocol
2. The resources it returns are not filtered through RBAC

So, it seems the best solution to this is to:

1. Remove the sensitive data from the OPTIONS request, and
2. Have the user/client query the required data from the providers API, where
all the normal rules (authorization/RBAC) apply

I've added some tests to show how to achieve (2)

@dkorn this is basically the essence of the meeting I had planned today - your feedback would be appreciated. Basically - if we go ahead with this it requires a corresponding change to https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js#L218-L229. However, I don't see any tests for that, and I can't access it for some reason in development - the option doesn't seem to be there when I go to create a containers provider as pictured in https://github.com/ManageIQ/manageiq/pull/7620. So I can't tell if I change this if I've broken the feature or not.

Related to https://github.com/ManageIQ/manageiq/pull/14368

@abellotti as discussed we could eschew this for now by creating some workaround in the container deployments API that returns the sensitive stuff optionally if authorized. That still leaves (2) outstanding (resources are not filtered through RBAC), so I think a change would still be required there. I'd still like to try this route first to avoid adding complexity to the system if we already have the features required by way of querying normally through the providers API. Any thoughts?

/cc @jntullo 
