### PR TITLE
Add label to Authentications

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -27,6 +27,8 @@ class Authentication < ApplicationRecord
 
   has_many :configuration_script_sources
 
+  virtual_column :label, :type => :string
+
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed
 
@@ -55,6 +57,8 @@ class Authentication < ApplicationRecord
     :embedded_ansible_credential_types => 'ManageIQ::Providers::EmbeddedAutomationManager::Authentication'
   }.freeze
 
+  LABEL = N_('Authentication').freeze
+
   # FIXME: To address problem with url resolution when displayed as a quadicon,
   # but it's not *really* the db_name. Might be more proper to override `to_partial_path`
   def self.db_name
@@ -71,6 +75,10 @@ class Authentication < ApplicationRecord
 
   def authentication_type
     authtype.nil? ? :default : authtype.to_sym
+  end
+
+  def label
+    self.class::LABEL
   end
 
   def available?

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -25,10 +25,11 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  LABEL = N_('Amazon')
 
   API_OPTIONS = {
     :type       => 'cloud',
-    :label      => N_('Amazon'),
+    :label      => LABEL,
     :attributes => API_ATTRIBUTES
   }.freeze
   TOWER_KIND = 'aws'.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -53,9 +53,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  LABEL = N_('Machine')
 
   API_OPTIONS = {
-    :label      => N_('Machine'),
+    :label      => LABEL,
     :type       => 'machine',
     :attributes => API_ATTRIBUTES
   }.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -28,9 +28,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  LABEL = N_('Scm')
 
   API_OPTIONS = {
-    :label      => N_('Scm'),
+    :label      => LABEL,
     :type       => 'scm',
     :attributes => API_ATTRIBUTES
   }.freeze

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -26,9 +26,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   }.freeze
 
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+  LABEL = N_('VMware')
 
   API_OPTIONS = {
-    :label      => N_('VMware'),
+    :label      => LABEL,
     :type       => 'cloud',
     :attributes => API_ATTRIBUTES
   }.freeze


### PR DESCRIPTION
The SUI needs a way of getting the label of an authentication on the resource, not just via `OPTIONS /api/authentications` (for a [bz](https://bugzilla.redhat.com/show_bug.cgi?id=1439632)). By moving the existing label that is returned into its own constant, it can then be returned as a virtual column.

Currently added in a constant that defaults the label to 'Authentication', although I am open to other options for what the default should be (if anything)

Thoughts on this @jameswnl ?

cc: @AllenBW 
