### PR TITLE
Add physical server ref into event streams table

### DIFF
--- a/db/migrate/20170331133247_add_physical_server_id_to_event_parser.rb
+++ b/db/migrate/20170331133247_add_physical_server_id_to_event_parser.rb
@@ -1,0 +1,5 @@
+class AddPhysicalServerIdToEventParser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :physical_server_ref, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1256,6 +1256,7 @@ event_streams:
 - middleware_deployment_id
 - middleware_deployment_name
 - generating_ems_id
+- physical_server_ref
 ext_management_systems:
 - id
 - name


### PR DESCRIPTION
This PR create a new column, called physical_server_ref, in the event_streams table.