### PR TITLE
return correct custom_attributes href 

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -91,6 +91,25 @@ module Api
       # Let's normalize an href based on type and id value
       #
       def normalize_href(type, value)
+        # If it is already a string, ie "/vms/:id/", OR it is defined as a collection
+        if type.kind_of?(String) || collection_config[type].options.include?(:collection)
+          collection_href(type, value)
+        else # If it is not a string and not defined as a collection
+          subcollection_href(type, value)
+        end
+      end
+
+      #
+      # Subcollection href
+      #
+      def subcollection_href(type, value)
+        normalize_url("#{@req.collection}/#{@req.c_id}/#{type}/#{value}")
+      end
+
+      #
+      # Collection href
+      #
+      def collection_href(type, value)
         normalize_url("#{type}/#{value}")
       end
 

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -91,24 +91,13 @@ module Api
       # Let's normalize an href based on type and id value
       #
       def normalize_href(type, value)
-        # If it is already a string, ie "/vms/:id/", OR it is defined as a collection
-        if type.kind_of?(String) || collection_config[type].options.include?(:collection)
-          collection_href(type, value)
-        else # If it is not a string and not defined as a collection
-          subcollection_href(type, value)
-        end
+        type.to_s == @req.subcollection ? subcollection_href(type, value) : collection_href(type, value)
       end
 
-      #
-      # Subcollection href
-      #
       def subcollection_href(type, value)
         normalize_url("#{@req.collection}/#{@req.c_id}/#{type}/#{value}")
       end
 
-      #
-      # Collection href
-      #
       def collection_href(type, value)
         normalize_url("#{type}/#{value}")
       end

--- a/spec/requests/api/custom_attributes_spec.rb
+++ b/spec/requests/api/custom_attributes_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe "Custom Attributes API" do
 
     expect(response).to have_http_status(:no_content)
   end
+
+  it 'returns the correct href' do
+    provider = FactoryGirl.create(:ext_management_system)
+    custom_attribute = FactoryGirl.create(:custom_attribute, :resource => provider, :name => 'foo', :value => 'bar')
+    url = "#{providers_url(provider.id)}/custom_attributes/#{custom_attribute.id}"
+    api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :edit, :post)
+
+    run_post(url, :action => :edit, :name => 'name1')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body['href']).to include(url)
+  end
 end

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -76,7 +76,7 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:ok)
       quota.reload
       expect(quota.value).to eq(5)
-      expect(response.parsed_body).to include('href' => /quotas/)
+      expect(response.parsed_body).to include('href' => a_string_including("tenants/#{tenant.id}/quotas/#{quota.id}"))
     end
 
     it "can update multiple quotas from a tenant with POST" do


### PR DESCRIPTION
Performing an action, such as `edit` on `custom_attributes` returns an href that does not exist:
```
https://<address>/api/custom_attributes/:attribute_id
```
Custom attributes is not a collection and results in a `not found` when attempting to retrieve that object.

It should return an href with reference to the subcollection that is a custom attribute of. 

Update: same issue was happening with tenant_quotas - added a spec to verify fix helped.

@miq-bot add_label wip, api, bug
@miq-bot assign @abellotti 