### PR TITLE
Fix broken spec on ui-classic

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -119,7 +119,7 @@ class MiqReport < ApplicationRecord
     {
       :data_type         => data_type,
       :available_formats => get_available_formats(path, data_type),
-      :default_format    => Formats.default_format_path(path, data_type),
+      :default_format    => Formats.default_format_for_path(path, data_type),
       :numeric           => [:integer, :decimal, :fixnum, :float].include?(data_type)
     }
   end

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -12,7 +12,7 @@ module MiqReport::Formatting
   end
 
   def javascript_format(col, format_name)
-    format_name ||= MiqReport::Formats.default_format_path(col, nil)
+    format_name ||= MiqReport::Formats.default_format_for_path(col, nil)
     return nil unless format_name && format_name != :_none_
 
     format = MiqReport::Formats.details(format_name)


### PR DESCRIPTION
Addressing:
```
 NoMethodError:       undefined method `default_format_path' for MiqReport::Formats:Class
     # ./spec/manageiq/app/models/miq_report/formatting.rb:15:in `javascript_format'
     # ./lib/report_formatter/c3.rb:81:in `build_document_header'
     # ./spec/support/report_helper.rb:5:in `render_report'
     # ./spec/lib/report_formater/c3_formatter_spec.rb:60:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/manageiq/spec/support/evm_spec_helper.rb:28:in `clear_caches'
     # ./spec/spec_helper.rb:75:in `block (2 levels) in <top (required)>'
```

Previously, https://github.com/ManageIQ/manageiq/pull/14631 was not successful. 