### PR TITLE
Add policy checking for retirement request.

### DIFF
--- a/db/fixtures/miq_event_definition_sets.csv
+++ b/db/fixtures/miq_event_definition_sets.csv
@@ -8,6 +8,7 @@ vm_operational,VM Operation
 vm_configurational,VM Configuration
 vm_process,VM Lifecycle
 service_process,Service Lifecycle
+orchestration_process,Orchestration Lifecycle
 storage_operational,Datastore Operation
 auth_validation,Authentication Validation
 container_operations,Container Operation

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -166,6 +166,11 @@ request_service_stop,Service Stop Request,Default,service_process
 service_stopped,Service Stopped,Default,service_process
 
 #
+# Orchestration
+#
+request_orchestration_stack_retire,Orchestration Stack Retire Request,Default,orchestration_process
+
+#
 # Container Operations
 #
 request_containerimage_scan,Container Image Analysis Request,Default,container_operations

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -153,6 +153,14 @@ module MiqAeEngine
       event_object_from_workspace(obj).process_evm_event
     end
 
+    def self.miq_check_policy_prevent(obj, _inputs)
+      event = event_object_from_workspace(obj)
+      if event.full_data && event.full_data[:policy][:prevented]
+        msg = "Event #{event.event_type} for #{event.target} was terminated: #{event.message}"
+        raise MiqAeException::StopInstantiation, msg
+      end
+    end
+
     def self.event_object_from_workspace(obj)
       event = obj.workspace.get_obj_from_path("/")['event_stream']
       raise MiqAeException::MethodParmMissing, "Event not specified" if event.nil?

--- a/lib/miq_automation_engine/service_models/miq_ae_service_event_stream.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_event_stream.rb
@@ -9,6 +9,7 @@ module MiqAeMethodService
     expose :dest_vm,               :association => true, :method => :dest_vm_or_template
     expose :dest_host,             :association => true
     expose :service,               :association => true
+    expose :target,                :association => true
 
     def event_namespace
       object_class.name

--- a/spec/lib/miq_automation_engine/engine/miq_ae_builtin_method_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_builtin_method_spec.rb
@@ -1,0 +1,19 @@
+describe MiqAeEngine::MiqAeBuiltinMethod do
+  describe '.miq_check_policy_prevent' do
+    let(:event)     { FactoryGirl.create(:miq_event) }
+    let(:svc_event) { MiqAeMethodService::MiqAeServiceEventStream.find(event.id) }
+    let(:workspace) { double('WORKSPACE', :get_obj_from_path => { 'event_stream' => svc_event }) }
+    let(:obj)       { double('OBJ', :workspace => workspace) }
+
+    subject { described_class.send(:miq_check_policy_prevent, obj, {}) }
+
+    it 'with policy not prevented' do
+      expect { subject }.not_to raise_error
+    end
+
+    it 'with policy prevented' do
+      event.update_attributes(:full_data => {:policy => {:prevented => true}})
+      expect { subject }.to raise_error(MiqAeException::StopInstantiation)
+    end
+  end
+end


### PR DESCRIPTION
All events are sent to automate for processing since [Event Switchboard PR](https://github.com/ManageIQ/manageiq/pull/4328).
Since then the policy checking for prevent action has changed from a sync process to an async process.

Depends on [#86](https://github.com/ManageIQ/manageiq-content/pull/86).

https://bugzilla.redhat.com/show_bug.cgi?id=1439331
 
@miq-bot assign @gmcculloug 
@miq-bot add_label bug, control, darga/yes, euwe/yes, automate, fine/yes