### PR TITLE
[WIP] [POC] Container refresh split by entity/project

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -115,6 +115,7 @@ module EmsRefresh::SaveInventoryHelper
     keys = Array(keys)
     hashes.each do |h|
       r = records.detect { |r| keys.all? { |k| r.send(k) == r.class.type_for_attribute(k.to_s).cast(h[k]) } }
+      h.clear  # HACK, DON'T MERGE
       h[:id] = r.id
     end
   end

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers
   module Openshift
     class ContainerManager::RefreshParser < ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser
+      attr_accessor :data, :data_index
+
       def ems_inv_to_hashes(inventory)
         super(inventory)
         get_projects(inventory)

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -105,12 +105,50 @@ module ManageIQ::Providers
         EmsRefresh.save_container_routes_inventory(ems, data[:container_routes], target)
         EmsRefresh.save_container_component_statuses_inventory(ems, data[:container_component_statuses], target)
         EmsRefresh.save_container_templates_inventory(ems, data[:container_templates], target)
+        ems.save!
       end
 
       def inlined_refresh2(ems)
         inlined_refresh_nodes(ems)
+        inlined_refresh_component_statuses(ems)
+        inlined_refresh_images(ems)
         inlined_refresh_projects(ems)
-        inlined_refresh_rest(ems)
+        inv = inlined_inventory_rest(ems)
+        inlined_parse_save_rest(ems, ems, inv)
+      end
+
+      def inlined_refresh3(ems, fake_split: false)
+        inlined_refresh_nodes(ems)
+        inlined_refresh_component_statuses(ems)
+        inlined_refresh_images(ems)
+        inlined_refresh_projects(ems)
+
+        @split_counts = {}
+        # Without this .reset, `ems.container_projects` sees each
+        # project twice in one of the tests.
+        # TODO: understand why, and if more .resets are needed?
+        ems.container_projects.reset
+        ems.container_projects.each do |project|
+          if fake_split
+            inventory = inlined_inventory_rest_fake_split(ems, namespace: project.name)
+          else
+            inventory = inlined_inventory_rest(ems, namespace: project.name)
+          end
+          inlined_parse_save_rest(ems, project, inventory)
+        end
+        byebug if @split_counts != @orig_counts
+      end
+
+      def inlined_refresh3_fake(ems)
+        inlined_refresh_nodes(ems)
+        inlined_refresh_component_statuses(ems)
+        inlined_refresh_images(ems)
+        inlined_refresh_projects(ems)
+        ems.container_projects.each do |project|
+          byebug if project.name == 'default'
+          inlined_parse_save_rest(ems, project, inventory)
+        end
+        byebug
       end
 
       def inlined_refresh_nodes(ems)
@@ -122,8 +160,7 @@ module ManageIQ::Providers
         parser.get_additional_attributes(inventory)
         parser.get_nodes(inventory)
         EmsRefresh.save_container_nodes_inventory(ems, parser.data[:container_nodes], ems)
-
-        $inventory1, $parser1 = inventory, parser  # for debugging
+        ems.save!
       end
 
       def inlined_refresh_projects(ems)
@@ -136,36 +173,72 @@ module ManageIQ::Providers
         parser.get_namespaces(inventory)
         parser.get_projects(inventory)
         EmsRefresh.save_container_projects_inventory(ems, parser.data[:container_projects], ems)
-
-        $inventory2, $parser2 = inventory, parser  # for debugging
+        ems.save!
       end
 
-      def inlined_refresh_rest(ems)
+      def inlined_refresh_component_statuses(ems)
+        kclient = ems.connect(:service => KUBERNETES_EMS_TYPE)
+        inventory = {}
+        inventory["component_status"] = kclient.get_component_statuses
+        parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
+        parser.get_component_statuses(inventory)
+        EmsRefresh.save_container_component_statuses_inventory(ems, parser.data[:container_component_statuses], ems)
+        ems.save!
+      end
+
+      def inlined_refresh_images(ems)
+        oclient = ems.connect(:service => OPENSHIFT_EMS_TYPE)
+        inventory = {}
+        inventory["image"] = oclient.get_images
+        parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
+        parser.get_openshift_images(inventory)
+        EmsRefresh.save_container_image_registries_inventory(ems, parser.data[:container_image_registries], ems)
+        EmsRefresh.save_container_images_inventory(ems, parser.data[:container_images], ems)
+        ems.save!
+      end
+
+      def inlined_inventory_rest(ems, *kubeclient_args)
         # fetch
         kclient = ems.connect(:service => KUBERNETES_EMS_TYPE)
         oclient = ems.connect(:service => OPENSHIFT_EMS_TYPE)
         inventory = {}
-        inventory["pod"] = kclient.get_pods
-        inventory["service"] = kclient.get_services
-        inventory["replication_controller"] = kclient.get_replication_controllers
-        inventory["endpoint"] = kclient.get_endpoints
-        inventory["resource_quota"] = kclient.get_resource_quotas
-        inventory["limit_range"] = kclient.get_limit_ranges
-        inventory["persistent_volume"] = kclient.get_persistent_volumes
-        inventory["persistent_volume_claim"] = kclient.get_persistent_volume_claims
-        inventory["component_status"] = kclient.get_component_statuses
-        inventory["route"] = oclient.get_routes
-        inventory["build_config"] = oclient.get_build_configs
-        inventory["build"] = oclient.get_builds
-        inventory["template"] = oclient.get_templates
-        inventory["image"] = oclient.get_images
+        inventory["pod"] = kclient.get_pods(*kubeclient_args)
+        inventory["service"] = kclient.get_services(*kubeclient_args)
+        inventory["replication_controller"] = kclient.get_replication_controllers(*kubeclient_args)
+        inventory["endpoint"] = kclient.get_endpoints(*kubeclient_args)
+        inventory["resource_quota"] = kclient.get_resource_quotas(*kubeclient_args)
+        inventory["limit_range"] = kclient.get_limit_ranges(*kubeclient_args)
+        inventory["persistent_volume"] = kclient.get_persistent_volumes(*kubeclient_args)
+        inventory["persistent_volume_claim"] = kclient.get_persistent_volume_claims(*kubeclient_args)
+        inventory["route"] = oclient.get_routes(*kubeclient_args)
+        inventory["build_config"] = oclient.get_build_configs(*kubeclient_args)
+        inventory["build"] = oclient.get_builds(*kubeclient_args)
+        inventory["template"] = oclient.get_templates(*kubeclient_args)
         EmsRefresh.log_inv_debug_trace(inventory, "inv_hash:")
+        inventory
+      end
 
+      # Fake per-project fetching without re-recording cassettes
+      # Needs :allow_playback_repeats => true
+      def inlined_inventory_rest_fake_split(ems, namespace:)
+        full_inv = inlined_inventory_rest(ems)
+        @orig_counts = full_inv.transform_values(&:count)
+        full_inv.each do |k, structs|
+          structs.select! { |s| s.metadata.namespace == namespace }
+          @split_counts[k] ||= 0
+          @split_counts[k] += structs.count
+        end
+        full_inv
+      end
+
+      def inlined_parse_save_rest(ems, target, inventory)
         # parse
         parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
-        # load back ids
+        # load back ids. TODO: lazy for only the mentioned ones?
         ems.container_projects.each { |r| parser.data_index.store_path(:container_projects, :by_name, r.name, {:id => r.id}) }
         ems.container_nodes.each { |r| parser.data_index.store_path(:container_nodes, :by_name, r.name, {:id => r.id}) }
+        ems.container_image_registries.each { |r| parser.data_index.store_path(:container_image_registry, :by_host_and_port, "#{r.host}:#{r.port}", {:id => r.id}) }
+        ems.container_images.each { |r| parser.data_index.store_path(:container_image, :by_digest, r.digest || r.image_ref, {:id => r.id}) }
 
         parser.get_resource_quotas(inventory)
         parser.get_limit_ranges(inventory)
@@ -175,29 +248,26 @@ module ManageIQ::Providers
         parser.get_pods(inventory)
         parser.get_endpoints(inventory)
         parser.get_services(inventory)
-        parser.get_component_statuses(inventory)
         parser.get_routes(inventory)
         parser.get_builds(inventory)
         parser.get_build_pods(inventory)
         parser.get_templates(inventory)
-        parser.get_openshift_images(inventory)
         EmsRefresh.log_inv_debug_trace(parser.data, "data:")
 
         # save
-        target = ems
         EmsRefresh.save_container_quotas_inventory(ems, parser.data[:container_quotas], target)
         EmsRefresh.save_container_limits_inventory(ems, parser.data[:container_limits], target)
         EmsRefresh.save_container_builds_inventory(ems, parser.data[:container_builds], target)
         EmsRefresh.save_container_build_pods_inventory(ems, parser.data[:container_build_pods], target)
         EmsRefresh.save_persistent_volume_claims_inventory(ems, parser.data[:persistent_volume_claims], target)
         EmsRefresh.save_persistent_volumes_inventory(ems, parser.data[:persistent_volume_claims], target)
+        # TODO is re-saving images here needed?
         EmsRefresh.save_container_image_registries_inventory(ems, parser.data[:container_image_registries], target)
         EmsRefresh.save_container_images_inventory(ems, parser.data[:container_images], target)
         EmsRefresh.save_container_replicators_inventory(ems, parser.data[:container_replicators], target)
         EmsRefresh.save_container_groups_inventory(ems, parser.data[:container_groups], target)
         EmsRefresh.save_container_services_inventory(ems, parser.data[:container_services], target)
         EmsRefresh.save_container_routes_inventory(ems, parser.data[:container_routes], target)
-        EmsRefresh.save_container_component_statuses_inventory(ems, parser.data[:container_component_statuses], target)
         EmsRefresh.save_container_templates_inventory(ems, parser.data[:container_templates], target)
       end
     end

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -106,6 +106,100 @@ module ManageIQ::Providers
         EmsRefresh.save_container_component_statuses_inventory(ems, data[:container_component_statuses], target)
         EmsRefresh.save_container_templates_inventory(ems, data[:container_templates], target)
       end
+
+      def inlined_refresh2(ems)
+        inlined_refresh_nodes(ems)
+        inlined_refresh_projects(ems)
+        inlined_refresh_rest(ems)
+      end
+
+      def inlined_refresh_nodes(ems)
+        kclient = ems.connect(:service => KUBERNETES_EMS_TYPE)
+        inventory = {}
+        inventory["additional_attributes"] = fetch_hawk_inv(ems) || {}
+        inventory["node"] = kclient.get_nodes
+        parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
+        parser.get_additional_attributes(inventory)
+        parser.get_nodes(inventory)
+        EmsRefresh.save_container_nodes_inventory(ems, parser.data[:container_nodes], ems)
+
+        $inventory1, $parser1 = inventory, parser  # for debugging
+      end
+
+      def inlined_refresh_projects(ems)
+        kclient = ems.connect(:service => KUBERNETES_EMS_TYPE)
+        oclient = ems.connect(:service => OPENSHIFT_EMS_TYPE)
+        inventory = {}
+        inventory["namespace"] = kclient.get_namespaces
+        inventory["project"] = oclient.get_projects
+        parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
+        parser.get_namespaces(inventory)
+        parser.get_projects(inventory)
+        EmsRefresh.save_container_projects_inventory(ems, parser.data[:container_projects], ems)
+
+        $inventory2, $parser2 = inventory, parser  # for debugging
+      end
+
+      def inlined_refresh_rest(ems)
+        # fetch
+        kclient = ems.connect(:service => KUBERNETES_EMS_TYPE)
+        oclient = ems.connect(:service => OPENSHIFT_EMS_TYPE)
+        inventory = {}
+        inventory["pod"] = kclient.get_pods
+        inventory["service"] = kclient.get_services
+        inventory["replication_controller"] = kclient.get_replication_controllers
+        inventory["endpoint"] = kclient.get_endpoints
+        inventory["resource_quota"] = kclient.get_resource_quotas
+        inventory["limit_range"] = kclient.get_limit_ranges
+        inventory["persistent_volume"] = kclient.get_persistent_volumes
+        inventory["persistent_volume_claim"] = kclient.get_persistent_volume_claims
+        inventory["component_status"] = kclient.get_component_statuses
+        inventory["route"] = oclient.get_routes
+        inventory["build_config"] = oclient.get_build_configs
+        inventory["build"] = oclient.get_builds
+        inventory["template"] = oclient.get_templates
+        inventory["image"] = oclient.get_images
+        EmsRefresh.log_inv_debug_trace(inventory, "inv_hash:")
+
+        # parse
+        parser = ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.new
+        # load back ids
+        ems.container_projects.each { |r| parser.data_index.store_path(:container_projects, :by_name, r.name, {:id => r.id}) }
+        ems.container_nodes.each { |r| parser.data_index.store_path(:container_nodes, :by_name, r.name, {:id => r.id}) }
+
+        parser.get_resource_quotas(inventory)
+        parser.get_limit_ranges(inventory)
+        parser.get_replication_controllers(inventory)
+        parser.get_persistent_volume_claims(inventory)
+        parser.get_persistent_volumes(inventory)
+        parser.get_pods(inventory)
+        parser.get_endpoints(inventory)
+        parser.get_services(inventory)
+        parser.get_component_statuses(inventory)
+        parser.get_routes(inventory)
+        parser.get_builds(inventory)
+        parser.get_build_pods(inventory)
+        parser.get_templates(inventory)
+        parser.get_openshift_images(inventory)
+        EmsRefresh.log_inv_debug_trace(parser.data, "data:")
+
+        # save
+        target = ems
+        EmsRefresh.save_container_quotas_inventory(ems, parser.data[:container_quotas], target)
+        EmsRefresh.save_container_limits_inventory(ems, parser.data[:container_limits], target)
+        EmsRefresh.save_container_builds_inventory(ems, parser.data[:container_builds], target)
+        EmsRefresh.save_container_build_pods_inventory(ems, parser.data[:container_build_pods], target)
+        EmsRefresh.save_persistent_volume_claims_inventory(ems, parser.data[:persistent_volume_claims], target)
+        EmsRefresh.save_persistent_volumes_inventory(ems, parser.data[:persistent_volume_claims], target)
+        EmsRefresh.save_container_image_registries_inventory(ems, parser.data[:container_image_registries], target)
+        EmsRefresh.save_container_images_inventory(ems, parser.data[:container_images], target)
+        EmsRefresh.save_container_replicators_inventory(ems, parser.data[:container_replicators], target)
+        EmsRefresh.save_container_groups_inventory(ems, parser.data[:container_groups], target)
+        EmsRefresh.save_container_services_inventory(ems, parser.data[:container_services], target)
+        EmsRefresh.save_container_routes_inventory(ems, parser.data[:container_routes], target)
+        EmsRefresh.save_container_component_statuses_inventory(ems, parser.data[:container_component_statuses], target)
+        EmsRefresh.save_container_templates_inventory(ems, parser.data[:container_templates], target)
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -32,6 +32,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     2.times do # Run twice to verify that a second run with existing data does not change anything
       VCR.use_cassette(described_class.name.underscore) do # , :record => :new_episodes) do
         EmsRefresh.refresh(@ems)
+        #@ems.refresher.inlined_refresh1(@ems)
       end
       @ems.reload
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -34,7 +34,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
                        :allow_playback_repeats => true, # TODO?
                        :match_requests_on => [:path,]) do # , :record => :new_episodes) do
         #EmsRefresh.refresh(@ems)
-        @ems.refresher.new([@ems]).inlined_refresh2(@ems)
+        @ems.refresher.new([@ems]).inlined_refresh3(@ems, :fake_split => true)
       end
       @ems.reload
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -31,7 +31,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       @ems.reload
       VCR.use_cassette(described_class.name.underscore,
                        :match_requests_on => [:path,]) do # , :record => :new_episodes) do
-        EmsRefresh.refresh(@ems)
+        #EmsRefresh.refresh(@ems)
+        @ems.refresher.new([@ems]).inlined_refresh1(@ems)
       end
       @ems.reload
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -30,9 +30,11 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     2.times do
       @ems.reload
       VCR.use_cassette(described_class.name.underscore,
+                       :allow_unused_http_interactions => true, # TODO kclient, oclient
+                       :allow_playback_repeats => true, # TODO?
                        :match_requests_on => [:path,]) do # , :record => :new_episodes) do
         #EmsRefresh.refresh(@ems)
-        @ems.refresher.new([@ems]).inlined_refresh1(@ems)
+        @ems.refresher.new([@ems]).inlined_refresh2(@ems)
       end
       @ems.reload
 
@@ -78,6 +80,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     VCR.use_cassette("#{described_class.name.underscore}_hawk_fails",
                      :match_requests_on => [:path,]) do # , :record => :new_episodes) do
       EmsRefresh.refresh(ems)
+      #TODO ems.refresher.new([ems]).inlined_refresh2(ems)
     end
     ems.reload
 


### PR DESCRIPTION
This is just a proof-of-concept that it's feasible to split container refresh by entity type and/or by project.
Uses existing parser & save_inventory code.

- Get nodes, parse, save, forget
- Get namespaces & projects, parse, save, forget
- Get images, parse, save, forget
- For each project:
  - Load back some ids from DB (too much, could do much less, esp)
  - Get all other entities *under this project*, parse, save, forget.

Assumes no entities from one namespace ever reference other namespaces.  Not sure if true, this will not be required after rewrite to graph refresh.

For simplicity I flattened everything refresh does into 1 function, and I'm ignoring all questions of targeted queueing — running the alternative refresh from console/test.

TODO: measure time & memory usage.  Confirm whether parse or save eats most memory?