### PR TITLE
Use base class only when it is supported by direct rbac

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -201,9 +201,7 @@ module Rbac
           target_ids       = targets.collect(&:id)
           klass            = targets.first.class
           unless klass.respond_to?(:find)
-            if klass.respond_to?(:base_class) && rbac_class(klass).nil? && rbac_class(klass.base_class)
-              klass = klass.base_class
-            end
+            klass = base_class if (base_class = rbac_base_class(klass))
           end
         end
         scope = apply_scope(klass, scope)
@@ -218,7 +216,7 @@ module Rbac
           klass = targets
           klass = klass.klass if klass.respond_to?(:klass)
           # working around MiqAeDomain not being in rbac_class
-          klass = klass.base_class if klass.respond_to?(:base_class) && rbac_class(klass).nil? && rbac_class(klass.base_class)
+          klass = base_class if (base_class = rbac_base_class(klass))
         end
         scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
       end
@@ -306,6 +304,10 @@ module Rbac
     #
     def apply_rbac_through_association?(klass)
       klass != VimPerformanceDaily && (klass < MetricRollup || klass < Metric)
+    end
+
+    def rbac_base_class(klass)
+      klass.base_class if klass.respond_to?(:base_class) && rbac_class(klass).nil? && rbac_class(klass.base_class)
     end
 
     def safe_base_class(klass)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -198,11 +198,9 @@ module Rbac
           target_ids = targets
           # assume klass is passed in
         else
-          target_ids       = targets.collect(&:id)
-          klass            = targets.first.class
-          unless klass.respond_to?(:find)
-            klass = base_class if (base_class = rbac_base_class(klass))
-          end
+          target_ids  = targets.collect(&:id)
+          klass       = targets.first.class
+          klass       = base_class if !klass.respond_to?(:find) && (base_class = rbac_base_class(klass))
         end
         scope = apply_scope(klass, scope)
         scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -199,7 +199,12 @@ module Rbac
           # assume klass is passed in
         else
           target_ids       = targets.collect(&:id)
-          klass            = targets.first.class.base_class unless klass.respond_to?(:find)
+          klass            = targets.first.class
+          unless klass.respond_to?(:find)
+            if klass.respond_to?(:base_class) && rbac_class(klass).nil? && rbac_class(klass.base_class)
+              klass = klass.base_class
+            end
+          end
         end
         scope = apply_scope(klass, scope)
         scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -41,6 +41,18 @@ describe Rbac::Filterer do
       end
     end
 
+    context 'when class does not participate in RBAC' do
+      let(:miq_ae_domain) { FactoryGirl.create(:miq_ae_domain) }
+
+      it 'returns same class as input' do
+        User.with_user(admin_user) do
+          results = described_class.search(:targets => [miq_ae_domain]).first
+          expect(results.first).to be_an_instance_of(MiqAeDomain)
+          expect(results).to match_array [miq_ae_domain]
+        end
+      end
+    end
+
     describe "with find_options_for_tenant filtering" do
       before do
         owned_vm # happy path


### PR DESCRIPTION
Use base only when it is supported by direct rbac

it is fixing that specialized class model is passed but
rbac is returing objects with the model's `base_class`.

for example:
`Rbac.filtered_object(MiqAeDomain.first, :user => User.first)`

before:
returned object is `MiqAeNamespace` (as parent of `MiqAeDomain`)
after:
returned object is `MiqAeDomain`

### About fix
I did similar thing as we have [here](https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L215-L216) for format of rbac calling:
`Rbac.search(:targets => MiqAeDomain, :user => User.first)`

@miq-bot add_label rbac, core, bug
cc @PanSpagetka @martinpovolny 
@miq-bot assign @gtanzillo  