### PR TITLE
allow seeding of dialogs from plugins

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -28,6 +28,12 @@ class Dialog < ApplicationRecord
     Dir.glob(ALL_YAML_FILES).each do |file|
       dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
     end
+
+    Vmdb::Plugins.instance.registered_provider_plugins.each do |plugin|
+      Dir.glob(plugin.root.join('content', 'service_dialogs', '*.{yaml,yml}')).each do |file|
+        dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
+      end
+    end
   end
 
   def each_dialog_field(&block)

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -1,8 +1,9 @@
 class Dialog < ApplicationRecord
-  DIALOG_DIR = Rails.root.join("product/dialogs/service_dialogs")
+  DIALOG_DIR_CORE   = 'product/dialogs/service_dialogs'.freeze
+  DIALOG_DIR_PLUGIN = 'content/service_dialogs'.freeze
 
   # The following gets around a glob symbolic link issue
-  ALL_YAML_FILES = DIALOG_DIR.join("{,*/**/}*.{yaml,yml}")
+  YAML_FILES_PATTERN = "{,*/**/}*.{yaml,yml}".freeze
 
   has_many :dialog_tabs, -> { order :position }, :dependent => :destroy
   validate :validate_children
@@ -25,12 +26,12 @@ class Dialog < ApplicationRecord
   def self.seed
     dialog_import_service = DialogImportService.new
 
-    Dir.glob(ALL_YAML_FILES).each do |file|
+    Dir.glob(Rails.root.join(DIALOG_DIR_CORE, YAML_FILES_PATTERN)).each do |file|
       dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
     end
 
     Vmdb::Plugins.instance.registered_provider_plugins.each do |plugin|
-      Dir.glob(plugin.root.join('content', 'service_dialogs', '*.{yaml,yml}')).each do |file|
+      Dir.glob(plugin.root.join(DIALOG_DIR_PLUGIN, YAML_FILES_PATTERN)).each do |file|
         dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
       end
     end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -48,10 +48,11 @@ describe Dialog do
       mock_engine = double(:root => Rails.root)
       expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])
 
-      described_class.with_constants(:DIALOG_DIR_PLUGIN => test_file_path) do
+      described_class.with_constants(:DIALOG_DIR_PLUGIN => test_file_path, :DIALOG_DIR_CORE => 'non-existent-dir') do
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
           Rails.root.join(test_file_path, "seed_test.yaml").to_path
         )
+        expect(mock_engine).to receive(:root)
         described_class.seed
       end
     end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -1,8 +1,7 @@
 describe Dialog do
   describe ".seed" do
     let(:dialog_import_service) { double("DialogImportService") }
-    let(:test_file_path) { Rails.root.join("spec/fixtures/files/dialogs") }
-    let(:all_yaml_files) { test_file_path.join("{,*/**/}*.{yaml,yml}") }
+    let(:test_file_path) { "spec/fixtures/files/dialogs" }
 
     before do
       allow(DialogImportService).to receive(:new).and_return(dialog_import_service)
@@ -10,32 +9,50 @@ describe Dialog do
     end
 
     it "delegates to the dialog import service with a file in the default directory" do
-      Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
+      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("seed_test.yaml").to_path)
+          Rails.root.join(test_file_path, "seed_test.yaml").to_path
+        )
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("seed_test.yml").to_path)
-        Dialog.seed
+          Rails.root.join(test_file_path, "seed_test.yml").to_path
+        )
+        described_class.seed
       end
     end
 
     it "delegates to the dialog import service with a file in a sub directory" do
-      Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
+      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("service_dialogs/service_seed_test.yaml").to_path)
+          Rails.root.join(test_file_path, "service_dialogs/service_seed_test.yaml").to_path
+        )
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("service_dialogs/service_seed_test.yml").to_path)
-        Dialog.seed
+          Rails.root.join(test_file_path, "service_dialogs/service_seed_test.yml").to_path
+        )
+        described_class.seed
       end
     end
 
     it "delegates to the dialog import service with a symlinked file" do
-      Dialog.with_constants(:DIALOG_DIR => test_file_path, :ALL_YAML_FILES => all_yaml_files) do
+      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("service_dialog_symlink/service_seed_test.yaml").to_path)
+          Rails.root.join(test_file_path, "service_dialog_symlink/service_seed_test.yaml").to_path
+        )
         expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          test_file_path.join("service_dialog_symlink/service_seed_test.yml").to_path)
-        Dialog.seed
+          Rails.root.join(test_file_path, "service_dialog_symlink/service_seed_test.yml").to_path
+        )
+        described_class.seed
+      end
+    end
+
+    it "seed files from plugins" do
+      mock_engine = double(:root => Rails.root)
+      expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])
+
+      described_class.with_constants(:DIALOG_DIR_PLUGIN => test_file_path) do
+        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+          Rails.root.join(test_file_path, "seed_test.yaml").to_path
+        )
+        described_class.seed
       end
     end
   end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -9,52 +9,49 @@ describe Dialog do
     end
 
     it "delegates to the dialog import service with a file in the default directory" do
-      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "seed_test.yaml").to_path
-        )
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "seed_test.yml").to_path
-        )
-        described_class.seed
-      end
+      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "seed_test.yaml").to_path
+      )
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "seed_test.yml").to_path
+      )
+      described_class.seed
     end
 
     it "delegates to the dialog import service with a file in a sub directory" do
-      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "service_dialogs/service_seed_test.yaml").to_path
-        )
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "service_dialogs/service_seed_test.yml").to_path
-        )
-        described_class.seed
-      end
+      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "service_dialogs", "service_seed_test.yaml").to_path
+      )
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "service_dialogs", "service_seed_test.yml").to_path
+      )
+      described_class.seed
     end
 
     it "delegates to the dialog import service with a symlinked file" do
-      described_class.with_constants(:DIALOG_DIR_CORE => test_file_path) do
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "service_dialog_symlink/service_seed_test.yaml").to_path
-        )
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "service_dialog_symlink/service_seed_test.yml").to_path
-        )
-        described_class.seed
-      end
+      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "service_dialog_symlink", "service_seed_test.yaml").to_path
+      )
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "service_dialog_symlink", "service_seed_test.yml").to_path
+      )
+      described_class.seed
     end
 
     it "seed files from plugins" do
       mock_engine = double(:root => Rails.root)
       expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])
 
-      described_class.with_constants(:DIALOG_DIR_PLUGIN => test_file_path, :DIALOG_DIR_CORE => 'non-existent-dir') do
-        expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-          Rails.root.join(test_file_path, "seed_test.yaml").to_path
-        )
-        expect(mock_engine).to receive(:root)
-        described_class.seed
-      end
+      stub_const('Dialog::DIALOG_DIR_PLUGIN', test_file_path)
+      stub_const('Dialog::DIALOG_DIR_CORE', 'non-existent-dir')
+      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
+        Rails.root.join(test_file_path, "seed_test.yaml").to_path
+      )
+      expect(mock_engine).to receive(:root)
+      described_class.seed
     end
   end
 


### PR DESCRIPTION
follows the same approach as in https://github.com/ManageIQ/manageiq/pull/14653

@miq-bot assign @bdunne 
@miq-bot add_label enhancement, pluggable providers

are there many more file seeds of that kind that should be allowed to be seeded from plugins?
if so, we might group the seeding somewhere under `Vmdb::Plugins` - like you did with `automate_domain`.

I'm just not sure, if we can hook nicely into the seeding process. Also, to have classes seeded only in the class (and not from an external location like plugins) has its upsides too