### PR TITLE
Add missing ui_lookup for Repository

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -749,6 +749,7 @@ en:
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential:        Credential (SCM)
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential:     Credential (VMware)
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook:             Playbook (Embedded Ansible)
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource: Repository (Embedded Ansible)
       ManageIQ::Providers::AutomationManager::Authentication:                     Credential
       ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential:     Credential (Amazon)
       ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential:      Credential (Microsoft Azure)


### PR DESCRIPTION
Add missing `ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource`.

Before:
ui_lookup returned `ManageIQ/Providers/Embedded Ansible/Automation Manager/Configuration Script Source`.
After:
ui_lookup returns `Repository (Embedded Provider)` 

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/346

@mzazrivec @h-kataria Please have a look.
