### PR TITLE
Remove references to Job#agent_message and use Job#message instead

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -64,21 +64,19 @@ class Job < ApplicationRecord
     true
   end
 
-  def self.agent_message_update_queue(jobid, message)
-    job = Job.where("guid = ?", jobid).select("id, state, guid").first
-    unless job.nil?
-      job.agent_message_update(message)
+  def self.update_message(job_guid, message)
+    job = Job.find_by(:guid => job_guid)
+    if job
+      job.update_message(message)
     else
-      _log.warn "jobid: [#{jobid}] not found"
+      _log.warn "jobs.guid: [#{jobid}] not found"
     end
-  rescue => err
-    _log.warn "Error '#{err.message}', updating jobid: [#{jobid}]"
-    _log.log_backtrace(err)
   end
 
-  def agent_message_update(agent_message)
-    $log.info("JOB([#{guid}] Agent message update: [#{agent_message}]")
-    update_attributes(:agent_message => agent_message)
+  def update_message(message)
+    $log.info("JOB([#{guid}] Message update: [#{message}]")
+    self.message = message
+    save
 
     return unless self.is_active?
 

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -210,7 +210,7 @@ module ScanningMixin
     ost.xml_class = XmlHash::Document
 
     _log.debug "Scanning - Initializing scan"
-    update_agent_message(ost, "Initializing scan")
+    update_job_message(ost, "Initializing scan")
     bb, last_err = nil
     xml_summary = ost.xml_class.createDoc(:summary)
     xml_node = xml_node_scan = xml_summary.root.add_element("scanmetadata")
@@ -246,10 +246,10 @@ module ScanningMixin
       _log.debug "categories = [ #{categories.join(', ')} ]"
 
       categories.each do |c|
-        update_agent_message(ost, "Scanning #{c}")
+        update_job_message(ost, "Scanning #{c}")
         _log.info "Scanning [#{c}] information.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         st = Time.now
-        xml = extractor.extract(c) { |scan_data| update_agent_message(ost, scan_data[:msg]) }
+        xml = extractor.extract(c) { |scan_data| update_job_message(ost, scan_data[:msg]) }
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
         if xml
@@ -277,7 +277,7 @@ module ScanningMixin
       last_err = scanErr
     ensure
       bb.close if bb
-      update_agent_message(ost, "Scanning completed.")
+      update_job_message(ost, "Scanning completed.")
 
       # If we are sent a TaskId transfer a end of job summary xml.
       _log.info "Starting: Sending scan summary to server.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
@@ -327,7 +327,7 @@ module ScanningMixin
       )
       bb = Manageiq::BlackBox.new(guid, ost)
 
-      update_agent_message(ost, "Synchronization in progress")
+      update_job_message(ost, "Synchronization in progress")
       categories.each do |c|
         c.delete!("\"")
         c.strip!
@@ -368,15 +368,24 @@ module ScanningMixin
       save_metadata_op(xml_summary.miqEncode, "b64,zlib,xml", ost.taskid)
       _log.info "Completed: Sending target summary to server.  TaskId:[#{ost.taskid}]  target:[#{name}]"
 
-      update_agent_message(ost, "Synchronization complete")
+      update_job_message(ost, "Synchronization complete")
 
       raise syncErr if syncErr
     end
     ost.value = "OK\n"
   end
 
-  def update_agent_message(ost, message)
-    ost.agent_message = message
-    agent_job_message_op(ost.taskid, ost.agent_message) if ost.taskid && ost.taskid.empty? == false
+  def update_job_message(ost, message)
+    ost.message = message
+    unless ost.taskid.blank?
+      MiqQueue.put(
+        :class_name  => "Job",
+        :method_name => "update_message",
+        :args        => [ost.taskid, message],
+        :task_id     => "job_message_#{Time.now.to_i}",
+        :zone        => MiqServer.my_zone,
+        :role        => "smartstate"
+      )
+    end
   end
 end

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -29,27 +29,6 @@ module ScanningOperationsMixin
     true
   end
 
-  def agent_job_message_op(jobid, message)
-    _log.info "jobid: [#{jobid}] starting"
-    begin
-      Timeout.timeout(WS_TIMEOUT) do
-        MiqQueue.put(
-          :class_name  => "Job",
-          :method_name => "agent_message_update_queue",
-          :args        => [jobid, message],
-          :task_id     => "agent_job_message_#{Time.now.to_i}",
-          :zone        => MiqServer.my_zone,
-          :role        => "smartstate"
-        )
-        return true
-      end
-    rescue Exception => err
-      _log.log_backtrace(err)
-      ScanningOperations.reconnect_to_db
-      return false
-    end
-  end
-
   def task_update_op(task_id, state, status, message)
     _log.info "task_id: [#{task_id}] starting"
     begin

--- a/product/views/Job.yaml
+++ b/product/views/Job.yaml
@@ -27,7 +27,6 @@ cols:
 - message
 - name
 - userid
-- agent_message
 - target_class
 - target_id
 
@@ -47,7 +46,6 @@ col_order:
 - name
 - userid
 - miq_server.name
-- agent_message
 
 # Column titles, in order
 headers:
@@ -59,7 +57,6 @@ headers:
 - Task Name
 - User
 - Owner
-- Owner Message
 
 # Condition(s) string for the SQL query
 conditions:

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -415,6 +415,26 @@ describe Job do
     end
   end
 
+  describe "#update_message" do
+    let(:message) { "Very Interesting Message" }
+
+    it "updates 'jobs.message' column" do
+      Job.create_job("VmScan").update_message(message)
+      expect(Job.first.message).to eq message
+    end
+  end
+
+  describe ".update_message" do
+    let(:message) { "Very Interesting Message" }
+    let(:guid) { "qwerty" }
+
+    it "finds job by passed guid and updates 'message' column for found record" do
+      Job.create_job("VmScan", :guid => guid)
+      Job.update_message(guid, message)
+      expect(Job.find_by(:guid => guid).message).to eq message
+    end
+  end
+
   private
 
   def expect_signal_abort_and_timeout_message

--- a/spec/models/mixins/scanning_mixin_spec.rb
+++ b/spec/models/mixins/scanning_mixin_spec.rb
@@ -1,0 +1,22 @@
+describe ScanningMixin do
+  let(:test_instance) do
+    Class.new do
+      include ScanningMixin
+    end.new
+  end
+
+  describe "#update_job_message" do
+    let(:job_guid) { "qwerty" }
+    let(:message) { "Test message Blah" }
+    let(:ost) do
+      allow(MiqServer).to receive(:my_zone)
+      OpenStruct.new(:taskid => job_guid)
+    end
+
+    it "adds to MiqQueue call to 'Job#update_message'" do
+      test_instance.update_job_message(ost, message)
+      queue_item = MiqQueue.find_by(:class_name => "Job", :method_name => "update_message")
+      expect(queue_item.args[0]).to eq job_guid
+    end
+  end
+end


### PR DESCRIPTION
related to #14698 - adding former Job specific columns to Task view

Logic related to 'agents' for Smart State Analysis was refactored and references to all `Job#agent_...` attributes were removed (in https://github.com/ManageIQ/manageiq/pull/14030) with exception of `Job#agent_message`.

Usage for `Job#agent_message` is to show progress on scan process by updating message.
`Job#agent_message` is redundant column since there is `Job#message` column exists and can be used to show all messages. 

In This PR:
- refactor `ScanningMixin` to use `Job#message` instead of `Job#agent_message`
- remove `Owner Message` column from `Job` view  (in `Job.yaml`)
