### PR TITLE
Add new setting for Physical Infrastructure prototype

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1035,6 +1035,7 @@
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
   :datawarehouse_manager: false
+  :physical_infrastructure: false
 :prototype:
   :monitoring: false
 :recommendations:


### PR DESCRIPTION
This new setting will be used to hide/show the Physical Infrastructure top level menu.  This will allow the development of the Physical Infrastructure provider to continue beyond the Fine release.