### PR TITLE
Render DELETE action for notifications

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1019,6 +1019,8 @@
       :post:
       - :name: mark_as_seen
       - :name: delete
+      :delete:
+      - :name: delete
   :orchestration_stacks:
     :description: Orchestration Stacks
     :options:

--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -15,6 +15,23 @@ describe 'Notifications API' do
     end
   end
 
+  describe "notification read" do
+    it "renders the available actions" do
+      api_basic_authorize
+
+      run_get(notification_url)
+
+      expected = {
+        "actions" => a_collection_including(
+          a_hash_including("name" => "mark_as_seen", "method" => "post"),
+          a_hash_including("name" => "delete", "method" => "post"),
+          a_hash_including("name" => "delete", "method" => "delete")
+        )
+      }
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
   describe 'notification edit' do
     it 'is not supported' do
       api_basic_authorize


### PR DESCRIPTION
Notifications can be deleted through the DELETE method, yet we don't
render that as an available action when we return notification members
through GET. This is beecause the method has been enabled but no
action has been configured. Configuring a delete action solves this
problem.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1420872

@miq-bot add-label api, bug
@miq-bot assign @abellotti 
