### PR TITLE
make event_groups error prone to non-array values in settings

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -27,7 +27,7 @@ class EmsEvent < EventStream
   def self.event_groups
     core_event_groups = ::Settings.event_handling.event_groups.to_hash
     Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
-      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
+      provider_event_groups = provider_settings.try(:fetch_path, :event_handling, :event_groups)
       next unless provider_event_groups
       DeepMerge.deep_merge!(
         provider_event_groups.to_hash, event_groups,

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -203,14 +203,23 @@ describe EmsEvent do
     let(:provider_event) { 'SomeSpecialProviderEvent' }
 
     it 'returns a list of groups' do
-      event_group_names = [
-        :addition, :application, :configuration, :console, :deletion, :general, :import_export, :migration, :network,
-        :power, :snapshot, :status, :storage
+      event_group_names = %i[
+        addition application configuration console deletion general import_export migration network
+        power snapshot status storage
       ]
       expect(described_class.event_groups.keys).to match_array(event_group_names)
       expect(described_class.event_groups[:addition]).to include(:name => 'Creation/Addition')
       expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
       expect(described_class.event_groups[:addition][:critical]).not_to include(provider_event)
+    end
+
+    it 'is prone to non-array subkeys' do
+      stub_settings_merge(
+        :ems => {
+          :some_provider => true
+        }
+      )
+      expect { described_class.event_groups }.not_to raise_error
     end
 
     it 'returns the provider event if configured' do
@@ -227,7 +236,6 @@ describe EmsEvent do
           }
         }
       )
-      allow(Vmdb::Plugins.instance).to receive(:registered_provider_plugin_names).and_return([:some_provider])
 
       expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
       expect(described_class.event_groups[:addition][:critical]).to include(provider_event)


### PR DESCRIPTION
`EmsEvent.event_groups` parses all keys under `ems -> * -> event_handling -> event_groups`

If somebody adds a key `ems -> some_key: true`, it would fail with an exception.

```
NoMethodError:
   undefined method `fetch_path' for true:TrueClass
 # ./app/models/ems_event.rb:30:in `block in event_groups'
 # ./app/models/ems_event.rb:29:in `each_with_object'
 # ./app/models/ems_event.rb:29:in `event_groups'
 # ./spec/models/ems_event_spec.rb:210:in `block (3 levels) in <top (required)>'
```

Unfortunately [this RHV spec](https://github.com/ManageIQ/manageiq/blob/64107863354b703149083520d9a2676e141b862f/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb#L60) did so :/ and it would hit us if it was run before this spec here.

I'll bring up another PR to fix the rhv spec

fine/yes - because the RHV spec is also in fine.

@miq-bot add_labels test, fine/yes