### PR TITLE
Exposing prototype as part of /api/settings

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1982,6 +1982,7 @@
     :verbs: *g
     :categories:
       - product
+      - prototype
     :collection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
GET /api/settings

```
  {
    "product": {
      "maindb": "ExtManagementSystem",
      "container_deployment_wizard": false,
      "datawarehouse_manager": false
    },
    "prototype": {
      "monitoring": false
    }
  }
```
