### PR TITLE
Remove code that creates phantom object on create

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -43,11 +43,6 @@ class CloudTenant < ApplicationRecord
 
     klass = class_by_ems(ext_management_system)
     created_cloud_tenant = klass.raw_create_cloud_tenant(ext_management_system, options)
-
-    klass.create(
-      :name                  => created_cloud_tenant[:name],
-      :ems_ref               => created_cloud_tenant[:ems_ref],
-      :ext_management_system => ext_management_system)
   end
 
   def self.raw_create_cloud_tenant(_ext_management_system, _options = {})

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -54,14 +54,6 @@ class CloudVolume < ApplicationRecord
     tenant = options[:cloud_tenant]
 
     created_volume = klass.raw_create_volume(ext_management_system, options)
-
-    klass.create(
-      :name                  => created_volume[:name],
-      :ems_ref               => created_volume[:ems_ref],
-      :status                => created_volume[:status],
-      :size                  => options[:size].to_i.gigabytes,
-      :ext_management_system => ext_management_system,
-      :cloud_tenant          => tenant)
   end
 
   def self.validate_create_volume(ext_management_system)


### PR DESCRIPTION
Cloud volumes and cloud tenants had code in their create methods that would create a 'phantom' version of the just-created object, prior to refresh.  This runs counter to the desired code pattern, and causes issues such as the BZ which this update resolves.

https://bugzilla.redhat.com/show_bug.cgi?id=1441469