### PR TITLE
Add multiline to ssh attribute

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   EXTRA_ATTRIBUTES = {
     :ssh_key_data => {
       :type       => :password,
+      :multiline  => true,
       :label      => N_('Private key'),
       :help_text  => N_('RSA or DSA private key to be used instead of password')
     },


### PR DESCRIPTION
UI needs to know that ssh attribute needs to consider it as multiline otherwise it removes EOL chars and makes ssh key invalid

@miq-bot add_label bug, providers/ansible_tower, fine/yes

@jameswnl please review, thanks :)

Links
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1439589
Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/976
