### PR TITLE
Fix task name for task that create Tower project

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -13,7 +13,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
     def create_in_provider_queue(manager_id, params)
       manager = ExtManagementSystem.find(manager_id)
-      action = "Creating #{name} with name=#{params[:name]}"
+      action = "Creating #{name} with name=#{params[:name] || params['name']}"
       queue(manager.my_zone, nil, "create_in_provider", [manager_id, params], action)
     end
 
@@ -56,7 +56,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   end
 
   def update_in_provider_queue(params)
-    action = "Updating #{self.class.name} with manager_ref=#{manager_ref}"
+    action = "Updating #{self.class.name} with Tower internal reference=#{manager_ref}"
     self.class.send('queue', manager.my_zone, id, "update_in_provider", [params], action)
   end
 
@@ -66,7 +66,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   end
 
   def delete_in_provider_queue
-    action = "Deleting #{self.class.name} with manager_ref=#{manager_ref}"
+    action = "Deleting #{self.class.name} with Tower internal reference=#{manager_ref}"
     self.class.send('queue', manager.my_zone, id, "delete_in_provider", [], action)
   end
 end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -79,7 +79,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#delete_in_provider_queue" do
       task_id = project.delete_in_provider_queue
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with manager_ref=#{project.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with Tower internal reference=#{project.manager_ref}")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => project.id,
         :args        => [],
@@ -105,7 +105,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider_queue" do
       task_id = project.update_in_provider_queue({})
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with manager_ref=#{project.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with Tower internal reference=#{project.manager_ref}")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => project.id,
         :args        => [{:task_id => task_id}],

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -84,7 +84,7 @@ shared_examples_for "ansible credential" do
 
     it "#delete_in_provider_queue" do
       task_id = ansible_cred.delete_in_provider_queue
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with manager_ref=#{ansible_cred.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with Tower internal reference=#{ansible_cred.manager_ref}")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => ansible_cred.id,
         :args        => [],
@@ -116,7 +116,7 @@ shared_examples_for "ansible credential" do
 
     it "#update_in_provider_queue" do
       task_id = ansible_cred.update_in_provider_queue({})
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with manager_ref=#{ansible_cred.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with Tower internal reference=#{ansible_cred.manager_ref}")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => ansible_cred.id,
         :args        => [{:task_id => task_id}],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439203
Fix that plus using `Tower internal reference` in stead of the ambiguous `manager_ref`

@miq-bot add_labels bug, providers/ansible_tower