### PR TITLE
Return provider_class on provider requests

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -83,7 +83,8 @@ module Api
       def normalize_url(value)
         svalue = value.to_s
         pref   = @req.api_prefix
-        svalue.match(pref) ? svalue : "#{pref}/#{svalue}"
+        suffix = @req.api_suffix
+        svalue.match(pref) ? svalue : "#{pref}/#{svalue}#{suffix}"
       end
 
       #

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -31,6 +31,10 @@ module Api
           @api_prefix ||= "#{base}#{prefix}"
         end
 
+        def api_suffix
+          @api_suffix ||= "?provider_class=#{@params['provider_class']}" if @params['provider_class']
+        end
+
         def attributes
           @attributes ||= @params['attributes'].to_s.split(',')
         end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -318,6 +318,37 @@ describe "Providers API" do
         expect(provider.send(item)).to eq(sample_foreman[item])
       end
     end
+
+    it 'returns the correct href reference on the collection' do
+      provider = FactoryGirl.create(:provider_foreman)
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get providers_url, :provider_class => 'provider'
+
+      expected = {
+        'resources' => [{'href' => a_string_including("/api/providers/#{provider.id}?provider_class=provider")}],
+        'actions'   => [a_hash_including('href' => a_string_including('?provider_class=provider'))]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns the correct href reference on a resource' do
+      provider = FactoryGirl.create(:provider_foreman)
+      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get),
+                          action_identifier(:providers, :edit)
+
+      run_get providers_url(provider.id), :provider_class => :provider
+
+      expected = {
+        'href'    => a_string_including("/api/providers/#{provider.id}?provider_class=provider"),
+        'actions' => [
+          a_hash_including('href' => a_string_including("/api/providers/#{provider.id}?provider_class=provider"))
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe "Providers create" do


### PR DESCRIPTION
Before:
```
GET /api/providers/:id?provider_class=provider
{
   "href": "/api/providers/:id".
   "actions": [
      { "href": "/api/providers/:id" }
  ]
}
```

After:
```
GET /api/providers/:id?provider_class=provider
{
   "href": "/api/providers/:id?provider_class=provider",
    "actions": [
      { "href": "/api/providers/:id?provider_class=provider" }
  ]
}
```

This PR resolves the issue where the provider_class is not being appended to the hrefs returned on both the object or actions. This could cause them to perform an action on a different object or get a different object in return.

@miq-bot add_label bug, api
@miq-bot assign @abellotti 

Links
----------------
* [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1386258)
