### PR TITLE
Handle exception when a metrics target doesn't have an ext_management_system

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -213,9 +213,13 @@ module Metric::Capture
 
       options = target_options[target]
 
-      target.perf_capture_queue(interval_name, options)
-      if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
-        target.perf_capture_queue('historical')
+      begin
+        target.perf_capture_queue(interval_name, options)
+        if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
+          target.perf_capture_queue('historical')
+        end
+      rescue => err
+        _log.warn("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
       end
     end
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -5,16 +5,14 @@ module Metric::CiMixin::Capture
 
   delegate :perf_collect_metrics, :to => :perf_capture_object
 
-  def queue_name_for_metrics_collection
-    ems = if self.kind_of?(ExtManagementSystem)
-            self
-          elsif respond_to?(:ext_management_system) && ext_management_system.present?
-            ext_management_system
-          elsif respond_to?(:old_ext_management_system) && old_ext_management_system.present?
-            old_ext_management_system
-          end
-    raise _("Unsupported type %{name} (id: %{number})") % {:name => self.class.name, :number => id} if ems.nil?
-    ems.metrics_collector_queue_name
+  def ems_for_capture_target
+    if self.kind_of?(ExtManagementSystem)
+      self
+    elsif respond_to?(:ext_management_system) && ext_management_system.present?
+      ext_management_system
+    elsif respond_to?(:old_ext_management_system) && old_ext_management_system.present?
+      old_ext_management_system
+    end
   end
 
   def split_capture_intervals(interval_name, start_time, end_time, threshold = 1.day)
@@ -38,8 +36,11 @@ module Metric::CiMixin::Capture
     task_id    = options[:task_id]
     zone       = options[:zone] || my_zone
     zone = zone.name if zone.respond_to?(:name)
+    ems        = ems_for_capture_target
+
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
     raise ArgumentError, "end_time cannot be specified if start_time is nil" if start_time.nil? && !end_time.nil?
+    raise ArgumentError, "target does not have an ExtManagementSystem" if ems.nil?
 
     start_time = start_time.utc unless start_time.nil?
     end_time = end_time.utc unless end_time.nil?
@@ -65,7 +66,7 @@ module Metric::CiMixin::Capture
       :class_name  => self.class.name,
       :instance_id => id,
       :role        => 'ems_metrics_collector',
-      :queue_name  => queue_name_for_metrics_collection,
+      :queue_name  => ems.metrics_collector_queue_name,
       :zone        => zone,
       :state       => ['ready', 'dequeue'],
     }

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -241,9 +241,9 @@ describe Metric::CiMixin::Capture do
       group.disconnect_inv
       project.disconnect_inv
 
-      expect(container.queue_name_for_metrics_collection).to eq ems.metrics_collector_queue_name
-      expect(group.queue_name_for_metrics_collection).to eq ems.metrics_collector_queue_name
-      expect(project.queue_name_for_metrics_collection).to eq ems.metrics_collector_queue_name
+      expect(container.ems_for_capture_target).to eq ems
+      expect(group.ems_for_capture_target).to     eq ems
+      expect(project.ems_for_capture_target).to   eq ems
 
       expect(container.my_zone).to eq ems.my_zone
       expect(group.my_zone).to eq ems.my_zone


### PR DESCRIPTION
If an invalid target finds its way into `Metric::Capture.queue_captures` the exception thrown will prevent all further targets from being queued.  This will catch and log the exception for that target then continue to queue the remaining targets.

Also since `Unsupported type ManageIQ::Providers::Kubernetes::ContainerManager::Container (id: 28453)` isn't very descriptive of the real issue (the target type is fine, the specific target doesn't have an ems) this will raise an ArgumentError saying `"target does not have an ExtManagementSystem"` if the target doesn't have an ems_id or an old_ems_id.

https://bugzilla.redhat.com/show_bug.cgi?id=1439888