### PR TITLE
Add index to event_streams#availability_zone

### DIFF
--- a/db/migrate/20170330234701_create_event_streams_index_availability_zone.rb
+++ b/db/migrate/20170330234701_create_event_streams_index_availability_zone.rb
@@ -1,0 +1,5 @@
+class CreateEventStreamsIndexAvailabilityZone < ActiveRecord::Migration[5.0]
+  def change
+    add_index :event_streams, [:availability_zone_id, :type]
+  end
+end


### PR DESCRIPTION
The `_angular_toolbar` determines if there are events for a given page.

This comes in the form of: `app/models/mixins/event_mixin.rb:28:in 'has_events?'`

and generates SQL like:

```SQL
SELECT  1 AS one
FROM "event_streams"
WHERE "event_streams"."type" IN ('EmsEvent')
AND (event_streams.availability_zone_id = 10000000000008)
LIMIT 1;
```

There are no indexes on `event_streams.availability_zone_id` and is causing a table scan.

This is taking ~8 seconds, but more significant, it is swapping all the other tables out of cache on the database server.

The solution is to add an index.
An alternative would be to remove the `has_event?`

Running: http://localhost:3000/availability_zone/show/10r8

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  8,719.9 |   21 | 8,394.0 |       10 |**before**
|  8,576.0 |    8 | 8,349.0 |        1 |`..Rendering: layouts/application`
|      ---:|  ---:|     ---:|      ---:| ---
|    179.1 |   21 |    64.8 |       10 |**after**
|     86.3 |    8 |    34.9 |        1 |`..Rendering: layouts/application`
