### PR TITLE
Ensure that genealogy_parent exists in the vm data before using it

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -201,8 +201,10 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
 
         # Fetch IDs of all vms and genealogy_parents, only if genealogy_parent is present
         vms_genealogy_parents = vms_inventory_collection.data.each_with_object({}) do |x, obj|
-          genealogy_parent_id = x.data[:genealogy_parent].load.try(:id)
-          obj[x.id]           = genealogy_parent_id if genealogy_parent_id
+          unless x.data[:genealogy_parent].nil?
+            genealogy_parent_id = x.data[:genealogy_parent].load.try(:id)
+            obj[x.id]           = genealogy_parent_id if genealogy_parent_id
+          end
         end
 
         miq_templates = miq_templates_inventory_collection.model_class


### PR DESCRIPTION
`vm_and_miq_template_ancestry` presently assumes that all VMs have a value for `genealogy_parent`, which results in an exception and a failed refresh if an instance doesn't have one. This PR checks for the presence of a parent before attempting to continue.