### PR TITLE
[WIP] Check for dirty records in save_inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -79,7 +79,7 @@ module EmsRefresh::SaveInventoryHelper
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys + [:id]
     if child
-      child.update_attributes!(hash.except(:type, *remove_keys))
+      update_attributes!(child, hash, [:type, *remove_keys])
     else
       child = parent.send("create_#{type}!", hash.except(*remove_keys))
     end
@@ -93,10 +93,17 @@ module EmsRefresh::SaveInventoryHelper
       found = association.build(hash.except(:id))
       new_records << found
     else
-      found.update_attributes!(hash.except(:id, :type))
+      update_attributes!(found, hash, [:id, :type])
       deletes.delete(found) unless deletes.blank?
     end
     found
+  end
+
+  def update_attributes!(ar_model, attributes, remove_keys)
+    ar_model.assign_attributes(attributes.except(*remove_keys))
+    ar_model.with_transaction_returning_status do
+      ar_model.save! if ar_model.changed?
+    end
   end
 
   def backup_keys(hash, keys)


### PR DESCRIPTION
Allow save inventory to skip starting a transaction if the record being saved was not actually changed by the provider's inventory data.

VMs and Storages still directly call `update_attributes!`.  At the moment, it doesn't seem like those object counts are limiting factors. If that changes, we can look at applying the same change there.