### PR TITLE
Ensure job is refreshed in the condition of state machine exits on error

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -49,6 +49,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   def on_error(action)
     _log.info("on_error called for service action: #{action}")
     update_attributes(:retirement_state => 'error') if action == "Retirement"
+    job(action).try(:refresh_ems)
     postprocess(action)
   end
 

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -42,8 +42,8 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   def postprocess(action)
-    hosts = options.fetch_path(job_option_key(action), :inventory)
-    delete_inventory(action) unless use_default_inventory?(hosts)
+    inventory_raw_id = options.fetch_path(job_option_key(action), :inventory)
+    delete_inventory(action, inventory_raw_id) if inventory_raw_id
   end
 
   def on_error(action)
@@ -123,10 +123,9 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     end
   end
 
-  def delete_inventory(action)
+  def delete_inventory(action, inventory_raw_id)
     manager(action).with_provider_connection do |connection|
-      inventory_id = options.fetch_path(job_option_key(action), :inventory)
-      connection.api.inventories.find(inventory_id).destroy!
+      connection.api.inventories.find(inventory_raw_id).destroy!
     end
   end
 

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -202,9 +202,27 @@ describe(ServiceAnsiblePlaybook) do
   end
 
   describe '#postprocess' do
-    it 'deletes inventory' do
-      expect(executed_service).to receive(:delete_inventory)
-      executed_service.postprocess(action)
+    context 'with user selected hosts' do
+      it 'deletes temporary inventory' do
+        expect(executed_service).to receive(:delete_inventory)
+        executed_service.postprocess(action)
+      end
+    end
+
+    context 'with default localhost' do
+      let(:provision_options) do
+        {
+          :provision_job_options => {
+            :credential => 1,
+            :extra_vars => {'var1' => 'value1', 'var2' => 'value2', 'pswd' => encrypted_val}
+          }
+        }
+      end
+
+      it 'needs not to delete the inventory' do
+        expect(executed_service).not_to receive(:delete_inventory)
+        executed_service.postprocess(action)
+      end
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439667

We want to refresh the job status and time stamps one final time at the error condition.

Also fix a coding error in `postprocess`. The old coincidentally correctly cleaned up the temporary inventory.