### PR TITLE
Verify response in orchestration template delete specs

### DIFF
--- a/spec/requests/api/orchestration_template_spec.rb
+++ b/spec/requests/api/orchestration_template_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe 'Orchestration Template API' do
       run_post(orchestration_templates_url,
                gen_request(:delete, [{'id' => cfn.id}, {'id' => hot.id}]))
 
+      expected = {
+        'results' => a_collection_containing_exactly(
+          a_hash_including('success' => true, 'message' => "orchestration_templates id: #{cfn.id} deleting"),
+          a_hash_including('success' => true, 'message' => "orchestration_templates id: #{hot.id} deleting")
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
       expect(OrchestrationTemplate.exists?(cfn.id)).to be_falsey
       expect(OrchestrationTemplate.exists?(hot.id)).to be_falsey
     end


### PR DESCRIPTION
Update the specs for orchestration delete to verify that https://github.com/ManageIQ/manageiq/pull/14097 successfully fixed this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1414845)

@miq-bot add_label api, test
@miq-bot assign @abellotti 