### PR TITLE
Edit VMs API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2265,7 +2265,6 @@
         :disabled: true
       - :name: edit
         :identifier: vm_edit
-        :disabled: true
       - :name: add_lifecycle_event
         :identifier: vm_edit
       - :name: add_event
@@ -2313,7 +2312,6 @@
       :post:
       - :name: edit
         :identifier: vm_edit
-        :disabled: true
       - :name: add_lifecycle_event
         :identifier: vm_edit
       - :name: add_event


### PR DESCRIPTION
Edit API to update basic attributes (custom_1, description) and parent, child relationships. These attributes align with what is currently allowed when editing a VM in the OpsUI. 

```
{
   "custom_1": "new_custom_identifier",
   "description": "new_description",
   "parent_relationships": { "href": <parent url> },
   "child_relationships": [ {"href":<child url>}, {"href": <child url>} ] 
} 
```
@miq-bot add_label enhancement, wip, api
@miq-bot assign @abellotti 