### PR TITLE
[WIP]Use create_with vs use blocks for miq_queue updates

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -135,16 +135,15 @@ class Job < ApplicationRecord
   end
 
   def timeout!
-    MiqQueue.put_unless_exists(
+    message = "job timed out after #{Time.now.utc - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
+    MiqQueue.create_with(:args => [message, "error"]).put_unless_exists(
       :class_name  => self.class.base_class.name,
       :instance_id => id,
       :method_name => "signal_abort",
       :role        => "smartstate",
       :zone        => MiqServer.my_zone
-    ) do |_msg, find_options|
-      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
-      _log.warn("Job: guid: [#{guid}], #{message}, aborting")
-      find_options.merge(:args => [message, "error"])
+    ) do |msg, _find_options|
+      _log.warn("Job: guid: [#{guid}], #{message}, aborting") if msg
     end
   end
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -84,19 +84,19 @@ module MiqServer::LogManagement
 
   def _post_my_logs(options)
     # Make the request to the MiqServer whose logs are needed
-    MiqQueue.put_or_update(
+    MiqQueue.create_with(
+      :miq_callback => options.delete(:callback),
+      :msg_timeout  => options.delete(:timeout),
+      :args         => [options]
+    ).put_unless_exists(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "post_logs",
       :server_guid => guid,
+      :priority    => MiqQueue::HIGH_PRIORITY,
       :zone        => my_zone,
-    ) do |msg, item|
+    ) do |msg|
       _log.info("Previous adhoc log collection is still running, skipping...Resource: [#{self.class.name}], id: [#{id}]") unless msg.nil?
-      item.merge(
-        :miq_callback => options.delete(:callback),
-        :msg_timeout  => options.delete(:timeout),
-        :priority     => MiqQueue::HIGH_PRIORITY,
-        :args         => [options])
     end
   end
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -97,7 +97,13 @@ class MiqWidget < ApplicationRecord
   end
 
   def queue_generate_content_for_users_or_group(*args)
-    MiqQueue.put_or_update(
+    cb_hash = {}
+    if miq_task_id
+      cb = {:class_name => self.class.name, :instance_id => id, :method_name => :generate_content_complete_callback}
+      cb_hash[:miq_callback] = cb
+    end
+
+    MiqQueue.create_with(cb_hash).put_unless_exists(
       :queue_name  => "reporting",
       :role        => "reporting",
       :class_name  => self.class.to_s,
@@ -105,15 +111,7 @@ class MiqWidget < ApplicationRecord
       :msg_timeout => 3600,
       :method_name => "generate_content",
       :args        => [*args]
-    ) do |msg, q_hash|
-      if msg.nil?
-        unless miq_task_id.nil?
-          cb = {:class_name => self.class.name, :instance_id => id, :method_name => :generate_content_complete_callback}
-          q_hash[:miq_callback] = cb
-        end
-        q_hash
-      end
-    end
+    )
   end
 
   def generate_content_complete_callback(status, _message, _result)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -82,6 +82,17 @@ describe MiqWidget do
         @widget.queue_generate_content_for_users_or_group(@user1.userid)
         expect(MiqQueue.exists?({:method_name => "generate_content"}.merge(@queue_conditions))).to be_truthy
       end
+
+      it "inserts a callback for tasks" do
+        @widget.create_miq_task
+        @widget.queue_generate_content_for_users_or_group([@user1.userid, @user2.userid])
+        expect(MiqQueue.where(@queue_conditions).count).to eq(1)
+        expect(MiqQueue.find_by(@queue_conditions).miq_callback).to eq(
+          :class_name  => @widget.class.name,
+          :instance_id => @widget.id,
+          :method_name => :generate_content_complete_callback
+        )
+      end
     end
 
     context "#grouped_subscribers" do


### PR DESCRIPTION
Blocked on

- [x] #14562 support `create_with(:deliver_on =>).put...`

The goal is to have fewer `put_or_update` calls and move over to `put_unless_exists`, which are easier to express as a single query.

The high-level premise is we are using `put_or_update` because we didn't know how to use `put_unless_exists` properly.


related: https://github.com/ManageIQ/manageiq/pull/14676