### PR TITLE
Add Physical Infra Topology feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6402,6 +6402,17 @@
       :feature_type: view
       :identifier: physical_server_show
 
+# Physical Infrastructure Topology
+- :name: Physical Infra Topology
+  :description: Physical Infra Topology
+  :feature_type: node
+  :identifier: physical_infra_topology
+  :children:
+    - :name: View
+      :description: View Physical Infra Topology
+      :feature_type: view
+      :identifier: physical_infra_topology_view
+
 # Monitor
 - :name: Monitor
   :description: Everything under Monitor


### PR DESCRIPTION
Adds the product feature id required for the `Physical Infrastructure` `Topology` menu.

<img width="651" alt="screen shot 2017-03-30 at 5 12 52 pm" src="https://cloud.githubusercontent.com/assets/1538216/24531230/43dcb434-156c-11e7-9610-cb210d0b90f4.png">

