### PR TITLE
`MiqQueue#put_unless_exists` supports create_with

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -98,19 +98,17 @@ class MiqQueue < ApplicationRecord
   end
 
   def self.put(options)
-    options = options.reverse_merge(
-      :priority     => NORMAL_PRIORITY,
-      :queue_name   => "generic",
-      :role         => nil,
-      :server_guid  => nil,
-      :msg_timeout  => TIMEOUT,
-      :deliver_on   => nil
-    ).merge(
+    options = options.merge(
       :zone         => Zone.determine_queue_zone(options),
       :state        => STATE_READY,
       :handler_type => nil,
       :handler_id   => nil,
     )
+
+    create_with_options = all.values[:create_with] || {}
+    options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
+    options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
+    options[:msg_timeout] ||= create_with_options[:msg_timeout] || TIMEOUT
     options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -334,6 +334,18 @@ describe MiqQueue do
       expect(msg_from_db.miq_callback).to eq({})
     end
 
+    it "does not allow objects on the queue" do
+      expect do
+        MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :args => [MiqServer.first])
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  context "#put_unless_exists" do
+    before do
+      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+    end
+
     it "should put a unique message on the queue if method_name is different" do
       msg1 = MiqQueue.put(
         :class_name  => 'MyClass',
@@ -406,6 +418,12 @@ describe MiqQueue do
       expect(MiqQueue.get).to eq(msg1)
       expect(MiqQueue.get).to eq(nil)
     end
+  end
+
+  context "#put_or_update" do
+    before do
+      _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
+    end
 
     it "should use args param to find messages on the queue" do
       msg1 = MiqQueue.put(
@@ -459,12 +477,6 @@ describe MiqQueue do
       expect(MiqQueue.get).to have_attributes(:args => [1, 2], :task_id => 'first_task')
       expect(MiqQueue.get).to have_attributes(:args => [3, 4], :task_id => 'fun_task')
       expect(MiqQueue.get).to eq(nil)
-    end
-
-    it "does not allow objects on the queue" do
-      expect do
-        MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :args => [MiqServer.first])
-      end.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -418,6 +418,15 @@ describe MiqQueue do
       expect(msg.priority).to eq(MiqQueue::LOW_PRIORITY)
     end
 
+    it "creates with :prority via create_with" do
+      msg = MiqQueue.create_with(:priority => MiqQueue::LOW_PRIORITY).put(
+        :class_name  => "Class1",
+        :method_name => "Method1",
+      )
+
+      expect(msg.priority).to eq(MiqQueue::LOW_PRIORITY)
+    end
+
     it "defaults :role" do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
@@ -455,6 +464,15 @@ describe MiqQueue do
       expect(msg.msg_timeout).to eq(3.minutes)
     end
 
+    it "sets :msg_timeout via create_with" do
+      msg = MiqQueue.create_with(:msg_timeout => 3.minutes).put(
+        :class_name  => "Class1",
+        :method_name => "Method1",
+      )
+
+      expect(msg.msg_timeout).to eq(3.minutes)
+    end
+
     it "defaults :deliver_on" do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
@@ -471,6 +489,18 @@ describe MiqQueue do
         :class_name  => "Class1",
         :method_name => "Method1",
         :deliver_on  => deliver_on
+      )
+
+      msg_from_db = MiqQueue.find(msg.id)
+      expect(msg_from_db.deliver_on).to eq(deliver_on)
+    end
+
+    it "creates with :deliver_on via create_with" do
+      deliver_on = 10.minutes.ago.change(:usec => 0)
+
+      msg = MiqQueue.create_with(:deliver_on => deliver_on).put(
+        :class_name  => "Class1",
+        :method_name => "Method1",
       )
 
       msg_from_db = MiqQueue.find(msg.id)


### PR DESCRIPTION
# Summary

`MiqQueue#put_unless_exists` adds a unique message to the `MiqQueue`.

This PR change:
- Make it easier to declare which parameters are used for uniqueness (the `_unless_exists` part) and which are used for creation (`put` part).
- Prep for: change the SQL `SELECT`, `INSERT` queries to a single `INSERT` statement. (all data in sql friendly hashes, and not looking at returning object)

# Before

We used a block that was clunky, nuanced, and preventing us from tuning the sql:

```ruby
MiqQueue.put_unless_exists(
  :class_name  => "Metric",
  :method_name => "purge_hourly",
) do |_msg, find_options|
  find_options.merge(:args => [timestamp])
end
```

What does this do?

- If a message for `Metric#purge_hourly` already exists, then don't create one. Ignore the `:args` value since it is a timestamp and probably won't match anyway.
- If a message for `Metric#purge_hourly` does not already exist, then create one. The new record will include the `:args` value provided.

Stated another way:
- `:class_name` and `:method_name` are part of the uniqueness constraint.
- `:class_name`, `:method_name`, and `:args` are used for creation.


# After

We can leverage an active record mechanism `created_with` to convert these parameters into SQL. On one hand, it does not introduce any change to `MiqQueue`, but it is more closely coupled with ActiveRecord:

```ruby
MiqQueue.create_with(:args => [timestamp]).put_unless_exists(
  :class_name  => "Metric",
  :method_name => "purge_hourly"
)
```

**UPDATE:** This PR only updates `MiqQueue` - ensuring that it works with `create_with` for the parameters of interest
