### PR TITLE
Fix startup shortcut YAML setting for Configuration Management

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -165,7 +165,7 @@
   :rbac_feature_name: storage_show_list
   :startup: true
 - :name: configuration_management
-  :description: Infrastructure / Configuration Management
+  :description: Configuration / Management
   :url: provider_foreman/explorer
   :rbac_feature_name: provider_foreman_explorer
   :startup: true


### PR DESCRIPTION
This fix required MiqShortcut.seed to refresh startup settings

https://bugzilla.redhat.com/show_bug.cgi?id=1342537

Screen shot prior to code fix:
![startup configuration management selection prior to code fix](https://cloud.githubusercontent.com/assets/552686/24310239/5abc3204-108c-11e7-809a-52a6969e7cd0.png)


Screen shot post to code fix:
![startup configuration management selection post code fix](https://cloud.githubusercontent.com/assets/552686/24421204/3f9e4c52-13aa-11e7-8f12-fdb86e76958e.png)

