### PR TITLE
Remove String#to_iec_integer preferring String#iec_60027_2_to_i

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -424,7 +424,7 @@ module ManageIQ::Providers::Kubernetes
     def parse_capacity_field(key, val)
       return nil unless val
       begin
-        val.to_iec_integer
+        val.iec_60027_2_to_i
       rescue ArgumentError
         _log.warn("Capacity attribute - #{key} was in bad format - #{val}")
         nil

--- a/db/migrate/20160414094300_change_capacity_to_hash_from_persistent_volume.rb
+++ b/db/migrate/20160414094300_change_capacity_to_hash_from_persistent_volume.rb
@@ -18,7 +18,7 @@ class ChangeCapacityToHashFromPersistentVolume < ActiveRecord::Migration[5.0]
             key, val = hash.split('=')
             next if val.nil?
             begin
-              result_hash[key.to_sym] = val.to_iec_integer
+              result_hash[key.to_sym] = val.iec_60027_2_to_i
             rescue ArgumentError
               _log.warn("Capacity attribute was in bad format - #{val}")
             end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -418,24 +418,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
   end
 
   describe "parse_iec_number" do
-    it "converts IEC bytes size to integer value" do
-      [
-        ["0",    0],
-        ["1",    1],
-        ["10",   10],
-        ["1Ki",  1_024],
-        ["7Ki",  7_168],
-        ["10Ki", 10_240],
-        ["1Mi",  1_048_576],
-        ["3Mi",  3_145_728],
-        ["10Mi", 10_485_760],
-        ["1Gi",  1_073_741_824],
-        ["1Ti",  1_099_511_627_776]
-      ].each do |iec, bytes|
-        expect(iec.to_iec_integer).to eq(bytes)
-      end
-    end
-
     it "parse capacity hash correctly" do
       hash = {:storage => "10Gi", :foo => "10"}
       expect(parser.send(:parse_resource_list, hash)).to eq({:storage => 10.gigabytes, :foo => 10})


### PR DESCRIPTION
Doing this in an effort to get rid of extensions in manageiq-gems-pending