### PR TITLE
Optimize number of transactions sent in refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -106,6 +106,7 @@ module EmsRefresh::SaveInventoryHelper
 
   def update_attributes!(ar_model, attributes, remove_keys)
     ar_model.assign_attributes(attributes.except(*remove_keys))
+    # HACK: Avoid empty BEGIN/COMMIT pair until fix is made for https://github.com/rails/rails/issues/17937
     ar_model.save! if ar_model.changed?
   end
 

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -62,8 +62,8 @@ module EmsRefresh::SaveInventoryHelper
 
     # Delete the items no longer found
     deletes = deletes_index.values
-    ActiveRecord::Base.transaction do
-      unless deletes.blank?
+    unless deletes.blank?
+      ActiveRecord::Base.transaction do
         type = association.proxy_association.reflection.name
         _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
         disconnect ? deletes.each(&:disconnect_inv) : association.delete(deletes)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -102,9 +102,7 @@ module EmsRefresh::SaveInventoryHelper
 
   def update_attributes!(ar_model, attributes, remove_keys)
     ar_model.assign_attributes(attributes.except(*remove_keys))
-    ar_model.with_transaction_returning_status do
-      ar_model.save! if ar_model.changed?
-    end
+    ar_model.save! if ar_model.changed?
   end
 
   def backup_keys(hash, keys)


### PR DESCRIPTION
Do not do a blank transaction if the record hasn't changed, because it causes extra 2 queries, transaction BEGIN and END. And wrap updating&deleting in 1 big transaction. Doing transaction per     update is expensive, since we do BEGIN, update, END, so 3 queries per one updateand the same for delete. With remote DB, this will add a lot of processing time.

Example:
```ruby
ca = CustomAttribute.first; ca1 = CustomAttribute.second

# This does 1 BEGIN and COMMIT query for all updates inside
ActiveRecord::Base.transaction { ca.update_attributes!(:section => "labels1"); ca1.update_attributes!(:section => "labels1") }

# This does 1 BEGIN and COMMIT for each update
ca.update_attributes!(:section => "labels1"); ca1.update_attributes!(:section => "labels1")
```

Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1436176

-------
The performance improvements are mainly visible with second+ refresh, since creating objects by  association.push(new_records) is already using 1 transaction for many records created. We are just optimizing that number of transaction also for nested objects created.

** stats are being measured with applied PRs https://github.com/ManageIQ/manageiq/issues/13594 https://github.com/ManageIQ/manageiq/issues/14542

Performance improvements, given we are saving 290k object to the DB during refresh:

| refresh | number of queries done during refresh | time on a local db | time on a remote db with ~5ms ping |
| --------- | ------------------------------------------------- | ---------------------- | ---------------------------------------|
| 1st refresh before | 421 146 | ~18min | ~53min |
| 1st refresh after    | 385 162 | ~18min | ~50min |
| improvement | **9.3% smaller** | 0% faster | **6% faster** |
| 2nd+ refresh before | 786 380 | ~14min | ~80min |
| 2nd+ refresh after | 135 198 | ~7min | ~18min |
| improvement | **481% smaller** | **100% faster** | **344% faster** |

** the second refresh is measured when nothing is updated (the same VCR). But this PR brings a big speedup when we do update/delete records, since we do only 1 query per updated/deleted item, not 3 queries, like we did before this PR.