### PR TITLE
Return correct resource hrefs

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -75,10 +75,12 @@ module Api
         return reftype unless resource.respond_to?(:attributes)
 
         rclass = resource.class
-        if collection_class(type) != rclass
-          matched_type = collection_config.name_for_klass(rclass)
-        end
-        matched_type || reftype
+        collection_class = collection_class(type)
+
+        # Ensures hrefs are consistent with those of the collection they were requested from
+        return reftype if collection_class == rclass || collection_class.descendants.include?(rclass)
+
+        collection_config.name_for_klass(rclass) || reftype
       end
 
       #

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Requests API" do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("id"   => service_request.id,
-                                              "href" => a_string_matching(service_requests_url(service_request.id)))
+                                              "href" => a_string_matching(requests_url(service_request.id)))
     end
 
     it "lists all the service requests if you are admin" do
@@ -110,7 +110,7 @@ RSpec.describe "Requests API" do
 
       expected = {
         "id"   => service_request.id,
-        "href" => a_string_matching(service_requests_url(service_request.id))
+        "href" => a_string_matching(requests_url(service_request.id))
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -443,6 +443,23 @@ RSpec.describe "Requests API" do
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "resource hrefs" do
+    it "returns the requests href reference for objects of different subclasses" do
+      provision_request = FactoryGirl.create(:service_template_provision_request, :requester => @user)
+      automation_request = FactoryGirl.create(:automation_request, :requester => @user)
+      api_basic_authorize collection_action_identifier(:requests, :read, :get)
+
+      run_get requests_url, :expand => :resources
+
+      expected = [
+        a_hash_including('href' => a_string_including(requests_url(provision_request.id))),
+        a_hash_including('href' => a_string_including(requests_url(automation_request.id)))
+      ]
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['resources']).to match_array(expected)
     end
   end
 end

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -396,7 +396,7 @@ describe "Service Catalogs API" do
 
       run_post(sc_templates_url(sc.id, st1.id), gen_request(:order))
 
-      expect_single_resource_query(order_request)
+      expect_single_resource_query(order_request.merge("href" => /service_requests/))
     end
 
     it "accepts order requests with required fields" do

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -76,6 +76,7 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:ok)
       quota.reload
       expect(quota.value).to eq(5)
+      expect(response.parsed_body).to include('href' => /quotas/)
     end
 
     it "can update multiple quotas from a tenant with POST" do


### PR DESCRIPTION
This PR fixes a bug where the hrefs being returned do not match those of the collection they were requested from. 

For a `service request`  retrieved via `/api/requests/:id`, the resource is being returned with:
```
{
   "href" : "/api/service_requests/:id"
  ...
}
```
On the collection, `GET /api/requests?expand=resources` returns inconsistent hrefs, ie:
```
{
   "resources":[
      {"href": "/api/provision_requests/:id" ...},
      {"href": "/api/service_requests/:id"...},
      {"href": "/api/automation_requests/:id"...},
      {"href": "/api/requests/:id"...}
   ]
}
```

This change ensures that all hrefs from `GET /api/requests?expand=resources` will be consistent:
```
{
   "resources":[
      {"href": "/api/requests/:id" ...},
      {"href": "/api/requests/:id"...},
      {"href": "/api/equests/:id"...},
      {"href": "/api/requests/:id"...}
   ]
}
```
and that the call to `GET /api/requests/:id` will also return a matching href:
```
{
   "href" : "/api/requests/:id"
  ...
}
```
for any subclass of `MiqRequest`

Additional tests for service catalogs and tenant quotas were added to ensure that the correct href is being returned when it is a [different object than the requested resource](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/api/base_controller/renderer.rb#L74)

@miq-bot add_label bug, api
@miq-bot assign @abellotti 