### PR TITLE
API support for adding/removing Policies to/from Policy Profiles

### DIFF
--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -8,19 +8,11 @@ module Api
       end
 
       def policies_assign_resource(object, _type, id = nil, data = nil)
-        if object.kind_of?(collection_class(:policy_profiles))
-          object.add_member(policy_specified(id, data, :policies, MiqPolicy))
-        else
-          policy_assign_action(object, :policies, id, data)
-        end
+        policy_assign_action(object, :policies, id, data)
       end
 
       def policies_unassign_resource(object, _type, id = nil, data = nil)
-        if object.kind_of?(collection_class(:policy_profiles))
-          object.remove_member(policy_specified(id, data, :policies, MiqPolicy))
-        else
-          policy_unassign_action(object, :policies, id, data)
-        end
+        policy_unassign_action(object, :policies, id, data)
       end
 
       def policies_resolve_resource(object, _type, id = nil, data = nil)

--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -8,11 +8,19 @@ module Api
       end
 
       def policies_assign_resource(object, _type, id = nil, data = nil)
-        policy_assign_action(object, :policies, id, data)
+        if object.kind_of?(collection_class(:policy_profiles))
+          object.add_member(policy_specified(id, data, :policies, MiqPolicy))
+        else
+          policy_assign_action(object, :policies, id, data)
+        end
       end
 
       def policies_unassign_resource(object, _type, id = nil, data = nil)
-        policy_unassign_action(object, :policies, id, data)
+        if object.kind_of?(collection_class(:policy_profiles))
+          object.remove_member(policy_specified(id, data, :policies, MiqPolicy))
+        else
+          policy_unassign_action(object, :policies, id, data)
+        end
       end
 
       def policies_resolve_resource(object, _type, id = nil, data = nil)

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -25,6 +25,18 @@ class MiqPolicySet < ApplicationRecord
     Tag.find_by(:name => "/miq_policy/assignment/#{self.class.to_s.underscore}/#{id}").try!(:destroy)
   end
 
+  def add_policy(policy)
+    add_member(policy)
+  end
+
+  def remove_policy(policy)
+    remove_member(policy)
+  end
+
+  def get_policies
+    miq_policies
+  end
+
   def add_to(ids, db)
     model = db.respond_to?(:constantize) ? db.constantize : db
     ids.each do|id|

--- a/config/api.yml
+++ b/config/api.yml
@@ -1160,15 +1160,19 @@
       - :name: delete
         :identifier: profile_delete
         :disabled: true
-    :subcollection_actions:
+    :policies_subcollection_actions:
       :post:
       - :name: assign
+        :identifier: policy_profile_assign
       - :name: unassign
+        :identifier: policy_profile_assign
       - :name: resolve
-    :subresource_actions:
+    :policies_subresource_actions:
       :post:
       - :name: assign
+        :identifier: policy_profile_assign
       - :name: unassign
+        :identifier: policy_profile_assign
       - :name: resolve
   :providers:
     :description: Providers

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1750,6 +1750,11 @@
         :feature_type: admin
         :hidden: true
         :identifier: profile_edit
+      - :name: Edit Policies Assignment
+        :description: Edit Policy Profile's policies assignments
+        :feature_type: admin
+        :hidden: true
+        :identifier: policy_profile_assign
   - :name: Policies
     :description: Everything under Policies Accordion
     :protected: true

--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -139,6 +139,29 @@ describe "Policies Assignment API" do
     expect(object.get_policies.first.guid).to eq(ps1.guid)
   end
 
+  context "Policy profile policies assignment" do
+    it "adds Policies to a Policy Profile" do
+      api_basic_authorize
+
+      run_post("#{policy_profiles_url(ps2.id)}/policies", gen_request(:assign, [{"id" => p1.id}, {"id" => p2.id}]))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["results"].count).to eq(2)
+      expect(ps2.reload.miq_policies.count).to eq(3)
+      expect(response.parsed_body["results"].first["guid"]).to eq(p1.guid)
+      expect(response.parsed_body["results"].second["guid"]).to eq(p2.guid)
+    end
+
+    it "removes a Policy from a Policy Profile" do
+      api_basic_authorize
+
+      run_post("#{policy_profiles_url(ps2.id)}/policies", gen_request(:unassign, [{"id" => p3.id}]))
+
+      expect(response).to have_http_status(:ok)
+      expect(ps2.reload.miq_policies.count).to eq(0)
+    end
+  end
+
   context "Provider policies subcollection assignment" do
     let(:provider_url)                  { providers_url(provider.id) }
     let(:provider_policies_url)         { "#{provider_url}/policies" }


### PR DESCRIPTION
Currently, it is only possible to add/remove MiqPolicy from MiqPolicySet using the UI.
This change adds to API support for these operations, using the `assign`/`unassign` actions.

Example:
`POST /api/policy_profiles/:id/policies`

Body:
```json
{
    "action": "assign",
    "resources": [
    	{ "href": "/api/policies/1" },
    	{ "href": "/api/policies/2" }
    ]
}
```