### PR TITLE
Ansible Playbook Service add on_error method.

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -46,6 +46,12 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     delete_inventory(action) unless use_default_inventory?(hosts)
   end
 
+  def on_error(action)
+    _log.info("on_error called for service action: #{action}")
+    update_attributes(:retirement_state => 'error') if action == "Retirement"
+    postprocess(action)
+  end
+
   private
 
   def manageiq_extra_vars(action)

--- a/app/models/service_generic.rb
+++ b/app/models/service_generic.rb
@@ -32,4 +32,7 @@ class ServiceGeneric < Service
   # Execute after refresh is done. Do cleaning up or update linkage here
   def postprocess(_action)
   end
+
+  def on_error(_action)
+  end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
@@ -6,5 +6,6 @@ module MiqAeMethodService
     expose :refresh
     expose :check_refreshed
     expose :postprocess
+    expose :on_error
   end
 end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -176,6 +176,21 @@ describe(ServiceAnsiblePlaybook) do
     end
   end
 
+  describe '#on_error' do
+    it 'handles retirement error' do
+      executed_service.update_attributes(:retirement_state => 'Retiring')
+      expect(executed_service).to receive(:postprocess)
+      executed_service.on_error(ResourceAction::RETIREMENT)
+      expect(executed_service.retirement_state).to eq('error')
+    end
+
+    it 'handles provisioning error' do
+      expect(executed_service).to receive(:postprocess)
+      executed_service.on_error(action)
+      expect(executed_service.retirement_state).to be_nil
+    end
+  end
+
   describe '#job' do
     before { service.add_resource!(tower_job, :name => action) }
 


### PR DESCRIPTION
Enhance Generic Service state machine error handling.  Cleanup after provisioning and retirement failures. 

https://www.pivotaltracker.com/story/show/142796573

Related PR https://github.com/ManageIQ/manageiq-content/pull/85
