### PR TITLE
Method for ensuring managers change zone and provider region with CloudManager

### DIFF
--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -27,9 +27,15 @@ module HasNetworkManagerMixin
 
     def ensure_managers
       ensure_network_manager
-      network_manager.name            = "#{name} Network Manager"
-      network_manager.zone_id         = zone_id
-      network_manager.provider_region = provider_region
+      network_manager.name = "#{name} Network Manager"
+      ensure_managers_zone_and_provider_region
+    end
+
+    def ensure_managers_zone_and_provider_region
+      if network_manager
+        network_manager.zone_id         = zone_id
+        network_manager.provider_region = provider_region
+      end
     end
   end
 end


### PR DESCRIPTION
Method for ensuring managers change zone and provider region with CloudManager

Method for ensuring managers change zone and provider region with
CloudManager, this method needs to be in :before_update in every
relevant provider

Fixes BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1439268
https://bugzilla.redhat.com/show_bug.cgi?id=1440327
