### PR TITLE
Alter embedded ansible for rpm builds

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -5,7 +5,7 @@ require "ansible_tower_client"
 
 class EmbeddedAnsible
   ANSIBLE_ROLE                = "embedded_ansible".freeze
-  SETUP_SCRIPT                = "#{APPLIANCE_ANSIBLE_DIRECTORY}/setup.sh".freeze
+  SETUP_SCRIPT                = "ansible-tower-setup".freeze
   SECRET_KEY_FILE             = "/etc/tower/SECRET_KEY".freeze
   CONFIGURE_EXCLUDE_TAGS      = "packages,migrations,firewall,supervisor".freeze
   START_EXCLUDE_TAGS          = "packages,migrations,firewall".freeze

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -86,9 +86,10 @@ class EmbeddedAnsible
 
   def self.run_setup_script(exclude_tags)
     json_extra_vars = {
-      :minimum_var_space => 0,
-      :http_port         => HTTP_PORT,
-      :https_port        => HTTPS_PORT
+      :minimum_var_space  => 0,
+      :http_port          => HTTP_PORT,
+      :https_port         => HTTPS_PORT,
+      :tower_package_name => "ansible-tower-server"
     }.to_json
 
     with_inventory_file do |inventory_file_path|

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -4,7 +4,6 @@ require "linux_admin"
 require "ansible_tower_client"
 
 class EmbeddedAnsible
-  APPLIANCE_ANSIBLE_DIRECTORY = "/opt/ansible-installer".freeze
   ANSIBLE_ROLE                = "embedded_ansible".freeze
   SETUP_SCRIPT                = "#{APPLIANCE_ANSIBLE_DIRECTORY}/setup.sh".freeze
   SECRET_KEY_FILE             = "/etc/tower/SECRET_KEY".freeze
@@ -15,8 +14,10 @@ class EmbeddedAnsible
   WAIT_FOR_ANSIBLE_SLEEP      = 1.second
 
   def self.available?
-    path = ENV["APPLIANCE_ANSIBLE_DIRECTORY"] || APPLIANCE_ANSIBLE_DIRECTORY
-    Dir.exist?(File.expand_path(path.to_s))
+    return false unless MiqEnvironment::Command.is_appliance?
+
+    required_rpms = Set["ansible-tower-server", "ansible-tower-setup"]
+    required_rpms.subset?(LinuxAdmin::Rpm.list_installed.keys.to_set)
   end
 
   def self.enabled?

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -235,7 +235,7 @@ describe EmbeddedAnsible do
           params                  = options[:params]
           inventory_file_contents = File.read(params[:inventory=])
 
-          expect(script_path).to eq("/opt/ansible-installer/setup.sh")
+          expect(script_path).to eq("ansible-tower-setup")
           expect(params["--"]).to be_nil
           expect(params[:extra_vars=]).to eq(extra_vars)
           expect(params[:skip_tags=]).to eq("packages,migrations,firewall,supervisor")
@@ -262,7 +262,7 @@ describe EmbeddedAnsible do
           params                  = options[:params]
           inventory_file_contents = File.read(params[:inventory=])
 
-          expect(script_path).to eq("/opt/ansible-installer/setup.sh")
+          expect(script_path).to eq("ansible-tower-setup")
           expect(params["--"]).to be_nil
           expect(params[:extra_vars=]).to eq(extra_vars)
           expect(params[:skip_tags=]).to eq("packages,migrations,firewall,supervisor")
@@ -293,7 +293,7 @@ describe EmbeddedAnsible do
           params                  = options[:params]
           inventory_file_contents = File.read(params[:inventory=])
 
-          expect(script_path).to eq("/opt/ansible-installer/setup.sh")
+          expect(script_path).to eq("ansible-tower-setup")
           expect(params["--"]).to be_nil
           expect(params[:extra_vars=]).to eq(extra_vars)
           expect(params[:skip_tags=]).to eq("packages,migrations,firewall")

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -92,9 +92,10 @@ describe EmbeddedAnsible do
     let(:miq_database) { MiqDatabase.first }
     let(:extra_vars) do
       {
-        :minimum_var_space => 0,
-        :http_port         => described_class::HTTP_PORT,
-        :https_port        => described_class::HTTPS_PORT
+        :minimum_var_space  => 0,
+        :http_port          => described_class::HTTP_PORT,
+        :https_port         => described_class::HTTPS_PORT,
+        :tower_package_name => "ansible-tower-server"
       }.to_json
     end
 


### PR DESCRIPTION
This PR allows our Embedded Ansible role to work with the new RPM installed packages.

We move away from checking for the setup script in `/opt/ansible-installer` and use the files provided for us by the RPM.

This PR also includes changes to account for the UI not being present when the setup script is run.