### PR TITLE
Create/update Tower project with scm_credential

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -4,6 +4,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
   include ProviderObjectMixin
 
   module ClassMethods
+    def provider_params(params)
+      authentication_id = params.delete(:authentication_id)
+      params[:credential] = Authentication.find(authentication_id).manager_ref if authentication_id
+      params
+    end
+
     def provider_collection(manager)
       manager.with_provider_connection do |connection|
         connection.api.projects


### PR DESCRIPTION
If a `configuration_script_source` is to be associated with a credential, the `create_in_provider` and `update_in_provider` is being sent a VMDB's `authentication_id`. We need to convert it to `credential => authentication.manager_ref` (Tower's credential native ID) so that Tower can act on.

@miq-bot add_labels providers/ansible_tower