### PR TITLE
Speed up MiqEventDefinitionSet.seed

### DIFF
--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -2,10 +2,11 @@ class MiqEventDefinitionSet < ApplicationRecord
   acts_as_miq_set
 
   def self.seed
+    existing = all.group_by(&:name)
     CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/) do |csv_row|
       set = csv_row.to_hash
 
-      rec = find_by(:name => set['name'])
+      rec = existing[set['name']].try(:first)
       if rec.nil?
         _log.info("Creating [#{set['name']}]")
         create!(set)


### PR DESCRIPTION
MiqEventDefinitionSet is static union. It is unfortunate to use 13 selects on every start-up (during the db lock) to ensure that the union is in place.

On my system, the `10_000.times { MiqEventDefinitionSet.seed }` gives:

:kiss: |  rows  | selects | time |  %
-------| ------ | ------- | ---- | ----
Before | 130000 |  130000 | 123s | 100%
After  | 130000 |   10000 |  34s |  27%

Note: MiqEventDefinition.seed is second biggest abuser after BlackListedEvent (https://github.com/ManageIQ/manageiq/pull/14712)
