### PR TITLE
[WIP] [DEBUG] CONTAINER_INFLATE_FACTOR env var to duplicate most entities

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -10,7 +10,7 @@ module EmsRefresh::SaveInventoryContainer
 
     # Save and link other subsections
     child_keys.each do |k|
-      send("save_#{k}_inventory", ems, hashes[k], target)
+      puts "save_#{k}_inventory", Benchmark.measure { send("save_#{k}_inventory", ems, hashes[k], target) }
     end
 
     ems.save!

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -351,7 +351,7 @@ module ManageIQ::Providers::Kubernetes
         if createdby.kind_of?(Hash) && !createdby['reference'].nil?
           new_result[:container_replicator] = @data_index.fetch_path(
             :container_replicators, :by_namespace_and_name,
-            createdby['reference']['namespace'], createdby['reference']['name'])
+            pod.metadata["table"][:namespace], createdby['reference']['name'])
         end
       end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -4,7 +4,11 @@ module ManageIQ::Providers::Kubernetes
   class ContainerManager::RefreshParser
     include Vmdb::Logging
     def self.ems_inv_to_hashes(inventory)
-      new.ems_inv_to_hashes(inventory)
+      result, t = Benchmark.realtime_block(:total_ems_inv_to_hashes) do
+        new.ems_inv_to_hashes(inventory)
+      end
+      puts "containers refresh_parser - Timings: #{t.inspect}"
+      result
     end
 
     def initialize
@@ -129,7 +133,9 @@ module ManageIQ::Providers::Kubernetes
 
     def process_collection(collection, key, &block)
       @data[key] ||= []
-      collection.each { |item| process_collection_item(item, key, &block) }
+      Benchmark.realtime_block(key) do
+        collection.each { |item| process_collection_item(item, key, &block) }
+      end
     end
 
     def process_collection_item(item, key)

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -32,9 +32,40 @@ module ManageIQ::Providers
           fetch_entities(openshift_client, OPENSHIFT_ENTITIES)
         end
         entities = openshift_entities.merge(kube_entities)
+        _inflate(entities)
         entities["additional_attributes"] = fetch_hawk_inv(ems) || {}
         EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
         ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities)
+      # DEBUGGING
+      INFLATE_FACTOR = ENV['CONTAINER_INFLATE_FACTOR'] ? ENV['CONTAINER_INFLATE_FACTOR'].to_i : 1
+
+      def _inflate(inventory)
+        return if INFLATE_FACTOR == 1
+        inventory.each do |k, structs|
+          orig = structs.dup
+          orig.each do |s|
+            (2..INFLATE_FACTOR).each do |i|
+              copy = s.deep_dup
+              # Hopefully most cross-refs are by name relative to current namespace?
+              case k
+              when "image", "node", "component_status"
+                # not inflated. TODO?
+                next
+              when "project", "namespace"
+                copy.metadata.name += "_inflate#{i}"
+              else
+                byebug unless copy.metadata.namespace
+                copy.metadata.namespace += "_inflate#{i}"
+              end
+              byebug unless copy.metadata.uid
+              copy.metadata.uid += "_inflate#{i}"
+              # selfLink doesn't matter.
+
+              structs << copy
+            end
+          end
+          puts "CONTAINER_INFLATE_FACTOR=#{INFLATE_FACTOR}: #{k}: \t#{orig.size} -> #{structs.size}"
+        end
       end
     end
   end

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -35,7 +35,12 @@ module ManageIQ::Providers
         _inflate(entities)
         entities["additional_attributes"] = fetch_hawk_inv(ems) || {}
         EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
-        ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities)
+
+        res = nil
+        puts "parser:", Benchmark.measure {  res = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities) }
+        res
+      end
+
       # DEBUGGING
       INFLATE_FACTOR = ENV['CONTAINER_INFLATE_FACTOR'] ? ENV['CONTAINER_INFLATE_FACTOR'].to_i : 1
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -1,4 +1,6 @@
 describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
+  let(:inflate_factor) { ManageIQ::Providers::Openshift::ContainerManager::Refresher::INFLATE_FACTOR }
+
   before(:each) do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname = 'host.example.com'
@@ -84,17 +86,17 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_table_counts
-    expect(ContainerGroup.count).to eq(20)
+    expect(ContainerGroup.count).to eq(20 * inflate_factor)
     expect(ContainerNode.count).to eq(2)
-    expect(Container.count).to eq(20)
-    expect(ContainerService.count).to eq(12)
-    expect(ContainerPortConfig.count).to eq(23)
-    expect(ContainerDefinition.count).to eq(20)
-    expect(ContainerRoute.count).to eq(6)
-    expect(ContainerProject.count).to eq(9)
-    expect(ContainerBuild.count).to eq(3)
-    expect(ContainerBuildPod.count).to eq(3)
-    expect(ContainerTemplate.count).to eq(26)
+    expect(Container.count).to eq(20 * inflate_factor)
+    expect(ContainerService.count).to eq(12 * inflate_factor)
+    expect(ContainerPortConfig.count).to eq(23 * inflate_factor)
+    expect(ContainerDefinition.count).to eq(20 * inflate_factor)
+    expect(ContainerRoute.count).to eq(6 * inflate_factor)
+    expect(ContainerProject.count).to eq(9 * inflate_factor)
+    expect(ContainerBuild.count).to eq(3 * inflate_factor)
+    expect(ContainerBuildPod.count).to eq(3 * inflate_factor)
+    expect(ContainerTemplate.count).to eq(26 * inflate_factor)
     expect(ContainerImage.count).to eq(40)
   end
 


### PR DESCRIPTION
@miq-bot add-label providers/containers, performance, wip

This is silly and incomplete but already useful to stress container refresh performance.
Plus more logging (TODO: separate PR with logging)

Usage:
```
env CONTAINER_INFLATE_FACTOR=100 bundle exec rspec ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb:40
```
Currently fails on wrong `@container_build_pod.container_build` but never mind.

- [untested] Should also work refreshing a live environment.
  Be ready to reset your DB, especially if you vary CONTAINER_INFLATE_FACTOR...

- TODO: does not inflate nodes & images.

Trying to understand what the customer may be hitting in https://bugzilla.redhat.com/show_bug.cgi?id=1436176.  However, they have huge number of **images**, which this does not inflate :-(

# First findings

https://gist.github.com/cben/4b8404346f42c917fd1aead993db895e

- speed becomes especially abysmal when it goes into swap.
  E.g. `CONTAINER_INFLATE_FACTOR=1000` sends my 12G laptop deep into swap...

using https://github.com/jvns/ruby-stacktrace to spy on the ruby stack:

-parsing:
  - during parser, I see 60~90% time in OpenStruct `new_ostruct_member`.  It seems that if Kubeclient left things as hashes and our parser accessed `foo[:bar]` or `foo["bar"]` instead of `foo.bar`,  we could gain a lot.
  - parser is not main bottleneck.
  - container_groups is ~30% of total parsing time - OK, container_templates is ~50% - surprising!
  - I'd expect RAM usage to reach approximate peak during parsing, but I do see significant increase later while saving.  TODO: study.  (especially plausible with one huge table — like images in customer's case)

- saving:
  - before #14542, during save a lot of time is indeed stuck in `store_ids_for_new_records`.
    rest of time it's spread around postgresql_adapter, active_record etc...
  - after  #14542, save is nicely faster and spread around postgres, AR etc all time.
    eg. for 11000 replicators, save became 3x faster.
   however, could still take hours in absolute time...
