### PR TITLE
Link MiqTemplates to their parent VM when one is present

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -215,8 +215,8 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
 
         # associate parent templates to child instances
         parent_miq_templates = miq_templates_inventory_collection.model_class
-                                                          .select([:id])
-                                                          .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
+                                                                 .select([:id])
+                                                                 .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
         vms_inventory_collection.model_class
                                 .select([:id])
                                 .where(:id => vms_genealogy_parents.keys).find_each do |vm|
@@ -228,8 +228,8 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
                                              .select([:id])
                                              .where(:id => miq_template_genealogy_parents.values).find_each.index_by(&:id)
         miq_templates_inventory_collection.model_class
-                                .select([:id])
-                                .where(:id => miq_template_genealogy_parents.keys).find_each do |miq_template|
+                                          .select([:id])
+                                          .where(:id => miq_template_genealogy_parents.keys).find_each do |miq_template|
           parent = parent_vms[miq_template_genealogy_parents[miq_template.id]]
           miq_template.with_relationship_type('genealogy') { miq_template.parent = parent }
         end


### PR DESCRIPTION
Some MiqTemplates (like Openstack images) have parent VMs. This PR updates `vm_and_miq_template_ancestry` to resolve those VM->Template relationships as well as the already existing Template->VM relationships.