### PR TITLE
Add ssl verification to datawarehouse provider

### DIFF
--- a/spec/models/manageiq/providers/hawkular/datawarehouse_manager/datawarehouse_manager_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/datawarehouse_manager/datawarehouse_manager_spec.rb
@@ -1,0 +1,25 @@
+describe ManageIQ::Providers::Hawkular::DatawarehouseManager do
+  context "#verify_ssl_mode" do
+    let(:ems) { FactoryGirl.build(:ems_hawkular_datawarehouse) }
+
+    it "is secure by default when no security_protocol is sent" do
+      endpoint = Endpoint.new(:security_protocol => nil)
+      expect(ems.verify_ssl_mode(endpoint)).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
+
+    it "uses security_protocol when given" do
+      # security_protocol should win over opposite verify_ssl
+      endpoint = Endpoint.new(:security_protocol => 'ssl-with-validation',
+                              :verify_ssl        => OpenSSL::SSL::VERIFY_NONE)
+      expect(ems.verify_ssl_mode(endpoint)).to eq(OpenSSL::SSL::VERIFY_PEER)
+
+      endpoint = Endpoint.new(:security_protocol => 'ssl-with-validation-custom-ca',
+                              :verify_ssl        => OpenSSL::SSL::VERIFY_NONE)
+      expect(ems.verify_ssl_mode(endpoint)).to eq(OpenSSL::SSL::VERIFY_PEER)
+
+      endpoint = Endpoint.new(:security_protocol => 'ssl-without-validation',
+                              :verify_ssl        => OpenSSL::SSL::VERIFY_PEER)
+      expect(ems.verify_ssl_mode(endpoint)).to eq(OpenSSL::SSL::VERIFY_NONE)
+    end
+  end
+end


### PR DESCRIPTION
Support verifying datawarehouse/hawkular TLS certificates, including self-signed certificates.

This is available only through REST API.
Creating Datawarehouse provider will set endpoint (security_protocol, verify_ssl, certificate_authority) for containers, with 3 modes:

(ssl-with-validation, 1, nil) - default
(ssl-with-validation-custom-ca, 1, certificate_authority text)
(ssl-without-validation, 0, nil)

