### PR TITLE
Allow partial POST edits on miq policy REST

### DIFF
--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -13,10 +13,9 @@ module Api
 
     def edit_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
-      assert_all_required_fields_exists(data, type, %w(conditions_ids policy_contents))
       policy = resource_search(id, type, collection_class(:policies))
       begin
-        add_policies_content(data, policy)
+        add_policies_content(data, policy) if data["policy_contents"]
         policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]
         policy.update_attributes(data)
       rescue => err
@@ -46,7 +45,7 @@ module Api
       policy.miq_policy_contents.destroy_all
       data.delete("policy_contents").each do |policy_content|
         add_policy_content(policy_content, policy)
-      end if data["policy_contents"]
+      end
     end
 
     def add_policy_content(policy_content, policy)

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -412,5 +412,14 @@ describe "Policies API" do
       expect(policy.events.count).to eq(1)
       expect(miq_policy.conditions.count).to eq(0)
     end
+
+    it "edits just the description" do
+      api_basic_authorize collection_action_identifier(:policies, :edit)
+      expect(miq_policy.description).to_not eq("BAR")
+      run_post(policies_url(miq_policy.id), gen_request(:edit, :description => "BAR"))
+      policy = MiqPolicy.find(response.parsed_body["id"])
+      expect(response).to have_http_status(:ok)
+      expect(policy.description).to eq("BAR")
+    end
   end
 end


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1435777

policies API (MiqPolicy) should allow partial POTS edits
e.g
```
POST localhost:3000/api/policies/1000000000007
{
  "action": "edit",
  "description": "Desc bar"
}
```

In addition the error message is wrong as it is about creation not edit:
```
{
  "error": {
    "kind": "bad_request",
    "message": "Resource conditions_ids, policy_contents needs be specified for creating a new policies",
    "klass": "Api::BadRequestError"
  }
}
```
