### PR TITLE
[EUWE] Tenancy for CloudTenant

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -430,6 +430,13 @@ module Rbac
       tenant_id_clause ? scope.where(tenant_id_clause) : scope
     end
 
+    def scope_to_cloud_tenant(scope, user, miq_group)
+      klass = scope.respond_to?(:klass) ? scope.klass : scope
+      user_or_group = user || miq_group
+      tenant_id_clause = klass.tenant_id_clause(user_or_group)
+      klass.tenant_joins_clause(scope).where(tenant_id_clause)
+    end
+
     ##
     # Main scoping method
     #
@@ -439,6 +446,8 @@ module Rbac
       # TENANT_ACCESS_STRATEGY are a consolidated list of them.
       if klass.respond_to?(:scope_by_tenant?) && klass.scope_by_tenant?
         scope = scope_to_tenant(scope, user, miq_group)
+      elsif klass.respond_to?(:scope_by_cloud_tenant?) && klass.scope_by_cloud_tenant?
+        scope = scope_to_cloud_tenant(scope, user, miq_group)
       end
 
       if apply_rbac_directly?(klass)


### PR DESCRIPTION
- this is allowing tenancy RBAC feature for CloudTenant objects when cloud tenant mapping is used

- pulled out from https://github.com/ManageIQ/manageiq/pull/13535 and https://github.com/ManageIQ/manageiq/pull/14036 but only functionality for  CloudTenant  as is need in the [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1436597)
- I am not creating new mixin for it but just I am adding needed methods to CloudTenant model
and then I using them in RBac similarly as is done in origin tenancny


@miq-bot add_label core, euwe/yes, blocker, enhancement

**Links**

https://bugzilla.redhat.com/show_bug.cgi?id=1433069

please review @gtanzillo @rwsu 

@miq-bot assign @simaishi 

