### PR TITLE
Skip test setup in prod env

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,12 @@
 require_relative '../lib/manageiq/environment'
 require 'optparse'
 
-options = {:do_tests => true, :do_db => true}
+options = {
+  # Don't run tests by default if we are in a prod env since no task exists.
+  :do_tests => ENV['RAILS_ENV'] != "production",
+  :do_db => true
+}
+
 OptionParser.new do |opts|
   opts.banner = "Usage: setup [options]"
   opts.on("-d", "--no-db", "Do not prepare db") do

--- a/bin/update
+++ b/bin/update
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 require_relative '../lib/manageiq/environment'
 
+# Don't run tests by default if we are in a prod env since no task exists.
+ENV["SKIP_TEST_RESET"] = '1' if ENV['RAILS_ENV'] == 'production'
+
 Dir.chdir ManageIQ::Environment::APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.


### PR DESCRIPTION
In bin/setup and bin/update, the task of `test:vmdb:setup` is run even in production, but will be disabled because we only create that rake task when `RSpec` is present (which it is not in the production group).

Disabling calling that task when `RAILS_ENV=production` is set avoids an error that can be confusing at first glance.


Steps for Testing/QA
--------------------
On this branch, run `bin/setup` and `bin/update` with `RAILS_ENV=production` and confirm you don't get an error and that `test:vmdb:setup` is not run.  You can confirm on master that this fails.