### PR TITLE
Metric#capture only goes back initial_capture_days days

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -48,11 +48,11 @@ module Metric::CiMixin::Capture
 
     cb = nil
     if interval_name == 'historical'
-      start_time = Metric::Capture.historical_start_time if start_time.nil?
-      end_time = Time.now.utc if end_time.nil?
+      start_time ||= Metric::Capture.historical_start_time
+      end_time   ||= Time.now.utc
     else
-      start_time = last_perf_capture_on unless start_time
-      end_time   = Time.now.utc unless end_time
+      start_time ||= [last_perf_capture_on, historical_start_time].max
+      end_time   ||= Time.now.utc
       cb = {:class_name => self.class.name, :instance_id => id, :method_name => :perf_capture_callback, :args => [[task_id]]} if task_id
     end
 


### PR DESCRIPTION
If metrics is turned off for an extended duration, the number of days to capture can be quite large.

This caps the number of days captured by the `initial_capture_days config` variable.

This change will create gaps, but the user can go in and fill in those gaps at a lower priority if necessary

links:
- https://bugzilla.redhat.com/show_bug.cgi?id=1436034