### PR TITLE
Updated providers refresh to return all tasks for multi-manager providers

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -139,8 +139,8 @@ module Api
 
     def refresh_provider(provider)
       desc = "#{provider_ident(provider)} refreshing"
-      task_id = provider.refresh_ems(:create_task => true).first
-      action_result(true, desc, :task_id => task_id)
+      task_ids = provider.refresh_ems(:create_task => true)
+      action_result(true, desc, :task_ids => task_ids)
     rescue => err
       action_result(false, err.to_s)
     end


### PR DESCRIPTION
Updated providers refresh to return the tasks in the action results when multiple managers have been targeted.

```
POST /api/providers/15
{
  "action" : "refresh"
}
```

```
{
  "success" : true,
  "message" : "Provider id:15 name:'sample_provider' refreshing",
  "href" : "/api/providers/15",
  "task_id" : 23,
  "task_href" : "/api/tasks/23",
  "tasks" : [
    { "id" : 23, "href" : "/api/tasks/23"},
    { "id" : 24, "href" : "/api/tasks/24"}
  ]
}
```
