### PR TITLE
remove unnecessary Settings setting in rhv provider spec

### DIFF
--- a/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_parser_spec.rb
@@ -57,7 +57,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventParser do
       @ems.default_endpoint.path = "/ovirt-engine/api"
       allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
       allow(@ems).to receive(:resolve_ip_address).with(ip_address).and_return(ip_address)
-      ::Settings.ems.use_ovirt_engine_sdk = true
     end
 
     require 'yaml'


### PR DESCRIPTION
removes Settings setting which should have been using `stub_settings`

see https://github.com/ManageIQ/manageiq/pull/14672

@miq-bot add_labels test, providers/rhevm