### PR TITLE
Restrict ServiceOrder deep_copy to non-cart states

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -93,6 +93,7 @@ class ServiceOrder < ApplicationRecord
   end
 
   def deep_copy(new_attributes = {})
+    raise _("Cannot copy a service order in the #{STATE_CART} state") if state == STATE_CART
     dup.tap do |new_service_order|
       # Set it to nil - the after_create hook will give it the correct name
       new_service_order.name = nil

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -99,6 +99,10 @@ describe ServiceOrder do
   end
 
   context '#deep_copy' do
+    before do
+      service_order.update_attributes(:state => ServiceOrder::STATE_ORDERED)
+    end
+
     it 'should copy the miq_requests' do
       service_order.miq_requests << [request, request2]
       service_order_copy = service_order.deep_copy
@@ -118,6 +122,19 @@ describe ServiceOrder do
     it 'should be in the cart state' do
       service_order_copy = service_order.deep_copy
       expect(service_order_copy.state).to eq(ServiceOrder::STATE_CART)
+    end
+
+    it 'should create only one new service order' do
+      expect do
+        service_order.deep_copy
+      end.to change(ServiceOrder, :count).by(1)
+    end
+
+    it 'does not allow copying of a service order in the cart state' do
+      service_order.update_attributes(:state => ServiceOrder::STATE_CART)
+      expect do
+        service_order.deep_copy
+      end.to raise_error(RuntimeError, 'Cannot copy a service order in the cart state')
     end
   end
 end

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -544,8 +544,8 @@ RSpec.describe "service orders API" do
 
   context 'Copy Service Order' do
     before do
-      @service_order = FactoryGirl.create(:shopping_cart, :user => @user)
-      @service_order_2 = FactoryGirl.create(:shopping_cart, :user => @user)
+      @service_order = FactoryGirl.create(:service_order, :user => @user)
+      @service_order2 = FactoryGirl.create(:service_order, :user => @user)
     end
 
     it 'forbids service order copy without an appropriate role' do
@@ -578,7 +578,7 @@ RSpec.describe "service orders API" do
       expect do
         run_post(service_orders_url, :action => 'copy', :resources => [
                    { :id => @service_order.id, :name => 'foo'},
-                   { :id => @service_order_2.id, :name => 'bar' }
+                   { :id => @service_order2.id, :name => 'bar' }
                  ])
       end.to change(ServiceOrder, :count).by(2)
       expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
Copying a ServiceOrder should be restricted to those that are not in the cart for the purpose of it becoming a new cart that can be ordered.

@miq-bot bug, services
cc: @AllenBW @imtayadeway 