### PR TITLE
fix spec to work with plugins providing dialog seeds

### DIFF
--- a/spec/models/miq_dialog_spec.rb
+++ b/spec/models/miq_dialog_spec.rb
@@ -3,6 +3,7 @@ describe MiqDialog do
     it 'seeds from the core with correct metadata' do
       root = Rails.root.join('product', 'dialogs', 'miq_dialogs')
       allow(described_class).to receive(:find_by)
+      allow(described_class).to receive(:sync_from_file).with(any_args)
 
       expect(described_class).to receive(:sync_from_file).at_least(:once).with(/^#{root}/, root).and_call_original
       expect(described_class).to receive(:find_by).once.with(


### PR DESCRIPTION
since https://github.com/ManageIQ/manageiq-providers-azure/pull/16 was merged, the spec actually seeded files from providers. Now stub the call.

Otherwise spec would fail with:

```bash
Randomized with seed 36542
.F

Failures:

  1) MiqDialog.seed seeds from the core with correct metadata
     Failure/Error: Dir.glob(root.join("*.{yaml,yml}")).each { |f| sync_from_file(f, root) }

       #<MiqDialog(id: integer, name: string, description: string, dialog_type: string, content: text, default: boolean, filename: string, file_mtime: datetime, created_at: datetime, updated_at: datetime, href_slug: string, region_number: integer, region_description: string) (class)> received :sync_from_file with unexpected arguments
         expected: (/^\/Users\/hild\/src\/manageiq\/product\/dialogs\/miq_dialogs/, #<Pathname:/Users/hild/src/manageiq/product/dialogs/miq_dialogs>)
              got: ("/Users/hild/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-providers-azure-992746dec8b9/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml", #<Pathname:/Users/hild/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-providers-azure-992746dec8b9/content/miq_dialogs>)
       Diff:
       @@ -1,3 +1,3 @@
       -[/^\/Users\/hild\/src\/manageiq\/product\/dialogs\/miq_dialogs/,
       - #<Pathname:/Users/hild/src/manageiq/product/dialogs/miq_dialogs>]
       +["/Users/hild/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-providers-azure-992746dec8b9/content/miq_dialogs/miq_provision_azure_dialogs_template.yaml",
       + #<Pathname:/Users/hild/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-providers-azure-992746dec8b9/content/miq_dialogs>]

     # ./app/models/miq_dialog.rb:20:in `block in sync_from_dir'
     # ./app/models/miq_dialog.rb:20:in `each'
     # ./app/models/miq_dialog.rb:20:in `sync_from_dir'
     # ./app/models/miq_dialog.rb:25:in `block in sync_from_plugins'
     # ./app/models/miq_dialog.rb:24:in `each'
     # ./app/models/miq_dialog.rb:24:in `sync_from_plugins'
     # ./app/models/miq_dialog.rb:16:in `seed'
     # ./spec/models/miq_dialog_spec.rb:12:in `block (3 levels) in <top (required)>'

Finished in 1.33 seconds (files took 17.57 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/models/miq_dialog_spec.rb:3 # MiqDialog.seed seeds from the core with correct metadata
```

@miq-bot add_labels test
@miq-bot assign @bdunne 