### PR TITLE
format memory to mb in nodes by capacity report

### DIFF
--- a/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
+++ b/product/reports/170_Configuration Management - Containers/010_Nodes by Capacity.yaml
@@ -41,7 +41,7 @@ generate_rows:
 col_formats:
 -
 -
--
+- :megabytes_human_precision_2
 tz:
 time_profile_id:
 display_filter:


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1435970
Format the memory column to memory sizes - MB, GB, TB....

@zakiva @nimrodshn Please review

@lpichler what do we do with the report that already in the system? do we need a migration here to add this formatting? 

cc @simon3z @moolitayer

@miq-bot add_label providers/containers, bug, reporting