### PR TITLE
Move entrypoint authorization code

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -30,30 +30,6 @@ module Api
         log_api_auth
       end
 
-      def auth_identity
-        user  = User.current_user
-        group = user.current_group
-        {
-          :userid     => user.userid,
-          :name       => user.name,
-          :user_href  => "#{@req.api_prefix}/users/#{user.id}",
-          :group      => group.description,
-          :group_href => "#{@req.api_prefix}/groups/#{group.id}",
-          :role       => group.miq_user_role_name,
-          :role_href  => "#{@req.api_prefix}/roles/#{group.miq_user_role.id}",
-          :tenant     => group.tenant.name,
-          :groups     => user.miq_groups.pluck(:description),
-        }
-      end
-
-      def auth_authorization
-        user  = User.current_user
-        group = user.current_group
-        {
-          :product_features => product_features(group.miq_user_role)
-        }
-      end
-
       def user_settings
         {
           :locale                     => I18n.locale.to_s.sub('-', '_'),
@@ -83,41 +59,6 @@ module Api
       end
 
       private
-
-      def product_features(role)
-        pf_result = {}
-        role.feature_identifiers.each { |ident| add_product_feature(pf_result, ident) }
-        pf_result
-      end
-
-      def add_product_feature(pf_result, ident)
-        details  = MiqProductFeature.features[ident.to_s][:details]
-        children = MiqProductFeature.feature_children(ident)
-        add_product_feature_details(pf_result, ident, details, children)
-        children.each { |child_ident| add_product_feature(pf_result, child_ident) }
-      end
-
-      def add_product_feature_details(pf_result, ident, details, children)
-        ident_str = ident.to_s
-        res = {
-          "name"        => details[:name],
-          "description" => details[:description]
-        }
-        collection, method, action = collection_config.what_refers_to_feature(ident_str)
-        collections = collection_config.names_for_feature(ident_str)
-        res["href"] = "#{@req.api_prefix}/#{collections.first}" if collections.one?
-        res["action"] = api_action_details(collection, method, action) if collection.present?
-        res["children"] = children if children.present?
-        pf_result[ident_str] = res
-      end
-
-      def api_action_details(collection, method, action)
-        {
-          "name"   => action[:name],
-          "method" => method,
-          "href"   => "#{@req.api_prefix}/#{collection}"
-        }
-      end
 
       def api_token_mgr
         Environment.user_token_service.token_mgr('api')


### PR DESCRIPTION
It's only used by the entrypoint controller, so belongs there. The
`Authentication` module is mixed into every API controller, so this
narrows the surface area of those a little bit.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 