### PR TITLE
Removing ems_events from config/api.yml

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -707,12 +707,6 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
-  :ems_events:
-     :description: LenovoXclarity Events
-     :options:
-     - :collection
-     :verbs: *g
-     :klass: EmsEvent
   :events:
     :description: Events
     :identifier: event


### PR DESCRIPTION
Removing ems_events from config/api.yml

collection definition specified but no implementation behind
it giving us a 404 for it and messing up the client.


