### PR TITLE
update options tests to use expect_options_results

### DIFF
--- a/spec/requests/api/clusters_spec.rb
+++ b/spec/requests/api/clusters_spec.rb
@@ -3,11 +3,10 @@ RSpec.describe 'Clusters API' do
     it 'returns clusters node_types' do
       api_basic_authorize
 
-      expected = a_hash_including("data" => {"node_types" => EmsCluster.node_types.to_s})
+      expected_data = {"node_types" => EmsCluster.node_types.to_s}
 
       run_options(clusters_url)
-      expect(response.parsed_body).to match(expected)
-      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect_options_results(:clusters, expected_data)
     end
   end
 end

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -82,11 +82,10 @@ RSpec.describe "hosts API" do
       it 'returns hosts node_types' do
         api_basic_authorize
 
-        expected = a_hash_including("data" => {"node_types" => Host.node_types.to_s})
+        expected_data = {"node_types" => Host.node_types.to_s}
 
         run_options(hosts_url)
-        expect(response.parsed_body).to match(expected)
-        expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+        expect_options_results(:hosts, expected_data)
       end
     end
   end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -695,16 +695,9 @@ describe "Querying" do
   describe 'OPTIONS /api/vms' do
     it 'returns the options information' do
       api_basic_authorize
-      expected = {
-        'attributes'         => (Vm.attribute_names - Vm.virtual_attribute_names).sort.as_json,
-        'virtual_attributes' => Vm.virtual_attribute_names.sort.as_json,
-        'relationships'      => (Vm.reflections.keys | Vm.virtual_reflections.keys.collect(&:to_s)).sort,
-        'subcollections'     => Array(Api::ApiConfig.collections[:vms].subcollections).collect(&:to_s).sort,
-        'data'               => {}
-      }
+
       run_options(vms_url)
-      expect(response.parsed_body).to eq(expected)
-      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+      expect_options_results(:vms)
     end
   end
 


### PR DESCRIPTION
Update existing options tests to use `expect_options_results` as introduced in #13951

@miq-bot add_label test, api
@miq-bot assign @abellotti 