### PR TITLE
Only return config_info actions that are applied

### DIFF
--- a/app/models/mixins/service_ansible_mixin.rb
+++ b/app/models/mixins/service_ansible_mixin.rb
@@ -1,0 +1,12 @@
+module ServiceAnsibleMixin
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def with_applied_config_info(actions, config_info, opts = nil)
+      actions.each do |action|
+        next unless config_info[action]
+        opts ? (yield action, opts) : (yield action)
+      end
+    end
+  end
+end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -1,6 +1,9 @@
 class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
+  include ServiceAnsibleMixin
   before_destroy :check_retirement_potential, :prepend => true
   around_destroy :around_destroy_callback
+
+  CONFIG_ACTIONS = [:provision, :retirement, :reconfigure].freeze
 
   RETIREMENT_ENTRY_POINTS = {
     'yes_without_playbook' => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Basic_Resource',
@@ -48,7 +51,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
     transaction do
       create_from_options(options).tap do |service_template|
-        [:provision, :retirement, :reconfigure].each do |action|
+        with_applied_config_info(CONFIG_ACTIONS, config_info) do |action|
           dialog_name = config_info.fetch_path(action, :new_dialog_name)
           next unless dialog_name
 
@@ -70,8 +73,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   private :create_new_dialog
 
   def self.create_job_templates(service_name, description, config_info, auth_user)
-    [:provision, :retirement, :reconfigure].each_with_object({}) do |action, hash|
-      next unless config_info[action] && config_info[action].key?(:playbook_id)
+    with_applied_config_info(CONFIG_ACTIONS, config_info, {}) do |action, hash|
+      next unless config_info[action].key?(:playbook_id)
       hash[action] = { :configuration_template => create_job_template("miq_#{service_name}_#{action}", description, config_info[action], auth_user) }
     end
   end
@@ -142,8 +145,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     config_info = validate_update_config_info(options)
     name = options[:name]
     description = options[:description]
-    [:provision, :retirement, :reconfigure].each do |action|
-      next unless config_info[action]
+    self.class.with_applied_config_info(CONFIG_ACTIONS, config_info) do |action|
       info = config_info[action]
 
       new_dialog = create_new_dialog(info[:new_dialog_name], job_template(action), info[:hosts]) if info[:new_dialog_name]

--- a/spec/models/mixins/service_ansible_mixin_spec.rb
+++ b/spec/models/mixins/service_ansible_mixin_spec.rb
@@ -1,0 +1,35 @@
+describe ServiceAnsibleMixin do
+  let(:catalog_item) do
+    {
+      :name                        => 'test_ansible_catalog_item',
+      :description                 => 'test ansible',
+      :service_template_catalog_id => 999,
+      :display                     => true,
+      :config_info                 => {
+        :provision => {
+          :new_dialog_name       => 'test_dialog',
+          :hosts                 => 'many',
+          :credential_id         => 88,
+          :network_credential_id => 87,
+          :playbook_id           => 68
+        },
+      }
+    }
+  end
+
+  let(:test_class) do
+    Class.new do
+      include ServiceAnsibleMixin
+    end
+  end
+
+  it "only returns applied config_info keys" do
+    actions_list = ServiceTemplateAnsiblePlaybook::CONFIG_ACTIONS
+    action_final_list = []
+    test_class.with_applied_config_info(actions_list, catalog_item[:config_info]) do |action|
+      action_final_list << action
+    end
+    expect(actions_list).to eq [:provision, :retirement, :reconfigure]
+    expect(action_final_list).to eq [:provision]
+  end
+end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -1,4 +1,6 @@
 describe ServiceTemplateAnsiblePlaybook do
+  include ServiceAnsibleMixin
+
   let(:user)     { FactoryGirl.create(:user_with_group) }
   let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
   let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 10) }
@@ -78,7 +80,7 @@ describe ServiceTemplateAnsiblePlaybook do
                                           catalog_item_options_two[:name],
                                           catalog_item_options_two[:description],
                                           catalog_item_options_two[:config_info], 'system')
-      [:provision, :retirement].each do |action|
+      described_class.with_applied_config_info(ServiceTemplateAnsiblePlaybook::CONFIG_ACTIONS, catalog_item_options) do |action|
         expect(options_hash[action.to_sym][:configuration_template]).to eq job_template
       end
     end


### PR DESCRIPTION
This refactor allows us to loop through all the config_info actions, but only yield what is currently applied in the config.