### PR TITLE
Link recently_discovered_pods widget to rpt

### DIFF
--- a/product/dashboard/widgets/recently_discovered_pods.yaml
+++ b/product/dashboard/widgets/recently_discovered_pods.yaml
@@ -11,7 +11,7 @@ visibility:
   :roles:
   - _ALL_
 user_id: 
-resource_id: 198
+resource_name: Recently Discovered Pods
 resource_type: MiqReport
 miq_schedule_options:
   :run_at:


### PR DESCRIPTION
### Background

Widgets link to reports by report name.
This is because the ids in our database are not consistent across installs.
There is one widget that references a report by id.

### Action

I updated the `recently_discovered_pods` widget to point to the report with the same name.

```ruby
MiqReport.find_by(id: 198)
# => nil
MiqReport.find_by(name: "Recently Discovered Pods")
# => <MiqReport .....>
```

### why do you think this is the right report?

1. There is only one report with a name like "recently discovered pods" (searched on `like '%discovered%'`)
2. Most widgets have the report name the same or very similar to the widget name.

### links

No BZ associated. I found while scanning through widget meta-data

/cc @nimrodshn FYI