### PR TITLE
Stub mini-mime in for mime-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "jbuilder",                       "~>2.5.0" # For the REST API
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-network_discovery",     "~>0.1.1",       :require => false
 gem "manageiq-smartstate",            "~>0.1.1",       :require => false
-gem "mime-types",                     "~>2.6.1",       :require => "mime/types/columnar"
+gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"
 gem "more_core_extensions",           "~>3.2"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false

--- a/mime-types-redirector/lib/mime-types.rb
+++ b/mime-types-redirector/lib/mime-types.rb
@@ -1,0 +1,16 @@
+require 'mini_mime'
+
+module MIME
+  class Types
+    class << self
+      def [](type)
+        Array.wrap MiniMime.lookup_by_content_type(type)
+      end
+
+      def type_for(filename)
+        Array.wrap MiniMime.lookup_by_filename(filename)
+      end
+      alias_method :of, :type_for
+    end
+  end
+end

--- a/mime-types-redirector/lib/mime/types.rb
+++ b/mime-types-redirector/lib/mime/types.rb
@@ -1,0 +1,1 @@
+require 'mime-types'

--- a/mime-types-redirector/mime-types.gemspec
+++ b/mime-types-redirector/mime-types.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+# stub: mime-types 3.1 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "mime-types"
+  s.version = "2.6.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Nick LaMuro"]
+  s.date = "2017-03-27"
+  s.description = "Stub mime-types repo that redirects to mini-mime"
+  s.files = ["lib/mime-types.rb", "lib/mime/types.rb"]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  s.rubygems_version = "2.6.4"
+  s.summary = "Stub mime-types repo that redirects to mini-mime"
+
+  s.add_dependency 'mini_mime', '>= 0.1.1'
+end


### PR DESCRIPTION
Uses a stub for the two `mime-types` methods used by `rest-client` and `mail` (the only dependencies of `mime-types`) and forwards them on to `mini-mime`.  Should reduce the memory footprint from that gem... hopefully...

**Before**

![before](http://vignette4.wikia.nocookie.net/disney/images/0/08/Mime.JPG/revision/latest?cb=20120108024347)


**After**

![after](http://www.bricktraincity.com/images/8684-Lego-Minifigures/Mime-8684-Lego-Minifigures-Series-2-4.jpg)