### PR TITLE
Do not destroy task if it is active

### DIFF
--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -278,11 +278,10 @@ describe MiqTask do
   end
 
   context "before_destroy callback" do
-    it "destroys miq_task record if there is no job associated with it" do
-      expect(MiqTask.count).to eq 0
-      FactoryGirl.create(:miq_task_plain)
-      expect(MiqTask.count).to eq 1
-      MiqTask.first.destroy
+    it "destroys miq_task record if there is no job associated with it and Task is not active" do
+      miq_task = FactoryGirl.create(:miq_task_plain)
+      miq_task.update_attributes!(:state => MiqTask::STATE_QUEUED)
+      miq_task.destroy
       expect(MiqTask.count).to eq 0
     end
 
@@ -294,6 +293,15 @@ describe MiqTask do
       MiqTask.first.destroy
       expect(MiqTask.count).to eq 1
       expect(Job.count).to eq 1
+    end
+
+    it "doesn't destroy miq_task if task is active" do
+      expect(MiqTask.count).to eq 0
+      miq_task = FactoryGirl.create(:miq_task_plain)
+      expect(MiqTask.count).to eq 1
+      miq_task.update_attributes!(:state => MiqTask::STATE_ACTIVE)
+      MiqTask.first.destroy
+      expect(MiqTask.count).to eq 1
     end
 
     it "destroys miq_task record and job record if job associated with it 'finished'" do

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -360,6 +360,7 @@ describe Storage do
           expect(miq_task.context_data[:pending].length).to eq(0)
           expect(miq_task.pct_complete).to eq(100)
 
+          miq_task.update_attributes!(:state => "Finished")
           miq_task.destroy
           expect(Storage).to receive(:scan_queue).never
           expect_any_instance_of(MiqTask).to receive(:update_status).never


### PR DESCRIPTION
Part of #14698 - adding former Job specific columns to Task view

**blocked:**
- [x] Replace `Waiting_to_start` value for state attribute in miq_tasks table with `Queued`  https://github.com/ManageIQ/manageiq/pull/14679



Some of Smart State Analysis processes going to `jobs` table and some to `miq_tasks`(as shown on screenshot). We are preventing destroying `Job` record if it is active, but missing this logic for `MiqTask`.

<img width="1114" alt="screen shot 2017-04-05 at 4 49 46 pm" src="https://cloud.githubusercontent.com/assets/6556758/24727773/4ea2bbbc-1a25-11e7-98e0-83de70e09f5b.png">

In this PR: do not destroy `MiqTask` record if this task is `Active`

@miq-bot add-label wip, bug, core
