### PR TITLE
Move ContainerDeploymentService + tests into this repo

### DIFF
--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -6,6 +6,9 @@ module Api
     end
 
     def options
+      # TODO: this service is rendering resources which (a) require
+      # authentication (problematic for CORS compatibility), and (b)
+      # are not being properly filtered by RBAC
       render_options(:container_deployments, ContainerDeploymentService.new.all_data)
     end
   end

--- a/lib/services/container_deployment_service.rb
+++ b/lib/services/container_deployment_service.rb
@@ -1,0 +1,63 @@
+class ContainerDeploymentService
+  def all_data
+    {
+      :deployment_types => optional_deployment_types,
+      :provision        => possible_provision_providers,
+      :providers        => possible_providers_and_vms
+    }.compact
+  end
+
+  def possible_provision_providers
+    providers = ExtManagementSystem.includes(:vm_or_template).select do |m|
+      m.instance_of?(ManageIQ::Providers::Amazon::CloudManager) ||
+        m.instance_of?(ManageIQ::Providers::Redhat::InfraManager)
+    end
+    providers.map do |provider|
+      {:provider => provider, :templates => templates(provider.miq_templates)}
+    end
+  end
+
+  def templates(templates)
+    templates.map do |template|
+      {
+        :cpu       => template.cpu_total_cores,
+        :memory    => template.mem_cpu,
+        :disk_size => ApplicationController.helpers.number_to_human_size(template.disks.first ? template.disks.first.size : 0),
+        :name      => template.name,
+        :ems_id    => template.ems_id,
+        :id        => template.id
+      }
+    end
+  end
+
+  def possible_providers_and_vms
+    providers = ExtManagementSystem.includes(:vm_or_template).select do |m|
+      m.kind_of?(ManageIQ::Providers::CloudManager) || m.kind_of?(ManageIQ::Providers::InfraManager)
+    end
+    providers.map do |provider|
+      {:provider => provider, :vms => optional_vms(provider.vms)}
+    end
+  end
+
+  def optional_vms(vms)
+    optional_vms = vms.select { |vm| !vm.hardware.ipaddresses.empty? }
+    optional_vms.map do |vm|
+      {
+        :cpu       => vm.hardware.cpu_total_cores,
+        :memory    => vm.hardware.memory_mb,
+        :disk_size => ApplicationController.helpers.number_to_human_size(vm.disks.first ? vm.disks.first.size : 0),
+        :name      => vm.name,
+        :ems_id    => vm.ems_id,
+        :id        => vm.id
+      }
+    end
+  end
+
+  def self.hide_deployment_wizard?
+    !Settings.product.container_deployment_wizard
+  end
+
+  def optional_deployment_types
+    ContainerDeployment::DEPLOYMENT_TYPES
+  end
+end

--- a/spec/lib/services/container_deployment_service_spec.rb
+++ b/spec/lib/services/container_deployment_service_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe ContainerDeploymentService do
+  before do
+    %w(amazon openstack google azure redhat vmware).each do |p|
+      network = FactoryGirl.create(:network, :ipaddress => "127.0.0.1")
+      hardware = FactoryGirl.create(:hardware)
+      hardware.networks << network
+      vm = FactoryGirl.create("vm_#{p}".to_sym, :hardware => hardware)
+      if %w(amazon redhat).include?(p)
+        template = FactoryGirl.create("template_#{p}".to_sym)
+        provider = FactoryGirl.create("ems_#{p}".to_sym, :miq_templates => [template])
+      else
+        provider = FactoryGirl.create("ems_#{p}".to_sym)
+      end
+      provider.vms << vm
+    end
+    @foreman_provider = FactoryGirl.create(:configuration_manager_foreman)
+  end
+
+  context "possible_providers_and_vms" do
+    it "finds all Cloud and Infra providers and their existing VMs" do
+      providers = described_class.new.possible_providers_and_vms
+      vms = providers.collect_concat { |p| p[:vms] }
+      expect(providers.size).to eq(6)
+      expect(vms.size).to eq(6)
+    end
+  end
+
+  context "possible_provision_providers" do
+    it "finds all providers with provision ability supported by deployment, and their templates" do
+      providers = described_class.new.possible_provision_providers
+      templates = providers.collect_concat { |p| p[:templates] }
+      expect(providers.size).to eq(2)
+      expect(templates.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
:point_right: To be merged together with https://github.com/ManageIQ/manageiq-ui-classic/pull/838

This service, which lives in the classic-ui repo, is almost entirely
concerned with things that happen in the UI. The parts that aren't can
be moved elsewhere.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 