### PR TITLE
Refactor MiqRequestTask::Dumping.

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_task/options_helper.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_task/options_helper.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionTask::Option
 
   def merge_provider_options_from_automate
     phase_context[:provider_options].merge!(get_option(:provider_options) || {})
-    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Merged Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
+    dump_obj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Merged Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
   end
 
   def prepare_provider_options
@@ -14,7 +14,7 @@ module ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionTask::Option
     h["ip"]        = options[:ip_addr]                            if options[:ip_addr]
     h["root_pass"] = MiqPassword.decrypt(options[:root_password]) if options[:root_password]
     phase_context[:provider_options] = h
-    dumpObj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
+    dump_obj(phase_context[:provider_options], "MIQ(#{self.class.name}##{__method__}) Default Provider Options: ", $log, :info, :protected => {:path => /root_pass/})
   end
 
   def validate_source

--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -33,8 +33,8 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
     _log.info("Destination Availability Zone: [#{clone_options[:zone_name]}]")
     _log.info("Machine Type:                  [#{clone_options[:machine_type]}]")
 
-    dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info,
+    dump_obj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
+    dump_obj(options, "#{_log.prefix} Prov Options:  ", $log, :info,
             :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 

--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -5,8 +5,8 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     _log.info("Provisioning [#{source.name}] to [#{clone_options[:name]}]")
     _log.info("Source Image:                    [#{clone_options[:image_ref]}]")
 
-    dumpObj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
-    dumpObj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
+    dump_obj(clone_options, "#{_log.prefix} Clone Options: ", $log, :info)
+    dump_obj(options, "#{_log.prefix} Prov Options:  ", $log, :info, :protected => {:path => workflow_class.encrypted_options_field_regs})
   end
 
   def clone_complete?

--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -12,7 +12,7 @@ module MiqProvision::StateMachine
   def prepare_provision
     update_and_notify_parent(:message => "Preparing to Clone #{clone_direction}")
     phase_context[:clone_options] = prepare_for_clone_task
-    dumpObj(phase_context[:clone_options], "MIQ(#{self.class.name}##{__method__}) Default Clone Options: ", $log, :info)
+    dump_obj(phase_context[:clone_options], "MIQ(#{self.class.name}##{__method__}) Default Clone Options: ", $log, :info)
     phase_context[:clone_options].merge!(get_option(:clone_options) || {}).delete_nils
 
     signal :start_clone_task

--- a/app/models/miq_request_task/dumping.rb
+++ b/app/models/miq_request_task/dumping.rb
@@ -20,10 +20,6 @@ module MiqRequestTask::Dumping
       end
     end
 
-    def dumpWIN32OLE(obj, prefix, prnt_obj, prnt_meth, _options)
-      prnt_obj.send(prnt_meth, "#{prefix} (WIN32OLE)\n#{obj.GetObjectText_.strip} #{obj.Path_.Path}\n\n")
-    end
-
     def dumpHash(hd, prefix, prnt_obj, prnt_meth, options)
       hd.each { |k, v| dumpObj(v, "#{prefix}[#{k.inspect}]", prnt_obj, prnt_meth, options) }
     end

--- a/app/models/miq_request_task/dumping.rb
+++ b/app/models/miq_request_task/dumping.rb
@@ -2,44 +2,42 @@ module MiqRequestTask::Dumping
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def dumpObj(obj, prefix = nil, prnt_obj = STDOUT, prnt_meth = :puts, options = {})
-      meth = "dump#{obj.class.name}".to_sym
+    def dump_obj(obj, prefix = nil, print_obj = STDOUT, print_method = :puts, &block)
+      meth = "dump_#{obj.class.name.underscore}".to_sym
+
       if self.respond_to?(meth)
-        prnt_obj.send(prnt_meth, "#{prefix}(#{obj.class}) = EMPTY") if obj.respond_to?(:blank?) && obj.blank?
-        send(meth, obj, prefix, prnt_obj, prnt_meth, options)
-      else
-        protected = false
-        if options[:protected].kind_of?(Hash)
-          protected = options[:protected][:path].to_miq_a.any? { |filter| prefix =~ filter }
-        end
-        if protected == true
-          prnt_obj.send(prnt_meth, "#{prefix}(#{obj.class}) = <PROTECTED>")
-        else
-          prnt_obj.send(prnt_meth, "#{prefix}(#{obj.class}) = #{obj.inspect}")
-        end
+        return send(meth, obj, prefix, print_obj, print_method, &block)
       end
+
+      yield obj, prefix
     end
 
-    def dumpHash(hd, prefix, prnt_obj, prnt_meth, options)
-      hd.each { |k, v| dumpObj(v, "#{prefix}[#{k.inspect}]", prnt_obj, prnt_meth, options) }
+    def dump_hash(hd, prefix, print_obj, print_method, &block)
+      hd.each { |k, v| dump_obj(v, "#{prefix}[#{k.inspect}]", print_obj, print_method, &block) }
     end
 
-    def dumpVimHash(hd, prefix, prnt_obj, prnt_meth, options)
-      prnt_obj.send(prnt_meth, "#{prefix} (#{hd.class}) xsiType: <#{hd.xsiType}>  vimType: <#{hd.vimType}>")
-      dumpHash(hd, prefix, prnt_obj, prnt_meth, options)
+    def dump_array(ad, prefix, print_obj, print_method, &block)
+      ad.each_with_index { |d, i| dump_obj(d, "#{prefix}[#{i}]", print_obj, print_method, &block) }
     end
 
-    def dumpArray(ad, prefix, prnt_obj, prnt_meth, options)
-      ad.each_with_index { |d, i| dumpObj(d, "#{prefix}[#{i}]", prnt_obj, prnt_meth, options) }
+    def dump_vim_hash(hd, prefix, print_obj, print_method, &block)
+      print_obj.send(print_method, "#{prefix} (#{hd.class}) xsiType: <#{hd.xsiType}>  vimType: <#{hd.vimType}>")
+      dump_hash(hd, prefix, print_obj, print_method, &block)
     end
 
-    def dumpVimArray(ad, prefix, prnt_obj, prnt_meth, options)
-      prnt_obj.send(prnt_meth, "#{prefix} (#{ad.class}) xsiType: <#{ad.xsiType}>  vimType: <#{ad.vimType}>")
-      dumpArray(ad, prefix, prnt_obj, prnt_meth, options)
+    def dump_vim_array(ad, prefix, print_obj, print_method, &block)
+      print_obj.send(print_method, "#{prefix} (#{ad.class}) xsiType: <#{ad.xsiType}>  vimType: <#{ad.vimType}>")
+      dump_array(ad, prefix, print_obj, print_method, &block)
     end
   end
 
-  def dumpObj(obj, prefix = nil, prnt_obj = STDOUT, prnt_meth = :puts, options = {})
-    self.class.dumpObj(obj, prefix, prnt_obj, prnt_meth, options)
+  def dump_obj(obj, prefix = nil, print_obj = STDOUT, print_method = :puts, options = {})
+    self.class.dump_obj(obj, prefix, print_obj, print_method) do |val, key|
+      value = val
+      if options.try(:[], :protected).try(:[], :path).to_miq_a.any? { |filter| key =~ filter }
+        value = "<PROTECTED>"
+      end
+      print_obj.send(print_method, "#{key}(#{val.class}) = #{value.inspect}")
+    end
   end
 end

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -41,7 +41,7 @@ class VmReconfigureTask < MiqRequestTask
 
   def do_request
     config = vm.build_config_spec(options)
-    dumpObj(config, "#{_log.prefix} Config spec: ", $log, :info)
+    dump_obj(config, "#{_log.prefix} Config spec: ", $log, :info)
     vm.spec_reconfigure(config)
 
     if AUTOMATE_DRIVES

--- a/spec/models/miq_request_task/dumping_spec.rb
+++ b/spec/models/miq_request_task/dumping_spec.rb
@@ -1,0 +1,53 @@
+describe MiqRequestTask do
+  context "::Dumping" do
+    let(:task) { FactoryGirl.create(:miq_request_task) }
+
+    describe '#dump_obj' do
+      it "calls .dump_obj" do
+        expect(task.class).to receive(:dump_obj)
+        task.dump_obj(:param_1 => 1)
+      end
+
+      it 'hides passwords' do
+        expect($log).to receive(:info).with(/<PROTECTED>/)
+        task.dump_obj({:my_password => "secret"}, "my choices: ", $log, :info, :protected => {:path => /[Pp]assword/})
+      end
+    end
+
+    describe '.dump_obj' do
+      it 'accepts a hash' do
+        expect(task.class).to receive(:dump_hash)
+        task.class.dump_obj(:param_1 => 1)
+      end
+
+      it 'accepts an array' do
+        expect(task.class).to receive(:dump_array)
+        task.class.dump_obj(%w(1 2 3))
+      end
+    end
+
+    it '#dump_vim_hash' do
+      data = VimHash.new('VirtualDisk') do |vh|
+        vh.backing = {'diskMode' => 'persistent', 'datastore' => 'datastore-001'}
+        vh.capacityInKB = 100
+      end
+      expect(MiqRequestTask).to receive(:dump_hash)
+      task.dump_obj(data)
+    end
+
+    it '#dump_vim_array' do
+      array = VimArray.new("ArrayOfHostInternetScsiHbaStaticTarget") do |ta|
+        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+          st.address    = "10.1.1.210"
+          st.iScsiName  = "iqn.1992-08.com.netapp:sn.135107242"
+        end
+        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+          st.address    = "10.1.1.100"
+          st.iScsiName  = "iqn.2008-08.com.starwindsoftware:starwindm1-starm1-test1"
+        end
+      end
+      expect(MiqRequestTask).to receive(:dump_array)
+      task.dump_obj(array)
+    end
+  end
+end


### PR DESCRIPTION
Remove dumpWIN32OLE which is not used any more.
Rename dumpObj to dump_obj.

Includes [Openstack PR #4](https://github.com/ManageIQ/manageiq-providers-openstack/pull/4).
Includes [Vmware PR #37](https://github.com/ManageIQ/manageiq-providers-vmware/pull/37).
Includes [Amazon PR #209](https://github.com/ManageIQ/manageiq-providers-amazon/pull/209).
Includes [Azure PR #48](https://github.com/ManageIQ/manageiq-providers-azure/pull/48).
Includes [Ovirt PR #12](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/12).

@miq-bot assign @gmcculloug 
@miq-bot add_label refactoring, fine/yes, euwe/no
cc @bzwei 