### PR TITLE
Set genealogy parent correctly to avoid multiple parents for graph refresh

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -213,7 +213,7 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
                                 .select([:id])
                                 .where(:id => vms_genealogy_parents.keys).find_each do |vm|
           parent = miq_templates[vms_genealogy_parents[vm.id]]
-          parent.with_relationship_type('genealogy') { parent.set_child(vm) }
+          vm.with_relationship_type('genealogy') { vm.parent = parent }
         end
       end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -478,7 +478,7 @@ class VmOrTemplate < ApplicationRecord
 
   def save_genealogy_information
     if defined?(@genealogy_parent_object) && @genealogy_parent_object
-      @genealogy_parent_object.with_relationship_type('genealogy') { @genealogy_parent_object.set_child(self) }
+      with_relationship_type('genealogy') { self.parent = @genealogy_parent_object }
     end
   end
 


### PR DESCRIPTION
Set genealogy parent correctly to avoid multiple parents for graph refresh

Only by doing child.parent = parent, we enforce that there can be on 1 parent at the time.

The hook variant is a slow n+1 for actual refresh, but it's used in some complex specs for graph refresh resolving cycles. The other is a custom saving code that does genealogy_parent assignment effectively and is currently used in AWS graph refresh.