### PR TITLE
Remove all service resources

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -43,6 +43,15 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def remove_all_resources_resource(type, id, _data)
+      raise "Must specify a service href or id to remove resources from" unless id
+      svc = resource_search(id, type, collection_class(type))
+      svc.remove_all_resources
+      action_result(true, "Removed all resources from #{service_ident(svc)}")
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def reconfigure_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -1931,6 +1931,8 @@
         :identifier: service_tag
       - :name: add_resource
         :identifier: service_edit
+      - :name: remove_all_resources
+        :identifier: service_edit
       - :name: remove_resource
         :identifier: service_edit
     :resource_actions:
@@ -1957,6 +1959,8 @@
       - :name: delete
         :identifier: service_delete
       - :name: add_resource
+        :identifier: service_edit
+      - :name: remove_all_resources
         :identifier: service_edit
       - :name: remove_resource
         :identifier: service_edit

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -75,7 +75,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource remove_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit add_resource remove_resource remove_all_resources))
     end
   end
 
@@ -91,7 +91,7 @@ describe "Custom Actions API" do
       run_get services_url(svc1.id)
 
       expect_result_to_have_keys(%w(id href actions))
-      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource remove_resource))
+      expect(response.parsed_body["actions"].collect { |a| a["name"] }).to match_array(%w(edit button1 button2 button3 add_resource remove_resource remove_all_resources))
     end
 
     it "supports the custom_actions attribute" do


### PR DESCRIPTION
This is an additional API action to remove all service resources:

```
POST /api/services
{
    'action' : 'remove_all_resources',
    'resources' : [
       { 'href' : '/api/services/:id' },
       { 'href' :  '/api/services/:id' }
     ]
}
```
or
```
POST /api/services/:id
{ "action" : "remove_all_resources" }
```

cc: @mkanoor 
@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 