### PR TITLE
Added virtual_column 'image?' for ::CloudManager::Template

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
   default_value_for :cloud, true
 
+  virtual_column :image?, :type => :boolean
+
   def image?
     genealogy_parent.nil?
   end


### PR DESCRIPTION
It's fixing the error ```ActiveRecord::StatementInvalid] PG::UndefinedColumn: ERROR:  column vms.image? does not exist``` when user tries to sort Images by column 'Type'.

@lpichler thanks!

https://bugzilla.redhat.com/show_bug.cgi?id=1437765