### PR TITLE
Refresh Configuration Script Sources action

### DIFF
--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -8,6 +8,7 @@ module Api
         res[:message] = message if message.present?
         res[:result]  = options[:result] unless options[:result].nil?
         add_task_to_result(res, options[:task_id]) if options[:task_id].present?
+        add_tasks_to_result(res, options[:task_ids]) if options[:task_ids].present?
         res
       end
 
@@ -23,8 +24,15 @@ module Api
 
       def add_task_to_result(hash, task_id)
         hash[:task_id]   = task_id
-        hash[:task_href] = "#{@req.api_prefix}/tasks/#{task_id}"
+        hash[:task_href] = task_href(task_id)
         hash
+      end
+
+      def add_tasks_to_result(hash, task_ids)
+        add_task_to_result(hash, task_ids.first)
+        hash[:tasks] = task_ids.collect do |task_id|
+          { :id => task_id, :href => task_href(task_id) }
+        end
       end
 
       def add_tag_to_result(hash, tag_spec)
@@ -32,6 +40,10 @@ module Api
         hash[:tag_name]     = tag_spec[:name] if tag_spec[:name].present?
         hash[:tag_href]     = "#{@req.api_prefix}/tags/#{tag_spec[:id]}" if tag_spec[:id].present?
         hash
+      end
+
+      def task_href(task_id)
+        "#{@req.api_prefix}/tasks/#{task_id}"
       end
 
       def add_subcollection_resource_to_result(hash, ctype, object)

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -31,6 +31,14 @@ module Api
       action_result(false, err.to_s)
     end
 
+    def refresh_resource(type, id, _data)
+      config_script_src = resource_search(id, type, collection_class(type))
+      task_id = EmsRefresh.queue_refresh_task(config_script_src).first
+      action_result(true, "Refreshing #{config_script_src_ident(config_script_src)}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     private
 
     def config_script_src_ident(config_script_src)

--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -33,8 +33,8 @@ module Api
 
     def refresh_resource(type, id, _data)
       config_script_src = resource_search(id, type, collection_class(type))
-      task_id = EmsRefresh.queue_refresh_task(config_script_src).first
-      action_result(true, "Refreshing #{config_script_src_ident(config_script_src)}", :task_id => task_id)
+      task_ids = EmsRefresh.queue_refresh_task(config_script_src)
+      action_result(true, "Refreshing #{config_script_src_ident(config_script_src)}", :task_ids => task_ids)
     rescue => err
       action_result(false, err.to_s)
     end

--- a/config/api.yml
+++ b/config/api.yml
@@ -621,6 +621,8 @@
         :identifier: embedded_configuration_script_source_delete
       - :name: create
         :identifier: embedded_configuration_script_source_add
+      - :name: refresh
+        :identifier: embedded_configuration_script_source_edit
     :resource_actions:
       :get:
       - :name: read
@@ -630,6 +632,8 @@
         :identifier: embedded_configuration_script_source_edit
       - :name: delete
         :identifier: embedded_configuration_script_source_delete
+      - :name: refresh
+        :identifier: embedded_configuration_script_source_edit
       :delete:
       - :name: delete
         :identifier: embedded_configuration_script_source_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -622,7 +622,7 @@
       - :name: create
         :identifier: embedded_configuration_script_source_add
       - :name: refresh
-        :identifier: embedded_configuration_script_source_edit
+        :identifier: embedded_configuration_script_source_refresh
     :resource_actions:
       :get:
       - :name: read
@@ -633,7 +633,7 @@
       - :name: delete
         :identifier: embedded_configuration_script_source_delete
       - :name: refresh
-        :identifier: embedded_configuration_script_source_edit
+        :identifier: embedded_configuration_script_source_refresh
       :delete:
       - :name: delete
         :identifier: embedded_configuration_script_source_delete

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -126,6 +126,29 @@ RSpec.describe 'Configuration Script Sources API' do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'can refresh multiple configuration_script_source with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:configuration_script_sources, :refresh, :post)
+
+      run_post(configuration_script_sources_url, :action => 'refresh', :resources => [{ :id => config_script_src.id}, {:id => config_script_src_2.id}])
+
+      expected = {
+        'results' => [
+          a_hash_including(
+            'success' => true,
+            'message' => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src.id}"),
+            'task_id' => a_kind_of(Numeric)
+          ),
+          a_hash_including(
+            'success' => true,
+            'message' => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src_2.id}"),
+            'task_id' => a_kind_of(Numeric)
+          )
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
   end
 
   describe 'PUT /api/configuration_script_sources/:id' do
@@ -217,6 +240,28 @@ RSpec.describe 'Configuration Script Sources API' do
       run_post(configuration_script_sources_url(config_script_src.id), :action => 'edit', :resource => params)
 
       expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'forbids refresh without an appropriate role' do
+      api_basic_authorize
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'refresh')
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can refresh a configuration_script_source with an appropriate role' do
+      api_basic_authorize action_identifier(:configuration_script_sources, :refresh)
+
+      run_post(configuration_script_sources_url(config_script_src.id), :action => 'refresh')
+
+      expected = {
+        'success' => true,
+        'message' => /Refreshing ConfigurationScriptSource/,
+        'task_id' => a_kind_of(Numeric)
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
     end
 
     it 'can delete a configuration_script_source with an appropriate role' do

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -130,19 +130,23 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can refresh multiple configuration_script_source with an appropriate role' do
       api_basic_authorize collection_action_identifier(:configuration_script_sources, :refresh, :post)
 
-      run_post(configuration_script_sources_url, :action => 'refresh', :resources => [{ :id => config_script_src.id}, {:id => config_script_src_2.id}])
+      run_post(configuration_script_sources_url, :action => :refresh, :resources => [{ :id => config_script_src.id}, {:id => config_script_src_2.id}])
 
       expected = {
         'results' => [
           a_hash_including(
-            'success' => true,
-            'message' => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src.id}"),
-            'task_id' => a_kind_of(Numeric)
+            'success'   => true,
+            'message'   => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src.id}"),
+            'task_id'   => a_kind_of(Numeric),
+            'task_href' => /task/,
+            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
           ),
           a_hash_including(
-            'success' => true,
-            'message' => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src_2.id}"),
-            'task_id' => a_kind_of(Numeric)
+            'success'   => true,
+            'message'   => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src_2.id}"),
+            'task_id'   => a_kind_of(Numeric),
+            'task_href' => /task/,
+            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
           )
         ]
       }
@@ -253,12 +257,14 @@ RSpec.describe 'Configuration Script Sources API' do
     it 'can refresh a configuration_script_source with an appropriate role' do
       api_basic_authorize action_identifier(:configuration_script_sources, :refresh)
 
-      run_post(configuration_script_sources_url(config_script_src.id), :action => 'refresh')
+      run_post(configuration_script_sources_url(config_script_src.id), :action => :refresh)
 
       expected = {
-        'success' => true,
-        'message' => /Refreshing ConfigurationScriptSource/,
-        'task_id' => a_kind_of(Numeric)
+        'success'   => true,
+        'message'   => /Refreshing ConfigurationScriptSource/,
+        'task_id'   => a_kind_of(Numeric),
+        'task_href' => /task/,
+        'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /tasks/)]
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)


### PR DESCRIPTION
Refresh action for configuration script sources collection and resource 

```
POST /api/configuration_script_sources/:id
{
  "action": "refresh"
}
```

```
POST /api/configuration_script_sources
{
  "action":"refresh",
  "resources" : [ { "id" : id }, { "id" : id } ]
}
```

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 

cc: @durandom @jameswnl @dclarizio @gmcculloug 
