### PR TITLE
[EUWE] Fix missing Back button on Host Drift comparison page

### DIFF
--- a/app/helpers/application_helper/button/show_summary.rb
+++ b/app/helpers/application_helper/button/show_summary.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::ShowSummary < ApplicationHelper::Button::ButtonWithoutRbacCheck
+  def visible?
+    !@explorer
+  end
+end

--- a/app/helpers/application_helper/toolbar/summary_center.rb
+++ b/app/helpers/application_helper/toolbar/summary_center.rb
@@ -1,14 +1,18 @@
 class ApplicationHelper::Toolbar::SummaryCenter < ApplicationHelper::Toolbar::Basic
-  button_group('record_summary', [
-    button(
-      :show_summary,
-      'fa fa-arrow-left fa-lg',
-      proc do
-        _('Show %{object_name} Summary') %
-          {:object_name => @layout == "cim_base_storage_extent" ? @record.evm_display_name : @record.name}
-      end,
-      nil,
-      :url       => "/show",
-      :url_parms => "?id=\#{@record.id}"),
-  ])
+  button_group(
+    'record_summary', [
+      button(
+        :show_summary,
+        'fa fa-arrow-left fa-lg',
+        proc do
+          _('Show %{object_name} Summary') %
+            {:object_name => @layout == "cim_base_storage_extent" ? @record.evm_display_name : @record.name}
+        end,
+        nil,
+        :url       => "/show",
+        :url_parms => "?id=\#{@record.id}",
+        :klass     => ApplicationHelper::Button::ShowSummary
+      )
+    ]
+  )
 end


### PR DESCRIPTION
Caused by missing cherry-pick of https://github.com/ManageIQ/manageiq/pull/13084
This PR is adding the class for ShowSummary (Back Button on Hosts' Drift comparison) from the original PR as it's sufficient as a bugfix

https://bugzilla.redhat.com/show_bug.cgi?id=1436074