### PR TITLE
Do not run these seeds twice

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -539,7 +539,6 @@ class MiqWidget < ApplicationRecord
   end
 
   def self.seed
-    RssFeed.seed
     sync_from_dir
     MiqWidgetSet.seed
   end

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -539,7 +539,6 @@ class MiqWidget < ApplicationRecord
   end
 
   def self.seed
-    MiqReport.seed
     RssFeed.seed
     sync_from_dir
     MiqWidgetSet.seed

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -540,7 +540,6 @@ class MiqWidget < ApplicationRecord
 
   def self.seed
     sync_from_dir
-    MiqWidgetSet.seed
   end
 
   def self.seed_widget(pattern)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,5 +1,8 @@
 describe MiqWidget do
-  include_examples(".seed called multiple times", 21)
+  describe '.seed' do
+    before { MiqReport.seed }
+    include_examples(".seed called multiple times", 21)
+  end
 
   before(:each) do
     EvmSpecHelper.local_miq_server

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,6 +1,6 @@
 describe MiqWidget do
   describe '.seed' do
-    before { MiqReport.seed }
+    before { [MiqReport, RssFeed].each(&:seed) }
     include_examples(".seed called multiple times", 21)
   end
 


### PR DESCRIPTION
We run seeds on every start-up. Certain methods were called twice. That is not efficient.

On my system, running `100.times { MiqWidget.seed }` gives:

|        ms |    bytes |  objects |queries | query (ms) |  % | comments
|       ---:|      ---:|      ---:|  ---:|      ---:| ---:| ----
|  55,532.4 | 89,772,866* | 61,866,274 |31,300 | 13,085.5 | 100% |before
|  9,343.4 | 7,196,824* | 8,821,284 |6,300 | 2,181.3 | 16% |after

