### PR TITLE
Adds physical_server methods to be used by miq-ui

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -9,11 +9,11 @@ class PhysicalServer < ApplicationRecord
   has_one :host, :inverse_of => :physical_server
 
   VENDOR_TYPES = {
-     # DB            Displayed
-    "lenovo"          => "lenovo",
-    "unknown"         => "Unknown",
-    nil               => "Unknown",
-  }
+    # DB        Displayed
+    "lenovo"  => "lenovo",
+    "unknown" => "Unknown",
+    nil       => "Unknown",
+  }.freeze
 
   def name_with_details
     details % {
@@ -27,6 +27,6 @@ class PhysicalServer < ApplicationRecord
   end
 
   def label_for_vendor
-    VENDOR_TYPES[self.vendor]
+    VENDOR_TYPES[vendor]
   end
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -1,5 +1,6 @@
 class PhysicalServer < ApplicationRecord
   include NewWithTypeStiMixin
+  include MiqPolicyMixin
 
   acts_as_miq_taggable
 
@@ -7,9 +8,25 @@ class PhysicalServer < ApplicationRecord
 
   has_one :host, :inverse_of => :physical_server
 
+  VENDOR_TYPES = {
+     # DB            Displayed
+    "lenovo"          => "lenovo",
+    "unknown"         => "Unknown",
+    nil               => "Unknown",
+  }
+
   def name_with_details
     details % {
       :name => name,
     }
+  end
+
+  def has_compliance_policies?
+    _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "physicalserver_compliance_check")
+    !plist.blank?
+  end
+
+  def label_for_vendor
+    VENDOR_TYPES[self.vendor]
   end
 end


### PR DESCRIPTION
1. Some changes, such as:
- Adding VendorTypes to physical_server
- Adding MiqPolicyMixin
- Implementation of hook method has_compliance_policies?
- Implementation of method label_for_vendor

All this changes is in `physical_server` model