### PR TITLE
Fetch Ansible job plays from job events.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "activerecord-session_store",     "~>1.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.2.1",       :require => false
-gem "ansible_tower_client",           "~>0.11.0",      :require => false
+gem "ansible_tower_client",           "~>0.12.0",      :require => false
 gem "aws-sdk",                        "~>2",           :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/job.rb
@@ -94,15 +94,15 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
 
   def update_plays(raw_job)
     last_play_hash = nil
-    plays = raw_job.job_plays.collect do |play|
+    plays = raw_job.job_events(:event => 'playbook_on_play_start').collect do |play|
       {
         :name              => play.play,
         :resource_status   => play.failed ? 'failed' : 'successful',
-        :start_time        => play.started,
+        :start_time        => play.created,
         :ems_ref           => play.id,
         :resource_category => 'job_play'
       }.tap do |h|
-        last_play_hash[:finish_time] = play.started if last_play_hash
+        last_play_hash[:finish_time] = play.created if last_play_hash
         last_play_hash = h
       end
     end

--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -72,7 +72,7 @@ describe ServiceAnsibleTower do
                             :verbosity       => 0,
                             :started         => Time.current,
                             :finished        => Time.current,
-                            :job_plays       => [],
+                            :job_events      => [],
                             :extra_vars_hash => {'var_name' => 'var_val'}))
 
       job_done = service_mix_dialog_setter.launch_job

--- a/spec/support/ansible_shared/automation_manager/job.rb
+++ b/spec/support/ansible_shared/automation_manager/job.rb
@@ -30,14 +30,14 @@ shared_examples_for "ansible job" do
       'network_credential_id' => network_credential.manager_ref
     ).tap do |rjob|
       allow(rjob).to receive(:stdout).with('html').and_return('<html><body>job stdout</body></html>')
-      allow(rjob).to receive(:job_plays).and_return(the_raw_plays)
+      allow(rjob).to receive(:job_events).with(:event => 'playbook_on_play_start').and_return(the_raw_plays)
     end
   end
 
   let(:the_raw_plays) do
     [
-      double('play1', :play => 'play1', :started => Time.current,     :failed => false, :id => 1),
-      double('play2', :play => 'play2', :started => Time.current + 1, :failed => true,  :id => 2)
+      double('play1', :play => 'play1', :created => Time.current,     :failed => false, :id => 1),
+      double('play2', :play => 'play2', :created => Time.current + 1, :failed => true,  :id => 2)
     ]
   end
 
@@ -88,14 +88,14 @@ shared_examples_for "ansible job" do
         expect(subject.authentications).to match_array([machine_credential, cloud_credential, network_credential])
 
         expect(subject.job_plays.first).to have_attributes(
-          :start_time        => the_raw_plays.first.started,
-          :finish_time       => the_raw_plays.last.started,
+          :start_time        => the_raw_plays.first.created,
+          :finish_time       => the_raw_plays.last.created,
           :resource_status   => 'successful',
           :resource_category => 'job_play',
           :name              => 'play1'
         )
         expect(subject.job_plays.last).to have_attributes(
-          :start_time        => the_raw_plays.last.started,
+          :start_time        => the_raw_plays.last.created,
           :finish_time       => the_raw_job.finished,
           :resource_status   => 'failed',
           :resource_category => 'job_play',


### PR DESCRIPTION
Starting from AnsibleTower 3.1, there is no longer a dedicated end point for job plays. Instead they need to be fetched by filtering job events.

https://github.com/ansible/ansible_tower_client_ruby/pull/85 already enhance the job class to list all job events. This PR updates the `Gemfile` to the latest ansible_tower_client and fetches job events in the new way.


Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1434961
* https://github.com/ansible/ansible_tower_client_ruby/pull/85
