### PR TITLE
ansible event catcher: fetch activity_stream by event id

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/event_catcher/stream.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream?order_by=timestamp&timestamp__gt=2016-01-01%2001:00:00
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream?order_by=-id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,11 +19,11 @@ http_interactions:
       message: MOVED PERMANENTLY
     headers:
       Date:
-      - Mon, 13 Mar 2017 16:14:55 GMT
+      - Wed, 05 Apr 2017 07:17:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Location:
-      - https://dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=timestamp&timestamp__gt=2016-01-01+01%3A00%3A00
+      - https://dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=-id
       Content-Length:
       - '0'
       Content-Type:
@@ -32,10 +32,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 15:14:45 GMT
+  recorded_at: Wed, 05 Apr 2017 07:17:59 GMT
 - request:
     method: get
-    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=timestamp&timestamp__gt=2016-01-01%2001:00:00
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream/?order_by=-id
     body:
       encoding: US-ASCII
       string: ''
@@ -52,7 +52,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 13 Mar 2017 16:14:56 GMT
+      - Wed, 05 Apr 2017 07:18:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
       Vary:
@@ -60,47 +60,145 @@ http_interactions:
       Allow:
       - GET, HEAD, OPTIONS
       X-Api-Time:
-      - 0.689s
-      Content-Length:
-      - '15180'
+      - 0.657s
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json
     body:
       encoding: UTF-8
-      string: '{"count":3275,"next":"/api/v1/activity_stream/?order_by=timestamp&page=2&timestamp__gt=2016-01-01+01%3A00%3A00","previous":null,"results":[{"id":1,"type":"activity_stream","url":"/api/v1/activity_stream/1/","related":{"user":["/api/v1/users/1/"]},"summary_fields":{"user":[{"username":"admin","first_name":"","last_name":"","id":1}]},"timestamp":"2016-08-02T17:56:37.212874Z","operation":"create","changes":{"username":"admin","first_name":"","last_name":"","is_active":true,"id":1,"is_superuser":true,"is_staff":true,"password":"hidden","email":"admin@example.com","date_joined":"2016-08-02
-        17:56:37.162225+00:00"},"object1":"user","object2":"","object_association":""},{"id":2,"type":"activity_stream","url":"/api/v1/activity_stream/2/","related":{"unified_job_template":"/api/v1/system_job_templates/1/","schedule":["/api/v1/schedules/1/"]},"summary_fields":{"schedule":[{"next_run":"2017-03-19T17:56:13Z","description":"Automatically
-        Generated Schedule","id":1,"name":"Cleanup Job Schedule"}],"system_job_template":{"id":1,"name":"Cleanup
-        Job Details"}},"timestamp":"2016-08-02T17:56:53.298836Z","operation":"update","changes":{"next_run":[null,"2016-08-07
-        17:56:13+00:00"],"dtstart":[null,"2016-08-07 17:56:13+00:00"],"modified":["2016-08-02
-        17:56:13.334787+00:00","2016-08-02 17:56:53.294137+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":3,"type":"activity_stream","url":"/api/v1/activity_stream/3/","related":{"unified_job_template":"/api/v1/system_job_templates/2/","schedule":["/api/v1/schedules/2/"]},"summary_fields":{"schedule":[{"next_run":"2017-03-14T17:56:13Z","description":"Automatically
-        Generated Schedule","id":2,"name":"Cleanup Activity Schedule"}],"system_job_template":{"id":2,"name":"Cleanup
-        Activity Stream"}},"timestamp":"2016-08-02T17:56:53.469192Z","operation":"update","changes":{"next_run":[null,"2016-08-09
-        17:56:13+00:00"],"dtstart":[null,"2016-08-02 17:56:13+00:00"],"modified":["2016-08-02
-        17:56:13.334787+00:00","2016-08-02 17:56:53.461383+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":4,"type":"activity_stream","url":"/api/v1/activity_stream/4/","related":{"unified_job_template":"/api/v1/system_job_templates/3/","schedule":["/api/v1/schedules/3/"]},"summary_fields":{"schedule":[{"next_run":"2017-04-01T17:56:13Z","description":"Automatically
-        Generated Schedule","id":3,"name":"Cleanup Fact Schedule"}],"system_job_template":{"id":3,"name":"Cleanup
-        Fact Details"}},"timestamp":"2016-08-02T17:56:53.534456Z","operation":"update","changes":{"next_run":[null,"2016-09-01
-        17:56:13+00:00"],"dtstart":[null,"2016-09-01 17:56:13+00:00"],"modified":["2016-08-02
-        17:56:13.334787+00:00","2016-08-02 17:56:53.530012+00:00"]},"object1":"schedule","object2":"","object_association":""},{"id":5,"type":"activity_stream","url":"/api/v1/activity_stream/5/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.864976Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"organization","object2":"role","object1_pk":1,"action":"associate"},"object1":"organization","object2":"role","object_association":"parents"},{"id":6,"type":"activity_stream","url":"/api/v1/activity_stream/6/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.886688Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"organization","object2":"role","object1_pk":1,"action":"associate"},"object1":"organization","object2":"role","object_association":"parents"},{"id":7,"type":"activity_stream","url":"/api/v1/activity_stream/7/","related":{"organization":["/api/v1/organizations/1/"]},"summary_fields":{"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.908036Z","operation":"create","changes":{"description":"","id":1,"name":"Default"},"object1":"organization","object2":"","object_association":""},{"id":8,"type":"activity_stream","url":"/api/v1/activity_stream/8/","related":{"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}]},"timestamp":"2016-08-02T17:57:02.933880Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"project","object2":"role","object1_pk":4,"action":"associate"},"object1":"project","object2":"role","object_association":"parents"},{"id":9,"type":"activity_stream","url":"/api/v1/activity_stream/9/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:02.942946Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":5,"object1":"project","object2":"organization","object1_pk":4,"action":"associate"},"object1":"project","object2":"organization","object_association":"parents"},{"id":10,"type":"activity_stream","url":"/api/v1/activity_stream/10/","related":{},"summary_fields":{},"timestamp":"2016-08-02T17:57:02.993553Z","operation":"create","changes":{"credential":null,"scm_branch":"","name":"Demo
-        Project","scm_update_cache_timeout":0,"scm_clean":false,"scm_url":"https://github.com/ansible/ansible-tower-samples","scm_delete_on_update":false,"local_path":"","scm_type":"git","scm_update_on_launch":true,"organization":"Default","id":4,"description":""},"object1":"project","object2":"","object_association":""},{"id":11,"type":"activity_stream","url":"/api/v1/activity_stream/11/","related":{"project":["/api/v1/projects/4/"]},"summary_fields":{"project":[{"status":"successful","description":"A
-        great demo","id":4,"name":"Demo Project"}]},"timestamp":"2016-08-02T17:57:03.007623Z","operation":"update","changes":{"local_path":["","_4__demo_project"]},"object1":"project","object2":"","object_association":""},{"id":12,"type":"activity_stream","url":"/api/v1/activity_stream/12/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/1/"]},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}]},"timestamp":"2016-08-02T17:57:03.037615Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"credential","object2":"role","object1_pk":1,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":13,"type":"activity_stream","url":"/api/v1/activity_stream/13/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}]},"timestamp":"2016-08-02T17:57:03.057364Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":12,"object1":"credential","object2":"credential","object1_pk":1,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":14,"type":"activity_stream","url":"/api/v1/activity_stream/14/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}]},"timestamp":"2016-08-02T17:57:03.066061Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":14,"object1":"credential","object2":"credential","object1_pk":1,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":15,"type":"activity_stream","url":"/api/v1/activity_stream/15/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/7/"]},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}]},"timestamp":"2016-08-02T17:57:03.073107Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"credential","object2":"role","object1_pk":1,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":16,"type":"activity_stream","url":"/api/v1/activity_stream/16/","related":{"credential":["/api/v1/credentials/1/"]},"summary_fields":{"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}]},"timestamp":"2016-08-02T17:57:03.103350Z","operation":"create","changes":{"authorize":false,"domain":"","vault_password":"hidden","become_username":"","id":1,"become_method":"","secret":"hidden","ssh_key_unlock":"hidden","authorize_password":"hidden","username":"admin","description":"","host":"","become_password":"hidden","password":"hidden","tenant":"","subscription":"","kind":"ssh","name":"Demo
-        Credential","security_token":"hidden","project":"","client":"","ssh_key_data":"hidden","organization":null},"object1":"credential","object2":"","object_association":""},{"id":17,"type":"activity_stream","url":"/api/v1/activity_stream/17/","related":{"credential":["/api/v1/credentials/1/"],"role":["/api/v1/roles/12/"],"user":["/api/v1/users/1/"]},"summary_fields":{"role":[{"id":12,"role_field":"admin_role"}],"credential":[{"cloud":false,"description":"","id":1,"kind":"ssh","name":"Demo
-        Credential"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}]},"timestamp":"2016-08-02T17:57:03.126094Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"credential","object2":"user","object1_pk":1,"action":"associate"},"object1":"credential","object2":"user","object_association":"role"},{"id":18,"type":"activity_stream","url":"/api/v1/activity_stream/18/","related":{"inventory":["/api/v1/inventories/1/"]},"summary_fields":{"inventory":[{"has_active_failures":false,"has_inventory_sources":false,"description":"","inventory_sources_with_failures":0,"groups_with_active_failures":0,"hosts_with_active_failures":0,"total_hosts":2,"total_inventory_sources":0,"total_groups":0,"id":1,"name":"Demo
-        Inventory"}]},"timestamp":"2016-08-02T17:57:03.201638Z","operation":"create","changes":{"organization":"Default","variables":"","description":"","id":1,"name":"Demo
-        Inventory"},"object1":"inventory","object2":"","object_association":""},{"id":19,"type":"activity_stream","url":"/api/v1/activity_stream/19/","related":{"host":["/api/v1/hosts/1/"]},"summary_fields":{"host":[{"description":"","has_inventory_sources":false,"id":1,"has_active_failures":false,"name":"localhost"}]},"timestamp":"2016-08-02T17:57:03.239272Z","operation":"create","changes":{"name":"localhost","variables":"ansible_connection:
-        local","enabled":true,"instance_id":"","inventory":"Demo Inventory-1","id":1,"description":""},"object1":"host","object2":"","object_association":""},{"id":20,"type":"activity_stream","url":"/api/v1/activity_stream/20/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/5/"]},"summary_fields":{"role":[{"id":5,"role_field":"admin_role"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:03.290739Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":5,"object1":"job_template","object2":"organization","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":21,"type":"activity_stream","url":"/api/v1/activity_stream/21/","related":{"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}]},"timestamp":"2016-08-02T17:57:03.347125Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":20,"object1":"job_template","object2":"job_template","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":22,"type":"activity_stream","url":"/api/v1/activity_stream/22/","related":{"organization":["/api/v1/organizations/1/"],"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}],"organization":[{"description":"","id":1,"name":"Default"}]},"timestamp":"2016-08-02T17:57:03.362262Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":6,"object1":"job_template","object2":"organization","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":23,"type":"activity_stream","url":"/api/v1/activity_stream/23/","related":{"role":["/api/v1/roles/6/"]},"summary_fields":{"role":[{"id":6,"role_field":"auditor_role"}]},"timestamp":"2016-08-02T17:57:03.380020Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":22,"object1":"job_template","object2":"job_template","object1_pk":5,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":24,"type":"activity_stream","url":"/api/v1/activity_stream/24/","related":{"job_template":["/api/v1/job_templates/5/"]},"summary_fields":{"job_template":[{"description":"","id":5,"name":"Demo
-        Job Template"}]},"timestamp":"2016-08-02T17:57:03.424469Z","operation":"create","changes":{"network_credential":null,"ask_tags_on_launch":false,"job_type":"run","skip_tags":"","playbook":"hello_world.yml","id":5,"survey_enabled":false,"force_handlers":false,"job_tags":"","ask_inventory_on_launch":false,"inventory":"Demo
-        Inventory-1","forks":0,"cloud_credential":null,"become_enabled":false,"credential":"Demo
-        Credential-1","description":"","ask_variables_on_launch":false,"ask_job_type_on_launch":false,"start_at_task":"","ask_limit_on_launch":false,"host_config_key":"","name":"Demo
-        Job Template","ask_credential_on_launch":false,"extra_vars":"","verbosity":0,"allow_simultaneous":false,"project":"Demo
-        Project-4","limit":""},"object1":"job_template","object2":"","object_association":""},{"id":25,"type":"activity_stream","url":"/api/v1/activity_stream/25/","related":{"unified_job_template":"/api/v1/system_job_templates/3/","schedule":["/api/v1/schedules/3/"]},"summary_fields":{"schedule":[{"next_run":"2017-04-01T17:56:13Z","description":"Automatically
-        Generated Schedule","id":3,"name":"Cleanup Fact Schedule"}],"system_job_template":{"id":3,"name":"Cleanup
-        Fact Details"}},"timestamp":"2016-08-02T17:57:12.865342Z","operation":"update","changes":{"modified":["2016-08-02
-        17:56:53.530012+00:00","2016-08-02 17:57:12.860263+00:00"]},"object1":"schedule","object2":"","object_association":""}]}'
+      string: '{"count":4853,"next":"/api/v1/activity_stream/?order_by=-id&page=2","previous":null,"results":[{"id":4853,"type":"activity_stream","url":"/api/v1/activity_stream/4853/","related":{"role":["/api/v1/roles/1873/"],"job_template":["/api/v1/job_templates/470/"],"actor":"/api/v1/users/1/","user":["/api/v1/users/1/"]},"summary_fields":{"job_template":[{"description":"is
+        here too","id":470,"name":"miq_Karel_provision"}],"role":[{"id":1873,"role_field":"admin_role"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.362958Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"job_template","object2":"user","object1_pk":470,"action":"associate"},"object1":"job_template","object2":"user","object_association":"role"},{"id":4852,"type":"activity_stream","url":"/api/v1/activity_stream/4852/","related":{"actor":"/api/v1/users/1/"},"summary_fields":{"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.343417Z","operation":"create","changes":{"network_credential":null,"ask_tags_on_launch":false,"job_type":"run","skip_tags":"","playbook":"product/alerts/rss/microsoft_vms.yml","id":470,"survey_enabled":false,"force_handlers":false,"job_tags":"","ask_inventory_on_launch":true,"inventory":null,"forks":0,"cloud_credential":"jwong-aws-test-10","become_enabled":false,"credential":"ManageIQ
+        Default Credential-27","description":"is here too","ask_variables_on_launch":true,"ask_job_type_on_launch":false,"start_at_task":"","ask_limit_on_launch":true,"host_config_key":"","name":"miq_Karel_provision","ask_credential_on_launch":true,"extra_vars":"{}","verbosity":0,"allow_simultaneous":false,"project":"jwong-org2-36","limit":""},"object1":"job_template","object2":"","object_association":""},{"id":4851,"type":"activity_stream","url":"/api/v1/activity_stream/4851/","related":{"organization":["/api/v1/organizations/2/"],"role":["/api/v1/roles/77/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":77,"role_field":"auditor_role"}],"organization":[{"description":"For
+        tests","id":2,"name":"Test Org"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.319613Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":77,"object1":"job_template","object2":"organization","object1_pk":470,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":4850,"type":"activity_stream","url":"/api/v1/activity_stream/4850/","related":{"role":["/api/v1/roles/77/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":77,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.310892Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":1875,"object1":"job_template","object2":"job_template","object1_pk":470,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4849,"type":"activity_stream","url":"/api/v1/activity_stream/4849/","related":{"role":["/api/v1/roles/77/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":77,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.300328Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1873,"object1":"job_template","object2":"job_template","object1_pk":470,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4848,"type":"activity_stream","url":"/api/v1/activity_stream/4848/","related":{"organization":["/api/v1/organizations/2/"],"role":["/api/v1/roles/76/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":76,"role_field":"admin_role"}],"organization":[{"description":"For
+        tests","id":2,"name":"Test Org"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:10:22.279090Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":76,"object1":"job_template","object2":"organization","object1_pk":470,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":4847,"type":"activity_stream","url":"/api/v1/activity_stream/4847/","related":{"project":["/api/v1/projects/469/"],"actor":"/api/v1/users/1/"},"summary_fields":{"project":[{"status":"successful","description":"","id":469,"name":"Carlos"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.403922Z","operation":"update","changes":{"local_path":["","_469__carlos"]},"object1":"project","object2":"","object_association":""},{"id":4846,"type":"activity_stream","url":"/api/v1/activity_stream/4846/","related":{"actor":"/api/v1/users/1/"},"summary_fields":{"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.393618Z","operation":"create","changes":{"credential":null,"scm_branch":"","name":"Carlos","scm_update_cache_timeout":0,"scm_clean":false,"scm_url":"https://github.com/ManageIQ/manageiq","scm_delete_on_update":false,"local_path":"","scm_type":"git","scm_update_on_launch":false,"organization":null,"id":469,"description":""},"object1":"project","object2":"","object_association":""},{"id":4845,"type":"activity_stream","url":"/api/v1/activity_stream/4845/","related":{"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.361406Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1871,"object1":"project","object2":"project","object1_pk":469,"action":"associate"},"object1":"project","object2":"project","object_association":"parents"},{"id":4844,"type":"activity_stream","url":"/api/v1/activity_stream/4844/","related":{"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.350835Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"project","object2":"role","object1_pk":469,"action":"associate"},"object1":"project","object2":"role","object_association":"parents"},{"id":4843,"type":"activity_stream","url":"/api/v1/activity_stream/4843/","related":{"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.341531Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1872,"object1":"project","object2":"project","object1_pk":469,"action":"associate"},"object1":"project","object2":"project","object_association":"parents"},{"id":4842,"type":"activity_stream","url":"/api/v1/activity_stream/4842/","related":{"role":["/api/v1/roles/1/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:55:42.322199Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"project","object2":"role","object1_pk":469,"action":"associate"},"object1":"project","object2":"role","object_association":"parents"},{"id":4841,"type":"activity_stream","url":"/api/v1/activity_stream/4841/","related":{"project":["/api/v1/projects/35/"],"actor":"/api/v1/users/1/"},"summary_fields":{"project":[{"status":"successful","description":"DB
+        Playbooks","id":35,"name":"DB"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T06:54:44.386398Z","operation":"update","changes":{"name":["DB
+        karel","DB"]},"object1":"project","object2":"","object_association":""},{"id":4840,"type":"activity_stream","url":"/api/v1/activity_stream/4840/","related":{"role":["/api/v1/roles/1866/"],"user":["/api/v1/users/1/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1866,"role_field":"admin_role"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.584942Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"job_template","object2":"user","object1_pk":468,"action":"associate"},"object1":"job_template","object2":"user","object_association":"role"},{"id":4839,"type":"activity_stream","url":"/api/v1/activity_stream/4839/","related":{"actor":"/api/v1/users/1/"},"summary_fields":{"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.565068Z","operation":"create","changes":{"network_credential":null,"ask_tags_on_launch":false,"job_type":"run","skip_tags":"","playbook":"copy_file_example.yml","id":468,"survey_enabled":false,"force_handlers":false,"job_tags":"","ask_inventory_on_launch":true,"inventory":null,"forks":0,"cloud_credential":null,"become_enabled":false,"credential":"ManageIQ
+        Default Credential-27","description":"DB APRIL 04 1747","ask_variables_on_launch":true,"ask_job_type_on_launch":false,"start_at_task":"","ask_limit_on_launch":true,"host_config_key":"","name":"miq_db_april_04_1747_retirement","ask_credential_on_launch":true,"extra_vars":"{}","verbosity":0,"allow_simultaneous":false,"project":"DB
+        Playbooks 2-457","limit":""},"object1":"job_template","object2":"","object_association":""},{"id":4838,"type":"activity_stream","url":"/api/v1/activity_stream/4838/","related":{"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.539030Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":1868,"object1":"job_template","object2":"job_template","object1_pk":468,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4837,"type":"activity_stream","url":"/api/v1/activity_stream/4837/","related":{"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.526164Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":1866,"object1":"job_template","object2":"job_template","object1_pk":468,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4836,"type":"activity_stream","url":"/api/v1/activity_stream/4836/","related":{"organization":["/api/v1/organizations/4/"],"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"organization":[{"description":"ManageIQ
+        Default Organization","id":4,"name":"ManageIQ"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.512089Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1432,"object1":"job_template","object2":"organization","object1_pk":468,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":4835,"type":"activity_stream","url":"/api/v1/activity_stream/4835/","related":{"organization":["/api/v1/organizations/4/"],"role":["/api/v1/roles/1431/"],"job_template":["/api/v1/job_templates/468/"],"actor":"/api/v1/users/1/"},"summary_fields":{"job_template":[{"description":"DB
+        APRIL 04 1747","id":468,"name":"miq_db_april_04_1747_retirement"}],"role":[{"id":1431,"role_field":"admin_role"}],"organization":[{"description":"ManageIQ
+        Default Organization","id":4,"name":"ManageIQ"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:53:01.489467Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1431,"object1":"job_template","object2":"organization","object1_pk":468,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":4834,"type":"activity_stream","url":"/api/v1/activity_stream/4834/","related":{"role":["/api/v1/roles/1863/"],"job_template":["/api/v1/job_templates/467/"],"actor":"/api/v1/users/1/","user":["/api/v1/users/1/"]},"summary_fields":{"job_template":[{"description":"DB
+        APRIL 04 1747","id":467,"name":"miq_db_april_04_1747_provision"}],"role":[{"id":1863,"role_field":"admin_role"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.262050Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"job_template","object2":"user","object1_pk":467,"action":"associate"},"object1":"job_template","object2":"user","object_association":"role"},{"id":4833,"type":"activity_stream","url":"/api/v1/activity_stream/4833/","related":{"actor":"/api/v1/users/1/"},"summary_fields":{"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.243127Z","operation":"create","changes":{"network_credential":null,"ask_tags_on_launch":false,"job_type":"run","skip_tags":"","playbook":"copy_file_example.yml","id":467,"survey_enabled":false,"force_handlers":false,"job_tags":"","ask_inventory_on_launch":true,"inventory":null,"forks":0,"cloud_credential":null,"become_enabled":false,"credential":"ManageIQ
+        Default Credential-27","description":"DB APRIL 04 1747","ask_variables_on_launch":true,"ask_job_type_on_launch":false,"start_at_task":"","ask_limit_on_launch":true,"host_config_key":"","name":"miq_db_april_04_1747_provision","ask_credential_on_launch":true,"extra_vars":"{}","verbosity":0,"allow_simultaneous":false,"project":"DB
+        Playbooks 2-457","limit":""},"object1":"job_template","object2":"","object_association":""},{"id":4832,"type":"activity_stream","url":"/api/v1/activity_stream/4832/","related":{"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.218584Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":1863,"object1":"job_template","object2":"job_template","object1_pk":467,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4831,"type":"activity_stream","url":"/api/v1/activity_stream/4831/","related":{"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.207443Z","operation":"associate","changes":{"relationship":"awx.main.models.organization.Organization.auditor_role","object2_pk":1865,"object1":"job_template","object2":"job_template","object1_pk":467,"action":"associate"},"object1":"job_template","object2":"job_template","object_association":"role"},{"id":4830,"type":"activity_stream","url":"/api/v1/activity_stream/4830/","related":{"organization":["/api/v1/organizations/4/"],"role":["/api/v1/roles/1432/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1432,"role_field":"auditor_role"}],"organization":[{"description":"ManageIQ
+        Default Organization","id":4,"name":"ManageIQ"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.195208Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1432,"object1":"job_template","object2":"organization","object1_pk":467,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"},{"id":4829,"type":"activity_stream","url":"/api/v1/activity_stream/4829/","related":{"organization":["/api/v1/organizations/4/"],"role":["/api/v1/roles/1431/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1431,"role_field":"admin_role"}],"organization":[{"description":"ManageIQ
+        Default Organization","id":4,"name":"ManageIQ"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-04T21:51:01.120759Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1431,"object1":"job_template","object2":"organization","object1_pk":467,"action":"associate"},"object1":"job_template","object2":"organization","object_association":"role"}]}'
     http_version: 
-  recorded_at: Mon, 13 Mar 2017 15:14:46 GMT
+  recorded_at: Wed, 05 Apr 2017 07:18:01 GMT
+- request:
+    method: post
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/credentials/
+    body:
+      encoding: UTF-8
+      string: '{"name":"test_stream","user":1}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 05 Apr 2017 07:18:01 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.157s
+      Location:
+      - https://dev-ansible-tower3.example.com/api/v1/credentials/62/
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"id":62,"type":"credential","url":"/api/v1/credentials/62/","related":{"created_by":"/api/v1/users/1/","modified_by":"/api/v1/users/1/","owner_teams":"/api/v1/credentials/62/owner_teams/","owner_users":"/api/v1/credentials/62/owner_users/","activity_stream":"/api/v1/credentials/62/activity_stream/","access_list":"/api/v1/credentials/62/access_list/","object_roles":"/api/v1/credentials/62/object_roles/","user":"/api/v1/users/1/"},"summary_fields":{"host":{},"project":{},"created_by":{"id":1,"username":"admin","first_name":"","last_name":""},"modified_by":{"id":1,"username":"admin","first_name":"","last_name":""},"object_roles":{"admin_role":{"description":"Can
+        manage all aspects of the credential","id":1876,"name":"Admin"},"use_role":{"description":"Can
+        use the credential in a job template","id":1878,"name":"Use"},"read_role":{"description":"May
+        view settings for the credential","id":1877,"name":"Read"}},"owners":[{"url":"/api/v1/users/1/","description":"
+        ","type":"user","id":1,"name":"admin"}]},"created":"2017-04-05T07:18:01.678Z","modified":"2017-04-05T07:18:01.767Z","name":"test_stream","description":"","kind":"ssh","cloud":false,"host":"","username":"","password":"","security_token":"","project":"","domain":"","ssh_key_data":"","ssh_key_unlock":"","become_method":"","become_username":"","become_password":"","vault_password":"","subscription":"","tenant":"","secret":"","client":"","authorize":false,"authorize_password":""}'
+    http_version: 
+  recorded_at: Wed, 05 Apr 2017 07:18:01 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream?id__gt=4853&order_by=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 301
+      message: MOVED PERMANENTLY
+    headers:
+      Date:
+      - Wed, 05 Apr 2017 07:18:02 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Location:
+      - https://dev-ansible-tower3.example.com/api/v1/activity_stream/?id__gt=4853&order_by=id
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 05 Apr 2017 07:18:02 GMT
+- request:
+    method: get
+    uri: https://testuser:secret@dev-ansible-tower3.example.com/api/v1/activity_stream/?id__gt=4853&order_by=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Apr 2017 07:18:03 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Api-Time:
+      - 0.215s
+      Content-Length:
+      - '4568'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"count":6,"next":null,"previous":null,"results":[{"id":4854,"type":"activity_stream","url":"/api/v1/activity_stream/4854/","related":{"credential":["/api/v1/credentials/62/"],"role":["/api/v1/roles/1/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1,"role_field":"system_administrator"}],"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.690828Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1,"object1":"credential","object2":"role","object1_pk":62,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":4855,"type":"activity_stream","url":"/api/v1/activity_stream/4855/","related":{"credential":["/api/v1/credentials/62/"],"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.711510Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1876,"object1":"credential","object2":"credential","object1_pk":62,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":4856,"type":"activity_stream","url":"/api/v1/activity_stream/4856/","related":{"credential":["/api/v1/credentials/62/"],"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.725378Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":1878,"object1":"credential","object2":"credential","object1_pk":62,"action":"associate"},"object1":"credential","object2":"credential","object_association":"parents"},{"id":4857,"type":"activity_stream","url":"/api/v1/activity_stream/4857/","related":{"credential":["/api/v1/credentials/62/"],"role":["/api/v1/roles/7/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":7,"role_field":"system_auditor"}],"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.736474Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_parents","object2_pk":7,"object1":"credential","object2":"role","object1_pk":62,"action":"associate"},"object1":"credential","object2":"role","object_association":"parents"},{"id":4858,"type":"activity_stream","url":"/api/v1/activity_stream/4858/","related":{"credential":["/api/v1/credentials/62/"],"actor":"/api/v1/users/1/"},"summary_fields":{"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.762271Z","operation":"create","changes":{"authorize":false,"domain":"","vault_password":"hidden","become_username":"","id":62,"become_method":"","secret":"hidden","ssh_key_unlock":"hidden","authorize_password":"hidden","username":"","description":"","host":"","become_password":"hidden","password":"hidden","tenant":"","subscription":"","kind":"ssh","name":"test_stream","security_token":"hidden","project":"","client":"","ssh_key_data":"hidden","organization":null},"object1":"credential","object2":"","object_association":""},{"id":4859,"type":"activity_stream","url":"/api/v1/activity_stream/4859/","related":{"credential":["/api/v1/credentials/62/"],"role":["/api/v1/roles/1876/"],"user":["/api/v1/users/1/"],"actor":"/api/v1/users/1/"},"summary_fields":{"role":[{"id":1876,"role_field":"admin_role"}],"credential":[{"cloud":false,"description":"","id":62,"kind":"ssh","name":"test_stream"}],"user":[{"username":"admin","first_name":"","last_name":"","id":1}],"actor":{"username":"admin","first_name":"","last_name":"","id":1}},"timestamp":"2017-04-05T07:18:01.780407Z","operation":"associate","changes":{"relationship":"awx.main.models.rbac.Role_members","object2_pk":1,"object1":"credential","object2":"user","object1_pk":62,"action":"associate"},"object1":"credential","object2":"user","object_association":"role"}]}'
+    http_version: 
+  recorded_at: Wed, 05 Apr 2017 07:18:03 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
fetching and ordering by timestamp involved setting timezones
and a specific date format (:iso8601) which was error prone.
E.g. sometimes ansible tower did not accept the format

It also returned events multiple times, because the filter
timestamp greater than included events with the same second.

@jameswnl please review
@miq-bot add_labels providers/ansible_tower, bug
@miq-bot assign @blomquisg 

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1438723