### PR TITLE
Reload the ems object in the event catcher if we fail to start

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/event_catcher/runner.rb
@@ -1,3 +1,12 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::EventCatcher::Runner
+
+  def start_event_monitor
+    tid = super
+    return tid unless tid.nil?
+
+    # Get a new copy of the ems record in case the embedded ansible role changed servers
+    @ems.reload
+    nil
+  end
 end


### PR DESCRIPTION
When the embedded ansible role changes servers the endpoint url changes. This causes the event catcher to get http errors on the old url.

Reloading the object will pick up the new url and allow the event monitor thread to start.

https://bugzilla.redhat.com/show_bug.cgi?id=1439392