### PR TITLE
Removing unused physical_servers_controller.rb file

### DIFF
--- a/app/controllers/api/physical_servers_controller.rb
+++ b/app/controllers/api/physical_servers_controller.rb
@@ -1,4 +1,0 @@
-module Api
-  class PhysicalServersController < BaseController
-  end
-end


### PR DESCRIPTION
This file should not have been added, there's no exposure of /api/physical_servers in the api.yml either as collection or subcollection.



