### PR TITLE
Dockerfile cleanup yarn cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,8 @@ RUN source /etc/default/evm && \
 RUN source /etc/default/evm && \
     cd ${SUI_ROOT} && \
     yarn install && \
-    yarn run build
+    yarn run build && \
+    yarn cache clean
 
 ## Copy appliance-initialize script and service unit file
 COPY docker-assets/appliance-initialize.service /usr/lib/systemd/system


### PR DESCRIPTION
- yarn cache clean on SUI build layer, reduces img size in ~300MB
- related to https://github.com/ManageIQ/manageiq-pods/pull/126

