### PR TITLE
Adding 'visible' field to custom attributes

### DIFF
--- a/app/models/custom_attribute.rb
+++ b/app/models/custom_attribute.rb
@@ -4,6 +4,8 @@ class CustomAttribute < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   serialize :serialized_value
 
+  default_value_for :visible, true
+
   def value=(value)
     self.serialized_value = value
     self[:value] = value

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -71,4 +71,8 @@ module CustomAttributeMixin
   def miq_custom_delete(key)
     miq_custom_attributes.find_by(:name => key.to_s).try(:delete)
   end
+
+  def miq_custom_visible
+    miq_custom_attributes.where(:visible => true)
+  end
 end

--- a/db/migrate/20170402131236_add_visible_field_for_custom_attributes.rb
+++ b/db/migrate/20170402131236_add_visible_field_for_custom_attributes.rb
@@ -1,0 +1,5 @@
+class AddVisibleFieldForCustomAttributes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :custom_attributes, :visible, :boolean
+  end
+end

--- a/db/migrate/20170403135631_set_visible_to_true_for_custom_attributes.rb
+++ b/db/migrate/20170403135631_set_visible_to_true_for_custom_attributes.rb
@@ -1,0 +1,13 @@
+class SetVisibleToTrueForCustomAttributes < ActiveRecord::Migration[5.0]
+  class CustomAttribute < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled # disable STI
+  end
+
+  def up
+    CustomAttribute.update_all(:visible => true)
+  end
+
+  def down
+    # NOP
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -993,6 +993,7 @@ custom_attributes:
 - value_interpolated
 - unique_name
 - serialized_value
+- visible
 custom_buttons:
 - id
 - guid

--- a/spec/migrations/20170403135631_set_visible_to_true_for_custom_attributes_spec.rb
+++ b/spec/migrations/20170403135631_set_visible_to_true_for_custom_attributes_spec.rb
@@ -1,0 +1,15 @@
+require_migration
+
+describe SetVisibleToTrueForCustomAttributes do
+  let(:custom_attribute_stub) { migration_stub(:CustomAttribute) }
+
+  migration_context :up do
+    it "sets display to true" do
+      ca = custom_attribute_stub.create!(:name => 'example', :value => 'foo')
+
+      migrate
+
+      expect(ca.reload.visible).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
The field's default value will be `true` to leave the behavior unchanged.