### PR TITLE
Change Start page labels to be consistent with pages

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -214,7 +214,7 @@
   :rbac_feature_name: container_node_show_list
   :startup: true
 - :name: container_groups
-  :description: Containers / Groups
+  :description: Containers / Pods
   :url: /container_group/show_list
   :rbac_feature_name: container_group_show_list
   :startup: true


### PR DESCRIPTION
Fix 'Start Page' labels: 'Container Groups' -> 'Pods'; this is to be consistent with the actual page it leads to.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1434789
cc: @simon3z @moolitayer 


Before:
![selection_avail](https://cloud.githubusercontent.com/assets/8366181/24401077/8fd18156-13bb-11e7-839c-5b18164b50b4.png)
After:
![screenshot from 2017-03-28 13-33-55](https://cloud.githubusercontent.com/assets/8366181/24401086/9837df66-13bb-11e7-8325-1e2700302014.png)
Pods page:
![start_page_groups](https://cloud.githubusercontent.com/assets/8366181/24401096/a22cd8dc-13bb-11e7-9504-7dc1635e0c34.png)

