### PR TITLE
Do not run MiqEventDefinitionSet.seed twice on every start-up

### DIFF
--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -117,7 +117,6 @@ class MiqEventDefinition < ApplicationRecord
   end
 
   def self.seed
-    MiqEventDefinitionSet.seed
     seed_default_events
     seed_default_definitions
   end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -23,6 +23,7 @@ class EvmDatabase
     RssFeed
     MiqWidget
     MiqAction
+    MiqEventDefinitionSet
     MiqEventDefinition
     MiqPolicySet
     ChargebackRateDetailMeasure

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -8,6 +8,7 @@ describe Authentication do
 
   context "with miq events seeded" do
     before(:each) do
+      MiqEventDefinitionSet.seed
       MiqEventDefinition.seed
     end
 


### PR DESCRIPTION
We do not need to run this twice. We have a mechanism to set dependencies between the seeds.

On my system, running `10.times { EvmDatabase.seed_last }` gives

:sake: | rows | selects | time |  %
------ | ---- | ------- | ---- | ---
Before |    ? |       ? |  55s | 100%
After  | -130 |    -130 |  51s |  91%

