### PR TITLE
Fix typo for physical_server_show_list

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6396,7 +6396,7 @@
     - :name: List
       :description: Display Lists of Physical Servers
       :feature_type: view
-      :identifier: shosical_server_show_list
+      :identifier: physical_server_show_list
     - :name: Show
       :description: Display Individual Physical Server
       :feature_type: view


### PR DESCRIPTION
Fixed typo for `physical_server_show_list`
