### PR TITLE
Avoid historical selects on MiqPolicy.seed

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -353,7 +353,7 @@ class MiqPolicy < ApplicationRecord
   end
 
   def self.seed
-    all.each do |p|
+    where(:towhat => nil).or(where(:active => nil)).or(where(:mode => nil)).each do |p|
       attrs = {}
       attrs[:towhat] = "Vm"      if p.towhat.nil?
       attrs[:active] = true      if p.active.nil?

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -353,15 +353,8 @@ class MiqPolicy < ApplicationRecord
   end
 
   def self.seed
-    where(:towhat => nil).or(where(:active => nil)).or(where(:mode => nil)).each do |p|
-      attrs = {}
-      attrs[:towhat] = "Vm"      if p.towhat.nil?
-      attrs[:active] = true      if p.active.nil?
-      attrs[:mode]   = "control" if p.mode.nil?
-      next if attrs.empty?
-      _log.info("Updating [#{p.name}]")
-      p.update_attributes(attrs)
-    end
+    defaults = { :towhat => 'Vm', :active => true, :mode => 'control' }
+    defaults.each { |col, val| where(col => nil).update_all(col => val) }
   end
 
   def self.get_policies_for_target(target, mode, event, inputs = {})

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -113,9 +113,6 @@ class MiqPolicySet < ApplicationRecord
     fixtures = File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
     MiqPolicy.import_from_array(fixtures, :save => true)
 
-    where(:mode => nil).each do |ps|
-      _log.info("Updating [#{ps.name}]")
-      ps.update_attribute(:mode, "control")
-    end
+    where(:mode => nil).update_all(:mode => 'control')
   end
 end # class MiqPolicySet

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -113,11 +113,9 @@ class MiqPolicySet < ApplicationRecord
     fixtures = File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
     MiqPolicy.import_from_array(fixtures, :save => true)
 
-    all.each do |ps|
-      if ps.mode.nil?
-        _log.info("Updating [#{ps.name}]")
-        ps.update_attribute(:mode, "control")
-      end
+    where(:mode => nil).each do |ps|
+      _log.info("Updating [#{ps.name}]")
+      ps.update_attribute(:mode, "control")
     end
   end
 end # class MiqPolicySet


### PR DESCRIPTION
Every start-up we seed things. Every time we put all MiqPolicies to a memory and iterate through them. Even though it is highly probable, there is no MiqPolicy record that needs this policing.

So, when I run
```
10_000.times { MiqPolicy.seed }
```
it gives

👯   | selected records | time
--------- | ------------ | -------------
before | 1080000 | 35.07s
after | 0 | 10.36s

Not extremely important, but this was bothering me for a while.

<sub><sup>Footnote: I wish I could rewrite this method to oneliner with `update_all`. However, I am afraid to do so as robocop and reviewers usually cannot tell when is good time to make an exception to the rule.</sup></sub>