### PR TITLE
Stop using deprecated names of hawkular-client gem

### DIFF
--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers
               when :metrics
                 ::Hawkular::Metrics::Client
               when :alerts
-                ::Hawkular::Alerts::AlertsClient
+                ::Hawkular::Alerts::Client
               else
                 raise ArgumentError, "Client not found for [#{type}]"
               end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers
     require_nested :Refresher
 
     include AuthenticationMixin
-    include ::HawkularUtilsMixin
+    include ::Hawkular::ClientUtils
 
     DEFAULT_PORT = 80
     default_value_for :port, DEFAULT_PORT
@@ -279,7 +279,7 @@ module ManageIQ::Providers
         :username => username,
         :password => password
       }
-      ::Hawkular::Alerts::AlertsClient.new(url, credentials)
+      ::Hawkular::Alerts::Client.new(url, credentials)
     end
 
     def add_middleware_datasource(ems_ref, hash)

--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   module Hawkular
     class MiddlewareManager::RefreshParser
-      include ::HawkularUtilsMixin
+      include ::Hawkular::ClientUtils
 
       def self.ems_inv_to_hashes(ems, options = nil)
         new(ems, options).ems_inv_to_hashes


### PR DESCRIPTION
Version 2.9.0 of hawkular-client has deprecated some names. This is
replacing the deprecated names with the current ones.

**NOTE:** This **must** be merged after ManageIQ/manageiq-gems-pending#102

@miq-bot add_labels providers/hawkular