### PR TITLE
Automate - Provisioning First and Last name are no longer required.

### DIFF
--- a/product/dialogs/miq_dialogs/miq_host_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_host_provision_dialogs.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name: 
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager: 
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name: 
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail: 

--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name: 
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager: 
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name: 
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail: 

--- a/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_configured_system_foreman_dialogs.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -41,7 +41,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -61,7 +61,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name:
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager:
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name:
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail:

--- a/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
@@ -32,7 +32,7 @@
           :data_type: :string
         :owner_first_name: 
           :description: First Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager: 
@@ -52,7 +52,7 @@
           :data_type: :string
         :owner_last_name: 
           :description: Last Name
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
         :owner_manager_mail: 


### PR DESCRIPTION
Fields are not being populate during life-cycle provisioning so
There is no reason to make them required.

This eliminates 2 required fields when provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1349607

@miq-bot add_label bug, fine/yes