### PR TITLE
Re-add removed migrations to avoid error messages

### DIFF
--- a/db/migrate/20160106214719_add_composite_primary_keys_to_join_tables.rb
+++ b/db/migrate/20160106214719_add_composite_primary_keys_to_join_tables.rb
@@ -1,0 +1,15 @@
+class AddCompositePrimaryKeysToJoinTables < ActiveRecord::Migration
+  # This migration is intentionally left blank
+  #
+  # We removed the contents of the migration, but don't want to incurr errors
+  # when we check for the schema status on server startup.
+  #
+  # If someone has already migrated past this migration and the file is removed,
+  # then they will see a message that looks like:
+  #
+  # MIQ(MiqServer.check_migrations_up_to_date) database schema is from a newer version of the product and may be incompatible.  Schema version is [20160922235000].  Missing files: [20160106214719]
+
+  def up
+    say "Migrating up NOOP migration for schema consistency"
+  end
+end

--- a/db/migrate/20160425161345_reset_ruby_rep_triggers_on_tables_with_new_primary_key.rb
+++ b/db/migrate/20160425161345_reset_ruby_rep_triggers_on_tables_with_new_primary_key.rb
@@ -1,0 +1,15 @@
+class ResetRubyRepTriggersOnTablesWithNewPrimaryKey < ActiveRecord::Migration[5.0]
+  # This migration is intentionally left blank
+  #
+  # We removed the contents of the migration, but don't want to cause errors
+  # when we check for the schema status on server startup.
+  #
+  # If someone has already migrated past this migration and the file is removed,
+  # then they will see a message that looks like:
+  #
+  # MIQ(MiqServer.check_migrations_up_to_date) database schema is from a newer version of the product and may be incompatible.  Schema version is [20160922235000].  Missing files: [20160425161345]
+
+  def up
+    say "Migrating up NOOP migration for schema consistency"
+  end
+end


### PR DESCRIPTION
If we no longer need a migration, we should remove the contents, but not the file itself.

This is because people who have already migrated past a particular migration, but then upgrade to a newer code release, will be missing the migration files that they have already run.

This causes an error on server startup which we would like to avoid.

https://bugzilla.redhat.com/show_bug.cgi?id=1417313

Backporting this change will allow users who migrate from darga to the latest euwe release to avoid these messages.