### PR TITLE
Allow container model to connect to provider.  Addresses https://gith…

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_ContainerManager < MiqAeServiceManageIQ_Providers_BaseManager
+    expose :api_endpoint
+    expose :connect
+  end
+end


### PR DESCRIPTION
…ub.com/ManageIQ/manageiq/pull/14688

In order to affect the container provider from the automate model, a connection needs to be exposed to automate.  

If there is a best practice that does not expose "connect", I'd be willing to explore alternatives.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1440141