### PR TITLE
Fix trailing whitespace in api.yml

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -712,7 +712,7 @@
      :options:
      - :collection
      :verbs: *g
-     :klass: EmsEvent        
+     :klass: EmsEvent
   :events:
     :description: Events
     :identifier: event


### PR DESCRIPTION
Not that I'm especially picky about this - more that my editor is set to kill trailing whitespace on save and I keep committing this by mistake. So committing this here for the right reason.

@miq-bot add-label api
@miq-bot assign @abellotti 
