### PR TITLE
Set genealogy parent correctly to avoid multiple parents

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -155,7 +155,7 @@ module EmsRefresh::SaveInventory
         parent = vms[h.fetch_path(:parent_vm, :id)]
         child = vms[h[:id]]
 
-        parent.with_relationship_type('genealogy') { parent.set_child(child) } if parent && child
+        child.with_relationship_type('genealogy') { child.parent = parent } if parent && child
       end
     end
 


### PR DESCRIPTION
Set genealogy parent correctly to avoid multiple parents. 

Only by doing child.parent = parent, we enforce that there can be on 1 parent at the time