### PR TITLE
Added migration for create column 'mac_addresses' in the table networks

### DIFF
--- a/db/migrate/20170411125301_add_mac_addresses_to_networks.rb
+++ b/db/migrate/20170411125301_add_mac_addresses_to_networks.rb
@@ -1,0 +1,5 @@
+class AddMacAddressesToNetworks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :networks, :mac_addresses, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5459,6 +5459,7 @@ networks:
 - hostname
 - domain
 - ipv6address
+- mac_addresses
 notification_recipients:
 - id
 - notification_id


### PR DESCRIPTION
This migration was created for the parse of the physical servers in "manageiq-providers-lenovo". The migration add a new column in the table Networks.