### PR TITLE
Update a catalog item with a new retirement template

### DIFF
--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -235,6 +235,17 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
     end
+
+    it 'creates a new job_template if a new one is passed in' do
+      service_template = prebuild_service_template(:job_template => false)
+      catalog_item_options[:config_info][:provision].delete(:new_dialog_name)
+
+      allow(service_template).to receive(:new_job_template_required).and_return(true)
+      expect(service_template).to receive(:populate_active_config).twice
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).never
+
+      service_template.update_catalog_item(catalog_item_options, user)
+    end
   end
 
   describe '#delete_job_templates' do


### PR DESCRIPTION
When updating an existing AnsiblePlaybook catalog item - add the ability to add a new retirement playbook if one didn't previously exist before

Testing notes:

1. Create new Ansible Playbook Catalog item without a retirement playbook
2. Edit the above Catalog Item and add a retirement playbook.

https://www.pivotaltracker.com/story/show/141868401

https://bugzilla.redhat.com/show_bug.cgi?id=1438839

