### PR TITLE
Drop 'jobs.process' column

### DIFF
--- a/db/migrate/20170417185038_remove_process_column_from_jobs.rb
+++ b/db/migrate/20170417185038_remove_process_column_from_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveProcessColumnFromJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :jobs, :process, :bytea
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1577,7 +1577,6 @@ jobs:
 - target_id
 - target_class
 - type
-- process
 - agent_id
 - agent_message
 - started_on


### PR DESCRIPTION
There are no any references to `jobs.process` column.

Dropping not used column will make future merging of `job` and `MiqTask` models simpler.


@miq-bot add-label core, technical debt


