### PR TITLE
Optimize store_ids_for_new_records by getting rid of the O(n^2) lookups

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -114,11 +114,7 @@ module EmsRefresh::SaveInventoryHelper
   def store_ids_for_new_records(records, hashes, keys)
     keys = Array(keys)
     # Lets first index the hashes based on keys, so we can do O(1) lookups
-    record_index = {}
-    records.each do |record|
-      record_index[build_index_from_record(keys, record)] = record
-    end
-
+    record_index = records.index_by { |record| build_index_from_record(keys, record) }
     record_class = records.first.class
 
     hashes.each do |hash|

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -115,7 +115,7 @@ module EmsRefresh::SaveInventoryHelper
     keys = Array(keys)
     # Lets first index the hashes based on keys, so we can do O(1) lookups
     record_index = {}
-    records.uniq.each do |record|
+    records.each do |record|
       record_index[build_index_from_record(keys, record)] = record
     end
 
@@ -123,7 +123,7 @@ module EmsRefresh::SaveInventoryHelper
 
     hashes.each do |hash|
       record = record_index[build_index_from_hash(keys, hash, record_class)]
-      hash[:id] = record.try(:id)
+      hash[:id] = record.id
     end
   end
 

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -129,15 +129,11 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def build_index_from_hash(keys, hash)
-    keys.map { |key| hash[key].to_s }.join(index_joiner)
+    keys.map { |key| hash[key].to_s }
   end
 
   def build_index_from_record(keys, record)
-    keys.map { |key| record.send(key).to_s }.join(index_joiner)
-  end
-
-  def index_joiner
-    "___"
+    keys.map { |key| record.send(key).to_s }
   end
 
   def link_children_references(records)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -112,6 +112,8 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def store_ids_for_new_records(records, hashes, keys)
+    return if records.blank?
+
     keys = Array(keys)
     # Lets first index the hashes based on keys, so we can do O(1) lookups
     record_index = records.index_by { |record| build_index_from_record(keys, record) }

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -119,7 +119,7 @@ module EmsRefresh::SaveInventoryHelper
       hashes_index[build_index_from_hash(keys, hash)] = hash
     end
 
-    records.find_each do |record|
+    records.uniq.each do |record|
       record_index = build_index_from_record(keys, record)
       hash = hashes_index[record_index]
       hash[:id] = record.id if hash

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -117,7 +117,7 @@ module EmsRefresh::SaveInventoryHelper
     keys = Array(keys)
     # Lets first index the hashes based on keys, so we can do O(1) lookups
     record_index = records.index_by { |record| build_index_from_record(keys, record) }
-    record_class = records.first.class
+    record_class = records.first.class.base_class
 
     hashes.each do |hash|
       record = record_index[build_index_from_hash(keys, hash, record_class)]


### PR DESCRIPTION
Optimize store_ids_for_new_records by getting rid of the O(n^2)
lookups. These lookups can take hours when we go over 50-100k records
being processed by store_ids_for_new_records.

And seems like there might be a Rails issue, since by doing
association.push(new_records) at
https://github.com/Ladas/manageiq/blob/48aa323551c8825e02170e251afa717ca807d2ed/app/models/ems_refresh/save_inventory_helper.rb#L69-L69

The association has the records doubled, the association is passed
into store_ids_for_new_records as 'records' parameter
https://github.com/Ladas/manageiq/blob/48aa323551c8825e02170e251afa717ca807d2ed/app/models/ems_refresh/save_inventory_helper.rb#L114-L114

And here when we do:
records.count => 50k
records.uniq.count => 25k
records.reload.count => 25k

That was slowing down the store_ids_for_new_records method even
more it seems.

Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1436176

