### PR TITLE
Update configuration_script_payloads spec

### DIFF
--- a/spec/requests/api/configuration_script_payloads_spec.rb
+++ b/spec/requests/api/configuration_script_payloads_spec.rb
@@ -73,12 +73,11 @@ RSpec.describe 'Configuration Script Payloads API' do
     let(:playbook) { FactoryGirl.create(:configuration_script_payload, :manager => manager) }
     let(:params) do
       {
-        :action           => 'create',
-        :description      => "Description",
-        :name             => "A Credential",
-        :related          => {},
-        :type             => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Credential',
-        :manager_resource => { :href => providers_url(manager.id) }
+        :action      => 'create',
+        :description => "Description",
+        :name        => "A Credential",
+        :related     => {},
+        :type        => 'ManageIQ::Providers::AnsibleTower::AutomationManager::Credential'
       }
     end
 


### PR DESCRIPTION
Removing the reference to `manager_resource` in this spec because it is misleading (and not used / required). 

When creating an authentication via `/api/configuration_script_sources/:id/authentications`, the manager resource of the configuration script payload [is used.](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/api/subcollections/authentications.rb#L9)

@miq-bot add_label api, test
@miq-bot assign @abellotti 
