### PR TITLE
Add ph_server_uuid foreign key to firmwares

### DIFF
--- a/db/migrate/20170324200857_add_physical_server_foreign_key_to_firmware.rb
+++ b/db/migrate/20170324200857_add_physical_server_foreign_key_to_firmware.rb
@@ -1,0 +1,5 @@
+class AddPhysicalServerForeignKeyToFirmware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :firmwares, :ph_server_uuid, :string
+  end
+end


### PR DESCRIPTION
Adds physical server uuid foreign key to firmwares table. It is an important data in order to manageiq-providers-lenovo work.