### PR TITLE
Charge since the first MetricRollup

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -10,7 +10,7 @@ class Chargeback
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
       #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
-                                        consumption_start = [@start_time, resource.try(:created_on)].compact.max
+                                        consumption_start = [@start_time, born_at].compact.max
                                         consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
                                         consumed = (consumption_end - consumption_start).round / 1.hour
                                         consumed > 0 ? consumed : 0
@@ -32,6 +32,10 @@ class Chargeback
     def monthly?
       # A heuristic. Is the interval lenght about 30 days?
       (hours_in_interval * 1.hour - 1.month).abs < 3.days
+    end
+
+    def born_at
+      resource.try(:created_on)
     end
   end
 end

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -32,6 +32,11 @@ class Chargeback
 
     private
 
+    def born_at
+      # metrics can be older than resource (first capture may go few days back)
+      [super, first_metric_rollup_record.timestamp].compact.min
+    end
+
     def values(metric)
       @values ||= {}
       @values[metric] ||= @rollups.collect(&metric.to_sym).compact


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1433984

On a fresh install, we start with inventory collection at time X. The resources are then created_on time X. However, the C&U collection can go few day back (by default we go back to `beginning_of_day`, but this is
subject to configuration. (See `Settings.performance.history.initial_capture_days`)

When charging, we cannot rely on created_on time, we can charge from the beginning of the C&U for the given resource.