### PR TITLE
RHV VM not saving FQDN

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb
@@ -533,6 +533,11 @@ class ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Parser
       guest_device[:network] = result.first unless guest_device.nil?
     end
 
+    # RHV reports hostname for the entire vm and not per specific network interface.
+    # Therefore, the hostname will be set for the first nic.
+    fqdn = inv.attributes.fetch_path(:guest_info, :fqdn)
+    result[0][:hostname] = fqdn if !result.blank? && fqdn
+
     result
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/strategies/vm_inventory.rb
@@ -169,6 +169,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Refresh::Parse::Strategies
         guest_device[:network] = result.first unless guest_device.nil?
       end
 
+      # RHV reports hostname for the entire vm and not per specific network interface.
+      # Therefore, the hostname will be set for the first nic.
+      result[0][:hostname] = inv.fqdn if !result.blank? && inv.respond_to?(:fqdn)
       result
     end
 


### PR DESCRIPTION
The PR allows to save the FQDN when it is reported by the VM's
guest agent.

https://bugzilla.redhat.com/show_bug.cgi?id=1417965
