### PR TITLE
use organization instead of organization_id when talking to Tower

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -2,6 +2,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
 
   def self.provider_params(params)
-    super.merge(:organization_id => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
+    super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
   end
 end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -32,7 +32,7 @@ shared_examples_for "ansible credential" do
         :username    => "john",
         :kind        => described_class::TOWER_KIND
       }
-      expected_params[:organization_id] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_credential(credential, manager)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
@@ -107,7 +107,7 @@ shared_examples_for "ansible credential" do
         :username => 'john',
         :kind     => described_class::TOWER_KIND
       }
-      expected_params[:organization_id] = 1 if described_class.name.include?("::EmbeddedAnsible::")
+      expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
       expect(credential).to receive(:update_attributes!).with(expected_params)


### PR DESCRIPTION
Tower takes parameter `organization` instead of `organization_id`

This is to fix https://github.com/ManageIQ/manageiq/issues/14532

@miq-bot add_labels bug, provider/ansible_providers