### PR TITLE
[WIP] [POC] Reduce docker disk space usage (possible usages elsewhere)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,7 @@ RUN source /etc/default/evm && \
     bower cache clean && \
     find ${RUBY_GEMS_ROOT}/gems/ -name .git | xargs rm -rvf && \
     find ${RUBY_GEMS_ROOT}/gems/ | grep "\.s\?o$" | xargs rm -rvf && \
+    rm -rvf ${RUBY_GEMS_ROOT}/bundler/gems/**/spec && \
     rm -rvf ${RUBY_GEMS_ROOT}/gems/rugged-*/vendor/libgit2/build && \
     rm -rvf ${RUBY_GEMS_ROOT}/cache/* && \
     rm -rvf /root/.bundle/cache && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,8 @@ RUN source /etc/default/evm && \
 RUN source /etc/default/evm && \
     cd ${SUI_ROOT} && \
     yarn install && \
-    yarn run build
+    yarn run build && \
+    rm -rvf node_modules
 
 ## Copy appliance-initialize script and service unit file
 COPY docker-assets/appliance-initialize.service /usr/lib/systemd/system


### PR DESCRIPTION
By removing two different sets of directories:

* The 'spec' directories from our git gems (around 200Mb)
* The 'node_modules' directories from the `manageiq-ui-service` repo (around 500Mb)

We end up saving what seems like 500Mb on the image size


Results
-------
These results were taken from my local machine by running the following in a "somewhat" prestine clone of the `manageiq` application (with the modifications to the Dockerfile from this PR):

```console
$ docker build .
```

This probably is including some extra cruft that is uploaded to the container, and might not fully reflect what will actually be generated and sent to dockerhub.  I will need to try this without my changes as well, but that is a longer process then worth doing before pushing this up to get some eyes and comments around.


The container size after the changes:

```console
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              1a398f615af2        52 minutes ago      1.542 GB
centos              7                   98d35105a391        12 days ago         192.5 MB
```


Links
-----
* https://gitter.im/ManageIQ/manageiq/performance?at=58da92a0dddd87f332d1f257