### PR TITLE
Remove deprecated smart column from vms table

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -177,7 +177,6 @@ class Host < ApplicationRecord
   include VimConnectMixin
   include AvailabilityMixin
 
-  before_create :make_smart
   after_save    :process_events
 
   supports :reset do
@@ -211,10 +210,6 @@ class Host < ApplicationRecord
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
-  end
-
-  def make_smart
-    self.smart = true
   end
 
   def process_events
@@ -879,7 +874,6 @@ class Host < ApplicationRecord
       send("#{key}=", nil)
     end
 
-    make_smart # before_create callback
     self.settings   = nil
     self.name       = "IPMI <#{ipmi_address}>"
     self.vmm_vendor = 'unknown'

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -312,11 +312,6 @@ class VmOrTemplate < ApplicationRecord
     raw_set_custom_field(attribute, value)
   end
 
-  def makesmart(_options = {})
-    self.smart = true
-    save
-  end
-
   def run_command_via_parent(verb, options = {})
     unless ext_management_system
       raise _("VM/Template <%{name}> with Id: <%{id}> is not associated with a provider.") % {:name => name, :id => id}

--- a/db/migrate/20170331150112_remove_smart_from_vms.rb
+++ b/db/migrate/20170331150112_remove_smart_from_vms.rb
@@ -1,0 +1,5 @@
+class RemoveSmartFromVms < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :vms, :smart, :boolean
+  end
+end

--- a/db/migrate/20170331152725_remove_smart_from_hosts.rb
+++ b/db/migrate/20170331152725_remove_smart_from_hosts.rb
@@ -1,0 +1,5 @@
+class RemoveSmartFromHosts < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :hosts, :smart, :integer
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1529,7 +1529,6 @@ hosts:
 - ems_id
 - user_assigned_os
 - power_state
-- smart
 - settings
 - last_perf_capture_on
 - uid_ems
@@ -6793,7 +6792,6 @@ vms:
 - last_perf_capture_on
 - registered
 - busy
-- smart
 - memory_reserve
 - memory_reserve_expand
 - memory_limit

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_4_spec.rb
@@ -122,7 +122,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :last_perf_capture_on   => nil,
       :registered             => nil,
       :busy                   => nil,
-      :smart                  => nil,
       :memory_reserve         => 1024,
       :memory_reserve_expand  => nil,
       :memory_limit           => nil,

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh/refresher_target_vm_spec.rb
@@ -178,7 +178,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresh::Refresher do
       :last_perf_capture_on   => nil,
       :registered             => nil,
       :busy                   => nil,
-      :smart                  => nil,
       :memory_reserve         => 1024,
       :memory_reserve_expand  => nil,
       :memory_limit           => nil,


### PR DESCRIPTION
Apparently this SSA related column is deprecated and hasn't been used in years. Let's remove it.

Update: Also removed it from the `hosts` table, and removed the various `makesmart` related code from the models.