### PR TITLE
inverse_of should be a symbol

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -5,7 +5,7 @@ class PhysicalServer < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
 
-  has_one :host, inverse_of => :physical_server
+  has_one :host, :inverse_of => :physical_server
 
   def name_with_details
     details % {


### PR DESCRIPTION
Fix:
```
   1) EmsPhysicalInfraController#show shows associated datastores
     Failure/Error: has_one :host, inverse_of => :physical_server

     ActionView::Template::Error:
       undefined local variable or method `inverse_of' for #<Class:0x00557e928fdf70>
```

Introduced by #14026 