### PR TITLE
Ansible Service: skip dialog options for retirement

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -71,7 +71,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   def save_job_options(action, overrides)
     job_options = options.fetch_path(:config_info, action.downcase.to_sym).slice(:hosts, :extra_vars)
-    job_options.deep_merge!(parse_dialog_options)
+    job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
     job_options.deep_merge!(overrides)
 
     credential_id = job_options.delete(:credential_id)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1437945

Although there is no dialog at retirement the old code would still read the dialog options from the provisioning time. The fix is to skip such options for retirement.

@miq-bot add_label bug, providers/ansible_tower, services, fine/yes
@miq-bot assign @gmcculloug 