### PR TITLE
quiesce_time_allowance per worker is not needed

### DIFF
--- a/app/models/miq_server/worker_management/monitor/kill.rb
+++ b/app/models/miq_server/worker_management/monitor/kill.rb
@@ -1,19 +1,6 @@
 module MiqServer::WorkerManagement::Monitor::Kill
   extend ActiveSupport::Concern
 
-  def kill_timed_out_worker_quiesce
-    killed_workers = []
-    miq_workers.each do |w|
-      if quiesce_timed_out?(w.quiesce_time_allowance)
-        _log.warn("Timed out quiesce of #{w.format_full_log_msg} after #{w.quiesce_time_allowance} seconds")
-        w.kill
-        worker_delete(w.pid)
-        killed_workers << w
-      end
-    end
-    miq_workers.delete(*killed_workers) unless killed_workers.empty?
-  end
-
   def kill_all_workers
     return unless self.is_local?
 

--- a/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -24,7 +24,6 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
       return true
     end
 
-    kill_timed_out_worker_quiesce
     false
   end
 
@@ -58,9 +57,5 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
       return true
     end
     false
-  end
-
-  def quiesce_timed_out?(allowance)
-    Time.now.utc > (@quiesce_started_on + allowance)
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -378,11 +378,6 @@ class MiqWorker < ApplicationRecord
     destroy
   end
 
-  def quiesce_time_allowance
-    allowance = self.class.worker_settings[:quiesce_time_allowance]
-    @quiesce_time_allowance ||= allowance || current_timeout || 5.minutes
-  end
-
   def is_current?
     STATUSES_CURRENT.include?(status)
   end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -72,16 +72,6 @@ describe "MiqWorker Monitor" do
         end
       end
 
-      it "quiesce time allowance will use message timeout" do
-        allow(@worker).to receive(:current_timeout).and_return(2.minutes)
-        expect(@worker.quiesce_time_allowance).to eq(2.minutes)
-      end
-
-      it "quiesce time allowance will use default of 5 minutes if no message timeout" do
-        allow(@worker).to receive(:current_timeout).and_return(nil)
-        expect(@worker.quiesce_time_allowance).to eq(5.minutes)
-      end
-
       context "with 1 message" do
         before(:each) do
           @message = FactoryGirl.create(:miq_queue, :state => 'dequeue', :handler => @worker)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -246,7 +246,6 @@ describe MiqServer do
       it "quiesce_workers do mini-monitor_workers loop" do
         expect(@miq_server).to receive(:heartbeat)
         expect(@miq_server).to receive(:quiesce_workers_loop_timeout?).never
-        expect(@miq_server).to receive(:kill_timed_out_worker_quiesce).never
         allow_any_instance_of(MiqWorker).to receive(:is_stopped?).and_return(true, false)
         @miq_server.workers_quiesced?
       end
@@ -266,24 +265,6 @@ describe MiqServer do
         @miq_server.instance_variable_set(:@quiesce_loop_timeout, 10.minutes)
         expect_any_instance_of(MiqWorker).to receive(:kill).never
         expect(@miq_server.quiesce_workers_loop_timeout?).not_to be_truthy
-      end
-
-      it "will not kill workers if their quiesce timeout is not reached" do
-        @miq_server.instance_variable_set(:@quiesce_started_on, Time.now.utc)
-        allow_any_instance_of(MiqWorker).to receive(:quiesce_time_allowance).and_return(10.minutes)
-        expect_any_instance_of(MiqWorker).to receive(:kill).never
-        @miq_server.kill_timed_out_worker_quiesce
-      end
-
-      it "will kill workers if their quiesce timeout is reached" do
-        @miq_server.instance_variable_set(:@quiesce_started_on, Time.now.utc)
-        allow_any_instance_of(MiqWorker).to receive(:quiesce_time_allowance).and_return(10.minutes)
-        @miq_server.kill_timed_out_worker_quiesce
-
-        Timecop.travel 10.minutes do
-          expect_any_instance_of(MiqWorker).to receive(:kill).once
-          @miq_server.kill_timed_out_worker_quiesce
-        end
       end
 
       context "with an active messsage and a second server" do


### PR DESCRIPTION
We already check quiesce_loop_timeout and kill all workers if the loop
timeout is reached.  It doesn't matter what quiesce_time_allowance is
for a worker if the quiesce_loop_timeout is lower, since the loop
timeout will expire first and cause all workers to be killed.

It doesn't seem necessary to have two timeouts and doing it at a worker
level seems too complex.

The original commit and bugzids don't indicate this per worker class
timeout as a feature so it must have been added as something we might
use in the future.

Below is the original commit found by NickL :tada:

```
commit aa2f40fa4504bae0854e6ac194b89a43845e9934
Author: Joe Rafaniello <jrafanie@redhat.com>
Date:   Tue Mar 29 23:21:47 2011 +0000

    Add a synchronous stop of the server and call it from EvmApplication(used by rake evm:stop/restart and black console)
    Add quiesce logic to allow queue worker types to exit gracefully, other types are killed, and only continue shutdown of the server when they're all stopped or killed.
    If provided, use :quiesce_loop_timeout in worker_monitor section of configuration
    If provided, use :quiesce_time_allowance in each worker's settings
    bugzid:11862,11825,11760,11719
```
