### PR TITLE
Change RHVM to RHV

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -39,7 +39,7 @@ describe ExtManagementSystem do
       "openstack_network"           => "OpenStack Network",
       "lenovo_ph_infra"             => "Lenovo XClarity",
       "nuage_network"               => "Nuage Network Manager",
-      "rhevm"                       => "Red Hat Virtualization Manager",
+      "rhevm"                       => "Red Hat Virtualization",
       "scvmm"                       => "Microsoft System Center VMM",
       "vmwarews"                    => "VMware vCenter",
       "vmware_cloud"                => "VMware vCloud",


### PR DESCRIPTION
Change "Red Hat Virtualization Manager" to "Red Hat Virtualization"

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1403358

This goes with: 
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/6
https://github.com/ManageIQ/manageiq-ui-classic/pull/973