### PR TITLE
Extract Api::OptionsSerializer

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -54,7 +54,7 @@ module Api
           normalize_time(value)
         elsif Environment.normalized_attributes[:url].key?(attr.to_s)
           normalize_url(value)
-        elsif encrypted_attribute?(attr)
+        elsif Api.encrypted_attribute?(attr)
           normalize_encrypted
         elsif Environment.normalized_attributes[:resource].key?(attr.to_s)
           normalize_resource(value)
@@ -98,13 +98,6 @@ module Api
       #
       def normalize_resource(value)
         value.to_s.starts_with?("/") ? "#{@req.base}#{value}" : value
-      end
-
-      #
-      # Let's determine if an attribute is encrypted
-      #
-      def encrypted_attribute?(attr)
-        Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
       end
 
       #

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -403,26 +403,8 @@ module Api
       end
 
       def render_options(resource, data = {})
-        collection = collection_class(resource)
-        options =
-          if collection.blank?
-            { :attributes => [], :virtual_attributes => [], :relationships => [] }
-          else
-            {
-              :attributes         => options_attribute_list(collection.attribute_names -
-                                                              collection.virtual_attribute_names),
-              :virtual_attributes => options_attribute_list(collection.virtual_attribute_names),
-              :relationships      => (collection.reflections.keys |
-                                       collection.virtual_reflections.keys.collect(&:to_s)).sort
-            }
-          end
-        options[:subcollections] = Array(collection_config[resource].subcollections).sort
-        options[:data] = data
-        render :json => options
-      end
-
-      def options_attribute_list(attrlist)
-        attrlist.sort.select { |attr| !encrypted_attribute?(attr) }
+        klass = collection_class(resource)
+        render :json => OptionsSerializer.serialize(klass, resource, data)
       end
     end
   end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -404,7 +404,7 @@ module Api
 
       def render_options(resource, data = {})
         klass = collection_class(resource)
-        render :json => OptionsSerializer.serialize(klass, data)
+        render :json => OptionsSerializer.new(klass, data).serialize
       end
     end
   end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -404,7 +404,7 @@ module Api
 
       def render_options(resource, data = {})
         klass = collection_class(resource)
-        render :json => OptionsSerializer.serialize(klass, resource, data)
+        render :json => OptionsSerializer.serialize(klass, data)
       end
     end
   end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -5,4 +5,8 @@ module Api
   BadRequestError = Class.new(ApiError)
   NotFoundError = Class.new(ApiError)
   UnsupportedMediaTypeError = Class.new(ApiError)
+
+  def self.encrypted_attribute?(attr)
+    Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
+  end
 end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -40,8 +40,8 @@ module Api
     end
 
     def subcollections
-      resource = config.name_for_klass(klass) if klass
-      Array(resource ? config[resource].subcollections : nil).sort
+      return [] unless klass
+      Array(config[config.name_for_klass(klass)].subcollections).sort
     end
 
     def options_attribute_list(attrlist)

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -14,15 +14,11 @@ module Api
 
     def serialize
       resource = config.name_for_klass(klass) if klass
-      options = if klass
-                  {
-                    :attributes         => attributes,
-                    :virtual_attributes => virtual_attributes,
-                    :relationships      => relationships
-                  }
-                else
-                  {:attributes => attributes, :virtual_attributes => virtual_attributes, :relationships => relationships}
-                end
+      options = {
+        :attributes         => attributes,
+        :virtual_attributes => virtual_attributes,
+        :relationships      => relationships
+      }
       options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
       options[:data] = data
       options

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -1,6 +1,7 @@
 module Api
   class OptionsSerializer
-    def self.serialize(klass, resource, data = {})
+    def self.serialize(klass, data = {})
+      resource = CollectionConfig.new.name_for_klass(klass) if klass
       options = if klass
                   {
                     :attributes         => options_attribute_list(klass.attribute_names -
@@ -12,7 +13,7 @@ module Api
                 else
                   {:attributes => [], :virtual_attributes => [], :relationships => []}
                 end
-      options[:subcollections] = Array(CollectionConfig.new[resource].subcollections).sort
+      options[:subcollections] = Array(resource ? CollectionConfig.new[resource].subcollections : nil).sort
       options[:data] = data
       options
     end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -13,13 +13,12 @@ module Api
     end
 
     def serialize
-      resource = config.name_for_klass(klass) if klass
       options = {
         :attributes         => attributes,
         :virtual_attributes => virtual_attributes,
         :relationships      => relationships
       }
-      options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
+      options[:subcollections] = subcollections
       options[:data] = data
       options
     end
@@ -39,6 +38,11 @@ module Api
     def relationships
       return [] unless klass
       (klass.reflections.keys | klass.virtual_reflections.keys.collect(&:to_s)).sort
+    end
+
+    def subcollections
+      resource = config.name_for_klass(klass) if klass
+      Array(resource ? config[resource].subcollections : nil).sort
     end
 
     def options_attribute_list(attrlist)

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -4,15 +4,15 @@ module Api
       new(klass, data).serialize
     end
 
-    attr_reader :klass, :data
+    attr_reader :klass, :data, :config
 
     def initialize(klass, data = {})
       @klass = klass
       @data = data
+      @config = CollectionConfig.new
     end
 
     def serialize
-      config = CollectionConfig.new
       resource = config.name_for_klass(klass) if klass
       options = if klass
                   {

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -13,14 +13,13 @@ module Api
     end
 
     def serialize
-      options = {
+      {
         :attributes         => attributes,
         :virtual_attributes => virtual_attributes,
-        :relationships      => relationships
+        :relationships      => relationships,
+        :subcollections     => subcollections,
+        :data               => data
       }
-      options[:subcollections] = subcollections
-      options[:data] = data
-      options
     end
 
     private

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -18,11 +18,7 @@ module Api
     end
 
     def self.options_attribute_list(attrlist)
-      attrlist.sort.select { |attr| !encrypted_attribute?(attr) }
-    end
-
-    def self.encrypted_attribute?(attr)
-      Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
+      attrlist.sort.select { |attr| !Api.encrypted_attribute?(attr) }
     end
   end
 end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -1,0 +1,28 @@
+module Api
+  class OptionsSerializer
+    def self.serialize(klass, resource, data = {})
+      options = if klass
+                  {
+                    :attributes         => options_attribute_list(klass.attribute_names -
+                                                                  klass.virtual_attribute_names),
+                    :virtual_attributes => options_attribute_list(klass.virtual_attribute_names),
+                    :relationships      => (klass.reflections.keys |
+                                            klass.virtual_reflections.keys.collect(&:to_s)).sort
+                  }
+                else
+                  {:attributes => [], :virtual_attributes => [], :relationships => []}
+                end
+      options[:subcollections] = Array(CollectionConfig.new[resource].subcollections).sort
+      options[:data] = data
+      options
+    end
+
+    def self.options_attribute_list(attrlist)
+      attrlist.sort.select { |attr| !encrypted_attribute?(attr) }
+    end
+
+    def self.encrypted_attribute?(attr)
+      Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
+    end
+  end
+end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -1,6 +1,17 @@
 module Api
   class OptionsSerializer
     def self.serialize(klass, data = {})
+      new(klass, data).serialize
+    end
+
+    attr_reader :klass, :data
+
+    def initialize(klass, data = {})
+      @klass = klass
+      @data = data
+    end
+
+    def serialize
       config = CollectionConfig.new
       resource = config.name_for_klass(klass) if klass
       options = if klass
@@ -19,7 +30,9 @@ module Api
       options
     end
 
-    def self.options_attribute_list(attrlist)
+    private
+
+    def options_attribute_list(attrlist)
       attrlist.sort.select { |attr| !Api.encrypted_attribute?(attr) }
     end
   end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -18,11 +18,10 @@ module Api
                   {
                     :attributes         => attributes,
                     :virtual_attributes => virtual_attributes,
-                    :relationships      => (klass.reflections.keys |
-                                            klass.virtual_reflections.keys.collect(&:to_s)).sort
+                    :relationships      => relationships
                   }
                 else
-                  {:attributes => attributes, :virtual_attributes => virtual_attributes, :relationships => []}
+                  {:attributes => attributes, :virtual_attributes => virtual_attributes, :relationships => relationships}
                 end
       options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
       options[:data] = data
@@ -39,6 +38,11 @@ module Api
     def virtual_attributes
       return [] unless klass
       options_attribute_list(klass.virtual_attribute_names)
+    end
+
+    def relationships
+      return [] unless klass
+      (klass.reflections.keys | klass.virtual_reflections.keys.collect(&:to_s)).sort
     end
 
     def options_attribute_list(attrlist)

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -16,14 +16,13 @@ module Api
       resource = config.name_for_klass(klass) if klass
       options = if klass
                   {
-                    :attributes         => options_attribute_list(klass.attribute_names -
-                                                                  klass.virtual_attribute_names),
+                    :attributes         => attributes,
                     :virtual_attributes => options_attribute_list(klass.virtual_attribute_names),
                     :relationships      => (klass.reflections.keys |
                                             klass.virtual_reflections.keys.collect(&:to_s)).sort
                   }
                 else
-                  {:attributes => [], :virtual_attributes => [], :relationships => []}
+                  {:attributes => attributes, :virtual_attributes => [], :relationships => []}
                 end
       options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
       options[:data] = data
@@ -31,6 +30,11 @@ module Api
     end
 
     private
+
+    def attributes
+      return [] unless klass
+      options_attribute_list(klass.attribute_names - klass.virtual_attribute_names)
+    end
 
     def options_attribute_list(attrlist)
       attrlist.sort.select { |attr| !Api.encrypted_attribute?(attr) }

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -1,9 +1,5 @@
 module Api
   class OptionsSerializer
-    def self.serialize(klass, data = {})
-      new(klass, data).serialize
-    end
-
     attr_reader :klass, :data, :config
 
     def initialize(klass, data = {})

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -1,7 +1,8 @@
 module Api
   class OptionsSerializer
     def self.serialize(klass, data = {})
-      resource = CollectionConfig.new.name_for_klass(klass) if klass
+      config = CollectionConfig.new
+      resource = config.name_for_klass(klass) if klass
       options = if klass
                   {
                     :attributes         => options_attribute_list(klass.attribute_names -
@@ -13,7 +14,7 @@ module Api
                 else
                   {:attributes => [], :virtual_attributes => [], :relationships => []}
                 end
-      options[:subcollections] = Array(resource ? CollectionConfig.new[resource].subcollections : nil).sort
+      options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
       options[:data] = data
       options
     end

--- a/lib/services/api/options_serializer.rb
+++ b/lib/services/api/options_serializer.rb
@@ -17,12 +17,12 @@ module Api
       options = if klass
                   {
                     :attributes         => attributes,
-                    :virtual_attributes => options_attribute_list(klass.virtual_attribute_names),
+                    :virtual_attributes => virtual_attributes,
                     :relationships      => (klass.reflections.keys |
                                             klass.virtual_reflections.keys.collect(&:to_s)).sort
                   }
                 else
-                  {:attributes => attributes, :virtual_attributes => [], :relationships => []}
+                  {:attributes => attributes, :virtual_attributes => virtual_attributes, :relationships => []}
                 end
       options[:subcollections] = Array(resource ? config[resource].subcollections : nil).sort
       options[:data] = data
@@ -34,6 +34,11 @@ module Api
     def attributes
       return [] unless klass
       options_attribute_list(klass.attribute_names - klass.virtual_attribute_names)
+    end
+
+    def virtual_attributes
+      return [] unless klass
+      options_attribute_list(klass.virtual_attribute_names)
     end
 
     def options_attribute_list(attrlist)

--- a/spec/lib/services/api/options_serializer_spec.rb
+++ b/spec/lib/services/api/options_serializer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::OptionsSerializer do
   it "returns some default values when the class is nil" do
-    actual = described_class.serialize(nil)
+    actual = described_class.new(nil).serialize
 
     expected = {
       :attributes         => [],

--- a/spec/lib/services/api/options_serializer_spec.rb
+++ b/spec/lib/services/api/options_serializer_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Api::OptionsSerializer do
+  it "returns some default values when the class is nil" do
+    actual = described_class.serialize(nil, :settings)
+
+    expected = {
+      :attributes         => [],
+      :virtual_attributes => [],
+      :relationships      => [],
+      :subcollections     => [],
+      :data               => {}
+    }
+
+    expect(actual).to eq(expected)
+  end
+end

--- a/spec/lib/services/api/options_serializer_spec.rb
+++ b/spec/lib/services/api/options_serializer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::OptionsSerializer do
   it "returns some default values when the class is nil" do
-    actual = described_class.serialize(nil, :settings)
+    actual = described_class.serialize(nil)
 
     expected = {
       :attributes         => [],

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -280,11 +280,7 @@ module Spec
       end
 
       def select_attributes(attrlist)
-        attrlist.sort.select { |attr| !encrypted_attribute?(attr) }
-      end
-
-      def encrypted_attribute?(attr)
-        Api::Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
+        attrlist.sort.select { |attr| !Api.encrypted_attribute?(attr) }
       end
     end
   end


### PR DESCRIPTION
Extracts a serializer for options responses that has well-defined boundaries and can be tested in isolation if needed.

Also DRYs up some code around checking for encrypted attributes by placing a helper method centrally at the module level so it can be accessed from the controllers, this serializer, and the test code.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 

/cc @jntullo 
