### PR TITLE
Return only requested attributes

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -44,8 +44,10 @@ module Api
       end
 
       def attribute_selection
-        if !@req.attributes.empty? || @additional_attributes
-          @req.attributes | Array(@additional_attributes) | ID_ATTRS
+        if @req.attributes.empty? && @additional_attributes
+          Array(@additional_attributes) | ID_ATTRS
+        elsif !@req.attributes.empty?
+          @req.attributes
         else
           "all"
         end

--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -47,7 +47,7 @@ module Api
         if @req.attributes.empty? && @additional_attributes
           Array(@additional_attributes) | ID_ATTRS
         elsif !@req.attributes.empty?
-          @req.attributes
+          @req.attributes | ID_ATTRS
         else
           "all"
         end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -192,7 +192,24 @@ module Api
       end
 
       def expand_subcollection?(sc, target)
-        respond_to?(target) && (@req.expand?(sc) || collection_config.show?(sc))
+        return false unless respond_to?(target) # If there's no query method, no need to go any further
+        expand_resources?(sc) || expand_action_resource?(sc) || resource_requested?(sc)
+      end
+
+      # Expand resource if:
+      # expand='resources' &&  no attributes selected && collection is configured for subcollection
+      def expand_resources?(sc)
+        @req.expand?('resources') && @req.attributes.empty? && collection_config.show?(sc)
+      end
+
+      # Expand resource if it is not a get but resource should be expanded
+      def expand_action_resource?(sc)
+        @req.method != :get && collection_config.show?(sc)
+      end
+
+      # Expand if explicitly requested
+      def resource_requested?(sc)
+        @req.expand?(sc)
       end
 
       #

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -196,18 +196,18 @@ module Api
         expand_resources?(sc) || expand_action_resource?(sc) || resource_requested?(sc)
       end
 
-      # Expand resource if:
-      # expand='resources' &&  no attributes selected && collection is configured for subcollection
+      # Expand if: expand='resources' && no attributes specified && subcollection is configured
       def expand_resources?(sc)
         @req.expand?('resources') && @req.attributes.empty? && collection_config.show?(sc)
       end
 
-      # Expand resource if it is not a get but resource should be expanded
+      # Expand if: resource is being returned and subcollection is configured
+      # IE an update to /service_catalogs expects service_templates as part of its resource
       def expand_action_resource?(sc)
         @req.method != :get && collection_config.show?(sc)
       end
 
-      # Expand if explicitly requested
+      # Expand if: explicitly requested
       def resource_requested?(sc)
         @req.expand?(sc)
       end

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -28,6 +28,15 @@ describe "Automate API" do
       )
     end
 
+    it 'returns only the requested attributes' do
+      api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
+
+      run_get automate_url, :expand => 'resources', :attributes => 'name'
+
+      expect(response).to have_http_status(:ok)
+      response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(fqname name)) }
+    end
+
     it "default to depth 0 for non-root queries" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe "categories API" do
   end
 
   it "will only return the requested attributes" do
-    FactoryGirl.create(:category)
+    FactoryGirl.create(:category, :example_text => 'foo')
     api_basic_authorize collection_action_identifier(:categories, :read, :get)
 
-    run_get categories_url, :expand => 'resources', :attributes => 'id'
+    run_get categories_url, :expand => 'resources', :attributes => 'example_text'
 
     expect(response).to have_http_status(:ok)
-    expect_hash_to_have_only_keys(response.parsed_body['resources'].first, %w(href id))
+    response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(href id example_text)) }
   end
 
   it "can list all the tags under a category" do

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe "categories API" do
     expect(response).to have_http_status(:ok)
   end
 
+  it "will only return the requested attributes" do
+    FactoryGirl.create(:category)
+    api_basic_authorize collection_action_identifier(:categories, :read, :get)
+
+    run_get categories_url, :expand => 'resources', :attributes => 'id'
+
+    expect(response).to have_http_status(:ok)
+    expect_hash_to_have_only_keys(response.parsed_body['resources'].first, %w(href id))
+  end
+
   it "can list all the tags under a category" do
     classification = FactoryGirl.create(:classification_tag)
     category = FactoryGirl.create(:category, :children => [classification])

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe "reports API" do
     expect(response).to have_http_status(:ok)
   end
 
+  it 'returns only the requested attributes' do
+    FactoryGirl.create(:miq_report_with_results)
+    api_basic_authorize collection_action_identifier(:reports, :read, :get)
+
+    run_get reports_url, :expand => 'resources', :attributes => 'template_type'
+
+    expect(response).to have_http_status(:ok)
+    response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(href id template_type)) }
+  end
+
   it "can fetch a report" do
     report = FactoryGirl.create(:miq_report_with_results)
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -80,6 +80,15 @@ describe "Roles API" do
                                 :miq_product_features => @product_features)
       test_features_query(role, roles_url(role.id), MiqProductFeature, :identifier)
     end
+
+    it 'returns only the requested attributes' do
+      api_basic_authorize action_identifier(:roles, :read, :collection_actions, :get)
+
+      run_get roles_url, :expand => 'resources', :attributes => 'name'
+
+      expect(response).to have_http_status(:ok)
+      response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(href id name)) }
+    end
   end
 
   describe "Roles create" do

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -29,10 +29,10 @@ describe "Service Catalogs API" do
       FactoryGirl.create(:service_template_catalog)
       api_basic_authorize collection_action_identifier(:service_catalogs, :read, :get)
 
-      run_get service_catalogs_url, :expand => 'resources', :attributes => 'id'
+      run_get service_catalogs_url, :expand => 'resources', :attributes => 'name'
 
       expect(response).to have_http_status(:ok)
-      expect_hash_to_have_only_keys(response.parsed_body['resources'].first, %w(href id))
+      response.parsed_body['resources'].each { |res| expect_hash_to_have_only_keys(res, %w(href id name)) }
     end
   end
 

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -24,6 +24,18 @@ describe "Service Catalogs API" do
     st_id ? "#{st_base}/#{st_id}" : st_base
   end
 
+  describe "Service Catalog Index" do
+    it "will return only the requested attributes" do
+      FactoryGirl.create(:service_template_catalog)
+      api_basic_authorize collection_action_identifier(:service_catalogs, :read, :get)
+
+      run_get service_catalogs_url, :expand => 'resources', :attributes => 'id'
+
+      expect(response).to have_http_status(:ok)
+      expect_hash_to_have_only_keys(response.parsed_body['resources'].first, %w(href id))
+    end
+  end
+
   describe "Service Catalogs create" do
     it "rejects resource creation without appropriate role" do
       api_basic_authorize


### PR DESCRIPTION
This PR ensures that only the requested attributes are being returned when:
`expand='resources'&attributes='<attributes>'` is specified.

**First fix:** `attribute_selection`: This was merging attribute selection with any additional attributes. As a result, any `@additional_attributes` specified within the controller were being returned, no matter what the user specified attributes were.

After I fixed ^, everything else broke 😄 ...

**Second fix:** `expand_subcollection?`: With the first fix, this was no longer rendering everything as expected. From the tests that were broken, I saw that there were essentially 3 cases:
 1.  Subcollection needed to be expanded if `expand=resources` was specified, no other attributes were specified, and it was in the `collection_config`
 2. A resource had an action performed on it, and it was expecting those [subcollections to be expanded](https://github.com/ManageIQ/manageiq/blob/master/spec/requests/api/service_catalogs_spec.rb#L162-L175)
 3. It was explicitly requested (ie `expand='service_templates'`) 

From the above cases I updated `expand_subcollection?` to use 3 methods that test those cases. 

Also of note: Although the BZ states that `fqname` should not be returned for the `automate` collection, it seems that it *may* be [done intentionally](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/api/automate_controller.rb#L28)  - otherwise that will need to be refactored as well

Definitely need some eyes, especially for number 2!

@miq-bot add_label api, bug
@miq-bot assign @abellotti 
cc: @imtayadeway 