### PR TITLE
extra_var to have metadata

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -75,6 +75,9 @@ class ServiceAnsiblePlaybook < ServiceGeneric
 
   def save_job_options(action, overrides)
     job_options = options.fetch_path(:config_info, action.downcase.to_sym).slice(:hosts, :extra_vars).with_indifferent_access
+    job_options[:extra_vars].try(:transform_values!) do |val|
+      val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
+    end
     job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
     job_options.deep_merge!(overrides)
 

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -101,7 +101,11 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :ask_inventory_on_launch  => true,
       :ask_credential_on_launch => true
     }
-    params[:extra_vars] = info[:extra_vars].to_json if info[:extra_vars]
+    if info[:extra_vars]
+      params[:extra_vars] = info[:extra_vars].transform_values do |val|
+        val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
+      end.to_json
+    end
 
     [:credential, :cloud_credential, :network_credential].each do |credential|
       cred_sym = "#{credential}_id".to_sym

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -47,9 +47,9 @@ describe(ServiceAnsiblePlaybook) do
           :credential_id => credential_0.id,
           :playbook_id   => 10,
           :extra_vars    => {
-            "var1" => "default_val1",
-            :var2  => "default_val2",
-            "var3" => "default_val3"
+            "var1" => {:default => "default_val1"},
+            :var2  => {:default => "default_val2"},
+            "var3" => {:default => "default_val3"}
           },
         }
       }

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -44,8 +44,8 @@ describe ServiceTemplateAnsiblePlaybook do
       :config_info => {
         :provision  => {
           :extra_vars => {
-            'key1' => 'val1',
-            'key2' => 'val2'
+            'key1' => {:default => 'val1'},
+            'key2' => {:default => 'val2'}
           }
         },
         :retirement => {
@@ -63,8 +63,8 @@ describe ServiceTemplateAnsiblePlaybook do
                         :provision => {
                           :new_dialog_name => 'test_dialog_updated',
                           :extra_vars      => {
-                            'key1' => 'updated_val1',
-                            'key2' => 'updated_val2'
+                            'key1' => {:default => 'updated_val1'},
+                            'key2' => {:default => 'updated_val2'}
                           }
                         }
                       }}
@@ -212,8 +212,8 @@ describe ServiceTemplateAnsiblePlaybook do
       expect(service_template.name).to eq(catalog_item_options_three[:name])
       expect(service_template.description).to eq(catalog_item_options_three[:description])
       expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars)).to have_attributes(
-        'key1' => 'updated_val1',
-        'key2' => 'updated_val2'
+        'key1' => {:default => 'updated_val1'},
+        'key2' => {:default => 'updated_val2'}
       )
       new_dialog_record = Dialog.where(:label => new_dialog_label).first
       expect(new_dialog_record).to be_truthy


### PR DESCRIPTION
Before extra_vars are hash key-default_value pairs. Now the hash value is another hash used to be store metadata. The first metadata is default value

For example this is the format for `:config_info` before
```
      :config_info => {
        :provision  => {
          :extra_vars => {
            'key1' => 'val1',
            'key2' => 'val2'
          }
        }
      }
```
and this is the new format
```
      :config_info => {
        :provision  => {
          :extra_vars => {
            'key1' => {:default => 'val1'},
            'key2' => {:default => 'val2'}
          }
        }
      }
```
In the future we can add more metadata, for example
```
      :config_info => {
        :provision  => {
          :extra_vars => {
            'key1'      => {:type => 'Integer', :default => 1},
            'secrect' => {:password => true}
          }
        }
      }
```