### PR TITLE
[Migration] Adds physical_server_id Column

### DIFF
--- a/db/migrate/20170324124321_add_physical_server_foreign_key_property_to_hardware.rb
+++ b/db/migrate/20170324124321_add_physical_server_foreign_key_property_to_hardware.rb
@@ -1,0 +1,5 @@
+class AddPhysicalServerForeignKeyPropertyToHardware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :physical_server_id, :string, index: true
+  end
+end


### PR DESCRIPTION
Adding the `physical_server_id` column to `hardware` table