### PR TITLE
Fix format for Tenant quotas report

### DIFF
--- a/db/migrate/20170328110106_fix_expression_in_tenant_quota_report.rb
+++ b/db/migrate/20170328110106_fix_expression_in_tenant_quota_report.rb
@@ -1,0 +1,24 @@
+class FixExpressionInTenantQuotaReport < ActiveRecord::Migration[5.0]
+  class MiqReport < ActiveRecord::Base
+    def self.with_tenant_custom_report_and_condition(value)
+      where(:db => 'Tenant', :rpt_type => 'Custom').where("conditions LIKE ?", "%#{value}%")
+    end
+  end
+
+  OLD_VALUE = 'count: tenants.tenant_quotas'.freeze
+  NEW_VALUE = 'count: Tenant.tenant_quotas'.freeze
+
+  def up
+    MiqReport.with_tenant_custom_report_and_condition(OLD_VALUE).each do |x|
+      x.conditions.gsub!(OLD_VALUE, NEW_VALUE)
+      x.save
+    end
+  end
+
+  def down
+    MiqReport.with_tenant_custom_report_and_condition(NEW_VALUE).each do |x|
+      x.conditions.gsub!(NEW_VALUE, OLD_VALUE)
+      x.save
+    end
+  end
+end

--- a/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
+++ b/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
@@ -9,7 +9,7 @@ db: Tenant
 conditions: !ruby/object:MiqExpression
   exp:
     ">":
-      count: tenants.tenant_quotas
+      count: Tenant.tenant_quotas
       value: 0
 include:
   tenant_quotas:

--- a/spec/migrations/20170328110106_fix_expression_in_tenant_quota_report_spec.rb
+++ b/spec/migrations/20170328110106_fix_expression_in_tenant_quota_report_spec.rb
@@ -1,0 +1,46 @@
+require_migration
+
+describe FixExpressionInTenantQuotaReport do
+  let(:miq_report_stub) { migration_stub(:MiqReport) }
+  let(:old_condition) do
+    <<-EOS
+      ---
+      - !ruby/object:MiqExpression
+          exp:
+              ">":
+              count: tenants.tenant_quotas
+          value: 0
+    EOS
+  end
+
+  let(:new_condition) do
+    <<-EOS
+      ---
+      - !ruby/object:MiqExpression
+          exp:
+              ">":
+              count: Tenant.tenant_quotas
+          value: 0
+    EOS
+  end
+
+  migration_context :up do
+    it 'converts old format of field to current format' do
+      miq_report = miq_report_stub.create!(:db => 'Tenant', :rpt_type => 'Custom', :conditions => old_condition)
+
+      migrate
+
+      expect(miq_report.reload.conditions).to eq(new_condition)
+    end
+  end
+
+  migration_context :down do
+    it 'converts current format of field to old format' do
+      miq_report = miq_report_stub.create!(:db => 'Tenant', :rpt_type => 'Custom', :conditions => new_condition)
+
+      migrate
+
+      expect(miq_report.reload.conditions).to eq(old_condition)
+    end
+  end
+end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -619,7 +619,7 @@ describe MiqReport do
         YAML.load '--- !ruby/object:MiqExpression
                        exp:
                          ">":
-                           count: tenants.tenant_quotas
+                           count: Tenant.tenant_quotas
                            value: 0'
       end
 


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/13692
blocking https://github.com/ManageIQ/manageiq/pull/13692
introduced in https://github.com/ManageIQ/manageiq/pull/7159

For fields in MiqExpression, which are for searching counts of has_many relations
we have newly regex: https://github.com/ManageIQ/manageiq/blob/master/lib/miq_expression/count_field.rb#L2

and default Tenant Quota is using bad old format: `tenants.tenant_quotas` 
correct format is `Tenant.tenant_quotas`
and we need to fix it for https://github.com/ManageIQ/manageiq/pull/13692

- default report is fixed by change in yaml 
- there can be reports created as copy of 'Tenant Quotas'  report and also in such report can be this condition changed and for such report I added migration also.

cc @Fryguy @kbrock @imtayadeway 

@miq-bot bug, core, sql migration
@miq-bot assign @gtanzillo 


