### PR TITLE
Add factories for embedded repository and credentials

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -94,6 +94,10 @@ FactoryGirl.define do
           :parent => :authentication,
           :class  => "ManageIQ::Providers::AutomationManager::Authentication"
 
+  factory :embedded_automation_manager_authentication,
+          :parent => :authentication,
+          :class  => "ManageIQ::Providers::EmbeddedAutomationManager::Authentication"
+
   factory :ansible_cloud_credential,
           :parent => :automation_manager_authentication,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential"

--- a/spec/factories/configuration_script_source.rb
+++ b/spec/factories/configuration_script_source.rb
@@ -6,4 +6,8 @@ FactoryGirl.define do
   factory :ansible_configuration_script_source,
           :parent => :configuration_script_source,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource"
+
+  factory :embedded_ansible_configuration_script_source,
+          :parent => :configuration_script_source,
+          :class  => "ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource"
 end


### PR DESCRIPTION
Add factories for `ManageIQ::Providers::EmbeddedAutomationManager::Authentication` and `ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource`

Links
----------------
Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/867

@martinpovolny please review, thanks.
