### PR TITLE
Load custom attribute before evaluation

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,6 +17,10 @@ class Tag < ApplicationRecord
 
       if virtual_custom_attribute
         predicate.map! { |x| URI::RFC2396_Parser.new.unescape(x) }
+        # it is always array with one string element - name of virtual custom attribute because they are supported only
+        # in direct relations
+        custom_attribute = predicate.first
+        object.class.add_custom_attribute(custom_attribute) if object.class < CustomAttributeMixin
       end
 
       begin

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -14,7 +14,10 @@ class Tag < ApplicationRecord
       ns.gsub!('/virtual/','')  # throw away /virtual
       ns, virtual_custom_attribute = MiqExpression.escape_virtual_custom_attribute(ns)
       predicate = ns.split("/")
-      predicate.map!{ |x| URI::RFC2396_Parser.new.unescape(x) } if virtual_custom_attribute
+
+      if virtual_custom_attribute
+        predicate.map! { |x| URI::RFC2396_Parser.new.unescape(x) }
+      end
 
       begin
         predicate.inject(object) { |target, method| target.public_send method }

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -343,16 +343,6 @@ class MiqExpression
   def initialize(exp, ctype = nil)
     @exp = exp
     @context_type = ctype
-
-    load_virtual_custom_attributes
-  end
-
-  def load_virtual_custom_attributes
-    return unless @exp
-
-    fields.compact.select { |x| x.instance_of?(MiqExpression::Field) && x.custom_attribute_column? }.each do |field|
-      field.model.add_custom_attribute(field.column)
-    end
   end
 
   def self.proto?

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1,42 +1,4 @@
 describe MiqExpression do
-  context "virtual custom attributes" do
-    let(:virtual_custom_attribute)   { "virtual_custom_attribute_attribute" }
-    let(:virtual_custom_attribute_1) { "virtual_custom_attribute_attribute_1" }
-    let(:virtual_custom_attribute_2) { "virtual_custom_attribute_attribute_2" }
-    let(:virtual_custom_attribute_3) { "virtual_custom_attribute_attribute_3" }
-    let(:virtual_custom_attribute_4) { "virtual_custom_attribute_attribute_4" }
-    let(:klass)                      { Vm }
-    let(:vm)                         { FactoryGirl.create(:vm) }
-
-    it "automatically loads virtual custom attributes from MiqExpression on class" do
-      expect do
-        MiqExpression.new("EQUAL" => {"field" => "#{klass}-#{virtual_custom_attribute}", "value" => "foo"})
-      end.to change { vm.respond_to?(virtual_custom_attribute) }.from(false).to(true)
-    end
-
-    it "automatically loads virtual custom attributes from right side in expression" do
-      expect do
-        MiqExpression.new("EQUAL" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_1}"})
-      end.to change { vm.respond_to?(virtual_custom_attribute_1) }.from(false).to(true)
-    end
-
-    it "automatically loads virtual custom attributes from right side in nested expression" do
-      exp1 = {"STARTS WITH" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_2}"}}
-      exp2 = {"ENDS WITH" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_3}"}}
-      exp3 = {"ENDS WITH" => {"field" => "#{klass}-#{virtual_custom_attribute_4}", "value" => "any_value"}}
-
-      expect do
-        MiqExpression.new("AND" => [exp1, {"AND" => [exp2, exp3]}])
-      end.to change {
-        [
-          vm.respond_to?(virtual_custom_attribute_2),
-          vm.respond_to?(virtual_custom_attribute_3),
-          vm.respond_to?(virtual_custom_attribute_4)
-        ]
-      }.from([false, false, false]).to([true, true, true])
-    end
-  end
-
   describe "#to_sql" do
     it "generates the SQL for an EQUAL expression" do
       sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-name", "value" => "foo"}).to_sql

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -20,6 +20,35 @@ describe Rbac::Filterer do
   let(:child_openstack_vm) { FactoryGirl.create(:vm_openstack, :tenant => child_tenant, :miq_group => child_group) }
 
   describe ".search" do
+    context 'with virtual custom attributes' do
+      let(:virtual_custom_attribute_1) { "virtual_custom_attribute_attribute_1" }
+      let(:virtual_custom_attribute_2) { "virtual_custom_attribute_attribute_2" }
+      let!(:vm_1)                { FactoryGirl.create(:vm) }
+      let!(:vm_2)                { FactoryGirl.create(:vm) }
+
+      let!(:custom_attribute_1) do
+        FactoryGirl.create(:custom_attribute, :name => 'attribute_1', :value => vm_1.name, :resource => vm_1)
+      end
+
+      let!(:custom_attribute_2) do
+        FactoryGirl.create(:custom_attribute, :name => 'attribute_2', :value => 'any_value', :resource => vm_1)
+      end
+
+      let(:miq_expression) do
+        exp1 = {'EQUAL' => {'field' => 'Vm-name', 'value' => "Vm-#{virtual_custom_attribute_1}"}}
+        exp2 = {'EQUAL' => {'field' => "Vm-#{virtual_custom_attribute_2}", "value" => 'any_value'}}
+
+        MiqExpression.new("AND" => [exp1, exp2])
+      end
+
+      it 'returns instance of Vm with related condition' do
+        User.with_user(admin_user) do
+          results = described_class.search(:class => Vm, :filter => miq_expression).first
+          expect(results).to match_array [vm_1]
+        end
+      end
+    end
+
     describe "with find_options_for_tenant filtering (basic) all resources" do
       {
         "ExtManagementSystem"    => :ems_vmware,


### PR DESCRIPTION
introduced in https://github.com/ManageIQ/manageiq/pull/11369 

Loading virtual custom attributes is not needed in constructor
we need to load them when we need them and this place is in
`Condition#_subst` method where `Tag.list` is called

In addition, constructor is not called when MiqExpressin is loaded from yaml (for example as it is in used MiqReport#condition for generation reports)

This is fixing a bug when report has defined expression with virtual custom attribute and these attributes are not listed in Report#cols


@miq-bot add_label bug, core
@miq-bot assign @gtanzillo 
