### PR TITLE
[EUWE] Optimize number of transactions sent in refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -103,6 +103,7 @@ module EmsRefresh::SaveInventoryHelper
 
   def update_attributes!(ar_model, attributes, remove_keys)
     ar_model.assign_attributes(attributes.except(*remove_keys))
+    # HACK: Avoid empty BEGIN/COMMIT pair until fix is made for https://github.com/rails/rails/issues/17937
     ar_model.save! if ar_model.changed?
   end
 

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -58,9 +58,9 @@ module EmsRefresh::SaveInventoryHelper
     end
 
     # Delete the items no longer found
-    ActiveRecord::Base.transaction do
-      deletes = deletes_index.values
-      unless deletes.blank?
+    deletes = deletes_index.values
+    unless deletes.blank?
+      ActiveRecord::Base.transaction do
         type = association.proxy_association.reflection.name
         _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
         disconnect ? deletes.each(&:disconnect_inv) : association.delete(deletes)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -99,9 +99,7 @@ module EmsRefresh::SaveInventoryHelper
 
   def update_attributes!(ar_model, attributes, remove_keys)
     ar_model.assign_attributes(attributes.except(*remove_keys))
-    ar_model.with_transaction_returning_status do
-      ar_model.save! if ar_model.changed?
-    end
+    ar_model.save! if ar_model.changed?
   end
 
   def backup_keys(hash, keys)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -77,7 +77,7 @@ module EmsRefresh::SaveInventoryHelper
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys + [:id]
     if child
-      child.update_attributes!(hash.except(:type, *remove_keys))
+      update_attributes!(child, hash, [:type, *remove_keys])
     else
       child = parent.send("create_#{type}!", hash.except(*remove_keys))
     end
@@ -91,10 +91,17 @@ module EmsRefresh::SaveInventoryHelper
       found = association.build(hash.except(:id))
       new_records << found
     else
-      found.update_attributes!(hash.except(:id, :type))
+      update_attributes!(found, hash, [:id, :type])
       deletes.delete(found) unless deletes.blank?
     end
     found
+  end
+
+  def update_attributes!(ar_model, attributes, remove_keys)
+    ar_model.assign_attributes(attributes.except(*remove_keys))
+    ar_model.with_transaction_returning_status do
+      ar_model.save! if ar_model.changed?
+    end
   end
 
   def backup_keys(hash, keys)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -50,17 +50,21 @@ module EmsRefresh::SaveInventoryHelper
     record_index = TypedIndex.new(association, find_key)
 
     new_records = []
-    hashes.each do |h|
-      found = save_inventory_with_findkey(association, h.except(*remove_keys), deletes_index, new_records, record_index)
-      save_child_inventory(found, h, child_keys)
+    ActiveRecord::Base.transaction do
+      hashes.each do |h|
+        found = save_inventory_with_findkey(association, h.except(*remove_keys), deletes_index, new_records, record_index)
+        save_child_inventory(found, h, child_keys)
+      end
     end
 
     # Delete the items no longer found
-    deletes = deletes_index.values
-    unless deletes.blank?
-      type = association.proxy_association.reflection.name
-      _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
-      disconnect ? deletes.each(&:disconnect_inv) : association.delete(deletes)
+    ActiveRecord::Base.transaction do
+      deletes = deletes_index.values
+      unless deletes.blank?
+        type = association.proxy_association.reflection.name
+        _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
+        disconnect ? deletes.each(&:disconnect_inv) : association.delete(deletes)
+      end
     end
 
     # Add the new items


### PR DESCRIPTION
Not clean cherry-pick of: https://github.com/ManageIQ/manageiq/pull/14670

Do not do a blank transaction if the record hasn't changed, because it causes extra 2 queries, transaction BEGIN and END. And wrap updating&deleting in 1 big transaction. Doing transaction per     update is expensive, since we do BEGIN, update, END, so 3 queries per one updateand the same for delete. With remote DB, this will add a lot of processing time.

Example:
```ruby
ca = CustomAttribute.first; ca1 = CustomAttribute.second

# This does 1 BEGIN and COMMIT query for all updates inside
ActiveRecord::Base.transaction { ca.update_attributes!(:section => "labels1"); ca1.update_attributes!(:section => "labels1") }

# This does 1 BEGIN and COMMIT for each update
ca.update_attributes!(:section => "labels1"); ca1.update_attributes!(:section => "labels1")
```
