### PR TITLE
Add Amazon Template model translation

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -778,6 +778,7 @@ en:
       ManageIQ::Providers::Amazon::CloudManager::Vm:                        Instance (Amazon)
       ManageIQ::Providers::Vmware::CloudManager::Vm:                        Instance (VMware vCloud)
       ManageIQ::Providers::CloudManager::Template:                          Image
+      ManageIQ::Providers::Amazon::CloudManager::Template:                  Image (Amazon)
       ManageIQ::Providers::CloudManager::VirtualTemplate:                   Resourceless Server Template
       ManageIQ::Providers::CloudManager::OrchestrationStack:                Orchestration Stack
       ManageIQ::Providers::ContainerManager:                                Containers Provider


### PR DESCRIPTION
This PR adds the ManageIQ::Providers::Amazon::CloudManager::Template model translation to "Image (Amazon)". This primarily for the UI, and is part of the AWS tagging effort. Specifically, it lets us create a proper drop down list for the tag mapping:

https://github.com/ManageIQ/manageiq-ui-classic/pull/780

You can see it "in action" like so:

```
> Dictionary.gettext("ManageIQ::Providers::Amazon::CloudManager::Template", :type => :model, :plural => true, :notfound => :titleize)
=> "Images (Amazon)"
```
