### PR TITLE
Do not pass nil to the assignment mixin

### DIFF
--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -52,7 +52,7 @@ module Metric::ChargebackHelper
     when ContainerProject.name
       [parent_ems, MiqEnterprise.my_enterprise].compact
     when Container.name
-      [parent_ems]
+      [parent_ems].compact
     end
   end
 end


### PR DESCRIPTION
## BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1440917

## Addressing
```
 [NoMethodError]: undefined method `base_model' for NilClass:Class  Method:[rescue in _async_generate_table]
app/models/mixins/assignment_mixin.rb:146:in `block in get_assigned_for_target'
app/models/mixins/assignment_mixin.rb:146:in `collect'
app/models/mixins/assignment_mixin.rb:146:in `get_assigned_for_target'
app/models/chargeback/rates_cache.rb:13:in `rates'
app/models/chargeback/rates_cache.rb:7:in `get'
app/models/chargeback.rb:9:in `block in build_results_for_report_chargeback'
app/models/chargeback/consumption_history.rb:31:in `block (2 levels) in for_report'
```

Introduced in 31fac86a962f16c080f453a44dcd20345b8fd24e

Lesson learned: when you see two lists with `[].compact` above your edit, it is usually good idea to consider using `.compact` too.

If we merged https://github.com/ManageIQ/manageiq/pull/14090 we wouldn't see this at customer. 😑 ❗️ 
