### PR TITLE
Storage removal

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -78,6 +78,12 @@ class Storage < ApplicationRecord
     end
   end
 
+  supports :delete do
+    if vms_and_templates.any? || hosts.any?
+      unsupported_reason_add(:delete, _("Only storage without VMs and Hosts can be removed"))
+    end
+  end
+
   def to_s
     name
   end


### PR DESCRIPTION
Datastores can't be removed if there are relations to hosts or vms.
We need provide a way to check whether datastore removal is supported
(no vm or host relations). When there condition is not met we need
to notify a user that relations needs to be removed first.

This PR fixes:
https://bugzilla.redhat.com/1439380