### PR TITLE
Link 'miq_servers' and 'miq_tasks' tables (make miq_task belongs_to miq_server)

### DIFF
--- a/db/migrate/20170410130134_copy_server_id_from_jobs_to_miq_tasks.rb
+++ b/db/migrate/20170410130134_copy_server_id_from_jobs_to_miq_tasks.rb
@@ -1,0 +1,21 @@
+class CopyServerIdFromJobsToMiqTasks < ActiveRecord::Migration[5.0]
+  class Job < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiqTask < ActiveRecord::Base; end
+
+  def up
+    say_with_time("Copying miq_server_id from jobs table to miq_tasks") do
+      Job.where.not(:miq_task_id => nil).find_each do |job|
+        MiqTask.find(job.miq_task_id).update_attributes!(:miq_server_id => job.miq_server_id)
+      end
+    end
+  end
+
+  def down
+    say_with_time("nullifying miq_server_id column on miq_tasks table") do
+      MiqTask.update_all(:miq_server_id => nil)
+    end
+  end
+end

--- a/spec/migrations/20170410130134_copy_server_id_from_jobs_to_miq_tasks_spec.rb
+++ b/spec/migrations/20170410130134_copy_server_id_from_jobs_to_miq_tasks_spec.rb
@@ -1,0 +1,29 @@
+require_migration
+
+describe CopyServerIdFromJobsToMiqTasks do
+  let(:task_name) { "Hello Test Task" }
+  let(:task_stub) { migration_stub(:MiqTask) }
+  let(:job_stub) { migration_stub(:Job) }
+  let(:server_id) { ArRegion.anonymous_class_with_ar_region.rails_sequence_start }
+
+  migration_context :up do
+    it "copies data from 'jobs.miq_server_id' to 'miq_tasks.miq_server_id'" do
+      task = task_stub.create!(:name => task_name)
+      job_stub.create!(:miq_server_id => server_id, :miq_task_id => task.id)
+
+      migrate
+
+      expect(task.reload.miq_server_id).to eq server_id
+    end
+  end
+
+  migration_context :down do
+    it "nullifying miq_server_id column on miq_tasks table" do
+      task = task_stub.create!(:name => task_name, :miq_server_id => server_id)
+
+      migrate
+
+      expect(task.reload.miq_server_id).to be nil
+    end
+  end
+end

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -316,4 +316,61 @@ describe MiqTask do
       expect(Job.count).to eq 0
     end
   end
+
+  describe "#update_status" do
+    let(:miq_task) { FactoryGirl.create(:miq_task_plain) }
+
+    context "to 'Active' state" do
+      it "sets 'started_on => Time.now.utc' if 'started_on' is nil" do
+        Timecop.freeze do
+          expect(miq_task.started_on).to be nil
+          miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+          expect(miq_task.started_on).to eq Time.now.utc
+        end
+      end
+
+      it "does not set 'started_on' if passed state is not 'active'" do
+        miq_task.update_status("Any state", MiqTask::STATUS_OK, "")
+        expect(miq_task.started_on).to be nil
+      end
+
+      it "does not changed 'started_on' if task already has 'started-on' attribute set" do
+        some_time = Time.now.utc - 5.hours
+        miq_task.update_attributes!(:started_on => some_time)
+        miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+        expect(miq_task.started_on).to eq some_time
+      end
+
+      it "sets 'miq_server' association" do
+        server = EvmSpecHelper.local_miq_server
+        miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+        expect(miq_task.miq_server.id).to eq server.id
+      end
+    end
+  end
+
+  describe "#state_active" do
+    let(:miq_task) { FactoryGirl.create(:miq_task_plain) }
+
+    it "sets 'started_on => Time.now.utc' if 'started_on' is nil" do
+      Timecop.freeze do
+        expect(miq_task.started_on).to be nil
+        miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+        expect(miq_task.started_on).to eq Time.now.utc
+      end
+    end
+
+    it "does not changed 'started_on' if task already has 'started-on' attribute set" do
+      some_time = Time.now.utc - 5.hours
+      miq_task.update_attributes!(:started_on => some_time)
+      miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+      expect(miq_task.started_on).to eq some_time
+    end
+
+    it "sets 'miq_server' association" do
+      server = EvmSpecHelper.local_miq_server
+      miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
+      expect(miq_task.miq_server.id).to eq server.id
+    end
+  end
 end


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/14698  - adding former `Job` specific columns to Task view

We linked `miq_server` and `jobs` table in https://github.com/ManageIQ/manageiq/pull/14385 in order to show server name as `Owner` column on jobs UI. After merging `Job` and `MiqTask` layouts in https://github.com/ManageIQ/manageiq-ui-classic/pull/242 UI we will need to show `Owner` column (which is server name) on tasks UI

Another benefit of having `miq_server` linked to task (in addition of providing the same UI for job management screens) : in multy-server environment it would be clear on which server we need to check logs if something wrong with task
 
Column `miq_task.miq_server_id` already exists but was not in use.

This PR i: 
- make miq_task `belongs_to :miq_server`
- assign `miq_server_id` to task when task status changed to `Active`
- data migration `jobs.miq_server_id` to `miq_tasks.miq_server_id`


@miq-bot add-label wip, core, refactoring