### PR TITLE
ems_refresh.openshift.store_unused_images setting

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -667,7 +667,8 @@ module ManageIQ::Providers::Kubernetes
       res
     end
 
-    def parse_container_image(image, imageID)
+    # may return nil if store_new_images = false
+    def parse_container_image(image, imageID, store_new_images: true)
       container_image, container_image_registry = parse_image_name(image, imageID)
       host_port = nil
 
@@ -690,6 +691,7 @@ module ManageIQ::Providers::Kubernetes
         :container_image, :by_digest, container_image_identity)
 
       if stored_container_image.nil?
+        return nil unless store_new_images
         @data_index.store_path(
           :container_image, :by_digest,
           container_image_identity, container_image

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -8,12 +8,13 @@ module ManageIQ::Providers
         get_builds(inventory)
         get_build_pods(inventory)
         get_templates(inventory)
-        get_openshift_images(inventory) if options.get_container_images
+        get_openshift_images(inventory)
         EmsRefresh.log_inv_debug_trace(@data, "data:")
         @data
       end
 
       def get_openshift_images(inventory)
+        return unless inventory["image"]
         inventory["image"].each { |img| parse_openshift_image(img) }
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -134,6 +134,7 @@
   :openshift:
     :refresh_interval: 15.minutes
     :get_container_images: true
+    :store_unused_images: true
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
   :scvmm:

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -2,6 +2,7 @@ require 'recursive-open-struct'
 
 describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
   let(:parser) { described_class.new }
+  let(:options) { Settings.ems_refresh.openshift }
 
   describe "get_openshift_images" do
     let(:image_name) { "image_name" }
@@ -67,7 +68,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
     it "collects data from openshift images correctly" do
       expect(parser.send(:parse_openshift_image,
-                         image_from_openshift).except(:registered_on)).to eq(
+                         image_from_openshift, options).except(:registered_on)).to eq(
                            :name                     => image_name,
                            :digest                   => image_digest,
                            :image_ref                => image_ref,
@@ -97,7 +98,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
     it "handles openshift images without dockerImageManifest and dockerImageMetadata" do
       expect(parser.send(:parse_openshift_image,
-                         image_without_dockerImage_fields).except(:registered_on)).to eq(
+                         image_without_dockerImage_fields, options).except(:registered_on)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
                            :image_ref                => "docker-pullable://sha256:abcdefg",
@@ -108,7 +109,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
     it "handles openshift image without dockerConfig" do
       expect(parser.send(:parse_openshift_image,
-                         image_without_dockerConfig).except(:registered_on)).to eq(
+                         image_without_dockerConfig, options).except(:registered_on)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
                            :image_ref                => "docker-pullable://sha256:abcdefg",
@@ -125,7 +126,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     # check https://bugzilla.redhat.com/show_bug.cgi?id=1414508
     it "handles openshift image without environment variables" do
       expect(parser.send(:parse_openshift_image,
-                         image_without_environment_variables).except(:registered_on)).to eq(
+                         image_without_environment_variables, options).except(:registered_on)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
                            :image_ref                => "docker-pullable://sha256:abcdefg",
@@ -160,7 +161,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
       inventory = {"image" => [image_from_openshift,]}
 
-      parser.get_openshift_images(inventory)
+      parser.get_openshift_images(inventory, options)
       expect(parser.instance_variable_get('@data')[:container_images].size).to eq(1)
       expect(parser.instance_variable_get('@data')[:container_images][0]).to eq(
         parser.instance_variable_get('@data_index')[:container_image][:by_digest].values[0])
@@ -187,7 +188,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
       inventory = {"image" => [image_from_openshift,]}
 
-      parser.get_openshift_images(inventory)
+      parser.get_openshift_images(inventory, options)
       expect(parser.instance_variable_get('@data')[:container_images].size).to eq(1)
       expect(parser.instance_variable_get('@data')[:container_images][0]).to eq(
         parser.instance_variable_get('@data_index')[:container_image][:by_digest].values[0]
@@ -200,7 +201,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       def parse_single_openshift_image_with_registry
         inventory = {"image" => [image_from_openshift]}
 
-        parser.get_openshift_images(inventory)
+        parser.get_openshift_images(inventory, options)
         expect(parser.instance_variable_get('@data_index')[:container_image_registry][:by_host_and_port].size).to eq(1)
         expect(parser.instance_variable_get('@data')[:container_image_registries].size).to eq(1)
       end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -112,12 +112,38 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     stub_settings_merge(
       :ems_refresh => {:openshift => {:get_container_images => false}},
     )
-
     VCR.use_cassette(described_class.name.underscore,
                      :match_requests_on              => [:path,],
                      :allow_unused_http_interactions => true) do # , :record => :new_episodes) do
       EmsRefresh.refresh(@ems)
     end
+
+    @ems.reload
+
+    # Unused images are disconnected, metadata is retained either way.
+    expect(@ems.container_images.count).to eq(pod_images_count)
+    assert_specific_used_container_image(:metadata => true)
+    assert_specific_unused_container_image(:metadata => true, :connected => false)
+  end
+
+  it 'will store only images used by pods if store_unused_images = false' do
+    stub_settings_merge(
+      :ems_refresh => {:openshift => {:store_unused_images => false}},
+    )
+    normal_refresh
+
+    @ems.reload
+
+    expect(ContainerImage.count).to eq(pod_images_count)
+    assert_specific_used_container_image(:metadata => true)
+  end
+
+  it 'will not delete previously collected metadata if store_unused_images = false' do
+    normal_refresh
+    stub_settings_merge(
+      :ems_refresh => {:openshift => {:store_unused_images => false}},
+    )
+    normal_refresh
 
     @ems.reload
 


### PR DESCRIPTION
Strawman alternative/baseline for #14628.
Allows to still get_container_images=true in one big request,
but instead of saving metadata (labels etc) on all images openshift gave us,
save it only for images that have been mentioned by pods.

- Images registries are still all saved, even if only mentioned in unused images.

#14628 fetching used images one-by-one may be better eventually, but I think this is a simple knob we'll want anyway, if only for comparison.
The end state here and in #14628 should be same — unused images get disconnected, used images have full metadata.
~~PR based off #14661 test additions.~~

Measuments on real data with 44000 images suggest this is acceptable time-wise (24min vs 11min with get_container_images=false), but eats a lot of RAM (preliminary data: ~2GB while parsing, GC after parse could reclaim ~0.7GB of that, then up to 1GB while saving?).
