### PR TITLE
Mark widgets as non timezone sensitive

### DIFF
--- a/product/dashboard/widgets/chart_hosts_summary_by_version.yaml
+++ b/product/dashboard/widgets/chart_hosts_summary_by_version.yaml
@@ -2,6 +2,7 @@ description: chart_hosts_summary_by_version
 title: Hosts - Summary by Version
 content_type: chart   
 options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_
@@ -14,4 +15,4 @@ miq_schedule_options:
       :value: "1"
       :unit: daily
 enabled: true        
-read_only: true  
+read_only: true

--- a/product/dashboard/widgets/chart_number_of_nodes_per_cpu_cores.yaml
+++ b/product/dashboard/widgets/chart_number_of_nodes_per_cpu_cores.yaml
@@ -1,7 +1,8 @@
 description: Number of Nodes per CPU Cores Chart
 title: Number of Nodes per CPU Cores Chart
 content_type: chart
-options: {}
+options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/chart_pods_per_ready.yaml
+++ b/product/dashboard/widgets/chart_pods_per_ready.yaml
@@ -2,6 +2,7 @@ description: Pods per Ready Status Chart
 title: Pods per Ready Status Chart
 content_type: chart
 options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/chart_virtual_infrastructure_platforms.yaml
+++ b/product/dashboard/widgets/chart_virtual_infrastructure_platforms.yaml
@@ -2,6 +2,7 @@ description: chart_virtual_infrastructure_platforms
 title: Virtual Infrastructure Platforms
 content_type: chart
 options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/nodes_by_cpu_capacity.yaml
+++ b/product/dashboard/widgets/nodes_by_cpu_capacity.yaml
@@ -7,6 +7,7 @@ options:
   - name
   - computer_system.hardware.cpu_total_cores
   - computer_system.hardware.memory_mb
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/pods_per_ready.yaml
+++ b/product/dashboard/widgets/pods_per_ready.yaml
@@ -6,6 +6,7 @@ options:
   :col_order:
   - name
   - ready_condition_status
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/projects_by_number_of_containers.yaml
+++ b/product/dashboard/widgets/projects_by_number_of_containers.yaml
@@ -6,6 +6,7 @@ options:
   :col_order:
   - name
   - containers_count
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/projects_by_number_of_pods.yaml
+++ b/product/dashboard/widgets/projects_by_number_of_pods.yaml
@@ -6,6 +6,7 @@ options:
   :col_order:
   - name
   - groups_count
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_

--- a/product/dashboard/widgets/tenant_quotas.yaml
+++ b/product/dashboard/widgets/tenant_quotas.yaml
@@ -1,6 +1,8 @@
 description: tenant_quotas
 title: Tenant Quotas
 content_type: report
+options:
+  :timezone_matters: false
 visibility:
   :roles:
   - _ALL_


### PR DESCRIPTION
Follow up to #14386 (to concept introduced in #14285 )

This change allows these widgets to run once per security group rather than once per timezone per security group. (expecting 1/2 the number of reports to run per widget)

Assumes: widgets that do not reference time-sensitive columns are not timezone-sensitive.

In the end, 12 reports do not need the timezone. 3 had already been updated, so this updates the remaining 9 report files used by widgets.

---

widget|report|need timezone|columns
---|---|---|---
chart_guest_os_information_any_os.yaml|Guest OS Information - any OS|No|`operating_system.product_name, operating_system.service_pack, name, vendor_display, os_image_name, operating_system.version, operating_system.build_number, operating_system.product_key, operating_system.productid`
chart_hosts_summary_by_version.yaml|Hosts Summary|No|`name, ipaddress, vmm_vendor_display, vmm_product, vmm_version, vmm_buildnumber`
chart_number_of_nodes_per_cpu_cores.yaml|Number of Nodes per CPU Cores|No|`name, computer_system.hardware.cpu_total_cores`
chart_pods_per_ready.yaml|Pods per Ready Status|No|`name,  ready_condition_status`
chart_vendor_and_guest_os.yaml|Vendor and Guest OS|No|`vendor_display,  operating_system.product_name,  name,  operating_system.name`
chart_virtual_infrastructure_platforms.yaml|Virtual Infrastructure Platforms|No|`vmm_vendor_display, vmm_product, operating_system.product_name, name`
nodes_by_cpu_capacity.yaml|Nodes By Capacity|No|`name, computer_system.hardware.cpu_total_cores, computer_system.hardware.memory_mb`
nodes_by_cpu_usage.yaml|Nodes By CPU Usage|Yes|`name,`**`max_cpu_usage_rate_average_avg_over_time_period`**
nodes_by_memory_usage.yaml|Nodes By Memory Usage|Yes|`name, `**`max_mem_usage_absolute_average_avg_over_time_period`**
pods_per_ready.yaml|Pods per Ready Status|No|`name,ready_condition_status`
projects_by_cpu_usage.yaml|Projects By CPU Usage|Yes|`name, `**`max_cpu_usage_rate_average_avg_over_time_period`**
projects_by_memory_usage.yaml|Projects By Memory Usage|Yes|`name, `**`max_mem_usage_absolute_average_avg_over_time_period`**
projects_by_number_of_containers.yaml|Projects by Number of Containers|No|`name, containers_count`
projects_by_number_of_pods.yaml|Projects by Number of Pods|No|`name, groups_count`
recently_discovered_pods.yaml|Recently Discovered Pods|Yes|`name, ready_condition_status,` **`ems_created_on`**
report_top_cpu_consumers_weekly.yaml|Top CPU Consumers (weekly)|Yes|`resource_name, ems_cluster.name, host.name, `**`cpu_usage_rate_average__avg`**, **`cpu_usage_rate_average`**
report_top_memory_consumers_weekly.yaml|Top Memory Consumers (weekly)|Yes|`resource_name, ems_cluster.name, host.name,` **`derived_memory_used__avg`**, **`derived_memory_used`**
report_top_storage_consumers.yaml|Top Storage Consumers|No|`name, ems_cluster.name, host.name, used_disk_storage, provisioned_storage`
tenant_quotas.yaml|Tenant Quotas|No|`name, tenant_quotas.name, tenant_quotas.total, tenant_quotas.used, tenant_quotas.allocated, tenant_quotas.available`