### PR TITLE
Removes call to reverse sysprep as array

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -100,7 +100,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def custom_sysprep_timezone(field, data_value)
     set_value_from_list(:sysprep_timezone, field, "%03d" % data_value, @timezones)
-    @values[:sysprep_timezone].reverse!
   end
 
   def custom_sysprep_domain_name(field, data_value)


### PR DESCRIPTION
Main repo component of ManageIQ/manageiq-providers-vmware#35 which changes sysprep_timezone to a hash. This removes the array sorting on the timezone field and allows the UI to handle the sysprep_timezone just like the other fields, also hashes.

https://github.com/ManageIQ/manageiq-ui-classic/pull/982