### PR TITLE
[WIP] Do not collect OpenShift images

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -8,7 +8,7 @@ module ManageIQ::Providers
         get_builds(inventory)
         get_build_pods(inventory)
         get_templates(inventory)
-        get_openshift_images(inventory)
+#       get_openshift_images(inventory)
         EmsRefresh.log_inv_debug_trace(@data, "data:")
         @data
       end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -47,7 +47,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       assert_specific_container_build
       assert_specific_container_build_pod
       assert_specific_container_template
-      assert_specific_container_image
+#     assert_specific_container_image
       assert_specific_container_node_custom_attributes
     end
   end
@@ -95,7 +95,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(ContainerBuild.count).to eq(3)
     expect(ContainerBuildPod.count).to eq(3)
     expect(ContainerTemplate.count).to eq(26)
-    expect(ContainerImage.count).to eq(40)
+    expect(ContainerImage.count).to eq(12)
   end
 
   def assert_ems


### PR DESCRIPTION
Attempting to debug and identify a scale issue by disabling images collection.

This is a test only, and it will make unusable (at the very least):

- Chargeback by Image (no collection of the docker labels used for the rates)
- OpenSCAP on Images that never ran before

On a running environment the already collected images by OpenShift will all be archived.
Discussing with @agrare if this is not enough he'll disable the `save_inventory` part as well.
