### PR TITLE
Make worker_monitor_drb act like a reader again!

### DIFF
--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -29,5 +29,13 @@ describe MiqWorker::Runner do
       allow(@worker_base).to receive(:run).and_raise(SignalException, "SIGALRM")
       expect { @worker_base.start }.to raise_error(SignalException, "SIGALRM")
     end
+
+    it "worker_monitor_drb caches DRbObject" do
+      @worker_base.instance_variable_set(:@server, FactoryGirl.create(:miq_server, :drb_uri => "druby://127.0.0.1:123456"))
+      require 'drb'
+      allow(DRbObject).to receive(:new).and_return(0, 1)
+      expect(@worker_base.worker_monitor_drb).to eq 0
+      expect(@worker_base.worker_monitor_drb).to eq 0
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1438935

For testing in e21d1b9, @worker_monitor_drb was changed to use the
method.  Unfortunately, this method isn't a reader, so it would create a
new drb client each time it was called.

It doesn't make sense for this method to make a new drb client each
time, so we can cache this client on first access so it functions like a
attr_reader now.  We can then remove some memoization/caching that
occurs in heartbeat since the getter method handles that for us.

Use https://github.com/ManageIQ/manageiq/commit/147aa6ba902054d0f881a6cd16fd8df42c9667c3?w=1 to ignore whitespace.

Note, the parent PR, https://github.com/ManageIQ/manageiq/pull/14365, was backported to euwe.