### PR TITLE
VmOrTemplate#provisioned_storage is delegated

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -145,7 +145,6 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :v_owning_blue_folder_path,            :type => :string,     :uses => :all_relationships
   virtual_column :v_datastore_path,                     :type => :string,     :uses => :storage
   virtual_column :thin_provisioned,                     :type => :boolean,    :uses => {:hardware => :disks}
-  virtual_column :provisioned_storage,                  :type => :integer,    :uses => [:allocated_disk_storage, :mem_cpu]
   virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
   virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
   virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_storage_by_state]


### PR DESCRIPTION
`VmOrTemplate#provisioned_storage` is now delegated.

The `virtual_column` definition (line 148) is overridden by the `virtual_delegate` definition (line [1526](https://github.com/kbrock/manageiq/blob/cec867f1a72d800211115dd96802bb673d29ab71/app/models/vm_or_template.rb#L1526)).

Since the correct one comes second, it will not cause problems.

But it is typically best to remove these duplications.

