### PR TITLE
Dont start chrony in containers

### DIFF
--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -26,7 +26,8 @@ module MiqServer::NtpManagement
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in atStartup of miq_server and on a configuration change for the server
   def ntp_reload(ntp_settings = server_ntp_settings)
-    return unless MiqEnvironment::Command.is_appliance? # matches ntp_reload_queue's guard clause
+    # matches ntp_reload_queue's guard clause
+    return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_container?
 
     if @ntp_settings && @ntp_settings == ntp_settings
       _log.info("Skipping reload of ntp settings since they are unchanged")

--- a/app/models/miq_server/queue_management.rb
+++ b/app/models/miq_server/queue_management.rb
@@ -55,7 +55,8 @@ module MiqServer::QueueManagement
   end
 
   def ntp_reload_queue
-    return unless MiqEnvironment::Command.is_appliance? # matches ntp_reload's guard clause
+    # matches ntp_reload's guard clause
+    return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_container?
 
     MiqQueue.put(
       :class_name  => "MiqServer",

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -19,6 +19,11 @@ module MiqEnvironment
       @supports_nohup = self.is_appliance? && self.supports_command?('nohup')
     end
 
+    def self.is_container?
+      return @is_container unless @is_container.nil?
+      @is_container = ENV["CONTAINER"] == "true"
+    end
+
     def self.is_appliance?
       return @is_appliance unless @is_appliance.nil?
       @is_appliance = self.is_linux? && File.exist?('/var/www/miq/vmdb')

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -43,6 +43,18 @@ describe MiqEnvironment do
           assert_same_result_every_time(:is_appliance?, true)
         end
       end
+
+      describe ".is_container?" do
+        it "returns false if the environment variable is not set" do
+          assert_same_result_every_time(:is_container?, false)
+        end
+
+        it "returns true if the environment variable is set" do
+          ENV["CONTAINER"] = "true"
+          assert_same_result_every_time(:is_container?, true)
+          ENV.delete("CONTAINER")
+        end
+      end
     end
   end
 

--- a/spec/models/miq_server/queue_management_spec.rb
+++ b/spec/models/miq_server/queue_management_spec.rb
@@ -1,0 +1,35 @@
+describe "Queue Management" do
+  let(:server) { EvmSpecHelper.local_miq_server }
+
+  describe "#ntp_reload_queue" do
+    it "enqueues a message if the server is an appliance, but not a container" do
+      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
+      expect(MiqEnvironment::Command).to receive(:is_container?).and_return(false)
+
+      server.ntp_reload_queue
+
+      expect(ntp_reload_enqueued?).to be_truthy
+    end
+
+    it "doesn't enqueue a message if the server is not an appliance" do
+      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
+
+      server.ntp_reload_queue
+
+      expect(ntp_reload_enqueued?).to be_falsey
+    end
+
+    it "doesn't enqueue a message if the server is a container" do
+      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
+      expect(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
+
+      server.ntp_reload_queue
+
+      expect(ntp_reload_enqueued?).to be_falsey
+    end
+  end
+
+  def ntp_reload_enqueued?
+    MiqQueue.find_by(:class_name => "MiqServer", :instance_id => server.id, :method_name => "ntp_reload")
+  end
+end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -157,6 +157,16 @@ describe MiqServer do
           allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
         end
 
+        it "doesn't sync the settings when running in a container" do
+          allow(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
+
+          @zone.update_attribute(:settings, :ntp => zone_ntp)
+          stub_settings(:ntp => server_ntp)
+
+          expect(LinuxAdmin::Chrony).not_to receive(:new)
+          @miq_server.ntp_reload
+        end
+
         it "syncs with server settings with zone and server configured" do
           @zone.update_attribute(:settings, :ntp => zone_ntp)
           stub_settings(:ntp => server_ntp)


### PR DESCRIPTION
This PR adds a method to determine if we are running within a container and also stops us from trying to sync ntp settings when running within a container.

The container system time should really be managed by the container host so we should avoid trying to do this manually.

We set the container ENV variable in the Dockerfile at image build time:

https://github.com/ManageIQ/manageiq-pods/blob/master/images/miq-app/Dockerfile#L132
https://github.com/ManageIQ/manageiq/blob/master/Dockerfile#L119