### PR TITLE
Pickup Tower Project's repo-sync status

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -60,7 +60,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
       inventory_object.scm_clean = project.scm_clean
       inventory_object.scm_delete_on_update = project.scm_delete_on_update
       inventory_object.scm_update_on_launch = project.scm_update_on_launch
-      inventory_object.last_update_failed = project.last_update_failed
+      inventory_object.status = project.status
 
       project.playbooks.each do |playbook_name|
         inventory_object_playbook = persister.configuration_script_payloads.find_or_build_by(

--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -60,6 +60,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
       inventory_object.scm_clean = project.scm_clean
       inventory_object.scm_delete_on_update = project.scm_delete_on_update
       inventory_object.scm_update_on_launch = project.scm_update_on_launch
+      inventory_object.last_update_failed = project.last_update_failed
 
       project.playbooks.each do |playbook_name|
         inventory_object_playbook = persister.configuration_script_payloads.find_or_build_by(

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -28,7 +28,7 @@ module ManagerRefresh::Inventory::Core
         :manager_ref                 => [:manager_ref],
         :inventory_object_attributes => %i(
           name description scm_type scm_url scm_branch scm_clean scm_delete_on_update
-          scm_update_on_launch authentication last_update_failed
+          scm_update_on_launch authentication status
         ),
       }.merge(options))
     end

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -26,7 +26,10 @@ module ManagerRefresh::Inventory::Core
       has_inventory({
         :model_class                 => ::ConfigurationScriptSource,
         :manager_ref                 => [:manager_ref],
-        :inventory_object_attributes => %i(name description scm_type scm_url scm_branch scm_clean scm_delete_on_update scm_update_on_launch authentication),
+        :inventory_object_attributes => %i(
+          name description scm_type scm_url scm_branch scm_clean scm_delete_on_update
+          scm_update_on_launch authentication last_update_failed
+        ),
       }.merge(options))
     end
 

--- a/db/migrate/20170320195660_add_last_update_failed_to_configuration_script_source.rb
+++ b/db/migrate/20170320195660_add_last_update_failed_to_configuration_script_source.rb
@@ -1,5 +1,0 @@
-class AddLastUpdateFailedToConfigurationScriptSource < ActiveRecord::Migration[5.0]
-  def change
-    add_column :configuration_script_sources, :last_update_failed, :boolean
-  end
-end

--- a/db/migrate/20170320195660_add_last_update_failed_to_configuration_script_source.rb
+++ b/db/migrate/20170320195660_add_last_update_failed_to_configuration_script_source.rb
@@ -1,0 +1,5 @@
+class AddLastUpdateFailedToConfigurationScriptSource < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configuration_script_sources, :last_update_failed, :boolean
+  end
+end

--- a/db/migrate/20170320195660_add_status_to_configuration_script_source.rb
+++ b/db/migrate/20170320195660_add_status_to_configuration_script_source.rb
@@ -1,0 +1,5 @@
+class AddStatusToConfigurationScriptSource < ActiveRecord::Migration[5.0]
+  def change
+    add_column :configuration_script_sources, :status, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -553,6 +553,7 @@ configuration_script_sources:
 - scm_update_on_launch
 - authentication_id
 - type
+- last_update_failed
 configuration_scripts:
 - id
 - manager_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -553,7 +553,7 @@ configuration_script_sources:
 - scm_update_on_launch
 - authentication_id
 - type
-- last_update_failed
+- status
 configuration_scripts:
 - id
 - manager_id

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -152,7 +152,7 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :scm_clean            => false,
       :scm_delete_on_update => false,
       :scm_update_on_launch => true,
-      :last_update_failed   => false
+      :status               => 'successful'
     )
     expect(expected_configuration_script_source.authentication.name).to eq('db-github')
   end

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -151,7 +151,8 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :scm_branch           => 'master',
       :scm_clean            => false,
       :scm_delete_on_update => false,
-      :scm_update_on_launch => true
+      :scm_update_on_launch => true,
+      :last_update_failed   => false
     )
     expect(expected_configuration_script_source.authentication.name).to eq('db-github')
   end


### PR DESCRIPTION
To allow user to know if Tower's latest attempt to sync a repo's playbooks is successful or not.

Part of the [pivotal tracker story](https://www.pivotaltracker.com/story/show/143133279)

Note: the other property we can use (instead of `last_update_failed`) is the `status` (`[successful|failed|missing|...]`).  Obviously, we can have both of them (plus some other fields) captured. They all give us different aspects of the repo state. But I think we probably want to be as frugal as possible.  And `status` needs string comparison, vs the `last_update_failed` `boolean` check, I pick `boolean`.

But 1 point to consider `status` is that In Tower, there's a `manual` type repo, there wouldn't be a sync and so `last_update_failed` won't be meaningful.  The `project.status` would show if there's problem with it.  

However, we only support `Git` type now. so I need someone to push one way or the other. ( @Fryguy @blomquisg )

@miq-bot add_labels enhancement, providers/ansible_tower, fine/yes

====  Updates ====
Switched to pickup `status` instead of `last_update_failed`

==== Related bug ====
https://bugzilla.redhat.com/show_bug.cgi?id=1439357