### PR TITLE
Fix saving hosts in ansible playbook job

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -10,10 +10,11 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   def execute(action)
     jt = job_template(action)
     opts = get_job_options(action).deep_merge(:extra_vars => {'manageiq' => manageiq_extra_vars(action)})
+    hosts = opts.delete(:hosts)
 
     _log.info("Launching Ansible Tower job with options: #{opts}")
     new_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create_job(jt, opts)
-    update_job_for_playbook(action, new_job, opts[:hosts])
+    update_job_for_playbook(action, new_job, hosts)
 
     _log.info("Ansible Tower job with ref #{new_job.ems_ref} was created.")
     add_resource!(new_job, :name => action)
@@ -72,7 +73,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     credential_id = job_options.delete(:credential_id)
     job_options[:credential] = Authentication.find(credential_id).manager_ref unless credential_id.blank?
 
-    hosts = job_options.delete(:hosts)
+    hosts = job_options[:hosts]
     job_options[:inventory] = create_inventory_with_hosts(action, hosts).id unless use_default_inventory?(hosts)
 
     # TODO: encryption my be needed
@@ -135,8 +136,9 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   # update job attributes only available to playbook provisioning
   def update_job_for_playbook(action, job, hosts)
-    hosts = (hosts || 'localhost').split(',')
+    hosts = 'localhost' if use_default_inventory?(hosts)
+    host_array = hosts.split(',')
     playbook_id = options.fetch_path(:config_info, action.downcase.to_sym, :playbook_id)
-    job.update_attributes(:configuration_script_base_id => playbook_id, :hosts => hosts)
+    job.update_attributes(:configuration_script_base_id => playbook_id, :hosts => host_array)
   end
 end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -120,7 +120,7 @@ describe(ServiceAnsiblePlaybook) do
         expect(jobtemp).to eq(tower_job_temp)
         exposed_miq = %w(api_url api_token service user action)
         expect(opts[:extra_vars].delete('manageiq').keys).to include(*exposed_miq)
-        expect(opts).to include(provision_options[:provision_job_options])
+        expect(opts).to include(provision_options[:provision_job_options].except(:hosts))
         tower_job
       end
       loaded_service.execute(action)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1434939

Before the hosts were left out before saving to `options[:provision_job_options]`, there was no way to find out actual hosts to create a job.

With the fix the hosts are saved to `options[:provision_job_options]`; they are excluded only when passing options to the provider to launch a job (Provider expects inventory option, not hosts).