### PR TITLE
blacklisted event names in settings.yml

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -248,10 +248,6 @@ class ExtManagementSystem < ApplicationRecord
     self::ProvisionWorkflow
   end
 
-  def self.default_blacklisted_event_names
-    []
-  end
-
   # UI methods for determining availability of fields
   def supports_port?
     false

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -23,5 +23,9 @@ module ManageIQ::Providers
     def http_proxy_uri
       VMDB::Util.http_proxy_uri(emstype.try(:to_sym)) || VMDB::Util.http_proxy_uri
     end
+
+    def self.default_blacklisted_event_names
+      Array(::Settings.ems["ems_#{provider_name.underscore}"].try(:blacklisted_event_names))
+    end
   end
 end

--- a/lib/generators/provider/templates/config/settings.yml
+++ b/lib/generators/provider/templates/config/settings.yml
@@ -1,6 +1,7 @@
 ---
 :ems:
   :ems_<%= provider_name %>:
+    :blacklisted_event_names: []
     :event_handling:
       :event_groups:
 :http_proxy:

--- a/spec/models/manageiq/providers/base_manager_spec.rb
+++ b/spec/models/manageiq/providers/base_manager_spec.rb
@@ -1,0 +1,19 @@
+describe ManageIQ::Providers::BaseManager do
+  context ".default_blacklisted_event_names" do
+    it 'returns an empty array for the base class' do
+      expect(described_class.default_blacklisted_event_names).to eq([])
+    end
+
+    it 'returns the provider event if configured' do
+      stub_settings_merge(
+        :ems => {
+          :ems_some_provider => {
+            :blacklisted_event_names => %w(ev1 ev2)
+          }
+        }
+      )
+      allow(described_class).to receive(:provider_name).and_return('SomeProvider')
+      expect(described_class.default_blacklisted_event_names).to eq(%w(ev1 ev2))
+    end
+  end
+end


### PR DESCRIPTION
### default blacklisted event names are now sourced from `settings.yml`

this allows providers just provide a setting in
```
 :ems:
   :ems_<%= provider_name %>:
     :blacklisted_event_names: []
```

I moved the method to `BaseManager`, because I think it belongs there  and `BaseManager` has the provider inflection methods (to get the provider name via `provider_name`)

In a follow up PR, we can move the method in the subclasses and just add the events to settings.yml in the provider repo.

ps. I just realised there is `ExtManagementSystem.short_token`, which arguably could also be used. I'll replace this method later with the inflection methods.

cc @agrare @bronaghs @blomquisg 

@Fryguy please review