### PR TITLE
Update API to use descendant_get to return valid types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "kubeclient",                     "~>2.4.0",       :require => false # For s
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-network_discovery",     "~>0.1.1",       :require => false
 gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"
-gem "more_core_extensions",           "~>3.2"
+gem "more_core_extensions",           "~>3.3"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -118,15 +118,6 @@ class Authentication < ApplicationRecord
     end
   end
 
-  def self.class_from_request_data(data)
-    if !data.key?('type') || data['type'] == to_s
-      return self
-    end
-    type = descendants.find { |klass| klass.name == data['type'] }
-    raise _('Must be an Authentication type') unless type
-    type
-  end
-
   private
 
   def set_credentials_changed_on

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -4,9 +4,4 @@ class ConfigurationScriptSource < ApplicationRecord
   belongs_to  :manager, :class_name => "ExtManagementSystem"
 
   virtual_total :total_payloads, :configuration_script_payloads
-
-  def self.class_for_manager(manager)
-    type = "#{manager.type}::ConfigurationScriptSource"
-    descendants.find { |klass| klass.name == type }
-  end
 end

--- a/lib/services/api/authentication_service.rb
+++ b/lib/services/api/authentication_service.rb
@@ -1,7 +1,7 @@
 module Api
   class AuthenticationService
     def self.create_authentication_task(manager_resource, attrs)
-      klass = ::Authentication.class_from_request_data(attrs)
+      klass = ::Authentication.descendant_get(attrs['type'])
       # TODO: Temporary validation - remove
       raise 'type not currently supported' unless klass.respond_to?(:create_in_provider_queue)
       klass.create_in_provider_queue(manager_resource.id, attrs.deep_symbolize_keys)

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -48,28 +48,4 @@ describe Authentication do
       expect(described_class.new(:status => 'Error').retryable_status?).to be_truthy
     end
   end
-
-  context '.class_from_request_data' do
-    it 'raises an error if it is not an authentication type' do
-      expect do
-        described_class.class_from_request_data('type' => 'ServiceTemplate')
-      end.to raise_error(RuntimeError, 'Must be an Authentication type')
-    end
-
-    it 'returns self if no type is specified' do
-      expect(described_class.class_from_request_data({})).to eq(described_class)
-    end
-
-    it 'returns self if Authentication is specified' do
-      expect(described_class.class_from_request_data('type' => 'Authentication')).to eq(described_class)
-    end
-
-    it 'returns the specified type' do
-      data = {
-        'type' => 'ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential'
-      }
-      expect(described_class.class_from_request_data(data))
-        .to eq(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential)
-    end
-  end
 end

--- a/spec/models/configuration_script_source_spec.rb
+++ b/spec/models/configuration_script_source_spec.rb
@@ -1,8 +1,0 @@
-describe ConfigurationScriptSource do
-  context '.class_for_manager' do
-    it 'returns the correct configuration script source' do
-      ems = FactoryGirl.create(:embedded_automation_manager_ansible)
-      expect(described_class.class_for_manager(ems)).to eq(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource)
-    end
-  end
-end


### PR DESCRIPTION
Mixin that returns the correct subclass from the specified string, or raises and error if it is not a subclass of that type.

Part of a refactoring effort for #14217 

@miq-bot assign @Fryguy 
@miq-bot add_label refactoring, wip 