### PR TITLE
Use existing embedded ansible default objects if they exist

### DIFF
--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -25,6 +25,8 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def ensure_credential(provider, connection)
     return if provider.default_credential
+    ensure_organization(provider, connection) unless provider.default_organization
+
     attrs = default_credential_attributes(provider.default_organization)
 
     provider.default_credential = connection.api.credentials.create!(attrs).id
@@ -32,6 +34,8 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def ensure_inventory(provider, connection)
     return if provider.default_inventory
+    ensure_organization(provider, connection) unless provider.default_organization
+
     attrs = default_inventory_attributes(provider.default_organization)
 
     provider.default_inventory = connection.api.inventories.create!(attrs).id
@@ -39,6 +43,8 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def ensure_host(provider, connection)
     return if provider.default_host
+    ensure_inventory(provider, connection) unless provider.default_inventory
+
     attrs = default_host_attributes(provider.default_inventory)
 
     provider.default_host = connection.api.hosts.create!(attrs).id

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -52,8 +52,14 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   private
 
+  def attributes_for_find(attrs)
+    # It seems the matching for attributes doesn't really work
+    # for YAML serialized data so we exclude the variables key here
+    attrs.dup.delete_if { |k, _v| k == :variables }
+  end
+
   def find_or_create!(collection, attrs)
-    resources = collection.all(attrs)
+    resources = collection.all(attributes_for_find(attrs))
     return resources.first unless resources.count.zero?
 
     collection.create!(attrs)

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -20,7 +20,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
     return if provider.default_organization
     attrs = default_organization_attributes
 
-    provider.default_organization = connection.api.organizations.create!(attrs).id
+    provider.default_organization = find_or_create!(connection.api.organizations, attrs).id
   end
 
   def ensure_credential(provider, connection)
@@ -29,7 +29,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
     attrs = default_credential_attributes(provider.default_organization)
 
-    provider.default_credential = connection.api.credentials.create!(attrs).id
+    provider.default_credential = find_or_create!(connection.api.credentials, attrs).id
   end
 
   def ensure_inventory(provider, connection)
@@ -38,7 +38,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
     attrs = default_inventory_attributes(provider.default_organization)
 
-    provider.default_inventory = connection.api.inventories.create!(attrs).id
+    provider.default_inventory = find_or_create!(connection.api.inventories, attrs).id
   end
 
   def ensure_host(provider, connection)
@@ -47,10 +47,17 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
     attrs = default_host_attributes(provider.default_inventory)
 
-    provider.default_host = connection.api.hosts.create!(attrs).id
+    provider.default_host = find_or_create!(connection.api.hosts, attrs).id
   end
 
   private
+
+  def find_or_create!(collection, attrs)
+    resources = collection.all(attrs)
+    return resources.first unless resources.count.zero?
+
+    collection.create!(attrs)
+  end
 
   def default_organization_attributes
     {

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -18,39 +18,61 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def ensure_organization(provider, connection)
     return if provider.default_organization
+    attrs = default_organization_attributes
 
-    provider.default_organization = connection.api.organizations.create!(
-      :name        => I18n.t("product.name"),
-      :description => "#{I18n.t("product.name")} Default Organization"
-    ).id
+    provider.default_organization = connection.api.organizations.create!(attrs).id
   end
 
   def ensure_credential(provider, connection)
     return if provider.default_credential
+    attrs = default_credential_attributes(provider.default_organization)
 
-    provider.default_credential = connection.api.credentials.create!(
-      :name         => "#{I18n.t("product.name")} Default Credential",
-      :kind         => "ssh",
-      :organization => provider.default_organization
-    ).id
+    provider.default_credential = connection.api.credentials.create!(attrs).id
   end
 
   def ensure_inventory(provider, connection)
     return if provider.default_inventory
+    attrs = default_inventory_attributes(provider.default_organization)
 
-    provider.default_inventory = connection.api.inventories.create!(
-      :name         => "#{I18n.t("product.name")} Default Inventory",
-      :organization => provider.default_organization
-    ).id
+    provider.default_inventory = connection.api.inventories.create!(attrs).id
   end
 
   def ensure_host(provider, connection)
     return if provider.default_host
+    attrs = default_host_attributes(provider.default_inventory)
 
-    provider.default_host = connection.api.hosts.create!(
+    provider.default_host = connection.api.hosts.create!(attrs).id
+  end
+
+  private
+
+  def default_organization_attributes
+    {
+      :name        => I18n.t("product.name"),
+      :description => "#{I18n.t("product.name")} Default Organization"
+    }
+  end
+
+  def default_credential_attributes(org_id)
+    {
+      :name         => "#{I18n.t("product.name")} Default Credential",
+      :kind         => "ssh",
+      :organization => org_id
+    }
+  end
+
+  def default_inventory_attributes(org_id)
+    {
+      :name         => "#{I18n.t("product.name")} Default Inventory",
+      :organization => org_id
+    }
+  end
+
+  def default_host_attributes(inv_id)
+    {
       :name      => "localhost",
-      :inventory => provider.default_inventory,
+      :inventory => inv_id,
       :variables => {'ansible_connection' => "local"}.to_yaml
-    ).id
+    }
   end
 end

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -1,6 +1,9 @@
 module EmbeddedAnsibleWorker::ObjectManagement
   extend ActiveSupport::Concern
 
+  # This should not change as we match this to existing objects on the ansible side
+  DEFAULT_NAME = "EVM".freeze
+
   def ensure_initial_objects(provider, connection)
     ensure_organization(provider, connection)
     ensure_credential(provider, connection)
@@ -67,14 +70,14 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def default_organization_attributes
     {
-      :name        => I18n.t("product.name"),
-      :description => "#{I18n.t("product.name")} Default Organization"
+      :name        => DEFAULT_NAME,
+      :description => "#{DEFAULT_NAME} Default Organization"
     }
   end
 
   def default_credential_attributes(org_id)
     {
-      :name         => "#{I18n.t("product.name")} Default Credential",
+      :name         => "#{DEFAULT_NAME} Default Credential",
       :kind         => "ssh",
       :organization => org_id
     }
@@ -82,7 +85,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def default_inventory_attributes(org_id)
     {
-      :name         => "#{I18n.t("product.name")} Default Inventory",
+      :name         => "#{DEFAULT_NAME} Default Inventory",
       :organization => org_id
     }
   end

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -92,6 +92,23 @@ describe EmbeddedAnsibleWorker do
 
         subject.ensure_credential(provider, api_connection)
       end
+
+      it "creates the organization if one doesn't exist" do
+        expect(org_collection).to receive(:create!).with(
+          :name        => "ManageIQ",
+          :description => "ManageIQ Default Organization"
+        ).and_return(org_resource)
+
+        expect(cred_collection).to receive(:create!).with(
+          :name         => "ManageIQ Default Credential",
+          :kind         => "ssh",
+          :organization => 12
+        ).and_return(cred_resource)
+
+        subject.ensure_credential(provider, api_connection)
+        expect(provider.default_credential).to eq(13)
+        expect(provider.default_organization).to eq(12)
+      end
     end
 
     describe "#ensure_inventory" do
@@ -111,6 +128,22 @@ describe EmbeddedAnsibleWorker do
         expect(inv_collection).not_to receive(:create!)
 
         subject.ensure_inventory(provider, api_connection)
+      end
+
+      it "creates the organization if one doesn't exist" do
+        expect(org_collection).to receive(:create!).with(
+          :name        => "ManageIQ",
+          :description => "ManageIQ Default Organization"
+        ).and_return(org_resource)
+
+        expect(inv_collection).to receive(:create!).with(
+          :name         => "ManageIQ Default Inventory",
+          :organization => 12
+        ).and_return(inv_resource)
+
+        subject.ensure_inventory(provider, api_connection)
+        expect(provider.default_inventory).to eq(14)
+        expect(provider.default_organization).to eq(12)
       end
     end
 
@@ -132,6 +165,24 @@ describe EmbeddedAnsibleWorker do
         expect(host_collection).not_to receive(:create!)
 
         subject.ensure_host(provider, api_connection)
+      end
+
+      it "creates the inventory if one doesn't exist" do
+        provider.default_organization = 12
+        expect(inv_collection).to receive(:create!).with(
+          :name         => "ManageIQ Default Inventory",
+          :organization => 12
+        ).and_return(inv_resource)
+
+        expect(host_collection).to receive(:create!).with(
+          :name      => "localhost",
+          :inventory => 14,
+          :variables => "---\nansible_connection: local\n"
+        ).and_return(host_resource)
+
+        subject.ensure_host(provider, api_connection)
+        expect(provider.default_host).to eq(15)
+        expect(provider.default_inventory).to eq(14)
       end
     end
   end

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -94,8 +94,8 @@ describe EmbeddedAnsibleWorker do
       describe "#ensure_organization" do
         it "sets the provider default organization" do
           expect(org_collection).to receive(:create!).with(
-            :name        => "ManageIQ",
-            :description => "ManageIQ Default Organization"
+            :name        => "EVM",
+            :description => "EVM Default Organization"
           ).and_return(org_resource)
 
           subject.ensure_organization(provider, api_connection)
@@ -114,7 +114,7 @@ describe EmbeddedAnsibleWorker do
         it "sets the provider default credential" do
           provider.default_organization = 123
           expect(cred_collection).to receive(:create!).with(
-            :name         => "ManageIQ Default Credential",
+            :name         => "EVM Default Credential",
             :kind         => "ssh",
             :organization => 123
           ).and_return(cred_resource)
@@ -132,12 +132,12 @@ describe EmbeddedAnsibleWorker do
 
         it "creates the organization if one doesn't exist" do
           expect(org_collection).to receive(:create!).with(
-            :name        => "ManageIQ",
-            :description => "ManageIQ Default Organization"
+            :name        => "EVM",
+            :description => "EVM Default Organization"
           ).and_return(org_resource)
 
           expect(cred_collection).to receive(:create!).with(
-            :name         => "ManageIQ Default Credential",
+            :name         => "EVM Default Credential",
             :kind         => "ssh",
             :organization => 12
           ).and_return(cred_resource)
@@ -152,7 +152,7 @@ describe EmbeddedAnsibleWorker do
         it "sets the provider default inventory" do
           provider.default_organization = 123
           expect(inv_collection).to receive(:create!).with(
-            :name         => "ManageIQ Default Inventory",
+            :name         => "EVM Default Inventory",
             :organization => 123
           ).and_return(inv_resource)
 
@@ -169,12 +169,12 @@ describe EmbeddedAnsibleWorker do
 
         it "creates the organization if one doesn't exist" do
           expect(org_collection).to receive(:create!).with(
-            :name        => "ManageIQ",
-            :description => "ManageIQ Default Organization"
+            :name        => "EVM",
+            :description => "EVM Default Organization"
           ).and_return(org_resource)
 
           expect(inv_collection).to receive(:create!).with(
-            :name         => "ManageIQ Default Inventory",
+            :name         => "EVM Default Inventory",
             :organization => 12
           ).and_return(inv_resource)
 
@@ -207,7 +207,7 @@ describe EmbeddedAnsibleWorker do
         it "creates the inventory if one doesn't exist" do
           provider.default_organization = 12
           expect(inv_collection).to receive(:create!).with(
-            :name         => "ManageIQ Default Inventory",
+            :name         => "EVM Default Inventory",
             :organization => 12
           ).and_return(inv_resource)
 

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -12,17 +12,9 @@ describe EmbeddedAnsibleWorker do
         :hosts         => host_collection,
         :job_templates => job_templ_collection,
         :projects      => proj_collection
-
       }
       double("TowerAPI", methods)
     end
-
-    let(:org_collection)       { double("AnsibleOrgCollection", :all => [org_resource]) }
-    let(:cred_collection)      { double("AnsibleCredCollection", :all => [cred_resource]) }
-    let(:inv_collection)       { double("AnsibleInvCollection", :all => [inv_resource]) }
-    let(:host_collection)      { double("AnsibleHostCollection", :all => [host_resource]) }
-    let(:job_templ_collection) { double("AnsibleJobTemplCollection", :all => [job_templ_resource]) }
-    let(:proj_collection)      { double("AnsibleProjCollection", :all => [proj_resource]) }
 
     let(:org_resource)         { double("AnsibleOrgResource", :id => 12) }
     let(:cred_resource)        { double("AnsibleCredResource", :id => 13) }
@@ -31,158 +23,204 @@ describe EmbeddedAnsibleWorker do
     let(:job_templ_resource)   { double("AnsibleJobTemplResource", :id => 16) }
     let(:proj_resource)        { double("AnsibleProjResource", :id => 17) }
 
-    describe "#ensure_initial_objects" do
-      it "creates the expected objects" do
-        expect(org_collection).to receive(:create!).and_return(org_resource)
-        expect(cred_collection).to receive(:create!).and_return(cred_resource)
-        expect(inv_collection).to receive(:create!).and_return(inv_resource)
-        expect(host_collection).to receive(:create!).and_return(host_resource)
+    context "with existing data" do
+      let(:org_collection)       { double("AnsibleOrgCollection", :all => [org_resource]) }
+      let(:cred_collection)      { double("AnsibleCredCollection", :all => [cred_resource]) }
+      let(:inv_collection)       { double("AnsibleInvCollection", :all => [inv_resource]) }
+      let(:host_collection)      { double("AnsibleHostCollection", :all => [host_resource]) }
+      let(:job_templ_collection) { double("AnsibleJobTemplCollection", :all => [job_templ_resource]) }
+      let(:proj_collection)      { double("AnsibleProjCollection", :all => [proj_resource]) }
 
-        subject.ensure_initial_objects(provider, api_connection)
+      describe "#remove_demo_data" do
+        it "removes the existing data" do
+          expect(org_resource).to receive(:destroy!)
+          expect(cred_resource).to receive(:destroy!)
+          expect(inv_resource).to receive(:destroy!)
+          expect(job_templ_resource).to receive(:destroy!)
+          expect(proj_resource).to receive(:destroy!)
+
+          subject.remove_demo_data(api_connection)
+        end
+      end
+
+      describe "#ensure_organization" do
+        it "sets the default organization to the existing one" do
+          subject.ensure_organization(provider, api_connection)
+          expect(provider.default_organization).to eq(12)
+        end
+      end
+
+      describe "#ensure_credential" do
+        it "sets the default credential to the existing one" do
+          subject.ensure_credential(provider, api_connection)
+          expect(provider.default_credential).to eq(13)
+        end
+      end
+
+      describe "#ensure_inventory" do
+        it "sets the default inventory to the existing one" do
+          subject.ensure_inventory(provider, api_connection)
+          expect(provider.default_inventory).to eq(14)
+        end
+      end
+
+      describe "#ensure_host" do
+        it "sets the default host to the existing one" do
+          subject.ensure_host(provider, api_connection)
+          expect(provider.default_host).to eq(15)
+        end
       end
     end
 
-    describe "#remove_demo_data" do
-      it "removes the existing data" do
-        expect(org_resource).to receive(:destroy!)
-        expect(cred_resource).to receive(:destroy!)
-        expect(inv_resource).to receive(:destroy!)
-        expect(job_templ_resource).to receive(:destroy!)
-        expect(proj_resource).to receive(:destroy!)
+    context "with no existing data" do
+      let(:org_collection)       { double("AnsibleOrgCollection", :all => []) }
+      let(:cred_collection)      { double("AnsibleCredCollection", :all => []) }
+      let(:inv_collection)       { double("AnsibleInvCollection", :all => []) }
+      let(:host_collection)      { double("AnsibleHostCollection", :all => []) }
+      let(:job_templ_collection) { double("AnsibleJobTemplCollection", :all => []) }
+      let(:proj_collection)      { double("AnsibleProjCollection", :all => []) }
 
-        subject.remove_demo_data(api_connection)
-      end
-    end
+      describe "#ensure_initial_objects" do
+        it "creates the expected objects" do
+          expect(org_collection).to receive(:create!).and_return(org_resource)
+          expect(cred_collection).to receive(:create!).and_return(cred_resource)
+          expect(inv_collection).to receive(:create!).and_return(inv_resource)
+          expect(host_collection).to receive(:create!).and_return(host_resource)
 
-    describe "#ensure_organization" do
-      it "sets the provider default organization" do
-        expect(org_collection).to receive(:create!).with(
-          :name        => "ManageIQ",
-          :description => "ManageIQ Default Organization"
-        ).and_return(org_resource)
-
-        subject.ensure_organization(provider, api_connection)
-        expect(provider.default_organization).to eq(12)
+          subject.ensure_initial_objects(provider, api_connection)
+        end
       end
 
-      it "doesn't recreate the organization if one is already set" do
-        provider.default_organization = 1
-        expect(org_collection).not_to receive(:create!)
+      describe "#ensure_organization" do
+        it "sets the provider default organization" do
+          expect(org_collection).to receive(:create!).with(
+            :name        => "ManageIQ",
+            :description => "ManageIQ Default Organization"
+          ).and_return(org_resource)
 
-        subject.ensure_organization(provider, api_connection)
-      end
-    end
+          subject.ensure_organization(provider, api_connection)
+          expect(provider.default_organization).to eq(12)
+        end
 
-    describe "#ensure_credential" do
-      it "sets the provider default credential" do
-        provider.default_organization = 123
-        expect(cred_collection).to receive(:create!).with(
-          :name         => "ManageIQ Default Credential",
-          :kind         => "ssh",
-          :organization => 123
-        ).and_return(cred_resource)
+        it "doesn't recreate the organization if one is already set" do
+          provider.default_organization = 1
+          expect(org_collection).not_to receive(:create!)
 
-        subject.ensure_credential(provider, api_connection)
-        expect(provider.default_credential).to eq(13)
+          subject.ensure_organization(provider, api_connection)
+        end
       end
 
-      it "doesn't recreate the credential if one is already set" do
-        provider.default_credential = 2
-        expect(cred_collection).not_to receive(:create!)
+      describe "#ensure_credential" do
+        it "sets the provider default credential" do
+          provider.default_organization = 123
+          expect(cred_collection).to receive(:create!).with(
+            :name         => "ManageIQ Default Credential",
+            :kind         => "ssh",
+            :organization => 123
+          ).and_return(cred_resource)
 
-        subject.ensure_credential(provider, api_connection)
+          subject.ensure_credential(provider, api_connection)
+          expect(provider.default_credential).to eq(13)
+        end
+
+        it "doesn't recreate the credential if one is already set" do
+          provider.default_credential = 2
+          expect(cred_collection).not_to receive(:create!)
+
+          subject.ensure_credential(provider, api_connection)
+        end
+
+        it "creates the organization if one doesn't exist" do
+          expect(org_collection).to receive(:create!).with(
+            :name        => "ManageIQ",
+            :description => "ManageIQ Default Organization"
+          ).and_return(org_resource)
+
+          expect(cred_collection).to receive(:create!).with(
+            :name         => "ManageIQ Default Credential",
+            :kind         => "ssh",
+            :organization => 12
+          ).and_return(cred_resource)
+
+          subject.ensure_credential(provider, api_connection)
+          expect(provider.default_credential).to eq(13)
+          expect(provider.default_organization).to eq(12)
+        end
       end
 
-      it "creates the organization if one doesn't exist" do
-        expect(org_collection).to receive(:create!).with(
-          :name        => "ManageIQ",
-          :description => "ManageIQ Default Organization"
-        ).and_return(org_resource)
+      describe "#ensure_inventory" do
+        it "sets the provider default inventory" do
+          provider.default_organization = 123
+          expect(inv_collection).to receive(:create!).with(
+            :name         => "ManageIQ Default Inventory",
+            :organization => 123
+          ).and_return(inv_resource)
 
-        expect(cred_collection).to receive(:create!).with(
-          :name         => "ManageIQ Default Credential",
-          :kind         => "ssh",
-          :organization => 12
-        ).and_return(cred_resource)
+          subject.ensure_inventory(provider, api_connection)
+          expect(provider.default_inventory).to eq(14)
+        end
 
-        subject.ensure_credential(provider, api_connection)
-        expect(provider.default_credential).to eq(13)
-        expect(provider.default_organization).to eq(12)
-      end
-    end
+        it "doesn't recreate the inventory if one is already set" do
+          provider.default_inventory = 3
+          expect(inv_collection).not_to receive(:create!)
 
-    describe "#ensure_inventory" do
-      it "sets the provider default inventory" do
-        provider.default_organization = 123
-        expect(inv_collection).to receive(:create!).with(
-          :name         => "ManageIQ Default Inventory",
-          :organization => 123
-        ).and_return(inv_resource)
+          subject.ensure_inventory(provider, api_connection)
+        end
 
-        subject.ensure_inventory(provider, api_connection)
-        expect(provider.default_inventory).to eq(14)
-      end
+        it "creates the organization if one doesn't exist" do
+          expect(org_collection).to receive(:create!).with(
+            :name        => "ManageIQ",
+            :description => "ManageIQ Default Organization"
+          ).and_return(org_resource)
 
-      it "doesn't recreate the inventory if one is already set" do
-        provider.default_inventory = 3
-        expect(inv_collection).not_to receive(:create!)
+          expect(inv_collection).to receive(:create!).with(
+            :name         => "ManageIQ Default Inventory",
+            :organization => 12
+          ).and_return(inv_resource)
 
-        subject.ensure_inventory(provider, api_connection)
-      end
-
-      it "creates the organization if one doesn't exist" do
-        expect(org_collection).to receive(:create!).with(
-          :name        => "ManageIQ",
-          :description => "ManageIQ Default Organization"
-        ).and_return(org_resource)
-
-        expect(inv_collection).to receive(:create!).with(
-          :name         => "ManageIQ Default Inventory",
-          :organization => 12
-        ).and_return(inv_resource)
-
-        subject.ensure_inventory(provider, api_connection)
-        expect(provider.default_inventory).to eq(14)
-        expect(provider.default_organization).to eq(12)
-      end
-    end
-
-    describe "#ensure_host" do
-      it "sets the provider default host" do
-        provider.default_inventory = 234
-        expect(host_collection).to receive(:create!).with(
-          :name      => "localhost",
-          :inventory => 234,
-          :variables => "---\nansible_connection: local\n"
-        ).and_return(host_resource)
-
-        subject.ensure_host(provider, api_connection)
-        expect(provider.default_host).to eq(15)
+          subject.ensure_inventory(provider, api_connection)
+          expect(provider.default_inventory).to eq(14)
+          expect(provider.default_organization).to eq(12)
+        end
       end
 
-      it "doesn't recreate the host if one is already set" do
-        provider.default_host = 1
-        expect(host_collection).not_to receive(:create!)
+      describe "#ensure_host" do
+        it "sets the provider default host" do
+          provider.default_inventory = 234
+          expect(host_collection).to receive(:create!).with(
+            :name      => "localhost",
+            :inventory => 234,
+            :variables => "---\nansible_connection: local\n"
+          ).and_return(host_resource)
 
-        subject.ensure_host(provider, api_connection)
-      end
+          subject.ensure_host(provider, api_connection)
+          expect(provider.default_host).to eq(15)
+        end
 
-      it "creates the inventory if one doesn't exist" do
-        provider.default_organization = 12
-        expect(inv_collection).to receive(:create!).with(
-          :name         => "ManageIQ Default Inventory",
-          :organization => 12
-        ).and_return(inv_resource)
+        it "doesn't recreate the host if one is already set" do
+          provider.default_host = 1
+          expect(host_collection).not_to receive(:create!)
 
-        expect(host_collection).to receive(:create!).with(
-          :name      => "localhost",
-          :inventory => 14,
-          :variables => "---\nansible_connection: local\n"
-        ).and_return(host_resource)
+          subject.ensure_host(provider, api_connection)
+        end
 
-        subject.ensure_host(provider, api_connection)
-        expect(provider.default_host).to eq(15)
-        expect(provider.default_inventory).to eq(14)
+        it "creates the inventory if one doesn't exist" do
+          provider.default_organization = 12
+          expect(inv_collection).to receive(:create!).with(
+            :name         => "ManageIQ Default Inventory",
+            :organization => 12
+          ).and_return(inv_resource)
+
+          expect(host_collection).to receive(:create!).with(
+            :name      => "localhost",
+            :inventory => 14,
+            :variables => "---\nansible_connection: local\n"
+          ).and_return(host_resource)
+
+          subject.ensure_host(provider, api_connection)
+          expect(provider.default_host).to eq(15)
+          expect(provider.default_inventory).to eq(14)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR implements some hardening around creating initial objects in the embedded ansible database.

Primarily it first searches for the object using the default attributes and uses the existing object id if it finds one rather than attempting (and then failing) to create a new copy of the object.

Additionally it handles cases where dependent objects were not created. This allows users to call each of the `ensure_*` methods without having to first know if the other defaults are set.

This ended up being a much larger patch than I first anticipated; the specs required some not insignificant refactoring to make this change testable. With that in mind, I suggest any reviewers go commit-by-commit and use the ignore whitespace flag :smile: 