### PR TITLE
Fix inverse_of usage in physical_server

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -5,7 +5,7 @@ class PhysicalServer < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
 
-  has_one :host, inverse_of => :physical_server
+  has_one :host, :inverse_of => :physical_server
 
   def name_with_details
     details % {


### PR DESCRIPTION
`PhysicalServer` has `inverse_of` instead of `:inverse_of`.

