### PR TITLE
Ensure google managers change zone and provider region with cloud manager

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -20,6 +20,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   supports :regions
 
   before_create :ensure_managers
+  before_update :ensure_managers_zone_and_provider_region
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Google::NetworkManager') unless network_manager

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -27,9 +27,15 @@ module HasNetworkManagerMixin
 
     def ensure_managers
       ensure_network_manager
-      network_manager.name            = "#{name} Network Manager"
-      network_manager.zone_id         = zone_id
-      network_manager.provider_region = provider_region
+      network_manager.name = "#{name} Network Manager"
+      ensure_managers_zone_and_provider_region
+    end
+
+    def ensure_managers_zone_and_provider_region
+      if network_manager
+        network_manager.zone_id         = zone_id
+        network_manager.provider_region = provider_region
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/google/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager_spec.rb
@@ -7,6 +7,36 @@ describe ManageIQ::Providers::Google::CloudManager do
     expect(described_class.description).to eq('Google Compute Engine')
   end
 
+  it "does not create orphaned network_manager" do
+    ems = FactoryGirl.create(:ems_google)
+    same_ems = ExtManagementSystem.find(ems.id)
+
+    ems.destroy
+    expect(ExtManagementSystem.count).to eq(0)
+
+    same_ems.save!
+    expect(ExtManagementSystem.count).to eq(0)
+  end
+
+  it "moves the network_manager to the same zone and provider region as the cloud_manager" do
+    zone1 = FactoryGirl.create(:zone)
+    zone2 = FactoryGirl.create(:zone)
+
+    ems = FactoryGirl.create(:ems_google, :zone => zone1, :provider_region => "us-east1")
+    expect(ems.network_manager.zone).to eq zone1
+    expect(ems.network_manager.zone_id).to eq zone1.id
+    expect(ems.network_manager.provider_region).to eq "us-east1"
+
+    ems.zone = zone2
+    ems.provider_region = "us-central1"
+    ems.save!
+    ems.reload
+
+    expect(ems.network_manager.zone).to eq zone2
+    expect(ems.network_manager.zone_id).to eq zone2.id
+    expect(ems.network_manager.provider_region).to eq "us-central1"
+  end
+
   context "#connectivity" do
     before do
       @google_project = "yourprojectid"


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/14741

Ensure google managers change zone and provider region with cloud manager, plus spec checking we don't reintroduce old bug with NetworkManager duplication.