### PR TITLE
MiqQueue consistency with purging

### DIFF
--- a/app/models/drift_state/purging.rb
+++ b/app/models/drift_state/purging.rb
@@ -14,17 +14,6 @@ module DriftState::Purging
       ::Settings.drift_states.history.purge_window_size
     end
 
-    def purge_timer
-      purge_queue(*purge_mode_and_value)
-    end
-
-    def purge_queue(mode, value)
-      MiqQueue.put_or_update(
-        :class_name  => name,
-        :method_name => "purge",
-      ) { |_msg, item| item.merge(:args => [mode, value]) }
-    end
-
     def purge_count(mode, value)
       send("purge_count_by_#{mode}", value)
     end

--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -14,19 +14,6 @@ module MiqReportResult::Purging
       ::Settings.reporting.history.purge_window_size
     end
 
-    def purge_timer
-      purge_queue(*purge_mode_and_value)
-    end
-
-    def purge_queue(mode, value)
-      MiqQueue.put_or_update(
-        :class_name  => name,
-        :method_name => "purge",
-        :role        => "reporting",
-        :queue_name  => "reporting"
-      ) { |_msg, item| item.merge(:args => [mode, value]) }
-    end
-
     def purge_count(mode, value)
       send("purge_count_by_#{mode}", value)
     end

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -43,6 +43,22 @@ module PurgingMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def purge_mode_and_value
+      [:date, purge_date]
+    end
+
+    def purge_timer
+      purge_queue(*purge_mode_and_value)
+    end
+
+    def purge_queue(mode, value)
+      MiqQueue.put(
+        :class_name  => name,
+        :method_name => "purge_by_#{mode}",
+        :args        => [value]
+      )
+    end
+
     def purge(older_than = nil, window = nil, &block)
       purge_by_date(older_than || purge_date, window || purge_window_size, &block)
     end

--- a/app/models/policy_event/purging.rb
+++ b/app/models/policy_event/purging.rb
@@ -12,16 +12,6 @@ class PolicyEvent < ApplicationRecord
         ::Settings.policy_events.history.purge_window_size
       end
 
-      def purge_queue
-        MiqQueue.put_unless_exists(
-          :class_name  => name,
-          :method_name => "purge",
-          :role        => "event",
-          :queue_name  => "ems"
-        )
-      end
-      alias_method :purge_timer, :purge_queue
-
       def purge_scope(older_than)
         where(arel_table[:timestamp].lt(older_than))
       end

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -29,14 +29,11 @@ module VmdbMetric::Purging
     end
 
     def purge_timer(value, interval)
-      MiqQueue.put_unless_exists(
+      MiqQueue.put(
         :class_name  => name,
         :method_name => "purge_#{interval}",
-        :role        => "database_operations",
-        :queue_name  => "generic",
-      ) do |_msg, find_options|
-        find_options.merge(:args => [value])
-      end
+        :args        => [value]
+      )
     end
 
     def purge_window_size
@@ -59,7 +56,7 @@ module VmdbMetric::Purging
     # queue is calling purge_interval directly. (and mode is no longer used)
     # keeping around in case messages are in the queue for upgrades
     def purge(_mode, older_than, interval, window = nil, &block)
-      send("purge_#{interval}", older_than, window, &block)
+      purge_by_date(older_than, interval, window, &block)
     end
 
     private

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -36,10 +36,9 @@ describe DriftState do
         expect(q.length).to eq(1)
         expect(q.first).to have_attributes(
           :class_name  => described_class.name,
-          :method_name => "purge"
+          :method_name => "purge_by_date"
         )
-        expect(q.first.args[0]).to eq(:date)
-        expect(q.first.args[1]).to be_same_time_as 6.months.to_i.seconds.ago.utc
+        expect(q.first.args[0]).to be_same_time_as 6.months.to_i.seconds.ago.utc
       end
     end
 
@@ -54,20 +53,8 @@ describe DriftState do
         expect(q.length).to eq(1)
         expect(q.first).to have_attributes(
           :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [:remaining, 1]
-        )
-      end
-
-      it "with item already in the queue" do
-        described_class.purge_queue(:remaining, 2)
-
-        q = MiqQueue.all
-        expect(q.length).to eq(1)
-        expect(q.first).to have_attributes(
-          :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [:remaining, 2]
+          :method_name => "purge_by_remaining",
+          :args        => [1]
         )
       end
     end

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -64,11 +64,10 @@ describe MiqReportResult do
         expect(q.length).to eq(1)
         expect(q.first).to have_attributes(
           :class_name  => described_class.name,
-          :method_name => "purge"
+          :method_name => "purge_by_date"
         )
 
-        expect(q.first.args[0]).to eq(:date)
-        expect(q.first.args[1]).to be_same_time_as 6.months.to_i.seconds.ago.utc
+        expect(q.first.args[0]).to be_same_time_as 6.months.to_i.seconds.ago.utc
       end
     end
 
@@ -83,20 +82,8 @@ describe MiqReportResult do
         expect(q.length).to eq(1)
         expect(q.first).to have_attributes(
           :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [:remaining, 1]
-        )
-      end
-
-      it "with item already in the queue" do
-        described_class.purge_queue(:remaining, 2)
-
-        q = MiqQueue.all
-        expect(q.length).to eq(1)
-        expect(q.first).to have_attributes(
-          :class_name  => described_class.name,
-          :method_name => "purge",
-          :args        => [:remaining, 2]
+          :method_name => "purge_by_remaining",
+          :args        => [1]
         )
       end
     end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -10,6 +10,14 @@ describe PurgingMixin do
     end
   end
 
+  describe ".purge_mode_and_value" do
+    it "purge_mode_and_value should return proper options" do
+      stub_settings(:policy_events => {:history => {:keep_policy_events => 120}})
+      expect(example_class.purge_mode_and_value.first).to eq(:date)
+      expect(example_class.purge_mode_and_value.last).to be_within(1.second).of(120.seconds.ago.utc)
+    end
+  end
+
   describe ".purge" do
     let(:events) do
       (-2..2).collect do |date_modifier|

--- a/spec/models/policy_event/purging_spec.rb
+++ b/spec/models/policy_event/purging_spec.rb
@@ -1,30 +1,18 @@
 describe PolicyEvent do
   context "::Purging" do
-    context ".purge_queue" do
+    context ".purge_timer" do
       before do
         EvmSpecHelper.create_guid_miq_server_zone
       end
 
       it "with nothing in the queue" do
-        described_class.purge_queue
+        described_class.purge_timer
 
         q = MiqQueue.all
         expect(q.length).to eq(1)
         expect(q.first).to  have_attributes(
           :class_name  => described_class.name,
-          :method_name => "purge"
-        )
-      end
-
-      it "with item already in the queue" do
-        described_class.purge_queue
-        described_class.purge_queue
-
-        q = MiqQueue.all
-        expect(q.length).to eq(1)
-        expect(q.first).to  have_attributes(
-          :class_name  => described_class.name,
-          :method_name => "purge"
+          :method_name => "purge_by_date"
         )
       end
     end

--- a/spec/models/vmdb_metric_spec.rb
+++ b/spec/models/vmdb_metric_spec.rb
@@ -6,7 +6,6 @@ describe VmdbMetric do
   it "should purge" do
     expect do
       VmdbMetric.purge_daily_timer
-      VmdbMetric.purge_daily_timer
     end.to change { MiqQueue.count }.by(1)
   end
 end


### PR DESCRIPTION
Bring consistency to `Purging`:

- remove boilerplate
- removing inconsistency (slowly)
- moving all from `put_unless_exists` over to `put`.
- put into the general queue
- following patterns (which are already tuned for performance)
