### PR TITLE
Remove reverse! call for timezone after converting structure to hash

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -100,7 +100,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def custom_sysprep_timezone(field, data_value)
     set_value_from_list(:sysprep_timezone, field, "%03d" % data_value, @timezones)
-    @values[:sysprep_timezone].reverse!
   end
 
   def custom_sysprep_domain_name(field, data_value)


### PR DESCRIPTION
Previously the list of Timezones used with the VMware customization spec were stored as an array to maintain order before hashes were guaranteed to return in the order of insertion.  Now the provisioning workflow can use a hash which matches the structure used by most of the `allowed_*` methods in the request workflow classes.

This allows us to treat the data in the UI like other fields (https://github.com/ManageIQ/manageiq-ui-classic/pull/982) and requires less data manipulation like the `.collect(&:reverse)` call in  https://github.com/ManageIQ/manageiq-providers-vmware/pull/35 and the change in this PR.

Changing the `get_timezones` method to return a hash allows data passed during an API call to be processed like other fields which resolves the reported issue.

Ultimately the customization spec logic needs to be refactored to live in the vmware repo but that is outside of the scope of this bug fix.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1406084
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/35
* https://github.com/ManageIQ/manageiq-ui-classic/pull/982

Steps for Testing/QA
-------------------------------
See https://bugzilla.redhat.com/show_bug.cgi?id=1406084

cc @d-m-u @himdel 