### PR TITLE
Avoid dozens of extra selects in seed_default_events

### DIFF
--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -122,6 +122,7 @@ class MiqEventDefinition < ApplicationRecord
   end
 
   def self.seed_default_events
+    event_sets = MiqEventDefinitionSet.all.index_by(&:name)
     fname = File.join(FIXTURE_DIR, "#{to_s.pluralize.underscore}.csv")
     CSV.foreach(fname, :headers => true, :skip_lines => /^#/, :skip_blanks => true) do |csv_row|
       event = csv_row.to_hash
@@ -139,7 +140,7 @@ class MiqEventDefinition < ApplicationRecord
         end
       end
 
-      es = MiqEventDefinitionSet.find_by(:name => set_type)
+      es = event_sets[set_type]
       rec.memberof.each { |old_set| rec.make_not_memberof(old_set) unless old_set == es } # handle changes in set membership
       es.add_member(rec) if es && !es.members.include?(rec)
     end

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -125,24 +125,28 @@ describe MiqEventDefinition do
       expect(event.definition).to be_nil
     end
 
-    it "won't update an event with a definition (keyed as a string)" do
-      described_class.seed_default_events
-      name = described_class.first.name
-      attributes = {"name" => name, "definition" => {:event => {:message => "`rm -rf /super/secret/file`"}}}
+    context 'with defaults in db' do
+      before do
+        described_class.seed_default_events
+      end
 
-      event, = described_class.import_from_hash(attributes)
+      it "won't update an event with a definition (keyed as a string)" do
+        name = described_class.first.name
+        attributes = {"name" => name, "definition" => {:event => {:message => "`rm -rf /super/secret/file`"}}}
 
-      expect(event.definition).to be_nil
-    end
+        event, = described_class.import_from_hash(attributes)
 
-    it "won't update an event with a definition (keyed as a symbol)" do
-      described_class.seed_default_events
-      name = described_class.first.name
-      attributes = {"name" => name, :definition => {:event => {:message => "`rm -rf /super/secret/file`"}}}
+        expect(event.definition).to be_nil
+      end
 
-      event, = described_class.import_from_hash(attributes)
+      it "won't update an event with a definition (keyed as a symbol)" do
+        name = described_class.first.name
+        attributes = {"name" => name, :definition => {:event => {:message => "`rm -rf /super/secret/file`"}}}
 
-      expect(event.definition).to be_nil
+        event, = described_class.import_from_hash(attributes)
+
+        expect(event.definition).to be_nil
+      end
     end
   end
 end

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -127,6 +127,7 @@ describe MiqEventDefinition do
 
     context 'with defaults in db' do
       before do
+        MiqEventDefinitionSet.seed
         described_class.seed_default_events
       end
 


### PR DESCRIPTION
MiqEventDefinitionSet is static union. It is inefficient to use multiple selects instead of a single one.

On my system `100.times { MiqEventDefinition.seed_default_events }` gives

:gear: |  rows | selects | time |  %
------ | ----- | ------- | ---- | ---
Before | 16900 |   16900 | 204s | 100%
After  |  1300 |     100 |  93s |  45%

