### PR TITLE
add X-Auth-Token header to all requests sent to Image Inspector

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -356,6 +356,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   end
 
   def pod_definition(inspector_admin_secret_name)
+    pod_env = inspector_proxy_env_variables << { :name  => INSPECTOR_AUTH_TOKEN,
+                                                 :value => auth_token }
     pod_def = {
       :apiVersion => "v1",
       :kind       => "Pod",
@@ -396,7 +398,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
                 :name      => "docker-socket"
               }
             ],
-            :env             => inspector_proxy_env_variables,
+            :env             => pod_env,
             :readinessProbe  => {
               "initialDelaySeconds" => 15,
               "periodSeconds"       => 5,
@@ -444,8 +446,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
                    :name    => PROXY_ENV_VARIABLES).each_with_object([]) do |att, env|
       env << {:name  => att.name.upcase,
               :value => att.value} unless att.value.blank?
-    end << { :name => INSPECTOR_AUTH_TOKEN,
-             :value => auth_token}
+    end
   end
 
   def auth_token

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -1,6 +1,5 @@
 require 'image-inspector-client'
 require 'kubeclient'
-require 'securerandom'
 
 class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   PROVIDER_CLASS = ManageIQ::Providers::Kubernetes::ContainerManager

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
   INSPECTOR_ADMIN_SECRET_PATH = '/var/run/secrets/kubernetes.io/inspector-admin-secret-'
   ATTRIBUTE_SECTION = 'cluster_settings'
   PROXY_ENV_VARIABLES = %w(no_proxy http_proxy https_proxy)
-  INSPECTOR_AUTH_TOKEN = "INSPECTOR_AUTH_TOKEN"
+  INSPECTOR_AUTH_TOKEN = "INSPECTOR_AUTH_TOKEN".freeze
 
   def load_transitions
     self.state ||= 'initializing'

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -287,9 +287,8 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
         :verify_ssl => ext_management_system.verify_ssl_mode,
         :cert_store => ext_management_system.ssl_cert_store
       },
-      :auth_options   => kubeclient.auth_options,
-      :http_proxy_uri => kubeclient.http_proxy_uri,
-      :auth_token     => auth_token
+      :auth_options   => kubeclient.auth_options.merge(:auth_token => auth_token),
+      :http_proxy_uri => kubeclient.http_proxy_uri
     )
   end
 

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -209,9 +209,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       :verify_mode => verify_ssl_mode,
       :cert_store  => ssl_cert_store,
     }
+    headers = client.headers
+    headers[:'X-Auth-Token'] = scan_data[:auth_token] if scan_data[:auth_token]
     MiqContainerGroup.new(pod_proxy + SCAN_CONTENT_PATH,
                           nethttp_options,
-                          client.headers.stringify_keys,
+                          headers.stringify_keys,
                           scan_data[:guest_os])
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -166,9 +166,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
       end
 
       it 'should create a pod spec with the auth_token environment variable' do
-        expect(Kubeclient::Resource).to have_received(:new).with(pod_env_containing(
-                                                         {:name => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_AUTH_TOKEN,
-                                                           :value => @job.options[:auth_token]}))
+        expect(Kubeclient::Resource).to have_received(:new).with(
+          pod_env_containing(
+            :name  => ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job::INSPECTOR_AUTH_TOKEN,
+            :value => @job.options[:auth_token]
+          )
+        )
       end
 
       it 'should report success' do
@@ -186,19 +189,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
 
       it 'should generate and store the image inspector auth_token' do
         expect(@job.options[:auth_token]).not_to be_nil
-      end
-
-      describe 'should fucking work fuck' do
-        let(:dbl) { double }
-        before { expect(dbl).to receive(:foo).with(hash_containing_string("3")) }
-
-        it "passes when the args match" do
-          dbl.foo({"args" => ["13"]})
-        end
-
-        it "fails when the args do not match" do
-          dbl.foo({"args" => ["13"]})
-        end
       end
 
       it 'should pass the auth_token as a parameter to scan_metadata' do


### PR DESCRIPTION
Token authentication is being added to all HTTP requests on the SSA image inspector pod in https://github.com/openshift/image-inspector/pull/38

The intent of this PR is to secure the image inspector pod, which currently performs no authentication to requests that may potentially come from other pods within the cluster.

These changes update ManageIQ:
- generate a shared secret token when creating the Image Inspector Pod
- authenticate all requests to Image Inspector Pod with header `X-Auth-Token: $TOKEN` 
- pass `:auth_token` parameter to `image_inspector_client` which is also responsible for making some HTTP requests to image inspector (see PR https://github.com/moolitayer/image-inspector-client/pull/17)
