### PR TITLE
[WIP] Fix FixVporTimeProfileIds migration

### DIFF
--- a/db/migrate/20170207215322_fix_vpor_time_profile_ids.rb
+++ b/db/migrate/20170207215322_fix_vpor_time_profile_ids.rb
@@ -33,7 +33,7 @@ class FixVporTimeProfileIds < ActiveRecord::Migration[5.0]
       say_with_time("Removing old VimPerformanceOperatingRanges") do
         VimPerformanceOperatingRange.where(:time_profile_id => nil).delete_all
       end
-    elsif TimeProfile.any?
+    elsif TimeProfile.any? && TimeProfile.default
       # User has not used an old version where TimeProfiles were corrected,
       # so the TimeProfile-less records just need to be updated to the default TP
       say_with_time("Updating old VimPerformanceOperatingRanges to the default TimeProfile") do


### PR DESCRIPTION
Not sure whether it is proper fix but it is failing when `TimeProfile.default` is nil 

@miq-bot assign @Fryguy 
@miq-bot add_label sql migration
