### PR TITLE
Add IOPS and encrypted columns to CloudVolume

### DIFF
--- a/db/migrate/20170410055056_add_iops_and_encrypted_to_cloud_volume.rb
+++ b/db/migrate/20170410055056_add_iops_and_encrypted_to_cloud_volume.rb
@@ -1,0 +1,6 @@
+class AddIopsAndEncryptedToCloudVolume < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_volumes, :iops, :integer
+    add_column :cloud_volumes, :encrypted, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -441,6 +441,8 @@ cloud_volumes:
 - bootable
 - creation_time
 - cloud_tenant_id
+- iops
+- encrypted
 compliance_details:
 - id
 - compliance_id


### PR DESCRIPTION
Amazon EBS provides information about volume's IOPS and encryption
status as part of the cloud volume model so this patch extends the
existing cloud model to include these two attributes.

@miq-bot add_label storage, sql migration