### PR TITLE
BlacklistedEvent.seed was so slow

### DIFF
--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -22,8 +22,9 @@ class BlacklistedEvent < ApplicationRecord
   end
 
   def self.seed
+    existing = where(:ems_id => nil).pluck(:provider_model, :event_name).group_by(&:first).each_with_object({}) { |(ems, q), res| res[ems] = q.map(&:last) }
     ExtManagementSystem.descendants.each do |ems|
-      missing_events = ems.default_blacklisted_event_names - where(:provider_model => ems.name, :ems_id => nil).pluck(:event_name)
+      missing_events = ems.default_blacklisted_event_names - (existing[ems.name] || [])
       create!(missing_events.collect { |e| {:event_name => e, :provider_model => ems.name, :system => true} })
     end
   end


### PR DESCRIPTION
## WHY??
This seed method takes the longest. This method takes 31% time of EvmDatabase.seed_last. On my set-up this method took 3 seconds.

Speed of seeds inside `EvmDatabase.seed_last`:
```
 {:class_RssFeed=>0.10288691520690918,
  :class_MiqWidget=>1.6629936695098877,
  :class_MiqAction=>0.04727506637573242,
  :class_MiqEventDefinition=>2.2581591606140137,
  :class_MiqPolicySet=>0.22873830795288086,
  :class_ChargebackRateDetailMeasure=>0.013733148574829102,
  :class_ChargeableField=>0.04409432411193848,
  :class_ChargebackRateDetailCurrency=>0.016520023345947266,
  :class_ChargebackRate=>0.30977392196655273,
  :class_ArbitrationSetting=>0.012874841690063477,
  :class_BlacklistedEvent=>3.0335240364074707,
  :class_Classification=>0.07406258583068848,
  :class_CustomizationTemplate=>0.03467273712158203,
  :class_Dialog=>0.47321200370788574,
  :class_MiqAlert=>0.03574037551879883,
  :class_MiqDialog=>0.24742746353149414,
  :class_MiqEventDefinitionSet=>0.013843536376953125,
  :class_MiqPolicy=>0.0014827251434326172,
  :class_MiqSearch=>0.5813729763031006,
  :class_MiqShortcut=>0.060210227966308594,
  :class_MiqWidgetSet=>0.02152729034423828,
  :class_NotificationType=>0.05846905708312988,
  :class_OrchestrationTemplate=>0.028501272201538086,
  :class_PxeImageType=>0.008610248565673828,
  :class_ScanItem=>0.09435367584228516,
  :class_TimeProfile=>0.020040273666381836,
  :class_MiqAeDatastore=>0.21139287948608398,
  :total_time=>9.695848226547241}]
```

## WHAT??
Use single select instead of `42` different select statements.

### Improvement

When I run
```
10_000.times { BlacklistedEvent.seed }
```
it gives

🤕 | # of queries | # of rows | time | % 
----- | ------- | ------ | ----- | -----
Before | 420,000 | 370,000 | 361.53 s | 100.00%
After | 10,000 | 370,000 | 13.67 s | 3.78%