### PR TITLE
Fix PasswordMixin.encrypted_columns

### DIFF
--- a/app/models/mixins/password_mixin.rb
+++ b/app/models/mixins/password_mixin.rb
@@ -1,11 +1,12 @@
 module PasswordMixin
   extend ActiveSupport::Concern
 
-  module ClassMethods
-    def encrypted_columns
-      @@encrypted_columns ||= []    # rubocop:disable Style/ClassVars
-    end
+  included do
+    class_attribute :encrypted_columns
+    self.encrypted_columns = []
+  end
 
+  module ClassMethods
     def encrypt_column(column)
       # Given a column of "password", create 4 instance methods:
       #   password            : Get the password in plain text

--- a/spec/models/auth_userid_password_spec.rb
+++ b/spec/models/auth_userid_password_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe AuthUseridPassword do
+  describe ".encrypted_columns" do
+    it "returns the encrypted columns" do
+      expected = %w(password password_encrypted auth_key auth_key_encrypted service_account service_account_encrypted)
+      expect(described_class.encrypted_columns).to match_array(expected)
+    end
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,6 +1,9 @@
 describe Authentication do
-  it ".encrypted_columns" do
-    expect(described_class.encrypted_columns).to include('password', 'auth_key')
+  describe ".encrypted_columns" do
+    it "returns the encrypted columns" do
+      expected = %w(password password_encrypted auth_key auth_key_encrypted service_account service_account_encrypted)
+      expect(described_class.encrypted_columns).to match_array(expected)
+    end
   end
 
   context "with miq events seeded" do

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -1,4 +1,11 @@
 describe MiqDatabase do
+  describe ".encrypted_columns" do
+    it "returns the encrypted columns" do
+      expected = %w(csrf_secret_token csrf_secret_token_encrypted session_secret_token session_secret_token_encrypted)
+      expect(described_class.encrypted_columns).to match_array(expected)
+    end
+  end
+
   let(:db) { described_class.seed }
 
   let!(:region) do


### PR DESCRIPTION
This mixin uses a class variable which has the (perhaps surprising)
behavior of sharing data up and down the inheritance
tree. Consequently, this leads to quirky behavior such as:

```
irb(main):001:0> Authentication.encrypted_columns
=> ["auth_key", "auth_key_encrypted", "password", "password_encrypted", "service_account", "service_account_encrypted"]
irb(main):002:0> MiqDatabase.encrypted_columns
=> ["auth_key", "auth_key_encrypted", "password", "password_encrypted", "service_account", "service_account_encrypted", "csrf_secret_token", "csrf_secret_token_encrypted", "session_secret_token", "session_secret_token_encrypted"]
irb(main):003:0> Authentication.encrypted_columns
=> ["auth_key", "auth_key_encrypted", "password", "password_encrypted", "service_account", "service_account_encrypted", "csrf_secret_token", "csrf_secret_token_encrypted", "session_secret_token", "session_secret_token_encrypted"]
```

You will notice here that the first invocation of
`Authentication.encrypted_columns` appears correct in returning the
encrypted columns as declared in that
model. `MiqDatabase.encrypted_columns` returns all its columns *plus*
those of `Authentication`. The second invokation of
`Authentication.encrypted_columns` now has `MiqDatabase`'s
concatenated to it.

~~The solution is to make this data an instance variable so that each
host has its own data.~~ The solution is to make this a `class_attribute` that's defined via
`ActiveSupport::Concern`'s `included`. This way, a base class such as
`Authentication` that includes this module can share that data with
its descendants, but that data isn't shared with other hosts that are
not kinds of `Authentication`

I've added tests for the two models mentioned above, however there are many  more subtypes of `Authentication` that are untested. This could possibly be done with the use of a shared example, but I'll leave that for a follow up PR as the tests I've provided are sufficient to expose the unexpected behavior.

@miq-bot add-label bug, core
@miq-bot assign @abellotti 

/cc @jrafanie 
