### PR TITLE
MiqQueue - remove MiqWorker lookup

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -163,12 +163,8 @@ class MiqQueue < ApplicationRecord
     msgs.each do |msg|
       begin
         _log.info("#{MiqQueue.format_short_log_msg(msg)} previously timed out, retrying...") if msg.state == STATE_TIMEOUT
-        w = MiqWorker.my_worker
-        if w.nil?
-          msg.update_attributes!(:state => STATE_DEQUEUE, :handler => MiqServer.my_server)
-        else
-          msg.update_attributes!(:state => STATE_DEQUEUE, :handler => w)
-        end
+        handler = MiqWorker.my_worker || MiqServer.my_server
+        msg.update_attributes!(:state => STATE_DEQUEUE, :handler => handler)
         result = msg
         break
       rescue ActiveRecord::StaleObjectError

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -163,7 +163,7 @@ class MiqQueue < ApplicationRecord
     msgs.each do |msg|
       begin
         _log.info("#{MiqQueue.format_short_log_msg(msg)} previously timed out, retrying...") if msg.state == STATE_TIMEOUT
-        w = MiqWorker.server_scope.find_by(:pid => Process.pid)
+        w = MiqWorker.my_worker
         if w.nil?
           msg.update_attributes!(:state => STATE_DEQUEUE, :handler => MiqServer.my_server)
         else

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -267,6 +267,10 @@ class MiqWorker < ApplicationRecord
     w
   end
 
+  def self.my_worker
+    server_scope.find_by(:pid => Process.pid)
+  end
+
   def self.find_all_current(server_id = nil)
     MiqWorker.find_current(server_id)
   end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -267,9 +267,7 @@ class MiqWorker < ApplicationRecord
     w
   end
 
-  def self.my_worker
-    server_scope.find_by(:pid => Process.pid)
-  end
+  cache_with_timeout(:my_worker) { server_scope.find_by(:pid => Process.pid) }
 
   def self.find_all_current(server_id = nil)
     MiqWorker.find_current(server_id)


### PR DESCRIPTION
For `MiqQuery.get`, we perform an unneeded worker lookup, which is always the same for a given process.

|       ms |   bytes | objects |query | query ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  1,894.9 | 31,002,739 | 353,789 |  602 | 1,373.5 |      955 |`count#before-1`
|  1,778.1 | 26,014,249 | 289,589 |  502 | 1,328.1 |      955 |`count#after-5`
| 6.2% | 16% | 18% | 17% | 3.3% | 0 | difference
---
TMI

```ruby
MiqWorker.my_worker ; 100.times { MiqQueue.put(:class_name  => 'MyClass', :method_name => 'method1', :args => [1, 2]) }
bookend("miq_queue.count") { 102.times { MiqQueue.get } }
```

I highlighted the`SELECT` which is present before but not after.

|       ms |query | query ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  1,900.1 |  602 | 1,356.4 |      955 |`count#after-1`
|    448.1 |  102 |   448.1 |          |`.SELECT COUNT(count_column) `
|    458.4 |  100 |   435.0 |      955 |`.SELECT  "miq_queue".* `
|     64.9 |  100 |    54.9 |          |**`.SELECT  "miq_workers".* `**
|     43.8 |  100 |    43.8 |          |`.BEGIN`
|    261.6 |  100 |   261.6 |          |`.UPDATE "miq_queue" SET "state" = 'dequeue', "handler_id" = 1, "handler_type" = 'MiqServer', "updated_on" = .{28}, "lock_version" = 1 `
|     79.6 |  100 |    79.6 |          |`.COMMIT`


The numbers I collected for this one were a little less consistent, but make they do show the trend

|       ms |   bytes | objects |query | query ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  1,894.9 | 31,002,739 | 353,789 |  602 | 1,373.5 |      955 |`count#before-1`
|  1,900.1 | 31,002,725 | 353,789 |  602 | 1,356.4 |      955 |`count#before-2`
|  2,008.4 | 31,002,759 | 353,789 |  602 | 1,477.2 |      955 |`count#before-3`
|  1,856.9 | 31,003,215 | 353,789 |  602 | 1,331.8 |      955 |`count#before-4`

|       ms |   bytes | objects |query | query ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  1,816.7 | 26,013,787 | 289,589 |  502 | 1,368.8 |      955 |`count#after-1`
|  1,820.6 | 26,013,789 | 289,589 |  502 | 1,372.6 |      955 |`count#after-2`
|  1,857.9 | 26,013,819 | 289,589 |  502 | 1,393.4 |      955 |`count#after-3`
|  1,771.0 | 26,014,391 | 289,589 |  502 | 1,317.5 |      955 |`count#after-4`
|  1,778.1 | 26,014,249 | 289,589 |  502 | 1,328.1 |      955 |`count#after-5`
