### PR TITLE
Drop 'jobs.agent_id' column.

### DIFF
--- a/db/migrate/20170509230548_remove_agent_id_from_jobs.rb
+++ b/db/migrate/20170509230548_remove_agent_id_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveAgentIdFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :agent_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1557,7 +1557,6 @@ jobs:
 - target_id
 - target_class
 - type
-- agent_id
 - agent_message
 - started_on
 - dispatch_status


### PR DESCRIPTION
**blocked:** 
- [x]   Refactor/clean up 'agent' related logic on `Job` model  https://github.com/ManageIQ/manageiq/pull/14030

All references to 'jobs.agent_id' were removed in #14030, and this column not in use.
Dropping it will make future merging of `Job` and `MiqTask` models simpler.


@miq-bot add-label core, technical debt, wip