### PR TITLE
Nullify dependents when destroying configuration_script_sources/configuration_scripts

### DIFF
--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -9,7 +9,10 @@ class ConfigurationScriptBase < ApplicationRecord
   belongs_to :manager,              :class_name => "ExtManagementSystem"
 
   belongs_to :parent,               :class_name => "ConfigurationScriptBase"
-  has_many   :children,             :class_name => "ConfigurationScriptBase", :foreign_key => "parent_id"
+  has_many   :children,
+             :class_name  => "ConfigurationScriptBase",
+             :foreign_key => "parent_id",
+             :dependent   => :nullify
 
   has_many   :authentication_configuration_script_bases,
              :dependent => :destroy

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -1,5 +1,5 @@
 class ConfigurationScriptSource < ApplicationRecord
-  has_many    :configuration_script_payloads
+  has_many    :configuration_script_payloads, :dependent => :destroy
   belongs_to  :authentication
   belongs_to  :manager, :class_name => "ExtManagementSystem"
 


### PR DESCRIPTION
Fixing https://bugzilla.redhat.com/show_bug.cgi?id=1437108

Once https://github.com/ManageIQ/manageiq/pull/14432 is in, this similar issue will happen to configuration_scripts and it's children.

@miq-bot add_labels bug, providers/ansible_provider