### PR TITLE
Fix ui-components to specific version (0.0.12)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "jquery-ujs": "~1.2.2",
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "kubernetes-topology-graph": "~0.0.23",
-    "manageiq-ui-components": "master",
+    "manageiq-ui-components": "0.0.12",
     "moment-duration-format": "~1.3.0",
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",


### PR DESCRIPTION
@Fryguy this should go in fine, but master is ok, https://github.com/ManageIQ/manageiq/pull/14536 removes it anyway.

The rationale is that we want manageiq-ui-component's `master` branch in master, because of the ongoing "move GTL to angular+json" effort, but it seems like it won't go in `fine` quite just yet (if at all).

So, fixing the version to 0.0.12 to prevent future breakage.

(This matches what we already have in ui-classic's bower.json)