### PR TITLE
[DARGA] Analysis profile update

### DIFF
--- a/app/views/ops/_ap_form_file.html.haml
+++ b/app/views/ops/_ap_form_file.html.haml
@@ -1,63 +1,63 @@
-%fieldset
-  - scan_id = "#{@scan.id || 'new'}"
-  - url = url_for(:action => 'ap_edit',
-                  :id     => scan_id)
-  %h3= _("File Entry")
-  %table.table.table-striped.table-bordered.table-hover
-    %thead
-      %tr
-        %th.narrow
-        %th= _("Name")
-        %th= _("Collect Contents?")
-    %tbody
-      - if !params[:add] && params[:add] != "new"
-        %tr#new_tr{:title => _("Click to add a new entry"), :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item => "file", :id => scan_id})}
-          %td
-            %button.btn.btn-default
-              %i.fa.fa-plus.fa-lg
-          %td= _("<New Entry>")
-          %td= _("<New Entry>")
-      - else
-        %tr#new_tr
-          %td
-            %button.btn.btn-default{:title => _("Add this entry"),
-              "data-submit"         => 'ap_form_div',
-              "data-miq_sparkle_on" => true,
-              :remote               => true,
-              "data-method"         => :post,
-              'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
-              %i.fa.fa-plus.fa-lg
+- scan_id = "#{@scan.id || 'new'}"
+- url = url_for(:action => 'ap_edit',
+                :id     => scan_id)
+%h3= _("File Entry")
+%table.table.table-striped.table-bordered.table-hover
+  %thead
+    %tr
+      %th= _("Name")
+      %th= _("Collect Contents?")
+      %th.action-cell= _("Actions")
+  %tbody
+    - if !params[:add] && params[:add] != "new"
+      %tr#new_tr{:title => _("Click to add a new entry"), :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item => "file", :id => scan_id})}
+        %td= _("<New Entry>")
+        %td
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
+    - else
+      %tr#new_tr
+        %td
+          = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
+          = hidden_field("item", "type1", :value => "file")
+        %td
+          = check_box_tag("entry_content", 1, false, :id => "entry_content")
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+            "data-submit"         => 'ap_form_div',
+            "data-miq_sparkle_on" => true,
+            :remote               => true,
+            "data-method"         => :post,
+            'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
+            = _("Save")
+    - Array(session[:file_names]).sort_by { |r| r["target"] }.each do |entry|
+      - if session[:edit_filename] != entry["target"]
+        %tr{:class => cycle('row0', 'row1'), :id => "#{entry['target']}_tr"}
+          %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
+            = h(entry["target"])
+          %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
+            = h(entry["content"] ? entry["content"] : false)
 
-          %td
-            = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
-            = hidden_field("item", "type1", :value => "file")
-          %td
-            = check_box_tag("entry_content", 1, false, :id => "entry_content")
-      - Array(session[:file_names]).sort_by { |r| r["target"] }.each do |entry|
-        - if session[:edit_filename] != entry["target"]
-          %tr{:class => cycle('row0', 'row1'), :id => "#{entry['target']}_tr"}
-            %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :file_name => entry["target"], :id => scan_id}), :title => _("Click to delete this entry")}
-              %button.btn.btn-default
-                %i.fa.fa-minus.fa-lg
-            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
-              = h(entry["target"])
-            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
-              = h(entry["content"] ? entry["content"] : false)
-        - else
-          - if params[:add] != "new"
-            %tr{:class => cycle('row0', 'row1'), :id => "edit_tr"}
-              %td
-                %button.btn.btn-default{:title => _("Update this entry"),
-                  "data-submit"         => 'ap_form_div',
-                  "data-miq_sparkle_on" => true,
-                  :remote               => true,
-                  "data-method"         => :post,
-                  'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
-                  %i.fa.fa-save.fa-lg
-              %td
-                = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, "value" => session[:edit_filename], :style => "width: 100%;")
-                = hidden_field("item", "type1", :value => "file")
-              %td
-                - checked = !!entry["content"]
-                = check_box_tag("entry_content", 1, checked, :id => "entry_content")
-                = hidden_field("item", "type1", :value => "file")
+          %td.action-cell{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :file_name => entry["target"], :id => scan_id}), :title => _("Click to delete this entry")}
+            %button.btn.btn-default.btn-block.btn-sm
+              = _("Delete")
+      - else
+        - if params[:add] != "new"
+          %tr{:class => cycle('row0', 'row1'), :id => "edit_tr"}
+            %td
+              = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, "value" => session[:edit_filename], :style => "width: 100%;")
+              = hidden_field("item", "type1", :value => "file")
+            %td
+              - checked = !!entry["content"]
+              = check_box_tag("entry_content", 1, checked, :id => "entry_content")
+              = hidden_field("item", "type1", :value => "file")
+            %td.action-cell
+              %button.btn.btn-default.btn-block.btn-sm{:title => _("Update this entry"),
+                "data-submit"         => 'ap_form_div',
+                "data-miq_sparkle_on" => true,
+                :remote               => true,
+                "data-method"         => :post,
+                'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
+                = _("Save")
+

--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -1,112 +1,128 @@
-%fieldset
-  %h3= _("Event Log Entry")
-  %table.table.table-striped.table-bordered.table-hover
-    %thead
-      %tr
-        %th.narrow
-        %th= _("Name")
-        %th= _("Filter Message")
-        %th= _("Level")
-        %th= _("Source")
-        %th= _(" # of Days")
-    %tbody
-      - if (!params[:add] && session[:nteventlog_data].empty?) || params[:edit_entry]
-        %tr#new_tr{:onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "nteventlog", :id => "#{@scan.id || "new"}"}), :title => _("Click to add a new entry")}
-          %td= image_tag(image_path('toolbars/import.png'), :class => "rollover small")
-          %td= _("<New Entry>")
-          %td= _("<Click on this row to create a new entry>")
-          %td= _("<Click on this row to create a new entry>")
-          %td= _("<Click on this row to create a new entry>")
-          %td= _("<Click on this row to create a new entry>")
-      - else
-        %tr#new_tr
-          %td
-            = image_submit_tag(image_path('toolbars/import.png'),
-              :class     => "rollover small",
-              :name      => "accept",
-              :alt       => _("Add this entry"),
-              :title     => _("Add this entry"),
-              :item_type => "nteventlog",
-              :id        => "#{@scan.id || "new"}")
-          %td
-            = text_field("entry", "name",
+- scan_id = "#{@scan.id || 'new'}"
+- url = url_for(:action => 'ap_edit',
+                :id     => scan_id)
+%h3= _("Event Log Entry")
+%table.table.table-striped.table-bordered.table-hover
+  %thead
+    %tr
+      %th= _("Name")
+      %th= _("Filter Message")
+      %th= _("Level")
+      %th= _("Source")
+      %th= _(" # of Days")
+      %th.action-cell= _("Actions")
+  %tbody
+    - if (!params[:add] && session[:nteventlog_data].empty?) || params[:edit_entry]
+      %tr#new_tr{:onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "nteventlog", :id => "#{@scan.id || "new"}"}), :title => _("Click to add a new entry")}
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %th.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
+    - else
+      %tr#new_tr
+        %td
+          = text_field("entry", "name",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:nteventlog_data][:name],
+            :style     => "width: 100%;")
+        %td
+          = text_field("entry", "message",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:nteventlog_data][:message],
+            :style     => "width: 100%;")
+        %td
+          = text_field("entry", "level",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:nteventlog_data][:level],
+            :style => "width: 100%;")
+        %td
+          = text_field("entry", "source",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:nteventlog_data][:source],
+            :style     => "width: 100%;")
+        %td
+          = text_field("entry", "num_days",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:nteventlog_data][:numdays],
+            :style     => "width: 100%;")
+        %td.action-cell
+          - url = url_for(:action    => 'ap_edit',
+                          :id        => scan_id,
+                          :accept    => 'accept',
+                          :item_type => 'nteventlog')
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+                                  "data-submit"         => 'ap_form_div',
+                                  "data-miq_sparkle_on" => true,
+                                  :remote               => true,
+                                  "data-method"         => :post,
+                                  'data-click_url'      => {:url => url}.to_json}
+            = _("Save")
+        = hidden_field("item", "type3", :value => "nteventlog")
+    - if !session[:nteventlog_entries].nil? && !session[:nteventlog_entries].empty?
+      - session[:nteventlog_entries].sort_by { |r| r[:name] }.each_with_index do |nteventlog, i|
+        - if session[:nteventlog_data][:name] == nteventlog[:name] && session[:nteventlog_data][:selected].to_i == i
+          %tr{:id => "edit_tr"}
+            %td
+              = text_field("entry", "name",
               :maxlength => MAX_NAME_LEN,
               "value"    => session[:nteventlog_data][:name],
               :style     => "width: 100%;")
-          %td
-            = text_field("entry", "message",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:nteventlog_data][:message],
-              :style     => "width: 100%;")
-          %td
-            = text_field("entry", "level",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:nteventlog_data][:level],
-              :style => "width: 100%;")
-          %td
-            = text_field("entry", "source",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:nteventlog_data][:source],
-              :style     => "width: 100%;")
-          %td
-            = text_field("entry", "num_days",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:nteventlog_data][:numdays],
-              :style     => "width: 100%;")
-          = hidden_field("item", "type3", :value => "nteventlog")
-      - if !session[:nteventlog_entries].nil? && !session[:nteventlog_entries].empty?
-        - session[:nteventlog_entries].sort_by { |r| r[:name] }.each_with_index do |nteventlog, i|
-          - if session[:nteventlog_data][:name] == nteventlog[:name] && session[:nteventlog_data][:selected].to_i == i
-            %tr{:id => "edit_tr"}
-              %td
-                = image_submit_tag(image_path('toolbars/import.png'),
-                  :class      => "rollover small",
-                  :name       => "accept",
-                  :edit_entry => 'edit_registry',
-                  :alt        => _("Update this entry"),
-                  :title      => _("Update this entry"),
-                  :id         => "#{@scan.id || "new"}")
-              %td
-                = text_field("entry", "name",
+            %td
+              = text_field("entry", "message",
                 :maxlength => MAX_NAME_LEN,
-                "value"    => session[:nteventlog_data][:name],
+                "value"    => session[:nteventlog_data][:message],
                 :style     => "width: 100%;")
-              %td
-                = text_field("entry", "message",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => session[:nteventlog_data][:message],
-                  :style     => "width: 100%;")
-              %td
-                = text_field("entry", "level",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => h(session[:nteventlog_data][:level]),
-                  :style     => "width: 100%;")
-              %td
-                = text_field("entry", "source",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => session[:nteventlog_data][:source],
-                  :style     => "width: 100%;")
-              %td
-                = text_field("entry", "num_days",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => session[:nteventlog_data][:num_days],
-                  :style     => "width: 100%;")
-              = hidden_field("item", "type3", :value => "nteventlog")
-              = hidden_field("item", "id", :value => i)
-          - else
-            %tr{:id => "#{i}_tr"}
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
-                = image_tag(image_path('toolbars/delete.png'), :class => "rollover small")
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :entry_id => i, :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                = h(nteventlog[:name])
+            %td
+              = text_field("entry", "level",
+                :maxlength => MAX_NAME_LEN,
+                "value"    => h(session[:nteventlog_data][:level]),
+                :style     => "width: 100%;")
+            %td
+              = text_field("entry", "source",
+                :maxlength => MAX_NAME_LEN,
+                "value"    => session[:nteventlog_data][:source],
+                :style     => "width: 100%;")
+            %td
+              = text_field("entry", "num_days",
+                :maxlength => MAX_NAME_LEN,
+                "value"    => session[:nteventlog_data][:num_days],
+                :style     => "width: 100%;")
+
+            %td.action-cell
+              - url = url_for(:action     => 'ap_edit',
+                              :id         => scan_id,
+                              :accept     => 'accept',
+                              :edit_entry => 'edit_entry_nteventlog',
+                              :entry_id   => i)
+              %button.btn.btn-default.btn-block.btn-sm{:title => _("Update this entry"),
+                "data-submit"         => 'ap_form_div',
+                "data-miq_sparkle_on" => true,
+                :remote               => true,
+                "data-method"         => :post,
+                'data-click_url'      => {:url => url}.to_json}
+                = _("Save")
+            = hidden_field("item", "type3", :value => "nteventlog")
+            = hidden_field("item", "id", :value => i)
+        - else
+          %tr{:id => "#{i}_tr"}
+            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :entry_id => i, :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              = h(nteventlog[:name])
+            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              = h(nteventlog[:filter][:message])
+            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              = h(nteventlog[:filter][:level])
+            - if false
               %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                = h(nteventlog[:filter][:message])
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                = h(nteventlog[:filter][:level])
-              - if false
-                %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                  = h(nteventlog[:filter][:rec_count].to_i)
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                = h(nteventlog[:filter][:source])
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
-                = h(nteventlog[:filter][:num_days].to_i)
+                = h(nteventlog[:filter][:rec_count].to_i)
+            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              = h(nteventlog[:filter][:source])
+            %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
+              = h(nteventlog[:filter][:num_days].to_i)
+            %td.action-cell{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")
+

--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -1,82 +1,102 @@
-%fieldset
-  %h3= _("Registry Entry")
-  %table.table.table-striped.table-bordered.table-hover
-    %thead
-      %tr
-        %th.narrow
-        %th= _("Registry Hive")
-        %th= _("Registry Key")
-        %th= _("Registry Value")
-    %tbody
-      - if (!params[:add] && session[:reg_data].empty?) || params[:edit_entry]
-        %tr#new_tr{:title => _("Click to add a new entry"),
-          :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "registry", :id => "#{@scan.id || "new"}"})}
-          %td
-            = image_tag(image_path('toolbars/new.png'), :class => "rollover small")
-          %td= _("<New Entry>")
-          %td= _("<Click on this row to create a new entry>")
-          %td= _("<Click on this row to create a new entry>")
-      - else
-        %tr#new_tr
-          %td
-            = image_submit_tag(image_path('toolbars/import.png'),
-              :class => "rollover small",
-              :name => "accept", :alt => _("Add this entry"), :title => _("Add this entry"), :item_type => "registry", :id => "#{@scan.id || "new"}")
-          %td
-            = _("HKLM")
-          %td
-            = text_field("entry", "kname",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:reg_data][:key],
-              :style     => "width: 100%;")
-          %td
-            = text_field("entry", "value",
-              :maxlength => MAX_NAME_LEN,
-              "value"    => session[:reg_data][:value],
-              :style     => "width: 100%;")
-          = hidden_field("item", "type2", :value => "registry")
-      - if !session[:reg_entries].nil? && !session[:reg_entries].empty?
-        - session[:reg_entries].sort_by { |r| r["key"] }.each_with_index do |reg, i|
-          - if session[:reg_data][:key] == reg["key"] && session[:reg_data][:value] == reg["value"]
-            %tr#edit_tr
-              %td
-                = image_submit_tag(image_path('toolbars/import.png'),
-                  :class => "rollover small",
-                  :name => "accept", :entry_id => i, :edit_entry => 'edit_registry', :alt => _("Update this entry"), :title => _("Update this entry"), :id => "#{@scan.id || "new"}")
-              %td
-                = _("HKLM")
-              %td
-                = text_field("entry", "kname",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => session[:reg_data][:key],
-                  :style     => "width: 100%;")
-              %td
-                = text_field("entry", "value",
-                  :maxlength => MAX_NAME_LEN,
-                  "value"    => session[:reg_data][:value],
-                  :style     => "width: 100%;")
-              = hidden_field("item", "type2", :value => "registry")
-              = hidden_field("entry", "id", :value => i)
-          - else
-            %tr{:id => "#{i}_tr"}
-              %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :entry_id => i, :item1 => "registry", :reg_key => reg["key"], :reg_value => reg["value"], :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
-            %tr{:id => "#{i}_tr"}
-              - url = {:action     => 'ap_ce_delete',
-                       :entry_id   => i,
-                       :item2      => "registry",
-                       :reg_key    => reg["key"],
-                       :reg_value  => reg["value"],
-                       :edit_entry => 'edit_registry',
-                       :field      => "kname",
-                       :id         => "#{@scan.id || "new"}"}
-              - remote_link = remote_function(:url => url).to_str
-              %td{:onclick => remote_link, :title => _("Click to delete this entry")}
-                = image_tag(image_path('toolbars/delete.png'))
-              - url[:action] = "ap_ce_select"
-              - remote_link = remote_function(:url => url).to_str
-              %td{:onclick => remote_link, :title => _("Click to update this entry")}
-                = _("HKLM")
-              %td{:onclick => remote_link, :title => _("Click to update this entry")}
-                = h(reg["key"])
-              %td{:onclick => remote_link, :title => _("Click to update this entry")}
-                = h(reg["value"])
+- scan_id = "#{@scan.id || 'new'}"
+- url = url_for(:action => 'ap_edit',
+                :id     => scan_id)
+%h3= _("Registry Entry")
+%table.table.table-striped.table-bordered.table-hover
+  %thead
+    %tr
+      %th= _("Registry Hive")
+      %th= _("Registry Key")
+      %th= _("Registry Value")
+      %th.action-cell= _("Actions")
+  %tbody
+    - if (!params[:add] && session[:reg_data].empty?) || params[:edit_entry]
+      %tr#new_tr{:title => _("Click to add a new entry"),
+        :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "registry", :id => "#{@scan.id || "new"}"})}
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
+    - else
+      %tr#new_tr
+        %td
+          = _("HKLM")
+        %td
+          = text_field("entry", "kname",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:reg_data][:key],
+            :style     => "width: 100%;")
+        %td
+          = text_field("entry", "value",
+            :maxlength => MAX_NAME_LEN,
+            "value"    => session[:reg_data][:value],
+            :style     => "width: 100%;")
+
+        %td.action-cell
+          - url = url_for(:action => 'ap_edit',
+                          :id     => scan_id,
+                          :accept => 'accept',
+                          :item_type => 'registry')
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+                                  "data-submit"         => 'ap_form_div',
+                                  "data-miq_sparkle_on" => true,
+                                  :remote               => true,
+                                  "data-method"         => :post,
+                                  'data-click_url'      => {:url => url}.to_json}
+            = _("Save")
+        = hidden_field("item", "type2", :value => "registry")
+    - if !session[:reg_entries].nil? && !session[:reg_entries].empty?
+      - session[:reg_entries].sort_by { |r| r["key"] }.each_with_index do |reg, i|
+        - if session[:reg_data][:key] == reg["key"] && session[:reg_data][:value] == reg["value"]
+          %tr#edit_tr
+            %td
+              = _("HKLM")
+            %td
+              = text_field("entry", "kname",
+                :maxlength => MAX_NAME_LEN,
+                "value"    => session[:reg_data][:key],
+                :style     => "width: 100%;")
+            %td
+              = text_field("entry", "value",
+                :maxlength => MAX_NAME_LEN,
+                "value"    => session[:reg_data][:value],
+                :style     => "width: 100%;")
+            %td.action-cell
+              - url = url_for(:action => 'ap_edit',
+                          :id         => scan_id,
+                          :accept     => 'accept',
+                          :edit_entry => 'edit_entry',
+                          :entry_id   => i)
+              %button.btn.btn-default.btn-block.btn-sm{:title                 => _("Update this entry"),
+                                                        "data-submit"         => 'ap_form_div',
+                                                        "data-miq_sparkle_on" => true,
+                                                        :remote               => true,
+                                                        "data-method"         => :post,
+                                                        'data-click_url'      => {:url => url}.to_json}
+                = _("Save")
+            = hidden_field("item", "type2", :value => "registry")
+            = hidden_field("entry", "id", :value => i)
+        - else
+          %tr{:id => "#{i}_tr"}
+            - url = {:action     => 'ap_ce_select',
+                     :entry_id   => i,
+                     :item2      => "registry",
+                     :reg_key    => reg["key"],
+                     :reg_value  => reg["value"],
+                     :edit_entry => 'edit_registry',
+                     :field      => "kname",
+                     :id         => "#{@scan.id || "new"}"}
+            - remote_link = remote_function(:url => url).to_str
+            %td{:onclick => remote_link, :title => _("Click to update this entry")}
+              = _("HKLM")
+            %td{:onclick => remote_link, :title => _("Click to update this entry")}
+              = h(reg["key"])
+            %td{:onclick => remote_link, :title => _("Click to update this entry")}
+              = h(reg["value"])
+            - url[:action] = "ap_ce_delete"
+            - remote_link = remote_function(:url => url).to_str
+            %td.action-cell{:onclick => remote_link, :title => _("Click to delete this entry")}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")


### PR DESCRIPTION
- Convert Analysis Profile to use Action Menu instead of images
- Fix bug on Event and Registry Edit screens where update didn't work
- Remove extra alternating row on Registry Edit screen (see screenshot)

original PR: https://github.com/ManageIQ/manageiq/pull/12200

https://bugzilla.redhat.com/show_bug.cgi?id=1440409
https://bugzilla.redhat.com/show_bug.cgi?id=1423381

Old
![screen shot 2017-04-11 at 12 41 44 pm](https://cloud.githubusercontent.com/assets/1287144/24922437/4a6cb6c4-1ebc-11e7-82ee-75302af518b8.png)
![screen shot 2017-04-11 at 12 41 37 pm](https://cloud.githubusercontent.com/assets/1287144/24922439/4a6e777a-1ebc-11e7-82a2-3c0f200bb302.png)
![screen shot 2017-04-11 at 12 41 30 pm](https://cloud.githubusercontent.com/assets/1287144/24922440/4a736500-1ebc-11e7-9b97-7bd0a0d04557.png)

New
![screen shot 2017-04-11 at 12 48 13 pm](https://cloud.githubusercontent.com/assets/1287144/24922434/4a6883d8-1ebc-11e7-85be-f5a43bc9363f.png)
![screen shot 2017-04-11 at 12 48 06 pm](https://cloud.githubusercontent.com/assets/1287144/24922435/4a695fc4-1ebc-11e7-9421-82f88e912062.png)
![screen shot 2017-04-11 at 12 47 59 pm](https://cloud.githubusercontent.com/assets/1287144/24922438/4a6cd6e0-1ebc-11e7-8143-afb68d337ee6.png)


