### PR TITLE
Remove resources from service

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -22,17 +22,23 @@ module Api
       raise "Must specify a service href or id to add_resource to" unless id
       svc = resource_search(id, type, collection_class(type))
 
-      resource_href = data.fetch_path("resource", "href")
-      raise "Must specify a resource reference" unless resource_href
-
-      resource_type, resource_id = parse_href(resource_href)
-      raise "Invalid resource href specified #{resource_href}" unless resource_type && resource_id
-
-      resource = resource_search(resource_id, resource_type, collection_class(resource_type))
+      resource_type, resource = validate_resource(data)
       raise "Cannot assign #{resource_type} to #{service_ident(svc)}" unless resource.respond_to? :add_to_service
 
       resource.add_to_service(svc)
-      action_result(true, "Assigned resource #{resource_type} id:#{resource_id} to #{service_ident(svc)}")
+      action_result(true, "Assigned resource #{resource_type} id:#{resource.id} to #{service_ident(svc)}")
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def remove_resource_resource(type, id, data)
+      raise 'Must specify a resource to remove_resource from' unless id
+      svc = resource_search(id, type, collection_class(type))
+
+      resource_type, resource = validate_resource(data)
+
+      svc.remove_resource(resource)
+      action_result(true, "Unassigned resource #{resource_type} id:#{resource.id} from #{service_ident(svc)}")
     rescue => err
       action_result(false, err.to_s)
     end
@@ -102,6 +108,17 @@ module Api
     end
 
     private
+
+    def validate_resource(data)
+      resource_href = data.fetch_path("resource", "href")
+      raise "Must specify a resource reference" unless resource_href
+
+      resource_type, resource_id = parse_href(resource_href)
+      raise "Invalid resource href specified #{resource_href}" unless resource_type && resource_id
+
+      resource = resource_search(resource_id, resource_type, collection_class(resource_type))
+      [resource_type, resource]
+    end
 
     def build_service_attributes(data)
       attributes                 = data.dup

--- a/config/api.yml
+++ b/config/api.yml
@@ -1931,6 +1931,8 @@
         :identifier: service_tag
       - :name: add_resource
         :identifier: service_edit
+      - :name: remove_resource
+        :identifier: service_edit
     :resource_actions:
       :get:
       - :name: read
@@ -1955,6 +1957,8 @@
       - :name: delete
         :identifier: service_delete
       - :name: add_resource
+        :identifier: service_edit
+      - :name: remove_resource
         :identifier: service_edit
       :delete:
       - :name: delete

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -75,7 +75,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource remove_resource))
     end
   end
 
@@ -91,7 +91,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource remove_resource))
     end
 
     it "supports the custom_actions attribute" do


### PR DESCRIPTION
This API enhancement allows for the removal of resources from a service as a follow up to the [add resources](https://github.com/ManageIQ/manageiq/pull/14409) enhancement.

Remove resources can be done from the collection:
```
POST /api/services
{
    'action'    => 'remove_resource',
    'resources' => [
          { 'href' => 'api/services/:id','resource' => { 'href' => 'api/vms/:id' },
          { 'href' => 'api/services/:id, 'resource' => { 'href' => 'api/vms/:id'} }
        ]
}
```

or from the resource:
```
POST /api/services/:id
{
    'action'   => 'remove_resource',
    'resource' => { 'resource' => {'href' => 'api/vms/:id' }}
}
```

cc: @mkanoor 
@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 