### PR TITLE
Reset fog cache before running openstack infra maintenance mode test

### DIFF
--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -1,3 +1,5 @@
+require 'fog/openstack'
+
 describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
   before(:each) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
@@ -41,6 +43,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
                      :match_requests_on => [:method, :host, :path]) do
       @ems.reload
       @ems.reset_openstack_handle
+      Fog::OpenStack.instance_variable_set(:@version, nil)
       EmsRefresh.refresh(@ems)
       EmsRefresh.refresh(@ems.network_manager)
       @ems.reload


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/14510; this clears the Fog version cache for one additional test.  Failure to do so can result in test failures if this test is run second.