### PR TITLE
Replace `Waiting_to_start` value for state attribute in miq_tasks table with `Queued`

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -226,7 +226,7 @@ class Job < ApplicationRecord
 
   def attributes_for_task
     {:status        => status.try(:capitalize),
-     :state         => state.try(:capitalize),
+     :state         => state == "waiting_to_start" ? MiqTask::STATE_QUEUED : state.try(:capitalize),
      :name          => name,
      :message       => message,
      :userid        => userid,

--- a/db/migrate/20170510125854_rename_waiting_to_start_state_to_queuedin_miq_task.rb
+++ b/db/migrate/20170510125854_rename_waiting_to_start_state_to_queuedin_miq_task.rb
@@ -1,0 +1,23 @@
+class RenameWaitingToStartStateToQueuedinMiqTask < ActiveRecord::Migration[5.0]
+  class Job < ActiveRecord::Base
+    belongs_to :miq_task, :class_name =>'RenameWaitingToStartStateToQueuedinMiqTask::MiqTask'
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiqTask < ActiveRecord::Base
+    has_one :job, :class_name => 'RenameWaitingToStartStateToQueuedinMiqTask::Job'
+  end
+
+  def up
+    say_with_time("updating 'state' attribute of 'miq_tasks' table from 'Waiting_to_start' to 'Queued'") do
+      MiqTask.where(:state => "Waiting_to_start").update_all(:state => "Queued")
+    end
+  end
+
+  def down
+    say_with_time("updating 'state' of 'miq_tasks' from 'Queued' to 'Waiting_to_start' if there is linked job") do
+      MiqTask.where("id IN (SELECT miq_task_id FROM jobs)")
+             .where(:state => "Queued").update_all(:state => "Waiting_to_start")
+    end
+  end
+end

--- a/spec/migrations/20170510125854_rename_waiting_to_start_state_to_queuedin_miq_task_spec.rb
+++ b/spec/migrations/20170510125854_rename_waiting_to_start_state_to_queuedin_miq_task_spec.rb
@@ -1,0 +1,34 @@
+require_migration
+
+describe RenameWaitingToStartStateToQueuedinMiqTask do
+  let(:task_stub) { migration_stub(:MiqTask) }
+  let(:task_name) { "Hello Test Task" }
+  let(:state_queued) { "Queued" }
+  let(:state_waiting_to_start) { "Waiting_to_start" }
+
+  migration_context :up do
+    it "updates 'state' attribute on 'miq_tasks' table from 'Waiting_to_start' to 'Queued'" do
+      task_stub.create!(:name => task_name, :state => state_waiting_to_start)
+
+      migrate
+
+      expect(task_stub.find_by(:name => task_name).state).to eq state_queued
+    end
+  end
+
+  migration_context :down do
+    let(:job_stub) { migration_stub(:Job) }
+
+    it "updates 'state' attribute on 'miq_tasks' table from 'Waiting_to_start' to 'Queued'" do
+      task = task_stub.create!(:name => task_name, :state => state_queued)
+      job_stub.create!(:miq_task_id => task.id)
+      task_stub.create!(:name => "Second task not linked to job", :state => state_queued)
+      expect(task_stub.where(:state => state_queued).count).to eq 2
+
+      migrate
+
+      expect(task_stub.where(:state => state_queued).count).to eq 1
+      expect(task_stub.where(:state => state_waiting_to_start).count).to eq 1
+    end
+  end
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -346,9 +346,10 @@ describe Job do
   end
 
   context "belongs_to task" do
-    before(:each) do
-      @job = Job.create_job("VmScan", :name => "Hello, World!")
-      @task = MiqTask.find_by(:name => "Hello, World!")
+    let(:job_name) { "Hello, World!" }
+    before do
+      @job = Job.create_job("VmScan", :name => job_name)
+      @task = MiqTask.find_by(:name => job_name)
     end
 
     describe ".create_job" do
@@ -360,15 +361,15 @@ describe Job do
     describe "#attributes_for_task" do
       it "returns hash with job's attributes to use for syncronization with linked task" do
         expect(@job.attributes_for_task).to include(
-          :status        => @job.status.try(:capitalize),
-          :state         => @job.state.try(:capitalize),
-          :name          => @job.name,
-          :message       => @job.message,
-          :userid        => @job.userid,
-          :miq_server_id => @job.miq_server_id,
-          :context_data  => @job.context,
-          :zone          => @job.zone,
-          :started_on    => @job.started_on
+          :status        => "Ok",
+          :state         => "Queued",
+          :name          => job_name,
+          :message       => "process initiated",
+          :userid        => "system",
+          :miq_server_id => nil,
+          :context_data  => {},
+          :zone          => nil,
+          :started_on    => nil
         )
       end
     end


### PR DESCRIPTION
Part of #14698 - adding former Job specific columns to Task view

After linking `jobs` and `miq_tasks` tables (in https://github.com/ManageIQ/manageiq/pull/13452), `Job#state` attribute duplicated to `MiqTask#state`. One of possible value for `state` attribute in `Job` model is `Waiting_to_start` which got assigned to job not started yet. in `MiqTask` there is `Queued` value for `state` attribute which indicate the same for task - task is not started yet.

This PR is updating `Waiting_to_start` value of `state` attribute in `miq_tasks` table to `Queued`.

It would make filtering of Tasks more intuitive after merging Tasks and Jobs screens in UI

