### PR TITLE
provider generator fixes

### DIFF
--- a/lib/generators/provider/provider_generator.rb
+++ b/lib/generators/provider/provider_generator.rb
@@ -40,6 +40,7 @@ class ProviderGenerator < Rails::Generators::NamedBase
     chmod "bin", 0755 & ~File.umask, :verbose => false
     template "config/initializers/gettext.rb"
     template "config/settings.yml"
+    template "lib/manageiq-providers-%provider_name%.rb"
     template "lib/manageiq/providers/%provider_name%.rb"
     template "lib/manageiq/providers/%provider_name%/engine.rb"
     template "lib/manageiq/providers/%provider_name%/version.rb"

--- a/lib/generators/provider/templates/Rakefile
+++ b/lib/generators/provider/templates/Rakefile
@@ -1,5 +1,4 @@
 require 'bundler/setup'
-require 'manageiq-providers-<%= provider_name %>'
 
 begin
   require 'rspec/core/rake_task'


### PR DESCRIPTION
actually add lib/manageiq-provider-%name%.rb when running the generator
and move requires to load after rails has been loaded

@miq-bot add_label bug, pluggable providers
@miq-bot assign @bdunne 