### PR TITLE
Service#my_zone should only reference a VM associated to a provider.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -275,8 +275,8 @@ class Service < ApplicationRecord
   end
 
   def my_zone
-    first_vm = vms.first
-    first_vm.ext_management_system.zone.name unless first_vm.nil?
+    # Verify the VM has a provider or my_zone will return the miq_server zone by default
+    vms.detect(&:ext_management_system).try(:my_zone)
   end
 
   def service_action(requested, service_resource)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -640,6 +640,41 @@ describe Service do
     end
   end
 
+  describe '#my_zone' do
+    let(:service) { FactoryGirl.create(:service) }
+
+    it 'returns nil without any resources' do
+      expect(service.my_zone).to be_nil
+    end
+
+    it 'returns nil zone when VM is archived' do
+      vm = FactoryGirl.build(:vm_vmware)
+
+      service.add_resource!(vm)
+      expect(service.my_zone).to be_nil
+    end
+
+    it 'returns the EMS zone when the VM is connected to a EMS' do
+      ems = FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone))
+      vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+
+      service.add_resource!(vm)
+
+      expect(service.my_zone).to eq(ems.my_zone)
+    end
+
+    it 'returns the EMS zone with one VM connected to a EMS and one archived' do
+      service.add_resource!(FactoryGirl.build(:vm_vmware))
+
+      ems = FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone))
+      vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+
+      service.add_resource!(vm)
+
+      expect(service.my_zone).to eq(ems.my_zone)
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)


### PR DESCRIPTION
Services do not have an inherent  zone association.  When one is desired, for example when running a custom button, we look at the associated VMs to select a zone.  The current logic always uses the first VM from the list of `vms`.  If that VM happens to be archived/orphaned (not associated with a provider) the logic raises an error.  The new logic checks that the VM has a valid provider before accessing the zone name.

Note: The `Vm` model contains a `my_zone` method which handles a `nil` provider, but in that scenario it returns the current MiqServer zone name which is not the desired result.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1439883

Steps for Testing/QA
-------------------------------

Options 1: Follow step list in BZ to recreate issue.
Options 2:

Run the following steps in the rails console (before changes):
```ruby
s = Service.create(:name => "Zone Test")
s.my_zone    # => nil

v = Vm.create!(:name => "Zone test", :vendor => "vmware", :location => "cannot_be_blank")
s.add_resource!(v)

s.my_zone    # => NoMethodError: undefined method `zone' for nil:NilClass
```

After applying the changes `s.my_zone` will return `nil` for the error case above.