### PR TITLE
Add logic for checking if a middleware server is immutable

### DIFF
--- a/app/models/middleware_deployment.rb
+++ b/app/models/middleware_deployment.rb
@@ -3,4 +3,6 @@ class MiddlewareDeployment < ApplicationRecord
   belongs_to :middleware_server, :foreign_key => "server_id"
   belongs_to :middleware_server_group, :foreign_key => "server_group_id", :optional => true
   acts_as_miq_taggable
+
+  delegate :mutable?, :in_domain?, :to => :middleware_server
 end

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -10,6 +10,10 @@ class MiddlewareServer < ApplicationRecord
 
   include LiveMetricsMixin
 
+  def properties
+    super || {}
+  end
+
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
   end
@@ -33,6 +37,22 @@ class MiddlewareServer < ApplicationRecord
   end
 
   def in_domain?
-    !middleware_server_group.nil?
+    middleware_server_group
+  end
+
+  # Returns whether a server is immutable or not.
+  #
+  # By default, we define all servers as being immutable, so that power
+  # operations are not allowed, and it is the provider responsability to
+  # reimplement this method if necessary.
+  def immutable?
+    true
+  end
+
+  # Returns whether a server is immutable or not.
+  #
+  # Just a convenience method over #immutable.
+  def mutable?
+    !immutable?
   end
 end

--- a/spec/models/middleware_server_spec.rb
+++ b/spec/models/middleware_server_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe MiddlewareServer do
+  subject(:server) { MiddlewareServer.new }
+
+  describe 'in_domain?' do
+    it 'is true if the server is in a group' do
+      server.middleware_server_group = MiddlewareServerGroup.new
+      expect(server).to be_in_domain
+    end
+
+    it 'is false otherwise' do
+      expect(server).not_to be_in_domain
+    end
+  end
+
+  describe 'properties' do
+    it 'is empty hash if not defined' do
+      expect(server.properties).to eq({})
+    end
+
+    it 'can be acessed normally if defined' do
+      hash = { 'foo' => 'bar' }
+      server.properties = hash
+      expect(server.properties).to eq(hash)
+    end
+  end
+
+  describe '#immutable?' do
+    it 'is always true' do
+      expect(server).to be_immutable
+    end
+  end
+
+  describe '#mutable?' do
+    it 'is true if not immutable' do
+      allow(server).to receive(:immutable?) { false }
+      expect(server).to be_mutable
+    end
+
+    it 'is false if immutable' do
+      allow(server).to receive(:immutable?) { true }
+      expect(server).not_to be_mutable
+    end
+  end
+end


### PR DESCRIPTION
This is a companion to another commit on manageiq-ui-classic, which
moves the logic to check if a server is mutable or not from an action on
the UI to the MiddlewareServer itself. It is a refactor of manageiq-ui-classic#636, and should be merged together with https://github.com/ManageIQ/manageiq-ui-classic/pull/839