### PR TITLE
Notify when an Openstack VM has been relocated

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
   extend ActiveSupport::Concern
 
+  include ManageIQ::Providers::Openstack::HelperMethods
+
   included do
     supports :live_migrate do
       unsupported_reason_add(:live_migrate, unsupported_reason(:control)) unless supports_control?
@@ -18,7 +20,14 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     block_migration  = options[:block_migration]  || false
     disk_over_commit = options[:disk_over_commit] || false
     with_provider_connection do |connection|
-      connection.live_migrate_server(ems_ref, hostname, block_migration, disk_over_commit)
+      begin
+        connection.live_migrate_server(ems_ref, hostname, block_migration, disk_over_commit)
+      rescue => ex
+        error_message = parse_error_message_from_fog_response(ex.to_s)
+        Notification.create(:type => :vm_cloud_live_migrate_error, :options => {:instance_name => name, :error_message => error_message})
+      else
+        Notification.create(:type => :vm_cloud_live_migrate_success, :options => {:instance_name => name})
+      end
     end
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "MIGRATING")
@@ -31,7 +40,14 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
     on_shared_storage = true if on_shared_storage.nil?
     admin_password    = options[:admin_password]
     with_provider_connection do |connection|
-      connection.evacuate_server(ems_ref, hostname, on_shared_storage, admin_password)
+      begin
+        connection.evacuate_server(ems_ref, hostname, on_shared_storage, admin_password)
+      rescue => ex
+        error_message = parse_error_message_from_fog_response(ex.to_s)
+        Notification.create(:type => :vm_cloud_evacuate_error, :options => {:instance_name => name, :error_message => error_message})
+      else
+        Notification.create(:type => :vm_cloud_evacuate_success, :options => {:instance_name => name})
+      end
     end
     # Temporarily update state for quick UI response until refresh comes along
     self.update_attributes!(:raw_power_state => "MIGRATING")

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -25,6 +25,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
       rescue => ex
         error_message = parse_error_message_from_fog_response(ex.to_s)
         Notification.create(:type => :vm_cloud_live_migrate_error, :options => {:instance_name => name, :error_message => error_message})
+        raise
       else
         Notification.create(:type => :vm_cloud_live_migrate_success, :options => {:instance_name => name})
       end
@@ -45,6 +46,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
       rescue => ex
         error_message = parse_error_message_from_fog_response(ex.to_s)
         Notification.create(:type => :vm_cloud_evacuate_error, :options => {:instance_name => name, :error_message => error_message})
+        raise
       else
         Notification.create(:type => :vm_cloud_evacuate_success, :options => {:instance_name => name})
       end

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers::Openstack::HelperMethods
+  def parse_error_message_from_fog_response(exception)
+    exception_string = exception.to_s
+    matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)
+    matched_message ? matched_message[1] : exception_string
+  end
+end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -119,3 +119,23 @@
   :expires_in: 24.hours
   :level: :info
   :audience: superadmin
+- :name: vm_cloud_live_migrate_success
+  :message: 'Live migrating Instance %{instance_name} completed successfully.'
+  :expires_in: 24.hours
+  :audience: global
+  :level: :success
+- :name: vm_cloud_live_migrate_error
+  :message: 'Live migrating Instance %{instance_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: vm_cloud_evacuate_success
+  :message: 'Evacuating Instance %{instance_name} completed successfully.'
+  :expires_in: 24.hours
+  :audience: global
+  :level: :success
+- :name: vm_cloud_evacuate_error
+  :message: 'Evacuating Instance %{instance_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -48,6 +48,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
 
   describe "vm actions" do
     context "#live_migrate" do
+      before do
+        NotificationType.seed
+      end
+
       it "live migrates with default options" do
         expect(handle).to receive(:live_migrate_server).with(vm.ems_ref, nil, false, false)
         vm.live_migrate
@@ -66,6 +70,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     end
 
     context "evacuate" do
+      before do
+        NotificationType.seed
+      end
+
       it "evacuates with default options" do
         expect(handle).to receive(:evacuate_server).with(vm.ems_ref, nil, true, nil)
         vm.evacuate


### PR DESCRIPTION
Emitting a notification when an Openstack VM relocation operation completes (successfully or otherwise) will allow the UI to further decouple from the underlying API call, rather than having to wait to report on its completion.