### PR TITLE
Update some request factories

### DIFF
--- a/spec/factories/miq_provision_request.rb
+++ b/spec/factories/miq_provision_request.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
   factory :miq_provision_request do
+    requester { create(:user) }
+    source { create(:miq_template) }
   end
 end

--- a/spec/factories/miq_provision_request.rb
+++ b/spec/factories/miq_provision_request.rb
@@ -1,6 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_request do
-    requester { create(:user) }
-    source { create(:miq_template) }
-  end
-end

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -4,7 +4,9 @@ FactoryGirl.define do
 
     factory :miq_host_provision_request,         :class => "MiqHostProvisionRequest"
     factory :service_reconfigure_request,        :class => "ServiceReconfigureRequest"
-    factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest"
+    factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest" do
+      source { create(:service_template) }
+    end
     factory :vm_migrate_request,                 :class => "VmMigrateRequest"
     factory :vm_reconfigure_request,             :class => "VmReconfigureRequest"
     factory :miq_provision_request,              :class => "MiqProvisionRequest" do

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -7,5 +7,8 @@ FactoryGirl.define do
     factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest"
     factory :vm_migrate_request,                 :class => "VmMigrateRequest"
     factory :vm_reconfigure_request,             :class => "VmReconfigureRequest"
+    factory :miq_provision_request,              :class => "MiqProvisionRequest" do
+      source { create(:miq_template) }
+    end
   end
 end

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -27,15 +27,11 @@ describe MiqProvisionRequest do
     let(:vm_template) { FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => ems) }
 
     it "should not be created without requester being specified" do
-      expect { FactoryGirl.create(:miq_provision_request) }.to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it "should not be created with an invalid userid being specified" do
-      expect { FactoryGirl.create(:miq_provision_request, :userid => 'barney', :src_vm_id => vm_template.id) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { FactoryGirl.create(:miq_provision_request, :requester => nil) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should not be created with a valid userid but no vm being specified" do
-      expect { FactoryGirl.create(:miq_provision_request, :requester => user) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect { FactoryGirl.create(:miq_provision_request, :requester => user, :source => nil) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it "should be created from either a VM or Template" do

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -95,7 +95,7 @@ module Spec
       def create_request(prov_options)
         @miq_provision_request = FactoryGirl.create(:miq_provision_request,
                                                     :requester => @user,
-                                                    :src_vm_id => @vm_template.id,
+                                                    :source    => @vm_template,
                                                     :options   => prov_options)
         @miq_request = @miq_provision_request
       end


### PR DESCRIPTION
Pulling this out of https://github.com/ManageIQ/manageiq/pull/14681 as it brought in some necessary but unrelated changes that might be better reviewed on their own. This revision:

- gives the `:miq_provision_request` factory a source and a requester, both required by validation
- gives `:service_template_provision_request` a source. It's not validated against but seems to be needed - can anyone corroborate this?
- removes a test that was testing the wrong thing
- updates a test that was testing the wrong thing
- updates a test that assumes the factory default will be invalid (it shouldn't be)
- updates the quota helper code to specify a `source` instead of setting the id directly - doing so seems to leave the resultant object in a confused state and breaks some tests based up on the count of templates

@miq-bot add-label test, technical debt
@miq-bot assign @gtanzillo 