### PR TITLE
Adjust power states on a service to handle children

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -84,7 +84,11 @@ module ServiceMixin
   end
 
   def each_group_resource(grp_idx = nil)
-    if grp_idx.nil?
+    if children.present? && service_resources.empty?
+      children.each do |child|
+        child.service_resources.each { |sr| yield(sr) }
+      end
+    elsif grp_idx.nil?
       service_resources.each do |sr|
         yield(sr)
       end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -186,16 +186,16 @@ class Service < ApplicationRecord
   end
 
   def all_states_match?(action)
-    return true if child_resources? && (power_states.uniq == map_power_states(action))
-    return true if empty_child_resources? && (power_states[0] == POWER_STATE_MAP[action])
+    return true if composite? && (power_states.uniq == map_power_states(action))
+    return true if atomic? && (power_states[0] == POWER_STATE_MAP[action])
     false
   end
 
-  def child_resources?
+  def composite?
     children.present?
   end
 
-  def empty_child_resources?
+  def atomic?
     children.empty?
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -181,8 +181,7 @@ class Service < ApplicationRecord
   end
 
   def power_states_match?(action)
-    return update_power_status(action) if all_states_match?(action)
-    false
+    all_states_match?(action) ? update_power_status(action) : false
   end
 
   def all_states_match?(action)
@@ -203,14 +202,17 @@ class Service < ApplicationRecord
     service_resources.where(:resource_type => 'OrchestrationStack').collect(&:resource)
   end
 
-  def map_power_states(action)
-    action_name = "#{action}_action"
-    service_actions = [].tap do |sa|
+  def group_resource_actions(action_name)
+    [].tap do |sa|
       each_group_resource do |svc_rsc|
         sa << svc_rsc
       end
-    end.map(&action_name.to_sym).uniq
+    end.map(&action_name).uniq
+  end
 
+  def map_power_states(action)
+    action_name = "#{action}_action".to_sym
+    service_actions = group_resource_actions(action_name)
     # We need to account for all nil :start_action or :stop_action attributes
     #   When all :start_actions are nil then return 'Power On' for the :start_action
     #   When all :stop_actions are nil then return 'Power Off' for the :stop_action

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -185,12 +185,14 @@ describe Service do
         expect(@service_c2.service_resources.first.id).to_not eq @service_c2.service_resources.last.id
         expect(@service_c2.service_resources.first.start_action).to be_nil
         expect(@service_c2.service_resources.last.start_action).to be_nil
+        expect(@service_c2.group_resource_actions(:start_action)).to eq [nil]
         expect(@service_c2.map_power_states(:start)).to eq ["on"]
       end
 
       it "assumes the stop_action and returns a value if none of the stop_actions are set" do
         expect(@service_c2.service_resources.first.stop_action).to be_nil
         expect(@service_c2.service_resources.last.stop_action).to be_nil
+        expect(@service_c2.group_resource_actions(:stop_action)).to eq [nil]
         expect(@service_c2.map_power_states(:stop)).to eq ["off"]
       end
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -101,31 +101,28 @@ describe Service do
 
     context "#power_states_match?" do
       it "returns the uniq value for the 'on' power state" do
-        allow(@service).to receive(:child_resources?).and_return(true)
+        allow(@service).to receive(:composite?).and_return(true)
         expect(@service).to receive(:map_power_states).with(:start).and_return(["on"])
         expect(@service).to receive(:update_power_status).with(:start).and_return(true)
         expect(@service.power_states_match?(:start)).to be_truthy
       end
 
       it "returns the uniq value for the 'off' power state" do
-        allow(@service).to receive(:child_resources?).and_return(true)
+        allow(@service).to receive(:composite?).and_return(true)
         expect(@service).to receive(:map_power_states).with(:stop).and_return(["off"])
         expect(@service).to receive(:update_power_status).with(:stop).and_return(true)
         expect(@service).to receive(:power_states).and_return(["off"])
         expect(@service.power_states_match?(:stop)).to be_truthy
       end
 
-      it "returns the uniq value for the 'on' power state with an empty_child_resources service" do
-        allow(@service).to receive(:chilren_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
-
+      it "returns the uniq value for the 'on' power state with an atomic service" do
         expect(@service).to receive(:update_power_status).with(:start).and_return(true)
         expect(@service.power_states_match?(:start)).to be_truthy
       end
 
-      it "returns the uniq value for the 'off' power state with an empty_child_resources service" do
-        allow(@service).to receive(:child_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
+      it "returns the uniq value for the 'off' power state with an atomic service" do
+        allow(@service).to receive(:composite?).and_return(false)
+        allow(@service).to receive(:atomic?).and_return(true)
         allow(@service).to receive(:children).and_return(false)
 
         expect(@service).to receive(:update_power_status).with(:stop).and_return(true)
@@ -135,39 +132,39 @@ describe Service do
     end
 
     context "#all_states_match?" do
-      it "returns false if the child_resources service power states do not match" do
-        allow(@service).to receive(:child_resources?).and_return(true)
+      it "returns false if the composite service power states do not match" do
+        allow(@service).to receive(:composite?).and_return(true)
         expect(@service.all_states_match?(:stop)).to be_falsey
       end
 
-      it "returns true if the child_resources service power states do  match" do
-        allow(@service).to receive(:child_resources?).and_return(true)
+      it "returns true if the composite service power states do  match" do
+        allow(@service).to receive(:composite?).and_return(true)
         allow(@service).to receive(:map_power_states).with(:start).and_return(['on'])
         expect(@service.all_states_match?(:start)).to be_truthy
       end
 
-      it "returns false if the empty_child_resources service power states do not match" do
-        allow(@service).to receive(:child_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
+      it "returns false if the atomic service power states do not match" do
+        allow(@service).to receive(:composite?).and_return(false)
+        allow(@service).to receive(:atomic?).and_return(true)
         expect(@service.all_states_match?(:stop)).to be_falsey
       end
 
-      it "returns true if the empty_child_resources service power states do  match" do
-        allow(@service).to receive(:child_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
+      it "returns true if the atomic service power states do  match" do
+        allow(@service).to receive(:composite?).and_return(false)
+        allow(@service).to receive(:atomic?).and_return(true)
         expect(@service.all_states_match?(:start)).to be_truthy
       end
 
-      it "returns false if the empty_child_resources service children power states do not match" do
-        allow(@service).to receive(:child_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
+      it "returns false if the atomic service children power states do not match" do
+        allow(@service).to receive(:composite?).and_return(false)
+        allow(@service).to receive(:atomic?).and_return(true)
         allow(@service).to receive(:children).and_return(true)
         expect(@service.all_states_match?(:stop)).to be_falsey
       end
 
-      it "returns true if the empty_child_resources service children power states do  match" do
-        allow(@service).to receive(:child_resources?).and_return(false)
-        allow(@service).to receive(:empty_child_resources?).and_return(true)
+      it "returns true if the atomic service children power states do  match" do
+        allow(@service).to receive(:composite?).and_return(false)
+        allow(@service).to receive(:atomic?).and_return(true)
         allow(@service).to receive(:children).and_return(true)
         expect(@service.all_states_match?(:start)).to be_truthy
       end
@@ -490,8 +487,8 @@ describe Service do
       create_deep_tree
       expect(@service.children).to match_array([@service_c1, @service_c2])
       expect(@service.service_template).to be_nil
-      expect(@service.child_resources?).to be_truthy
-      expect(@service.empty_child_resources?).to be_falsey
+      expect(@service.composite?).to be_truthy
+      expect(@service.atomic?).to be_falsey
       expect(@service.services).to match_array([@service_c1, @service_c2]) # alias
       expect(@service.direct_service_children).to match_array([@service_c1, @service_c2]) # alias
     end
@@ -499,8 +496,8 @@ describe Service do
     it "returns no children" do
       @service = FactoryGirl.create(:service)
       expect(@service.children).to be_empty
-      expect(@service.child_resources?).to be_falsey
-      expect(@service.empty_child_resources?).to be_truthy
+      expect(@service.composite?).to be_falsey
+      expect(@service.atomic?).to be_truthy
     end
   end
 


### PR DESCRIPTION
For an atomic service with children.

1. Iterate through the children if there are no `service_resources` on the parent
2. Iterate through the children for `power_states` to adjust the power state and status for
the entire service

https://bugzilla.redhat.com/show_bug.cgi?id=1416903