### PR TITLE
Raise a notification when the embedded ansible server starts

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -36,6 +36,8 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     _log.info("calling EmbeddedAnsible.start")
     EmbeddedAnsible.start
     _log.info("calling EmbeddedAnsible.start finished")
+
+    raise_role_notification
   end
 
   def update_embedded_ansible_provider
@@ -64,4 +66,14 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def set_connection_pool_size; end
   def message_sync_active_roles(*_args); end
   def message_sync_config(*_args); end
+
+  private
+
+  def raise_role_notification
+    notification_options = {
+      :role_name   => ServerRole.find_by(:name => worker.class.required_roles.first).description,
+      :server_name => MiqServer.my_server.name
+    }
+    Notification.create(:type => :role_activate_success, :options => notification_options)
+  end
 end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -114,3 +114,8 @@
   :expires_in: 24.hours
   :level: :warning
   :audience: global
+- :name: role_activate_success
+  :message: 'The role %{role_name} has been activated on server %{server_name}'
+  :expires_in: 24.hours
+  :level: :info
+  :audience: superadmin


### PR DESCRIPTION
This process can take quite a long time (at least 10 minutes to do the initial configuration and about 4 minutes to start) so it would be good to give the user an idea of when they will be able to start using the ansible based features.

https://www.pivotaltracker.com/story/show/142511083

/cc @mkanoor 