### PR TITLE
Move Openstack settings to own repo

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,10 +96,6 @@
     :keep_drift_states: 6.months
     :purge_window_size: 10000
 :ems:
-  :ems_openstack:
-    :excon:
-      :omit_default_port: true
-      :read_timeout: 60
   :ems_redhat:
     :use_ovirt_engine_sdk: false
     :resolve_ip_addresses: true
@@ -1221,46 +1217,6 @@
         :poll: 20.seconds
       :event_catcher_redhat:
         :poll: 15.seconds
-      :event_catcher_openstack:
-        :poll: 15.seconds
-        :topics:
-          :nova: notifications.*
-          :cinder: notifications.*
-          :glance: notifications.*
-          :heat: notifications.*
-        :duration: 10.seconds
-        :capacity: 50
-        :amqp_port: 5672
-        :amqp_heartbeat: 30
-        :amqp_recovery_attempts: 4
-        :ceilometer:
-          :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
-      :event_catcher_openstack_infra:
-        :poll: 15.seconds
-        :topics:
-          :nova: notifications.*
-          :cinder: notifications.*
-          :glance: notifications.*
-          :heat: notifications.*
-          :ironic: notifications.*
-        :duration: 10.seconds
-        :capacity: 50
-        :amqp_port: 5672
-        :amqp_heartbeat: 30
-        :amqp_recovery_attempts: 4
-        :ceilometer:
-          :event_types_regex: '\A(?!firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
-      :event_catcher_openstack_network:
-        :poll: 15.seconds
-        :topics:
-          :neutron: "notifications.*"
-        :duration: 10.seconds
-        :capacity: 50
-        :amqp_port: 5672
-        :amqp_heartbeat: 30
-        :amqp_recovery_attempts: 4
-        :ceilometer:
-          :event_types_regex: '\A(firewall|floatingip|gateway|net|port|router|subnet|security_group|vpn)'
       :event_catcher_hawkular:
         :poll: 10.seconds
       :event_catcher_hawkular_datawarehouse:
@@ -1278,7 +1234,6 @@
         :poll: 10.seconds
       :event_catcher_swift:
         :poll: 10.seconds
-      :event_catcher_openstack_service: "auto"
     :queue_worker_base:
       :defaults:
         :cpu_usage_threshold: 100.percent
@@ -1297,11 +1252,7 @@
           :metrics_port: 5000
           :metrics_path: "/hawkular/metrics"
         :ems_metrics_collector_worker_openshift: {}
-        :ems_metrics_collector_worker_openstack: {}
-        :ems_metrics_collector_worker_openstack_infra: {}
-        :ems_metrics_collector_worker_openstack_network: {}
         :ems_metrics_collector_worker_redhat: {}
-        :ems_metrics_openstack_default_service: "auto"
       :ems_metrics_processor_worker:
         :count: 2
         :memory_threshold: 600.megabytes
@@ -1326,9 +1277,6 @@
         :ems_refresh_worker_lenovo_physical_infra: {}
         :ems_refresh_worker_microsoft: {}
         :ems_refresh_worker_openshift: {}
-        :ems_refresh_worker_openstack: {}
-        :ems_refresh_worker_openstack_infra: {}
-        :ems_refresh_worker_openstack_network: {}
         :ems_refresh_worker_nuage_network: {}
         :ems_refresh_worker_redhat: {}
         :ems_refresh_worker_cinder: {}


### PR DESCRIPTION
Removing options related to Openstack from settings.yml in master repo.

Links
----------------

* Original issue https://github.com/ManageIQ/manageiq-providers-openstack/issues/10
* Openstack provider repo PR https://github.com/ManageIQ/manageiq-providers-openstack/pull/13