### PR TITLE
[EUWE] Drop support for oVirt /api, always use /ovirt-engine/api

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -19,12 +19,10 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     unless options[:skip_supported_api_validation] || supports_the_api_version?(version)
       raise "version #{version} of the api is not supported by the provider"
     end
-    # If there is API path stored in the endpoints table and use it:
-    path = options[:path] || default_endpoint.path
-    _log.info("Using stored API path '#{path}'.") unless path.blank?
 
     server   = options[:ip] || address
     port     = options[:port] || self.port
+    path     = options[:path] || '/ovirt-engine/api'
     username = options[:user] || authentication_userid(options[:auth_type])
     password = options[:pass] || authentication_password(options[:auth_type])
     service  = options[:service] || "Service"
@@ -47,7 +45,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     connection = self.class.public_send(connect_method, server, port, path, username, password, service)
 
     # Copy the API path to the endpoints table:
-    default_endpoint.path = version == 4 ? '/ovirt-engine/api' : connection.api_path
+    default_endpoint.path = path
 
     connection
   end

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_0.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_0.yml
@@ -2,18 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.252.231:8443/api
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      WWW-Authenticate:
-      - Basic realm="RESTAPI"
-  recorded_at: Tue, 26 Apr 2016 10:00:00 GMT
-- request:
-    method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -42,20 +31,20 @@ http_interactions:
       X-Powered-By:
       - Servlet 2.5; JBoss-5.0/JBossWeb-2.1
       Link:
-      - <https://192.168.252.231:8443/api/capabilities>; rel=capabilities,<https://192.168.252.231:8443/api/clusters>;
-        rel=clusters,<https://192.168.252.231:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.231:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.252.231:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.252.231:8443/api/events>; rel=events,<https://192.168.252.231:8443/api/events?search={query}&from={event_id}>;
-        rel=events/search,<https://192.168.252.231:8443/api/hosts>; rel=hosts,<https://192.168.252.231:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.252.231:8443/api/networks>; rel=networks,<https://192.168.252.231:8443/api/roles>;
-        rel=roles,<https://192.168.252.231:8443/api/storagedomains>; rel=storagedomains,<https://192.168.252.231:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.252.231:8443/api/tags>; rel=tags,<https://192.168.252.231:8443/api/templates>;
-        rel=templates,<https://192.168.252.231:8443/api/templates?search={query}>;
-        rel=templates/search,<https://192.168.252.231:8443/api/users>; rel=users,<https://192.168.252.231:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.252.231:8443/api/groups>; rel=groups,<https://192.168.252.231:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.252.231:8443/api/domains>; rel=domains,<https://192.168.252.231:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.252.231:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.252.231:8443/api/vms>;
-        rel=vms,<https://192.168.252.231:8443/api/vms?search={query}>; rel=vms/search
+      - <https://192.168.252.231:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.252.231:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.252.231:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.231:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.252.231:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.252.231:8443/ovirt-engine/api/events>; rel=events,<https://192.168.252.231:8443/ovirt-engine/api/events?search={query}&from={event_id}>;
+        rel=events/search,<https://192.168.252.231:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.252.231:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.252.231:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.252.231:8443/ovirt-engine/api/roles>;
+        rel=roles,<https://192.168.252.231:8443/ovirt-engine/api/storagedomains>; rel=storagedomains,<https://192.168.252.231:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.252.231:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.252.231:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.252.231:8443/ovirt-engine/api/templates?search={query}>;
+        rel=templates/search,<https://192.168.252.231:8443/ovirt-engine/api/users>; rel=users,<https://192.168.252.231:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.252.231:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.252.231:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.252.231:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.252.231:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.252.231:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.252.231:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.252.231:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search
       Content-Type:
       - application/xml
       Content-Length:
@@ -65,25 +54,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<api>\n
-        \   <link rel=\"capabilities\" href=\"/api/capabilities\"/>\n    <link rel=\"clusters\"
-        href=\"/api/clusters\"/>\n    <link rel=\"clusters/search\" href=\"/api/clusters?search={query}\"/>\n
-        \   <link rel=\"datacenters\" href=\"/api/datacenters\"/>\n    <link rel=\"datacenters/search\"
-        href=\"/api/datacenters?search={query}\"/>\n    <link rel=\"events\" href=\"/api/events\"/>\n
-        \   <link rel=\"events/search\" href=\"/api/events?search={query}&amp;from={event_id}\"/>\n
-        \   <link rel=\"hosts\" href=\"/api/hosts\"/>\n    <link rel=\"hosts/search\"
-        href=\"/api/hosts?search={query}\"/>\n    <link rel=\"networks\" href=\"/api/networks\"/>\n
-        \   <link rel=\"roles\" href=\"/api/roles\"/>\n    <link rel=\"storagedomains\"
-        href=\"/api/storagedomains\"/>\n    <link rel=\"storagedomains/search\" href=\"/api/storagedomains?search={query}\"/>\n
-        \   <link rel=\"tags\" href=\"/api/tags\"/>\n    <link rel=\"templates\" href=\"/api/templates\"/>\n
-        \   <link rel=\"templates/search\" href=\"/api/templates?search={query}\"/>\n
-        \   <link rel=\"users\" href=\"/api/users\"/>\n    <link rel=\"users/search\"
-        href=\"/api/users?search={query}\"/>\n    <link rel=\"groups\" href=\"/api/groups\"/>\n
-        \   <link rel=\"groups/search\" href=\"/api/groups?search={query}\"/>\n    <link
-        rel=\"domains\" href=\"/api/domains\"/>\n    <link rel=\"vmpools\" href=\"/api/vmpools\"/>\n
-        \   <link rel=\"vmpools/search\" href=\"/api/vmpools?search={query}\"/>\n
-        \   <link rel=\"vms\" href=\"/api/vms\"/>\n    <link rel=\"vms/search\" href=\"/api/vms?search={query}\"/>\n
-        \   <special_objects>\n        <link rel=\"templates/blank\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
-        \       <link rel=\"tags/root\" href=\"/api/tags/00000000-0000-0000-0000-000000000000\"/>\n
+        \   <link rel=\"capabilities\" href=\"/ovirt-engine/api/capabilities\"/>\n    <link rel=\"clusters\"
+        href=\"/ovirt-engine/api/clusters\"/>\n    <link rel=\"clusters/search\" href=\"/ovirt-engine/api/clusters?search={query}\"/>\n
+        \   <link rel=\"datacenters\" href=\"/ovirt-engine/api/datacenters\"/>\n    <link rel=\"datacenters/search\"
+        href=\"/ovirt-engine/api/datacenters?search={query}\"/>\n    <link rel=\"events\" href=\"/ovirt-engine/api/events\"/>\n
+        \   <link rel=\"events/search\" href=\"/ovirt-engine/api/events?search={query}&amp;from={event_id}\"/>\n
+        \   <link rel=\"hosts\" href=\"/ovirt-engine/api/hosts\"/>\n    <link rel=\"hosts/search\"
+        href=\"/ovirt-engine/api/hosts?search={query}\"/>\n    <link rel=\"networks\" href=\"/ovirt-engine/api/networks\"/>\n
+        \   <link rel=\"roles\" href=\"/ovirt-engine/api/roles\"/>\n    <link rel=\"storagedomains\"
+        href=\"/ovirt-engine/api/storagedomains\"/>\n    <link rel=\"storagedomains/search\" href=\"/ovirt-engine/api/storagedomains?search={query}\"/>\n
+        \   <link rel=\"tags\" href=\"/ovirt-engine/api/tags\"/>\n    <link rel=\"templates\" href=\"/ovirt-engine/api/templates\"/>\n
+        \   <link rel=\"templates/search\" href=\"/ovirt-engine/api/templates?search={query}\"/>\n
+        \   <link rel=\"users\" href=\"/ovirt-engine/api/users\"/>\n    <link rel=\"users/search\"
+        href=\"/ovirt-engine/api/users?search={query}\"/>\n    <link rel=\"groups\" href=\"/ovirt-engine/api/groups\"/>\n
+        \   <link rel=\"groups/search\" href=\"/ovirt-engine/api/groups?search={query}\"/>\n    <link
+        rel=\"domains\" href=\"/ovirt-engine/api/domains\"/>\n    <link rel=\"vmpools\" href=\"/ovirt-engine/api/vmpools\"/>\n
+        \   <link rel=\"vmpools/search\" href=\"/ovirt-engine/api/vmpools?search={query}\"/>\n
+        \   <link rel=\"vms\" href=\"/ovirt-engine/api/vms\"/>\n    <link rel=\"vms/search\" href=\"/ovirt-engine/api/vms?search={query}\"/>\n
+        \   <special_objects>\n        <link rel=\"templates/blank\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        \       <link rel=\"tags/root\" href=\"/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000\"/>\n
         \   </special_objects>\n    <product_info>\n        <name>Red Hat Enterprise
         Virtualization</name>\n        <vendor>Red Hat</vendor>\n        <version
         revision=\"0\" build=\"0\" minor=\"0\" major=\"3\"/>\n    </product_info>\n
@@ -96,7 +85,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:28 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/clusters
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/clusters
     body:
       encoding: US-ASCII
       string: ''
@@ -133,52 +122,52 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<clusters>\n
-        \   <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\" href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\">\n
-        \       <name>Cluster1-iSCSI</name>\n        <link rel=\"networks\" href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085/networks\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085/permissions\"/>\n
+        \   <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\" href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\">\n
+        \       <name>Cluster1-iSCSI</name>\n        <link rel=\"networks\" href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085/networks\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085/permissions\"/>\n
         \       <cpu id=\"Intel Conroe Family\"/>\n        <data_center id=\"199560d0-9b83-4212-b2a1-077e1b4371af\"
-        href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n        <memory_policy>\n
+        href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"150\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version minor=\"0\"
         major=\"3\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n    </cluster>\n    <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\">\n        <name>Cluster2</name>\n
-        \       <link rel=\"networks\" href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085/networks\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085/permissions\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\">\n        <name>Cluster2</name>\n
+        \       <link rel=\"networks\" href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085/networks\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085/permissions\"/>\n
         \       <cpu id=\"Intel Conroe Family\"/>\n        <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <memory_policy>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"150\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version minor=\"0\"
         major=\"3\"/>\n        <error_handling>\n            <on_error>do_not_migrate</on_error>\n
         \       </error_handling>\n    </cluster>\n    <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\">\n        <name>DC2Cluster1</name>\n
-        \       <link rel=\"networks\" href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085/networks\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085/permissions\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\">\n        <name>DC2Cluster1</name>\n
+        \       <link rel=\"networks\" href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085/networks\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085/permissions\"/>\n
         \       <cpu id=\"Intel Conroe Family\"/>\n        <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\"
-        href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <memory_policy>\n
+        href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version minor=\"0\"
         major=\"3\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n    </cluster>\n    <cluster id=\"40acd32e-4ce6-11e1-8f17-005056af0085\"
-        href=\"/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085\">\n        <name>DC2-iSCSI</name>\n
-        \       <link rel=\"networks\" href=\"/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085/networks\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085/permissions\"/>\n
+        href=\"/ovirt-engine/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085\">\n        <name>DC2-iSCSI</name>\n
+        \       <link rel=\"networks\" href=\"/ovirt-engine/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085/networks\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/clusters/40acd32e-4ce6-11e1-8f17-005056af0085/permissions\"/>\n
         \       <cpu id=\"Intel Conroe Family\"/>\n        <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\"
-        href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <memory_policy>\n
+        href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version minor=\"0\"
         major=\"3\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n    </cluster>\n    <cluster id=\"99408929-82cf-4dc7-a532-9d998063fa95\"
-        href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\">\n        <name>Default</name>\n
+        href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\">\n        <name>Default</name>\n
         \       <description>The default server cluster</description>\n        <link
-        rel=\"networks\" href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/networks\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/permissions\"/>\n
+        rel=\"networks\" href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/networks\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/permissions\"/>\n
         \       <cpu id=\"Intel Conroe Family\"/>\n        <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <memory_policy>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version minor=\"0\"
@@ -188,7 +177,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:28 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vmpools
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vmpools
     body:
       encoding: US-ASCII
       string: ''
@@ -233,7 +222,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:29 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/networks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/networks
     body:
       encoding: US-ASCII
       string: ''
@@ -270,45 +259,45 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<networks>\n
-        \   <network id=\"1f042099-5783-4dee-af1b-e2940046fd7e\" href=\"/api/networks/1f042099-5783-4dee-af1b-e2940046fd7e\">\n
+        \   <network id=\"1f042099-5783-4dee-af1b-e2940046fd7e\" href=\"/ovirt-engine/api/networks/1f042099-5783-4dee-af1b-e2940046fd7e\">\n
         \       <name>test</name>\n        <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <vlan
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <vlan
         id=\"1\"/>\n        <stp>false</stp>\n        <status>\n            <state>non_operational</state>\n
         \       </status>\n    </network>\n    <network id=\"00000000-0000-0000-0000-000000000009\"
-        href=\"/api/networks/00000000-0000-0000-0000-000000000009\">\n        <name>rhevm</name>\n
+        href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
-        id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
+        id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
         \       <stp>false</stp>\n        <status>\n            <state>operational</state>\n
         \       </status>\n    </network>\n    <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"
-        href=\"/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\">\n        <name>rhevm</name>\n
+        href=\"/ovirt-engine/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
-        id=\"199560d0-9b83-4212-b2a1-077e1b4371af\" href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n
+        id=\"199560d0-9b83-4212-b2a1-077e1b4371af\" href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n
         \       <stp>false</stp>\n        <status>\n            <state>operational</state>\n
         \       </status>\n    </network>\n    <network id=\"2e61e550-84e1-4db4-b6ba-270dcd8389a7\"
-        href=\"/api/networks/2e61e550-84e1-4db4-b6ba-270dcd8389a7\">\n        <name>temp</name>\n
-        \       <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
+        href=\"/ovirt-engine/api/networks/2e61e550-84e1-4db4-b6ba-270dcd8389a7\">\n        <name>temp</name>\n
+        \       <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
         \       <stp>false</stp>\n        <status>\n            <state>non_operational</state>\n
         \       </status>\n    </network>\n    <network id=\"00000000-0000-0000-0000-000000000009\"
-        href=\"/api/networks/00000000-0000-0000-0000-000000000009\">\n        <name>rhevm</name>\n
+        href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
-        id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
+        id=\"eb5592d2-ce76-11e0-a703-005056af0085\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n
         \       <stp>false</stp>\n        <status>\n            <state>operational</state>\n
         \       </status>\n    </network>\n    <network id=\"2f17d722-a330-4861-959e-699af75ff608\"
-        href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\">\n        <name>rhevm</name>\n
+        href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
-        id=\"cb50d90a-f585-4d17-a524-a577a97da928\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n
+        id=\"cb50d90a-f585-4d17-a524-a577a97da928\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n
         \       <stp>false</stp>\n        <status>\n            <state>operational</state>\n
         \       </status>\n    </network>\n    <network id=\"674d7bb5-15de-4ac8-b6d7-3ff935f041fc\"
-        href=\"/api/networks/674d7bb5-15de-4ac8-b6d7-3ff935f041fc\">\n        <name>iSCSI</name>\n
+        href=\"/ovirt-engine/api/networks/674d7bb5-15de-4ac8-b6d7-3ff935f041fc\">\n        <name>iSCSI</name>\n
         \       <description>iSCSI network</description>\n        <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\"
-        href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <stp>false</stp>\n
+        href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <stp>false</stp>\n
         \       <status>\n            <state>operational</state>\n        </status>\n
         \   </network>\n</networks>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:29 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/storagedomains?search=sortby%20name%20asc%20page%201
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -345,43 +334,43 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain id=\"fc5483fa-b48d-4394-9e9b-551540f7bf65\" href=\"/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65\">\n
-        \       <name>export</name>\n        <link rel=\"permissions\" href=\"/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/permissions\"/>\n
-        \       <link rel=\"templates\" href=\"/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/templates\"/>\n
-        \       <link rel=\"vms\" href=\"/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/vms\"/>\n
+        \   <storage_domain id=\"fc5483fa-b48d-4394-9e9b-551540f7bf65\" href=\"/ovirt-engine/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65\">\n
+        \       <name>export</name>\n        <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/permissions\"/>\n
+        \       <link rel=\"templates\" href=\"/ovirt-engine/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/templates\"/>\n
+        \       <link rel=\"vms\" href=\"/ovirt-engine/api/storagedomains/fc5483fa-b48d-4394-9e9b-551540f7bf65/vms\"/>\n
         \       <type>export</type>\n        <status>\n            <state>unattached</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>10.10.1.39</address>\n            <path>/srv/export</path>\n
         \       </storage>\n        <available>41875931136</available>\n        <used>10737418240</used>\n
         \       <committed>0</committed>\n        <storage_format>v1</storage_format>\n
         \   </storage_domain>\n    <storage_domain id=\"f291819d-6f09-4a5b-9e48-0bc40898362b\"
-        href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\">\n        <name>Export</name>\n
-        \       <link rel=\"permissions\" href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/permissions\"/>\n
-        \       <link rel=\"templates\" href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/templates\"/>\n
-        \       <link rel=\"vms\" href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/vms\"/>\n
+        href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\">\n        <name>Export</name>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/permissions\"/>\n
+        \       <link rel=\"templates\" href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/templates\"/>\n
+        \       <link rel=\"vms\" href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/vms\"/>\n
         \       <type>export</type>\n        <status>\n            <state>unattached</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.65</address>\n            <path>/srv/export</path>\n
         \       </storage>\n        <available>51539607552</available>\n        <used>11811160064</used>\n
         \       <committed>0</committed>\n        <storage_format>v1</storage_format>\n
         \   </storage_domain>\n    <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"
-        href=\"/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4\">\n        <name>HostNFS</name>\n
-        \       <link rel=\"permissions\" href=\"/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/permissions\"/>\n
+        href=\"/ovirt-engine/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4\">\n        <name>HostNFS</name>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/permissions\"/>\n
         \       <type>data</type>\n        <master>true</master>\n        <storage>\n
         \           <type>nfs</type>\n            <address>192.168.252.119</address>\n
         \           <path>/srv/nfs</path>\n        </storage>\n        <available>69793218560</available>\n
         \       <used>98784247808</used>\n        <committed>532575944704</committed>\n
         \       <storage_format>v1</storage_format>\n    </storage_domain>\n    <storage_domain
-        id=\"298906e7-e1a8-446f-85e9-dc894d0e284b\" href=\"/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b\">\n
-        \       <name>NFS-ISO-Domain</name>\n        <link rel=\"permissions\" href=\"/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/permissions\"/>\n
-        \       <link rel=\"files\" href=\"/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/files\"/>\n
+        id=\"298906e7-e1a8-446f-85e9-dc894d0e284b\" href=\"/ovirt-engine/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b\">\n
+        \       <name>NFS-ISO-Domain</name>\n        <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/permissions\"/>\n
+        \       <link rel=\"files\" href=\"/ovirt-engine/api/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/files\"/>\n
         \       <type>iso</type>\n        <master>false</master>\n        <storage>\n
         \           <type>nfs</type>\n            <address>192.168.252.231</address>\n
         \           <path>/srv/nfs</path>\n        </storage>\n        <available>11811160064</available>\n
         \       <used>45097156608</used>\n        <committed>0</committed>\n        <storage_format>v1</storage_format>\n
         \   </storage_domain>\n    <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"
-        href=\"/api/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0\">\n        <name>StarM1RHEV-1</name>\n
-        \       <link rel=\"permissions\" href=\"/api/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/permissions\"/>\n
+        href=\"/ovirt-engine/api/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0\">\n        <name>StarM1RHEV-1</name>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/permissions\"/>\n
         \       <type>data</type>\n        <master>true</master>\n        <storage>\n
         \           <type>iscsi</type>\n            <volume_group id=\"ETu16x-1cnn-Z1Xi-k9Bj-GMzq-ke5s-gsou2g\">\n
         \               <logical_unit id=\"2403027f93d7780fa\">\n                    <address>10.1.1.202</address>\n
@@ -394,8 +383,8 @@ http_interactions:
         \       <available>75161927680</available>\n        <used>134217728000</used>\n
         \       <committed>201863462912</committed>\n        <storage_format>v2</storage_format>\n
         \   </storage_domain>\n    <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"
-        href=\"/api/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa\">\n        <name>StarM1-RHEVM1</name>\n
-        \       <link rel=\"permissions\" href=\"/api/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/permissions\"/>\n
+        href=\"/ovirt-engine/api/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa\">\n        <name>StarM1-RHEVM1</name>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/permissions\"/>\n
         \       <type>data</type>\n        <master>true</master>\n        <storage>\n
         \           <type>iscsi</type>\n            <volume_group id=\"9Al9cf-ML4f-Ch0m-mI0x-Kz8n-bUYL-uycuBn\">\n
         \               <logical_unit id=\"298b42b5b7976b220\">\n                    <address>10.1.1.202</address>\n
@@ -412,7 +401,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:29 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/storagedomains?search=sortby%20name%20asc%20page%202
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -457,7 +446,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:29 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/datacenters
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/datacenters
     body:
       encoding: US-ASCII
       string: ''
@@ -494,28 +483,28 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<data_centers>\n
-        \   <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\">\n
+        \   <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\">\n
         \       <name>DC2</name>\n        <description></description>\n        <link
-        rel=\"storagedomains\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/permissions\"/>\n
+        rel=\"storagedomains\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/permissions\"/>\n
         \       <storage_type>iscsi</storage_type>\n        <storage_format>v2</storage_format>\n
         \       <version minor=\"0\" major=\"3\"/>\n        <supported_versions>\n
         \           <version minor=\"0\" major=\"3\"/>\n        </supported_versions>\n
         \       <status>\n            <state>maintenance</state>\n        </status>\n
         \   </data_center>\n    <data_center id=\"199560d0-9b83-4212-b2a1-077e1b4371af\"
-        href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\">\n        <name>DC-iSCSI</name>\n
+        href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\">\n        <name>DC-iSCSI</name>\n
         \       <description></description>\n        <link rel=\"storagedomains\"
-        href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/permissions\"/>\n
+        href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/permissions\"/>\n
         \       <storage_type>iscsi</storage_type>\n        <storage_format>v2</storage_format>\n
         \       <version minor=\"0\" major=\"3\"/>\n        <supported_versions>\n
         \           <version minor=\"0\" major=\"3\"/>\n        </supported_versions>\n
         \       <status>\n            <state>not_operational</state>\n        </status>\n
         \   </data_center>\n    <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\">\n        <name>Default</name>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\">\n        <name>Default</name>\n
         \       <description>The default Data Center</description>\n        <link
-        rel=\"storagedomains\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/permissions\"/>\n
+        rel=\"storagedomains\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/permissions\"/>\n
         \       <storage_type>nfs</storage_type>\n        <storage_format>v1</storage_format>\n
         \       <version minor=\"0\" major=\"3\"/>\n        <supported_versions>\n
         \           <version minor=\"0\" major=\"3\"/>\n        </supported_versions>\n
@@ -525,7 +514,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:29 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/hosts?search=sortby%20name%20asc%20page%201
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -562,24 +551,24 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<hosts>\n
-        \   <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\">\n
+        \   <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\">\n
         \       <name>rhelvirt.manageiq.com</name>\n        <actions>\n            <link
-        rel=\"install\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/install\"/>\n
-        \           <link rel=\"activate\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/activate\"/>\n
-        \           <link rel=\"fence\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/fence\"/>\n
-        \           <link rel=\"deactivate\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/deactivate\"/>\n
-        \           <link rel=\"approve\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/approve\"/>\n
-        \           <link rel=\"iscsilogin\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/iscsilogin\"/>\n
-        \           <link rel=\"iscsidiscover\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/iscsidiscover\"/>\n
-        \           <link rel=\"commitnetconfig\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/commitnetconfig\"/>\n
-        \       </actions>\n        <link rel=\"storage\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/storage\"/>\n
-        \       <link rel=\"nics\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics\"/>\n
-        \       <link rel=\"tags\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics\"/>\n
+        rel=\"install\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/install\"/>\n
+        \           <link rel=\"activate\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/activate\"/>\n
+        \           <link rel=\"fence\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/fence\"/>\n
+        \           <link rel=\"deactivate\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/deactivate\"/>\n
+        \           <link rel=\"approve\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/approve\"/>\n
+        \           <link rel=\"iscsilogin\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/iscsilogin\"/>\n
+        \           <link rel=\"iscsidiscover\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/iscsidiscover\"/>\n
+        \           <link rel=\"commitnetconfig\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/commitnetconfig\"/>\n
+        \       </actions>\n        <link rel=\"storage\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/storage\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics\"/>\n
         \       <address>192.168.252.119</address>\n        <status>\n            <state>non_responsive</state>\n
         \       </status>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <port>54321</port>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <port>54321</port>\n
         \       <type>rhel</type>\n        <storage_manager>true</storage_manager>\n
         \       <power_management>\n            <enabled>false</enabled>\n            <options/>\n
         \       </power_management>\n        <ksm>\n            <enabled>false</enabled>\n
@@ -593,7 +582,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:30 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/hosts?search=sortby%20name%20asc%20page%202
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -638,7 +627,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:30 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms?search=sortby%20name%20asc%20page%201
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -675,24 +664,24 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<vms>\n
-        \   <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\">\n
+        \   <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\">\n
         \       <name>Brandon-Clone1</name>\n        <actions>\n            <link
-        rel=\"shutdown\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/statistics\"/>\n
+        rel=\"shutdown\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>10737418240</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -701,30 +690,30 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\"
-        href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
-        id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n
+        href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
+        id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n
         \       <creation_time>2012-06-27T15:00:18.389-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>10737418240</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"
-        href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\">\n        <name>CLI-Provision-1</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\">\n        <name>CLI-Provision-1</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>10737418240</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -735,31 +724,31 @@ http_interactions:
         \           <address>192.168.252.173</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\"
-        href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
-        id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n
+        href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
+        id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n
         \       <creation_time>2012-04-30T12:50:29.781-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>10737418240</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\">\n        <name>EmsRefreshSpec-PoweredOff</name>\n
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\">\n        <name>EmsRefreshSpec-PoweredOff</name>\n
         \       <description>Powered Off VM for EmsRefresh testing</description>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/statistics\"/>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -768,31 +757,31 @@ http_interactions:
         \       <high_availability>\n            <enabled>true</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-09-26T14:28:16.355-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\">\n        <name>EmsRefreshSpec-PoweredOn</name>\n
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\">\n        <name>EmsRefreshSpec-PoweredOn</name>\n
         \       <description>Powered On VM for EmsRefresh testing</description>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/statistics\"/>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -802,31 +791,31 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-09-26T14:46:28.426-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>715128832</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\">\n        <name>EVM-RH-50013</name>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\">\n        <name>EVM-RH-50013</name>\n
         \       <description>EVM v5.0.0.11</description>\n        <actions>\n            <link
-        rel=\"shutdown\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/statistics\"/>\n
+        rel=\"shutdown\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -837,30 +826,30 @@ http_interactions:
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-08-02T14:15:26.376-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\"
-        href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\">\n        <name>EVM-RH-50015</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\">\n        <name>EVM-RH-50015</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -871,30 +860,30 @@ http_interactions:
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-09-07T16:28:35.249-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\"
-        href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\">\n        <name>EVM-RH-5005-test</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\">\n        <name>EVM-RH-5005-test</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -903,31 +892,31 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\"
-        href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-02-08T18:31:40.541-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\">\n        <name>EVM-TrunkSVN</name>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\">\n        <name>EVM-TrunkSVN</name>\n
         \       <description>Based on Nightly 31894</description>\n        <actions>\n
-        \           <link rel=\"shutdown\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/statistics\"/>\n
+        \           <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"4\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -936,31 +925,31 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5901</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2011-12-19T15:13:39.345-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>4294967296</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\"
-        href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\">\n        <name>EVM-V5001</name>\n
+        href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\">\n        <name>EVM-V5001</name>\n
         \       <description>CentOs</description>\n        <actions>\n            <link
-        rel=\"shutdown\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/statistics\"/>\n
+        rel=\"shutdown\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -970,8 +959,8 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2011-12-27T11:17:46.815-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <custom_properties>\n            <custom_property
         value=\"2403027f93d7780fa:readonly\" name=\"directlun\"/>\n        </custom_properties>\n
@@ -979,23 +968,23 @@ http_interactions:
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>4294967296</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\"
-        href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\">\n        <name>EVM-V50025</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\">\n        <name>EVM-V50025</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1006,30 +995,30 @@ http_interactions:
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-10-08T22:31:32.423-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\">\n        <name>EVM-v5005</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\">\n        <name>EVM-v5005</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -1039,31 +1028,31 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.173</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\"
-        href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-02-07T11:52:46.317-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\"
-        href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\">\n        <name>GM-Ubuntu-1</name>\n
+        href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\">\n        <name>GM-Ubuntu-1</name>\n
         \       <description></description>\n        <actions>\n            <link
-        rel=\"shutdown\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/statistics\"/>\n
+        rel=\"shutdown\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/statistics\"/>\n
         \       <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"4\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
@@ -1073,31 +1062,31 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-01-11T13:14:51.347-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <host
         id=\"ca389dbc-2054-11e1-9241-005056af0085\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\"
-        href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33\">\n        <name>kmwin2k8a</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33\">\n        <name>kmwin2k8a</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1107,30 +1096,30 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5901</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-08-29T22:48:47.826-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>715128832</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\">\n        <name>MIQ-PXE</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\">\n        <name>MIQ-PXE</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1141,30 +1130,30 @@ http_interactions:
         \           <address>192.168.252.119</address>\n            <port>5902</port>\n
         \           <secure_port>5903</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-08-09T16:20:23.950-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\"
-        href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\">\n        <name>new-server</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\">\n        <name>new-server</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6\">\n
@@ -1173,30 +1162,30 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2011-12-27T17:16:17.230-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\"
-        href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\">\n        <name>obarenboim_test_01</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\">\n        <name>obarenboim_test_01</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1204,30 +1193,30 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-11-26T13:00:56.830-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"31d7505f-e739-4024-84da-2d8df1db9b39\"
-        href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\">\n        <name>RHEL</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\">\n        <name>RHEL</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1237,30 +1226,30 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2011-12-20T13:20:23.845-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"
-        href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\">\n        <name>rpo-evm</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\">\n        <name>rpo-evm</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1271,8 +1260,8 @@ http_interactions:
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \       </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2013-03-28T11:44:18.863-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <custom_properties>\n            <custom_property
         value=\"2403027f93d7780fa:readonly\" name=\"directlun\"/>\n        </custom_properties>\n
@@ -1280,23 +1269,23 @@ http_interactions:
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\"
-        href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\">\n        <name>rpo-test</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\">\n        <name>rpo-test</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/statistics\"/>\n
         \       <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1305,31 +1294,31 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
-        id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <template
+        id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n
         \       <creation_time>2013-03-11T12:07:08.224-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"
-        href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\">\n        <name>ULin1</name>\n
+        href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\">\n        <name>ULin1</name>\n
         \       <description>Test VM Description</description>\n        <actions>\n
-        \           <link rel=\"shutdown\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/statistics\"/>\n
+        \           <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
@@ -1339,8 +1328,8 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5901</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2011-12-19T15:13:15.927-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <custom_properties>\n            <custom_property
         value=\"2403027f93d7780fa:readonly\" name=\"directlun\"/>\n        </custom_properties>\n
@@ -1348,23 +1337,23 @@ http_interactions:
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </vm>\n    <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"
-        href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\">\n        <name>V5-test</name>\n
-        \       <actions>\n            <link rel=\"shutdown\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/shutdown\"/>\n
-        \           <link rel=\"start\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/start\"/>\n
-        \           <link rel=\"stop\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/stop\"/>\n
-        \           <link rel=\"suspend\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/suspend\"/>\n
-        \           <link rel=\"detach\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/detach\"/>\n
-        \           <link rel=\"export\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/export\"/>\n
-        \           <link rel=\"move\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/move\"/>\n
-        \           <link rel=\"ticket\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/ticket\"/>\n
-        \           <link rel=\"migrate\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/migrate\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/cdroms\"/>\n
-        \       <link rel=\"snapshots\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots\"/>\n
-        \       <link rel=\"tags\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/tags\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/permissions\"/>\n
-        \       <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/statistics\"/>\n
+        href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\">\n        <name>V5-test</name>\n
+        \       <actions>\n            <link rel=\"shutdown\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/shutdown\"/>\n
+        \           <link rel=\"start\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/start\"/>\n
+        \           <link rel=\"stop\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/stop\"/>\n
+        \           <link rel=\"suspend\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/suspend\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/detach\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/export\"/>\n
+        \           <link rel=\"move\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/move\"/>\n
+        \           <link rel=\"ticket\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/ticket\"/>\n
+        \           <link rel=\"migrate\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/migrate\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/cdroms\"/>\n
+        \       <link rel=\"snapshots\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots\"/>\n
+        \       <link rel=\"tags\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/tags\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/permissions\"/>\n
+        \       <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/statistics\"/>\n
         \       <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
@@ -1374,8 +1363,8 @@ http_interactions:
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <address>192.168.252.119</address>\n            <port>5900</port>\n
         \           <monitors>1</monitors>\n        </display>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
-        id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <template
+        id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
         \       <creation_time>2012-01-04T14:04:14.598-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>4294967296</guaranteed>\n
@@ -1385,7 +1374,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:30 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms?search=sortby%20name%20asc%20page%202
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -1430,7 +1419,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:31 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates
     body:
       encoding: US-ASCII
       string: ''
@@ -1467,266 +1456,266 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<templates>\n
-        \   <template id=\"00000000-0000-0000-0000-000000000000\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\">\n
+        \   <template id=\"00000000-0000-0000-0000-000000000000\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\">\n
         \       <name>Blank</name>\n        <description>Blank template</description>\n
-        \       <actions>\n            <link rel=\"export\" href=\"/api/templates/00000000-0000-0000-0000-000000000000/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/00000000-0000-0000-0000-000000000000/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/00000000-0000-0000-0000-000000000000/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/00000000-0000-0000-0000-000000000000/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/00000000-0000-0000-0000-000000000000/permissions\"/>\n
+        \       <actions>\n            <link rel=\"export\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions\"/>\n
         \       <type>desktop</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
         \           <boot dev=\"hd\"/>\n        </os>\n        <cluster id=\"99408929-82cf-4dc7-a532-9d998063fa95\"
-        href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2008-04-01T00:00:00.000-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2008-04-01T00:00:00.000-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"e3af998a-7104-4a10-a7c0-bc90c4250bf5\"
-        href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5\">\n        <name>empty</name>\n
-        \       <actions>\n            <link rel=\"export\" href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/permissions\"/>\n
+        href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5\">\n        <name>empty</name>\n
+        \       <actions>\n            <link rel=\"export\" href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-08-09T22:48:36.870-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-08-09T22:48:36.870-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\"
-        href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\">\n        <name>EmsRefreshSpec</name>\n
+        href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\">\n        <name>EmsRefreshSpec</name>\n
         \       <description>Template for EmsRefresh testing</description>\n        <actions>\n
-        \           <link rel=\"export\" href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/permissions\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <boot dev=\"cdrom\"/>\n            <kernel></kernel>\n
         \           <initrd></initrd>\n            <cmdline></cmdline>\n        </os>\n
-        \       <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\" href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n
+        \       <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\" href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n
         \       <creation_time>2012-09-26T14:43:23.417-04:00</creation_time>\n        <origin>rhev</origin>\n
         \       <high_availability>\n            <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n        </display>\n        <stateless>false</stateless>\n
         \       <usb>\n            <enabled>true</enabled>\n        </usb>\n    </template>\n
-        \   <template id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\" href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf\">\n
+        \   <template id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\" href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf\">\n
         \       <name>EVM</name>\n        <actions>\n            <link rel=\"export\"
-        href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/export\"/>\n        </actions>\n
-        \       <link rel=\"disks\" href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/permissions\"/>\n
+        href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/export\"/>\n        </actions>\n
+        \       <link rel=\"disks\" href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-27T11:07:56.690-05:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-27T11:07:56.690-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>vnc</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356\">\n        <name>EVM-50011</name>\n
+        href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356\">\n        <name>EVM-50011</name>\n
         \       <description>RedHat based appliance version 5.0.0.11</description>\n
-        \       <actions>\n            <link rel=\"export\" href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/permissions\"/>\n
+        \       <actions>\n            <link rel=\"export\" href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-07-19T11:20:01.171-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-07-19T11:20:01.171-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\">\n        <name>EVMv5</name>\n
+        href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\">\n        <name>EVMv5</name>\n
         \       <description>ManageIQ EVM 5.0.0.13</description>\n        <actions>\n
-        \           <link rel=\"export\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/permissions\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-08-02T17:50:40.563-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-08-02T17:50:40.563-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572\">\n        <name>EVM-V5</name>\n
+        href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572\">\n        <name>EVM-V5</name>\n
         \       <description>Factory Clean</description>\n        <actions>\n            <link
-        rel=\"export\" href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/permissions\"/>\n
+        rel=\"export\" href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-27T14:24:41.643-05:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-27T14:24:41.643-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>vnc</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff\">\n        <name>EVMv50015</name>\n
+        href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff\">\n        <name>EVMv50015</name>\n
         \       <description>RedHat appliance EVM5.0.0.15</description>\n        <actions>\n
-        \           <link rel=\"export\" href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/permissions\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
         \           <boot dev=\"hd\"/>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-09-08T08:51:03.000-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-09-08T08:51:03.000-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\">\n        <name>EVM-v50017</name>\n
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\">\n        <name>EVM-v50017</name>\n
         \       <description>EVM v5.0.0.17 RedHat Appliance</description>\n        <actions>\n
-        \           <link rel=\"export\" href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/permissions\"/>\n
+        \           <link rel=\"export\" href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-10-09T09:21:58.584-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-10-09T09:21:58.584-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9\">\n        <name>EVM-v50025</name>\n
+        href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9\">\n        <name>EVM-v50025</name>\n
         \       <description>EVM-v50025</description>\n        <actions>\n            <link
-        rel=\"export\" href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/permissions\"/>\n
+        rel=\"export\" href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-12-18T10:20:46.655-05:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-12-18T10:20:46.655-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\">\n        <name>EVM-v5-Base</name>\n
+        href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\">\n        <name>EVM-v5-Base</name>\n
         \       <description>Empty</description>\n        <actions>\n            <link
-        rel=\"export\" href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/permissions\"/>\n
+        rel=\"export\" href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-21T12:30:14.283-05:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-21T12:30:14.283-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>vnc</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"83f76598-4797-40ff-b0ec-433eb74db8be\"
-        href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be\">\n        <name>GM-Template</name>\n
+        href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be\">\n        <name>GM-Template</name>\n
         \       <description></description>\n        <actions>\n            <link
-        rel=\"export\" href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/permissions\"/>\n
+        rel=\"export\" href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/permissions\"/>\n
         \       <type>desktop</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
         \           <boot dev=\"hd\"/>\n        </os>\n        <cluster id=\"d373fcee-e91a-11e0-83d7-005056af0085\"
-        href=\"/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-08T15:40:32.000-05:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/d373fcee-e91a-11e0-83d7-005056af0085\"/>\n        <creation_time>2011-12-08T15:40:32.000-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>true</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"57eb8fef-58ea-4f40-a308-f88b05d18f5d\"
-        href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d\">\n        <name>pxe-template</name>\n
+        href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d\">\n        <name>pxe-template</name>\n
         \       <description>pxe-template</description>\n        <actions>\n            <link
-        rel=\"export\" href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/permissions\"/>\n
+        rel=\"export\" href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-07-17T16:25:01.610-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-07-17T16:25:01.610-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>vnc</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <usb>\n            <enabled>false</enabled>\n
         \       </usb>\n    </template>\n    <template id=\"bb3289d7-6dce-4cfc-9973-c01f3abfe13f\"
-        href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f\">\n        <name>pxe-template-wi</name>\n
-        \       <actions>\n            <link rel=\"export\" href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/export\"/>\n
-        \       </actions>\n        <link rel=\"disks\" href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/permissions\"/>\n
+        href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f\">\n        <name>pxe-template-wi</name>\n
+        \       <actions>\n            <link rel=\"export\" href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/export\"/>\n
+        \       </actions>\n        <link rel=\"disks\" href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         cores=\"1\" sockets=\"2\"/>\n        </cpu>\n        <os type=\"windows_2008r2\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"40c1c666-e919-11e0-9c6b-005056af0085\"
-        href=\"/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-09-05T15:39:15.778-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/40c1c666-e919-11e0-9c6b-005056af0085\"/>\n        <creation_time>2012-09-05T15:39:15.778-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n        </display>\n
         \       <stateless>false</stateless>\n        <timezone>Europe/London</timezone>\n
         \       <usb>\n            <enabled>true</enabled>\n        </usb>\n    </template>\n
-        \   <template id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\">\n
+        \   <template id=\"276fcf44-afeb-4591-b3a6-82544124f898\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898\">\n
         \       <name>Template1</name>\n        <actions>\n            <link rel=\"export\"
-        href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/export\"/>\n        </actions>\n
-        \       <link rel=\"disks\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/disks\"/>\n
-        \       <link rel=\"nics\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/nics\"/>\n
-        \       <link rel=\"cdroms\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/cdroms\"/>\n
-        \       <link rel=\"permissions\" href=\"/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/permissions\"/>\n
+        href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/export\"/>\n        </actions>\n
+        \       <link rel=\"disks\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/disks\"/>\n
+        \       <link rel=\"nics\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/nics\"/>\n
+        \       <link rel=\"cdroms\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/cdroms\"/>\n
+        \       <link rel=\"permissions\" href=\"/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/permissions\"/>\n
         \       <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         cores=\"2\" sockets=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
         \           <cmdline></cmdline>\n        </os>\n        <cluster id=\"ee0f6da6-4ce6-11e1-9348-005056af0085\"
-        href=\"/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <creation_time>2012-04-30T11:01:07.697-04:00</creation_time>\n
+        href=\"/ovirt-engine/api/clusters/ee0f6da6-4ce6-11e1-9348-005056af0085\"/>\n        <creation_time>2012-04-30T11:01:07.697-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>vnc</type>\n            <monitors>1</monitors>\n        </display>\n
@@ -1736,7 +1725,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:31 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -1773,12 +1762,12 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0\">\n
+        \   <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0\">\n
         \       <name>StarM1RHEV-1</name>\n        <actions>\n            <link rel=\"activate\"
-        href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/activate\"/>\n
-        \           <link rel=\"deactivate\" href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/deactivate\"/>\n
+        href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/activate\"/>\n
+        \           <link rel=\"deactivate\" href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928/storagedomains/6efaa0f3-d832-4e8f-846f-aacdc974e6d0/deactivate\"/>\n
         \       </actions>\n        <data_center id=\"cb50d90a-f585-4d17-a524-a577a97da928\"
-        href=\"/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <type>data</type>\n
+        href=\"/ovirt-engine/api/datacenters/cb50d90a-f585-4d17-a524-a577a97da928\"/>\n        <type>data</type>\n
         \       <status>\n            <state>inactive</state>\n        </status>\n
         \       <master>true</master>\n        <storage>\n            <type>iscsi</type>\n
         \           <volume_group id=\"ETu16x-1cnn-Z1Xi-k9Bj-GMzq-ke5s-gsou2g\">\n
@@ -1796,7 +1785,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:32 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -1833,12 +1822,12 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\" href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa\">\n
+        \   <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\" href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa\">\n
         \       <name>StarM1-RHEVM1</name>\n        <actions>\n            <link rel=\"activate\"
-        href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/activate\"/>\n
-        \           <link rel=\"deactivate\" href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/deactivate\"/>\n
+        href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/activate\"/>\n
+        \           <link rel=\"deactivate\" href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af/storagedomains/40f45969-31e9-4db6-9c9c-9a683c3755aa/deactivate\"/>\n
         \       </actions>\n        <data_center id=\"199560d0-9b83-4212-b2a1-077e1b4371af\"
-        href=\"/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n        <type>data</type>\n
+        href=\"/ovirt-engine/api/datacenters/199560d0-9b83-4212-b2a1-077e1b4371af\"/>\n        <type>data</type>\n
         \       <status>\n            <state>unknown</state>\n        </status>\n
         \       <master>true</master>\n        <storage>\n            <type>iscsi</type>\n
         \           <volume_group id=\"9Al9cf-ML4f-Ch0m-mI0x-Kz8n-bUYL-uycuBn\">\n
@@ -1856,7 +1845,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:32 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -1893,24 +1882,24 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4\">\n
+        \   <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4\">\n
         \       <name>HostNFS</name>\n        <actions>\n            <link rel=\"activate\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/activate\"/>\n
-        \           <link rel=\"deactivate\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/deactivate\"/>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/activate\"/>\n
+        \           <link rel=\"deactivate\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/65ca9577-0d95-4909-8532-4c45201fbfe4/deactivate\"/>\n
         \       </actions>\n        <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <type>data</type>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <type>data</type>\n
         \       <status>\n            <state>unknown</state>\n        </status>\n
         \       <master>true</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.119</address>\n            <path>/srv/nfs</path>\n
         \       </storage>\n        <available>69793218560</available>\n        <used>98784247808</used>\n
         \       <committed>532575944704</committed>\n        <storage_format>v1</storage_format>\n
         \   </storage_domain>\n    <storage_domain id=\"298906e7-e1a8-446f-85e9-dc894d0e284b\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b\">\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b\">\n
         \       <name>NFS-ISO-Domain</name>\n        <actions>\n            <link
-        rel=\"activate\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/activate\"/>\n
-        \           <link rel=\"deactivate\" href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/deactivate\"/>\n
+        rel=\"activate\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/activate\"/>\n
+        \           <link rel=\"deactivate\" href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085/storagedomains/298906e7-e1a8-446f-85e9-dc894d0e284b/deactivate\"/>\n
         \       </actions>\n        <data_center id=\"eb5592d2-ce76-11e0-a703-005056af0085\"
-        href=\"/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <type>iso</type>\n
+        href=\"/ovirt-engine/api/datacenters/eb5592d2-ce76-11e0-a703-005056af0085\"/>\n        <type>iso</type>\n
         \       <status>\n            <state>inactive</state>\n        </status>\n
         \       <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.231</address>\n            <path>/srv/nfs</path>\n
@@ -1921,7 +1910,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:32 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics
     body:
       encoding: US-ASCII
       string: ''
@@ -1958,95 +1947,95 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<statistics>\n
-        \   <statistic id=\"7816602b-c05c-3db7-a4da-3769f7ad8896\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\">\n
+        \   <statistic id=\"7816602b-c05c-3db7-a4da-3769f7ad8896\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\">\n
         \       <name>memory.total</name>\n        <description>Total memory</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>8185184256</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"b7499508-c1c3-32f0-8174-c1783e57bb08\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\">\n
         \       <name>memory.used</name>\n        <description>Used memory</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"5a0fba9d-33d7-3cbf-addd-ba462040c946\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\">\n
         \       <name>memory.free</name>\n        <description>Free memory</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>4889509888</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"c81c86f0-bc61-3c78-a543-898b8339d03f\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\">\n
         \       <name>memory.buffers</name>\n        <description>IO buffers</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"1b6244ee-8dbd-365d-8762-482ddc05ee11\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\">\n
         \       <name>memory.cached</name>\n        <description>OS caches</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\">\n
         \       <name>swap.total</name>\n        <description>Total swap</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>10484711424</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\">\n
         \       <name>swap.free</name>\n        <description>Free swap</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>10473177088</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\">\n
         \       <name>swap.used</name>\n        <description>Used swap</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>11534336</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"ea00da15-de2d-3393-a7cb-810c4b19ed07\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\">\n
         \       <name>swap.cached</name>\n        <description>Swap also in memory</description>\n
         \       <values type=\"INTEGER\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"f740b9ad-14a7-3f6c-9b80-efff44777169\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\">\n
         \       <name>ksm.cpu.current</name>\n        <description>KSM CPU usage</description>\n
         \       <values type=\"DECIMAL\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"a1fab379-66e2-3b1d-9914-81a9e79cb719\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\">\n
         \       <name>cpu.current.user</name>\n        <description>User CPU usage</description>\n
         \       <values type=\"DECIMAL\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"a98c1e11-078c-3593-a57e-4b12c1ce9815\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\">\n
         \       <name>cpu.current.system</name>\n        <description>System CPU usage</description>\n
         \       <values type=\"DECIMAL\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"4ae97794-f56d-3f05-a9e7-8798887cd1ac\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\">\n
         \       <name>cpu.current.idle</name>\n        <description>Idle CPU usage</description>\n
         \       <values type=\"DECIMAL\">\n            <value>\n                <datum>0</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \   </statistic>\n    <statistic id=\"65860dae-c890-312e-9314-5c01f31225ab\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/65860dae-c890-312e-9314-5c01f31225ab\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/statistics/65860dae-c890-312e-9314-5c01f31225ab\">\n
         \       <name>cpu.load.avg.5m</name>\n        <description>CPU 5 minute load
         average</description>\n        <values type=\"DECIMAL\">\n            <value>\n
         \               <datum>0</datum>\n            </value>\n        </values>\n
         \       <type>GAUGE</type>\n        <unit>PERCENT</unit>\n        <host id=\"ca389dbc-2054-11e1-9241-005056af0085\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n    </statistic>\n</statistics>\n"
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n    </statistic>\n</statistics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:33 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2083,24 +2072,24 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<host_nics>\n
-        \   <host_nic id=\"15b731b5-fa78-46f5-8467-e25aa3041775\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775\">\n
+        \   <host_nic id=\"15b731b5-fa78-46f5-8467-e25aa3041775\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775\">\n
         \       <name>eth1</name>\n        <actions>\n            <link rel=\"attach\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/attach\"/>\n
-        \           <link rel=\"detach\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/detach\"/>\n
-        \       </actions>\n        <link rel=\"statistics\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/statistics\"/>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/attach\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/detach\"/>\n
+        \       </actions>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/15b731b5-fa78-46f5-8467-e25aa3041775/statistics\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
         \       <network>\n            <name>iSCSI</name>\n        </network>\n        <mac
         address=\"E0:91:F5:1B:66:5B\"/>\n        <ip gateway=\"0.0.0.0\" netmask=\"255.255.255.0\"
         address=\"10.1.1.171\"/>\n        <boot_protocol>static</boot_protocol>\n
         \       <speed>1000000000</speed>\n        <status>\n            <state>up</state>\n
         \       </status>\n    </host_nic>\n    <host_nic id=\"dc7bc21d-f0e6-4b1d-a627-adb82dfe9777\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777\">\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777\">\n
         \       <name>eth0</name>\n        <actions>\n            <link rel=\"attach\"
-        href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/attach\"/>\n
-        \           <link rel=\"detach\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/detach\"/>\n
-        \       </actions>\n        <link rel=\"statistics\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/statistics\"/>\n
-        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/attach\"/>\n
+        \           <link rel=\"detach\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/detach\"/>\n
+        \       </actions>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085/nics/dc7bc21d-f0e6-4b1d-a627-adb82dfe9777/statistics\"/>\n
+        \       <host id=\"ca389dbc-2054-11e1-9241-005056af0085\" href=\"/ovirt-engine/api/hosts/ca389dbc-2054-11e1-9241-005056af0085\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <mac address=\"00:1D:09:06:9A:3C\"/>\n        <ip gateway=\"192.168.252.1\"
         netmask=\"255.255.254.0\" address=\"192.168.252.119\"/>\n        <speed>1000000000</speed>\n
         \       <status>\n            <state>up</state>\n        </status>\n    </host_nic>\n</host_nics>\n"
@@ -2108,7 +2097,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:34 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2145,41 +2134,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"2c364312-e3d0-4399-92ed-2975181d88b2\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \   <disk id=\"2c364312-e3d0-4399-92ed-2975181d88b2\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"59edb695-2044-4010-aa8e-c4de5d6683cb\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/59edb695-2044-4010-aa8e-c4de5d6683cb\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/59edb695-2044-4010-aa8e-c4de5d6683cb/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \   </disk>\n    <disk id=\"59edb695-2044-4010-aa8e-c4de5d6683cb\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/59edb695-2044-4010-aa8e-c4de5d6683cb\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/59edb695-2044-4010-aa8e-c4de5d6683cb/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"6dc2af11-9ed5-4831-9080-a34315779e8d\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/6dc2af11-9ed5-4831-9080-a34315779e8d\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/6dc2af11-9ed5-4831-9080-a34315779e8d/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \   </disk>\n    <disk id=\"6dc2af11-9ed5-4831-9080-a34315779e8d\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/6dc2af11-9ed5-4831-9080-a34315779e8d\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/6dc2af11-9ed5-4831-9080-a34315779e8d/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"048ccac3-214b-49ea-b31e-51f647f39c0a\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/048ccac3-214b-49ea-b31e-51f647f39c0a\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/048ccac3-214b-49ea-b31e-51f647f39c0a/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \   </disk>\n    <disk id=\"048ccac3-214b-49ea-b31e-51f647f39c0a\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/048ccac3-214b-49ea-b31e-51f647f39c0a\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/048ccac3-214b-49ea-b31e-51f647f39c0a/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"2c372aeb-25e4-4caa-a867-1889395867d6\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c372aeb-25e4-4caa-a867-1889395867d6\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c372aeb-25e4-4caa-a867-1889395867d6/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \   </disk>\n    <disk id=\"2c372aeb-25e4-4caa-a867-1889395867d6\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c372aeb-25e4-4caa-a867-1889395867d6\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c372aeb-25e4-4caa-a867-1889395867d6/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -2190,7 +2179,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:34 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2227,18 +2216,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"04255418-bf6b-4b54-af5e-b50a477fc1c6\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots/04255418-bf6b-4b54-af5e-b50a477fc1c6\">\n
+        \   <snapshot id=\"04255418-bf6b-4b54-af5e-b50a477fc1c6\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots/04255418-bf6b-4b54-af5e-b50a477fc1c6\">\n
         \       <description>_ActiveImage_Brandon-Clone1_Wed Jun 27 15:00:18 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots/04255418-bf6b-4b54-af5e-b50a477fc1c6/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/snapshots/04255418-bf6b-4b54-af5e-b50a477fc1c6/restore\"/>\n
         \       </actions>\n        <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\"
-        href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n        <disk id=\"2c364312-e3d0-4399-92ed-2975181d88b2\"
-        href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2\"/>\n
+        href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n        <disk id=\"2c364312-e3d0-4399-92ed-2975181d88b2\"
+        href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/disks/2c364312-e3d0-4399-92ed-2975181d88b2\"/>\n
         \       <date>2012-06-27T14:43:38.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:34 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2275,17 +2264,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"5ed2fe3c-5f22-4ab7-8f98-18ee5b114264\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics/5ed2fe3c-5f22-4ab7-8f98-18ee5b114264\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics/5ed2fe3c-5f22-4ab7-8f98-18ee5b114264/statistics\"/>\n
-        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
-        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
+        \   <nic id=\"5ed2fe3c-5f22-4ab7-8f98-18ee5b114264\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics/5ed2fe3c-5f22-4ab7-8f98-18ee5b114264\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0/nics/5ed2fe3c-5f22-4ab7-8f98-18ee5b114264/statistics\"/>\n
+        \       <vm id=\"f84706ea-a68a-4206-a6cf-a06e11da70c0\" href=\"/ovirt-engine/api/vms/f84706ea-a68a-4206-a6cf-a06e11da70c0\"/>\n
+        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/ovirt-engine/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:0d\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:35 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2322,41 +2311,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"8ea1916d-d09c-4bfe-a81a-54179b355b0c\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \   <disk id=\"8ea1916d-d09c-4bfe-a81a-54179b355b0c\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"ccbc5b89-b2fc-451f-aec1-a5a82899a258\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/ccbc5b89-b2fc-451f-aec1-a5a82899a258\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/ccbc5b89-b2fc-451f-aec1-a5a82899a258/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \   </disk>\n    <disk id=\"ccbc5b89-b2fc-451f-aec1-a5a82899a258\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/ccbc5b89-b2fc-451f-aec1-a5a82899a258\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/ccbc5b89-b2fc-451f-aec1-a5a82899a258/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"4e1a7b97-5f8d-4491-8be6-e70255c9beda\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/4e1a7b97-5f8d-4491-8be6-e70255c9beda\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/4e1a7b97-5f8d-4491-8be6-e70255c9beda/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \   </disk>\n    <disk id=\"4e1a7b97-5f8d-4491-8be6-e70255c9beda\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/4e1a7b97-5f8d-4491-8be6-e70255c9beda\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/4e1a7b97-5f8d-4491-8be6-e70255c9beda/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"e8c7fe62-1d08-4626-bef1-c9193a1f18a4\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/e8c7fe62-1d08-4626-bef1-c9193a1f18a4\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/e8c7fe62-1d08-4626-bef1-c9193a1f18a4/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \   </disk>\n    <disk id=\"e8c7fe62-1d08-4626-bef1-c9193a1f18a4\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/e8c7fe62-1d08-4626-bef1-c9193a1f18a4\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/e8c7fe62-1d08-4626-bef1-c9193a1f18a4/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"7dad5e69-f405-422f-aa0d-662a582126b9\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/7dad5e69-f405-422f-aa0d-662a582126b9\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/7dad5e69-f405-422f-aa0d-662a582126b9/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \   </disk>\n    <disk id=\"7dad5e69-f405-422f-aa0d-662a582126b9\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/7dad5e69-f405-422f-aa0d-662a582126b9\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/7dad5e69-f405-422f-aa0d-662a582126b9/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -2367,7 +2356,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:35 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2404,18 +2393,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"e168099f-08b9-40fc-9444-d401e8dd7f90\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots/e168099f-08b9-40fc-9444-d401e8dd7f90\">\n
+        \   <snapshot id=\"e168099f-08b9-40fc-9444-d401e8dd7f90\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots/e168099f-08b9-40fc-9444-d401e8dd7f90\">\n
         \       <description>_ActiveImage_CLI-Provision-1_Mon Apr 30 12:50:44 EDT
-        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots/e168099f-08b9-40fc-9444-d401e8dd7f90/restore\"/>\n
+        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/snapshots/e168099f-08b9-40fc-9444-d401e8dd7f90/restore\"/>\n
         \       </actions>\n        <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"
-        href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n        <disk id=\"8ea1916d-d09c-4bfe-a81a-54179b355b0c\"
-        href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c\"/>\n
+        href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n        <disk id=\"8ea1916d-d09c-4bfe-a81a-54179b355b0c\"
+        href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/disks/8ea1916d-d09c-4bfe-a81a-54179b355b0c\"/>\n
         \       <date>2012-04-30T12:32:57.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:35 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2452,17 +2441,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"35e210f9-e0b4-407b-88d5-b63caf89131a\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics/35e210f9-e0b4-407b-88d5-b63caf89131a\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics/35e210f9-e0b4-407b-88d5-b63caf89131a/statistics\"/>\n
-        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
-        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
+        \   <nic id=\"35e210f9-e0b4-407b-88d5-b63caf89131a\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics/35e210f9-e0b4-407b-88d5-b63caf89131a\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3/nics/35e210f9-e0b4-407b-88d5-b63caf89131a/statistics\"/>\n
+        \       <vm id=\"209666c9-e9d6-4e55-89f9-cc7fdf023ba3\" href=\"/ovirt-engine/api/vms/209666c9-e9d6-4e55-89f9-cc7fdf023ba3\"/>\n
+        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/ovirt-engine/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:0a\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:36 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2499,17 +2488,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5/statistics\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \   <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5/statistics\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"190fa724-91e7-49ba-8dcc-5dda4d0186d8\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8/statistics\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \   </disk>\n    <disk id=\"190fa724-91e7-49ba-8dcc-5dda4d0186d8\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8/statistics\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -2520,7 +2509,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:36 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2557,40 +2546,40 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"4ecc2f4c-2932-4eea-8597-e6aad5da305a\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/4ecc2f4c-2932-4eea-8597-e6aad5da305a\">\n
+        \   <snapshot id=\"4ecc2f4c-2932-4eea-8597-e6aad5da305a\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/4ecc2f4c-2932-4eea-8597-e6aad5da305a\">\n
         \       <description>_ActiveImage_EmsRefreshSpec-PoweredOff_Wed Sep 26 14:37:54
         EDT 2012</description>\n        <actions>\n            <link rel=\"restore\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/4ecc2f4c-2932-4eea-8597-e6aad5da305a/restore\"/>\n
-        \       </actions>\n        <link rel=\"prev\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
-        \       <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/4ecc2f4c-2932-4eea-8597-e6aad5da305a/restore\"/>\n
+        \       </actions>\n        <link rel=\"prev\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \       <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
         \       <date>2012-09-26T10:40:23.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"abf6f7aa-cd46-426e-83be-9f7a492a073b\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b\">\n
+        id=\"abf6f7aa-cd46-426e-83be-9f7a492a073b\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b\">\n
         \       <description>Snapshot2</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b/restore\"/>\n
-        \       </actions>\n        <link rel=\"prev\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
-        \       <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/abf6f7aa-cd46-426e-83be-9f7a492a073b/restore\"/>\n
+        \       </actions>\n        <link rel=\"prev\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \       <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
         \       <date>2012-09-26T10:39:46.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"123c6a56-7998-4275-bb8d-0f232f5d19a5\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5\">\n
+        id=\"123c6a56-7998-4275-bb8d-0f232f5d19a5\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5\">\n
         \       <description>Snapshot1</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5/restore\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/123c6a56-7998-4275-bb8d-0f232f5d19a5/restore\"/>\n
         \       </actions>\n        <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <disk id=\"a9a57d05-aca5-4117-868e-beb31f0523a5\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/a9a57d05-aca5-4117-868e-beb31f0523a5\"/>\n
         \       <date>2012-09-26T10:31:54.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"1eaef769-fea8-4177-9f94-b78ef8f7a992\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/1eaef769-fea8-4177-9f94-b78ef8f7a992\">\n
+        id=\"1eaef769-fea8-4177-9f94-b78ef8f7a992\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/1eaef769-fea8-4177-9f94-b78ef8f7a992\">\n
         \       <description>Snapshot1</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/1eaef769-fea8-4177-9f94-b78ef8f7a992/restore\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/1eaef769-fea8-4177-9f94-b78ef8f7a992/restore\"/>\n
         \       </actions>\n        <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <disk id=\"190fa724-91e7-49ba-8dcc-5dda4d0186d8\"
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8\"/>\n
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <disk id=\"190fa724-91e7-49ba-8dcc-5dda4d0186d8\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/190fa724-91e7-49ba-8dcc-5dda4d0186d8\"/>\n
         \       <date>2012-09-26T10:31:37.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:37 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2627,27 +2616,27 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"c586cd90-fc74-4b17-9fad-f5a559b40bf2\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/c586cd90-fc74-4b17-9fad-f5a559b40bf2\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/c586cd90-fc74-4b17-9fad-f5a559b40bf2/statistics\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"c586cd90-fc74-4b17-9fad-f5a559b40bf2\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/c586cd90-fc74-4b17-9fad-f5a559b40bf2\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/c586cd90-fc74-4b17-9fad-f5a559b40bf2/statistics\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:0c\"/>\n
-        \   </nic>\n    <nic id=\"ef139207-c197-46b7-aff2-e12b85514af2\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/ef139207-c197-46b7-aff2-e12b85514af2\">\n
-        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/ef139207-c197-46b7-aff2-e12b85514af2/statistics\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   </nic>\n    <nic id=\"ef139207-c197-46b7-aff2-e12b85514af2\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/ef139207-c197-46b7-aff2-e12b85514af2\">\n
+        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/ef139207-c197-46b7-aff2-e12b85514af2/statistics\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:0e\"/>\n
-        \   </nic>\n    <nic id=\"08e80c46-5846-4b04-90f0-223cd23d5228\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/08e80c46-5846-4b04-90f0-223cd23d5228\">\n
-        \       <name>nic3</name>\n        <link rel=\"statistics\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/08e80c46-5846-4b04-90f0-223cd23d5228/statistics\"/>\n
-        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   </nic>\n    <nic id=\"08e80c46-5846-4b04-90f0-223cd23d5228\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/08e80c46-5846-4b04-90f0-223cd23d5228\">\n
+        \       <name>nic3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/08e80c46-5846-4b04-90f0-223cd23d5228/statistics\"/>\n
+        \       <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\" href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>rtl8139</interface>\n        <mac address=\"00:1a:4a:a8:fc:0f\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:37 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2684,17 +2673,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"2b427acc-9182-493e-a8d9-783ccb12afd5\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5/statistics\"/>\n
-        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
+        \   <disk id=\"2b427acc-9182-493e-a8d9-783ccb12afd5\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5/statistics\"/>\n
+        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"061baae8-69bc-410c-a950-7d78be535c8c\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c/statistics\"/>\n
-        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
+        \   </disk>\n    <disk id=\"061baae8-69bc-410c-a950-7d78be535c8c\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c/statistics\"/>\n
+        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -2705,7 +2694,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:37 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2742,27 +2731,27 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"b5557722-d376-4201-b869-538204f67c01\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/b5557722-d376-4201-b869-538204f67c01\">\n
+        \   <snapshot id=\"b5557722-d376-4201-b869-538204f67c01\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/b5557722-d376-4201-b869-538204f67c01\">\n
         \       <description>_ActiveImage_EmsRefreshSpec-PoweredOn_Wed Sep 26 14:46:28
         EDT 2012</description>\n        <actions>\n            <link rel=\"restore\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/b5557722-d376-4201-b869-538204f67c01/restore\"/>\n
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/b5557722-d376-4201-b869-538204f67c01/restore\"/>\n
         \       </actions>\n        <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <disk id=\"2b427acc-9182-493e-a8d9-783ccb12afd5\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5\"/>\n
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <disk id=\"2b427acc-9182-493e-a8d9-783ccb12afd5\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/2b427acc-9182-493e-a8d9-783ccb12afd5\"/>\n
         \       <date>2012-09-26T10:48:56.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"cf999f1f-aa72-4a0b-8fac-b208ce1de882\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/cf999f1f-aa72-4a0b-8fac-b208ce1de882\">\n
+        id=\"cf999f1f-aa72-4a0b-8fac-b208ce1de882\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/cf999f1f-aa72-4a0b-8fac-b208ce1de882\">\n
         \       <description>_ActiveImage_EmsRefreshSpec-PoweredOn_Wed Sep 26 14:49:58
         EDT 2012</description>\n        <actions>\n            <link rel=\"restore\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/cf999f1f-aa72-4a0b-8fac-b208ce1de882/restore\"/>\n
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/cf999f1f-aa72-4a0b-8fac-b208ce1de882/restore\"/>\n
         \       </actions>\n        <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <disk id=\"061baae8-69bc-410c-a950-7d78be535c8c\"
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c\"/>\n
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <disk id=\"061baae8-69bc-410c-a950-7d78be535c8c\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/061baae8-69bc-410c-a950-7d78be535c8c\"/>\n
         \       <date>2012-09-26T10:52:25.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:37 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2799,27 +2788,27 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"ceef88cc-b9af-4e65-a7f0-120a27f1cb66\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/ceef88cc-b9af-4e65-a7f0-120a27f1cb66\">\n
-        \       <name>nic3</name>\n        <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/ceef88cc-b9af-4e65-a7f0-120a27f1cb66/statistics\"/>\n
-        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"ceef88cc-b9af-4e65-a7f0-120a27f1cb66\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/ceef88cc-b9af-4e65-a7f0-120a27f1cb66\">\n
+        \       <name>nic3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/ceef88cc-b9af-4e65-a7f0-120a27f1cb66/statistics\"/>\n
+        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>rtl8139</interface>\n        <mac address=\"00:1a:4a:a8:fc:10\"/>\n
-        \   </nic>\n    <nic id=\"a8b7c139-4986-428b-9204-e7d364643e8f\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/a8b7c139-4986-428b-9204-e7d364643e8f\">\n
-        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/a8b7c139-4986-428b-9204-e7d364643e8f/statistics\"/>\n
-        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   </nic>\n    <nic id=\"a8b7c139-4986-428b-9204-e7d364643e8f\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/a8b7c139-4986-428b-9204-e7d364643e8f\">\n
+        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/a8b7c139-4986-428b-9204-e7d364643e8f/statistics\"/>\n
+        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:11\"/>\n
-        \   </nic>\n    <nic id=\"82a2b96c-b17d-4d22-9445-31da58f8b24a\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/82a2b96c-b17d-4d22-9445-31da58f8b24a\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/82a2b96c-b17d-4d22-9445-31da58f8b24a/statistics\"/>\n
-        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   </nic>\n    <nic id=\"82a2b96c-b17d-4d22-9445-31da58f8b24a\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/82a2b96c-b17d-4d22-9445-31da58f8b24a\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/82a2b96c-b17d-4d22-9445-31da58f8b24a/statistics\"/>\n
+        \       <vm id=\"fe052832-2350-48ce-8e56-c24b4cd91876\" href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:12\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:38 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2856,41 +2845,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"4b92f601-1781-4584-a798-58b13a9f6e49\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \   <disk id=\"4b92f601-1781-4584-a798-58b13a9f6e49\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"df80c03f-baea-4a19-808f-ac4a51aa3e46\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \   </disk>\n    <disk id=\"df80c03f-baea-4a19-808f-ac4a51aa3e46\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"69cadec7-2670-4bb8-8bbe-2c74391b23f9\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \   </disk>\n    <disk id=\"69cadec7-2670-4bb8-8bbe-2c74391b23f9\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"840a68fd-c467-4d32-b7f4-2ccceedc976b\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \   </disk>\n    <disk id=\"840a68fd-c467-4d32-b7f4-2ccceedc976b\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"a4f7b574-2754-458d-a784-65586212440b\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \   </disk>\n    <disk id=\"a4f7b574-2754-458d-a784-65586212440b\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -2901,7 +2890,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:38 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2938,46 +2927,46 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"fbd325dc-30b1-4d64-b906-be54a3b15075\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/fbd325dc-30b1-4d64-b906-be54a3b15075\">\n
+        \   <snapshot id=\"fbd325dc-30b1-4d64-b906-be54a3b15075\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/fbd325dc-30b1-4d64-b906-be54a3b15075\">\n
         \       <description>_ActiveImage_EVM-RH-50013_Thu Aug 02 14:17:51 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/fbd325dc-30b1-4d64-b906-be54a3b15075/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/fbd325dc-30b1-4d64-b906-be54a3b15075/restore\"/>\n
         \       </actions>\n        <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"4b92f601-1781-4584-a798-58b13a9f6e49\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49\"/>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"4b92f601-1781-4584-a798-58b13a9f6e49\"
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/4b92f601-1781-4584-a798-58b13a9f6e49\"/>\n
         \       <date>2012-08-02T14:34:55.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"3d57c707-37ce-4fdb-bfa5-44db36cdb555\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d57c707-37ce-4fdb-bfa5-44db36cdb555\">\n
+        id=\"3d57c707-37ce-4fdb-bfa5-44db36cdb555\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d57c707-37ce-4fdb-bfa5-44db36cdb555\">\n
         \       <description>_ActiveImage_EVM-RH-50013_Thu Aug 02 14:16:55 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d57c707-37ce-4fdb-bfa5-44db36cdb555/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d57c707-37ce-4fdb-bfa5-44db36cdb555/restore\"/>\n
         \       </actions>\n        <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"df80c03f-baea-4a19-808f-ac4a51aa3e46\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46\"/>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"df80c03f-baea-4a19-808f-ac4a51aa3e46\"
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/df80c03f-baea-4a19-808f-ac4a51aa3e46\"/>\n
         \       <date>2012-08-02T14:33:58.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8\">\n
+        id=\"3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8\">\n
         \       <description>_ActiveImage_EVM-RH-50013_Thu Aug 02 14:16:37 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/3d7b51f4-2146-41d3-9dfc-1a9ce0bb76c8/restore\"/>\n
         \       </actions>\n        <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"69cadec7-2670-4bb8-8bbe-2c74391b23f9\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9\"/>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"69cadec7-2670-4bb8-8bbe-2c74391b23f9\"
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/69cadec7-2670-4bb8-8bbe-2c74391b23f9\"/>\n
         \       <date>2012-08-02T14:33:41.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"ee034253-59ee-4ad7-94fc-31f3f5b667c1\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/ee034253-59ee-4ad7-94fc-31f3f5b667c1\">\n
+        id=\"ee034253-59ee-4ad7-94fc-31f3f5b667c1\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/ee034253-59ee-4ad7-94fc-31f3f5b667c1\">\n
         \       <description>_ActiveImage_EVM-RH-50013_Thu Aug 02 14:18:04 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/ee034253-59ee-4ad7-94fc-31f3f5b667c1/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/ee034253-59ee-4ad7-94fc-31f3f5b667c1/restore\"/>\n
         \       </actions>\n        <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"840a68fd-c467-4d32-b7f4-2ccceedc976b\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b\"/>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"840a68fd-c467-4d32-b7f4-2ccceedc976b\"
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/840a68fd-c467-4d32-b7f4-2ccceedc976b\"/>\n
         \       <date>2012-08-02T14:35:07.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"93ee15b3-0554-4b95-9a75-2fac9f5a0d03\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/93ee15b3-0554-4b95-9a75-2fac9f5a0d03\">\n
+        id=\"93ee15b3-0554-4b95-9a75-2fac9f5a0d03\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/93ee15b3-0554-4b95-9a75-2fac9f5a0d03\">\n
         \       <description>_ActiveImage_EVM-RH-50013_Thu Aug 02 14:18:13 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/93ee15b3-0554-4b95-9a75-2fac9f5a0d03/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/snapshots/93ee15b3-0554-4b95-9a75-2fac9f5a0d03/restore\"/>\n
         \       </actions>\n        <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"a4f7b574-2754-458d-a784-65586212440b\"
-        href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b\"/>\n
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n        <disk id=\"a4f7b574-2754-458d-a784-65586212440b\"
+        href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/disks/a4f7b574-2754-458d-a784-65586212440b\"/>\n
         \       <date>2012-08-02T14:35:17.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:38 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3014,17 +3003,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics/7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics/7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2/statistics\"/>\n
-        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics/7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de/nics/7cb8363c-a15a-4ac3-afc8-0d1ceb8425c2/statistics\"/>\n
+        \       <vm id=\"7427031c-c3d1-4e06-99b4-19fd893606de\" href=\"/ovirt-engine/api/vms/7427031c-c3d1-4e06-99b4-19fd893606de\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:4e\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:38 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3061,41 +3050,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"ff633058-57b3-479e-a00e-c0f43091c151\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \   <disk id=\"ff633058-57b3-479e-a00e-c0f43091c151\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"9cf3799f-44c4-441f-a079-2754507f8b19\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/9cf3799f-44c4-441f-a079-2754507f8b19\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/9cf3799f-44c4-441f-a079-2754507f8b19/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \   </disk>\n    <disk id=\"9cf3799f-44c4-441f-a079-2754507f8b19\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/9cf3799f-44c4-441f-a079-2754507f8b19\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/9cf3799f-44c4-441f-a079-2754507f8b19/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"eea14dda-d67c-4a4a-b428-567e7a0cf076\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/eea14dda-d67c-4a4a-b428-567e7a0cf076\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/eea14dda-d67c-4a4a-b428-567e7a0cf076/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \   </disk>\n    <disk id=\"eea14dda-d67c-4a4a-b428-567e7a0cf076\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/eea14dda-d67c-4a4a-b428-567e7a0cf076\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/eea14dda-d67c-4a4a-b428-567e7a0cf076/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"dffa083d-7603-4869-9fd4-f54458529960\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/dffa083d-7603-4869-9fd4-f54458529960\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/dffa083d-7603-4869-9fd4-f54458529960/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \   </disk>\n    <disk id=\"dffa083d-7603-4869-9fd4-f54458529960\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/dffa083d-7603-4869-9fd4-f54458529960\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/dffa083d-7603-4869-9fd4-f54458529960/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"475055f8-d5e4-4ebd-b164-2b2cfe156864\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/475055f8-d5e4-4ebd-b164-2b2cfe156864\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/475055f8-d5e4-4ebd-b164-2b2cfe156864/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \   </disk>\n    <disk id=\"475055f8-d5e4-4ebd-b164-2b2cfe156864\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/475055f8-d5e4-4ebd-b164-2b2cfe156864\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/475055f8-d5e4-4ebd-b164-2b2cfe156864/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -3106,7 +3095,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:38 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3143,18 +3132,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"f6107e87-4ba3-49aa-b1b1-134fda26263f\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots/f6107e87-4ba3-49aa-b1b1-134fda26263f\">\n
+        \   <snapshot id=\"f6107e87-4ba3-49aa-b1b1-134fda26263f\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots/f6107e87-4ba3-49aa-b1b1-134fda26263f\">\n
         \       <description>_ActiveImage_EVM-RH-50015_Fri Sep 07 16:28:37 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots/f6107e87-4ba3-49aa-b1b1-134fda26263f/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/snapshots/f6107e87-4ba3-49aa-b1b1-134fda26263f/restore\"/>\n
         \       </actions>\n        <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\"
-        href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n        <disk id=\"ff633058-57b3-479e-a00e-c0f43091c151\"
-        href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151\"/>\n
+        href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n        <disk id=\"ff633058-57b3-479e-a00e-c0f43091c151\"
+        href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/disks/ff633058-57b3-479e-a00e-c0f43091c151\"/>\n
         \       <date>2012-09-07T16:50:11.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:39 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3191,17 +3180,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"7028584c-21a6-4908-afbd-9364f59394a6\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics/7028584c-21a6-4908-afbd-9364f59394a6\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics/7028584c-21a6-4908-afbd-9364f59394a6/statistics\"/>\n
-        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"7028584c-21a6-4908-afbd-9364f59394a6\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics/7028584c-21a6-4908-afbd-9364f59394a6\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a/nics/7028584c-21a6-4908-afbd-9364f59394a6/statistics\"/>\n
+        \       <vm id=\"a42314f4-4381-468f-ba9c-93b4276f155a\" href=\"/ovirt-engine/api/vms/a42314f4-4381-468f-ba9c-93b4276f155a\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:33\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:39 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3238,41 +3227,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"4611586d-e56e-47e9-8316-17ff7f462816\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816/statistics\"/>\n
-        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
+        \   <disk id=\"4611586d-e56e-47e9-8316-17ff7f462816\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816/statistics\"/>\n
+        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"933eaa97-bbff-4291-b39d-b0e1a8be46c8\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/933eaa97-bbff-4291-b39d-b0e1a8be46c8\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/933eaa97-bbff-4291-b39d-b0e1a8be46c8/statistics\"/>\n
-        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
+        \   </disk>\n    <disk id=\"933eaa97-bbff-4291-b39d-b0e1a8be46c8\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/933eaa97-bbff-4291-b39d-b0e1a8be46c8\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/933eaa97-bbff-4291-b39d-b0e1a8be46c8/statistics\"/>\n
+        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"0cc57bfb-8990-4527-a614-6378e08d9799\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/0cc57bfb-8990-4527-a614-6378e08d9799\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/0cc57bfb-8990-4527-a614-6378e08d9799/statistics\"/>\n
-        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
+        \   </disk>\n    <disk id=\"0cc57bfb-8990-4527-a614-6378e08d9799\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/0cc57bfb-8990-4527-a614-6378e08d9799\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/0cc57bfb-8990-4527-a614-6378e08d9799/statistics\"/>\n
+        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"e11d43ca-8823-4b3b-b519-a8ff877a2006\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/e11d43ca-8823-4b3b-b519-a8ff877a2006\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/e11d43ca-8823-4b3b-b519-a8ff877a2006/statistics\"/>\n
-        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
+        \   </disk>\n    <disk id=\"e11d43ca-8823-4b3b-b519-a8ff877a2006\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/e11d43ca-8823-4b3b-b519-a8ff877a2006\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/e11d43ca-8823-4b3b-b519-a8ff877a2006/statistics\"/>\n
+        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"b5e8bfec-aae4-4474-bbc3-d863bf5d041d\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/b5e8bfec-aae4-4474-bbc3-d863bf5d041d\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/b5e8bfec-aae4-4474-bbc3-d863bf5d041d/statistics\"/>\n
-        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
+        \   </disk>\n    <disk id=\"b5e8bfec-aae4-4474-bbc3-d863bf5d041d\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/b5e8bfec-aae4-4474-bbc3-d863bf5d041d\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/b5e8bfec-aae4-4474-bbc3-d863bf5d041d/statistics\"/>\n
+        \       <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -3283,7 +3272,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:39 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3320,18 +3309,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"0ccfbf62-abc4-4f7b-af4a-da2893a511a7\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots/0ccfbf62-abc4-4f7b-af4a-da2893a511a7\">\n
+        \   <snapshot id=\"0ccfbf62-abc4-4f7b-af4a-da2893a511a7\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots/0ccfbf62-abc4-4f7b-af4a-da2893a511a7\">\n
         \       <description>_ActiveImage_EVM-RH-5005-test_Wed Feb 08 18:31:40 EST
-        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots/0ccfbf62-abc4-4f7b-af4a-da2893a511a7/restore\"/>\n
+        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/snapshots/0ccfbf62-abc4-4f7b-af4a-da2893a511a7/restore\"/>\n
         \       </actions>\n        <vm id=\"4655202c-c752-461d-89bd-db42ff76b69f\"
-        href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n        <disk id=\"4611586d-e56e-47e9-8316-17ff7f462816\"
-        href=\"/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816\"/>\n
+        href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f\"/>\n        <disk id=\"4611586d-e56e-47e9-8316-17ff7f462816\"
+        href=\"/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/disks/4611586d-e56e-47e9-8316-17ff7f462816\"/>\n
         \       <date>2012-02-08T18:28:54.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:39 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/4655202c-c752-461d-89bd-db42ff76b69f/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3376,7 +3365,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:39 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3413,41 +3402,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"cd5ec8e5-79c2-45a1-866f-8b26dd67faea\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \   <disk id=\"cd5ec8e5-79c2-45a1-866f-8b26dd67faea\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>6442450944</size>\n        <type>system</type>\n
         \       <status>\n            <state>locked</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"2c98ac9f-a311-4acd-91ec-493a9bc6d041\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \   </disk>\n    <disk id=\"2c98ac9f-a311-4acd-91ec-493a9bc6d041\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>locked</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \   </disk>\n    <disk id=\"eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>locked</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"9821b4a4-4c2b-49b8-b221-ad794c926266\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \   </disk>\n    <disk id=\"9821b4a4-4c2b-49b8-b221-ad794c926266\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>locked</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"eaa3042a-ed09-49c4-87ac-c162c36ff17b\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \   </disk>\n    <disk id=\"eaa3042a-ed09-49c4-87ac-c162c36ff17b\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>locked</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -3458,7 +3447,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:40 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3495,46 +3484,46 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"07bef93a-0db9-4376-8193-65243706be56\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/07bef93a-0db9-4376-8193-65243706be56\">\n
+        \   <snapshot id=\"07bef93a-0db9-4376-8193-65243706be56\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/07bef93a-0db9-4376-8193-65243706be56\">\n
         \       <description>_ActiveImage_EVM-TrunkSVN_Thu Dec 08 12:05:20 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/07bef93a-0db9-4376-8193-65243706be56/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/07bef93a-0db9-4376-8193-65243706be56/restore\"/>\n
         \       </actions>\n        <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"cd5ec8e5-79c2-45a1-866f-8b26dd67faea\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea\"/>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"cd5ec8e5-79c2-45a1-866f-8b26dd67faea\"
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/cd5ec8e5-79c2-45a1-866f-8b26dd67faea\"/>\n
         \       <date>2011-12-08T12:00:51.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"f518f3ac-b113-4775-b9bf-7cf2b9543fd1\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/f518f3ac-b113-4775-b9bf-7cf2b9543fd1\">\n
+        id=\"f518f3ac-b113-4775-b9bf-7cf2b9543fd1\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/f518f3ac-b113-4775-b9bf-7cf2b9543fd1\">\n
         \       <description>_ActiveImage_EVM-TrunkSVN_Thu Dec 08 12:06:17 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/f518f3ac-b113-4775-b9bf-7cf2b9543fd1/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/f518f3ac-b113-4775-b9bf-7cf2b9543fd1/restore\"/>\n
         \       </actions>\n        <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"2c98ac9f-a311-4acd-91ec-493a9bc6d041\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041\"/>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"2c98ac9f-a311-4acd-91ec-493a9bc6d041\"
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/2c98ac9f-a311-4acd-91ec-493a9bc6d041\"/>\n
         \       <date>2011-12-08T12:01:48.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d\">\n
+        id=\"367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d\">\n
         \       <description>_ActiveImage_EVM-TrunkSVN_Thu Dec 08 12:05:53 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/367a7afa-8d4d-44cc-aa2d-d4a66b76cc8d/restore\"/>\n
         \       </actions>\n        <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\"/>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\"
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eb193027-4aab-4ddf-90a5-a7c2cefdf7f8\"/>\n
         \       <date>2011-12-08T12:01:24.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"e1e2d42e-a119-4eee-a792-83eb4d82a72d\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/e1e2d42e-a119-4eee-a792-83eb4d82a72d\">\n
+        id=\"e1e2d42e-a119-4eee-a792-83eb4d82a72d\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/e1e2d42e-a119-4eee-a792-83eb4d82a72d\">\n
         \       <description>_ActiveImage_EVM-TrunkSVN_Thu Dec 08 12:05:35 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/e1e2d42e-a119-4eee-a792-83eb4d82a72d/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/e1e2d42e-a119-4eee-a792-83eb4d82a72d/restore\"/>\n
         \       </actions>\n        <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"9821b4a4-4c2b-49b8-b221-ad794c926266\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266\"/>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"9821b4a4-4c2b-49b8-b221-ad794c926266\"
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/9821b4a4-4c2b-49b8-b221-ad794c926266\"/>\n
         \       <date>2011-12-08T12:01:06.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"0431f2c6-ce6a-4314-9653-f307747e5f52\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/0431f2c6-ce6a-4314-9653-f307747e5f52\">\n
+        id=\"0431f2c6-ce6a-4314-9653-f307747e5f52\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/0431f2c6-ce6a-4314-9653-f307747e5f52\">\n
         \       <description>_ActiveImage_EVM-TrunkSVN_Thu Dec 08 12:06:05 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/0431f2c6-ce6a-4314-9653-f307747e5f52/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/snapshots/0431f2c6-ce6a-4314-9653-f307747e5f52/restore\"/>\n
         \       </actions>\n        <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"eaa3042a-ed09-49c4-87ac-c162c36ff17b\"
-        href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b\"/>\n
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n        <disk id=\"eaa3042a-ed09-49c4-87ac-c162c36ff17b\"
+        href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/disks/eaa3042a-ed09-49c4-87ac-c162c36ff17b\"/>\n
         \       <date>2011-12-08T12:01:36.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:40 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3571,17 +3560,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics/9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics/9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e/statistics\"/>\n
-        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
-        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
+        \   <nic id=\"9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics/9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f/nics/9dde4cd9-fbee-4e6c-8fe8-0b0553b0654e/statistics\"/>\n
+        \       <vm id=\"9a9e4a4b-fdac-4370-b429-a8df3c96f11f\" href=\"/ovirt-engine/api/vms/9a9e4a4b-fdac-4370-b429-a8df3c96f11f\"/>\n
+        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:01\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:40 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3618,41 +3607,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"0a5c89b3-e8ad-490a-bae7-922ffef313f9\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \   <disk id=\"0a5c89b3-e8ad-490a-bae7-922ffef313f9\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"4b6e64b5-a124-44db-b54e-490d98ca7723\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/4b6e64b5-a124-44db-b54e-490d98ca7723\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/4b6e64b5-a124-44db-b54e-490d98ca7723/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \   </disk>\n    <disk id=\"4b6e64b5-a124-44db-b54e-490d98ca7723\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/4b6e64b5-a124-44db-b54e-490d98ca7723\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/4b6e64b5-a124-44db-b54e-490d98ca7723/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"48055c92-478c-4171-9b8a-30028b923d5a\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/48055c92-478c-4171-9b8a-30028b923d5a\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/48055c92-478c-4171-9b8a-30028b923d5a/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \   </disk>\n    <disk id=\"48055c92-478c-4171-9b8a-30028b923d5a\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/48055c92-478c-4171-9b8a-30028b923d5a\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/48055c92-478c-4171-9b8a-30028b923d5a/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"99015666-6fe2-46e6-b007-090f0c4ba178\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/99015666-6fe2-46e6-b007-090f0c4ba178\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/99015666-6fe2-46e6-b007-090f0c4ba178/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \   </disk>\n    <disk id=\"99015666-6fe2-46e6-b007-090f0c4ba178\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/99015666-6fe2-46e6-b007-090f0c4ba178\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/99015666-6fe2-46e6-b007-090f0c4ba178/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"5a75d3ee-54ec-4740-b3d6-689c4d9dd682\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/5a75d3ee-54ec-4740-b3d6-689c4d9dd682\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/5a75d3ee-54ec-4740-b3d6-689c4d9dd682/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \   </disk>\n    <disk id=\"5a75d3ee-54ec-4740-b3d6-689c4d9dd682\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/5a75d3ee-54ec-4740-b3d6-689c4d9dd682\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/5a75d3ee-54ec-4740-b3d6-689c4d9dd682/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -3663,7 +3652,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:40 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3700,18 +3689,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"fd4d2aa1-836f-4f2e-b427-39e80692574a\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots/fd4d2aa1-836f-4f2e-b427-39e80692574a\">\n
+        \   <snapshot id=\"fd4d2aa1-836f-4f2e-b427-39e80692574a\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots/fd4d2aa1-836f-4f2e-b427-39e80692574a\">\n
         \       <description>_ActiveImage_EVM-V5001_Tue Dec 27 11:17:51 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots/fd4d2aa1-836f-4f2e-b427-39e80692574a/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/snapshots/fd4d2aa1-836f-4f2e-b427-39e80692574a/restore\"/>\n
         \       </actions>\n        <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\"
-        href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n        <disk id=\"0a5c89b3-e8ad-490a-bae7-922ffef313f9\"
-        href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9\"/>\n
+        href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n        <disk id=\"0a5c89b3-e8ad-490a-bae7-922ffef313f9\"
+        href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/disks/0a5c89b3-e8ad-490a-bae7-922ffef313f9\"/>\n
         \       <date>2011-12-27T11:18:00.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:40 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3748,17 +3737,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"f8862214-0a35-4922-91b6-4eda0f139d24\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics/f8862214-0a35-4922-91b6-4eda0f139d24\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics/f8862214-0a35-4922-91b6-4eda0f139d24/statistics\"/>\n
-        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
-        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
+        \   <nic id=\"f8862214-0a35-4922-91b6-4eda0f139d24\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics/f8862214-0a35-4922-91b6-4eda0f139d24\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045/nics/f8862214-0a35-4922-91b6-4eda0f139d24/statistics\"/>\n
+        \       <vm id=\"70c4e710-846c-453e-bfc8-f02113f34045\" href=\"/ovirt-engine/api/vms/70c4e710-846c-453e-bfc8-f02113f34045\"/>\n
+        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:04\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:41 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3795,41 +3784,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"852765a3-7c12-4366-b10d-6e97954958b6\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \   <disk id=\"852765a3-7c12-4366-b10d-6e97954958b6\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"583aa89b-e3ae-4016-801e-7209b87c99f5\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/583aa89b-e3ae-4016-801e-7209b87c99f5\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/583aa89b-e3ae-4016-801e-7209b87c99f5/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \   </disk>\n    <disk id=\"583aa89b-e3ae-4016-801e-7209b87c99f5\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/583aa89b-e3ae-4016-801e-7209b87c99f5\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/583aa89b-e3ae-4016-801e-7209b87c99f5/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \   </disk>\n    <disk id=\"cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/cf5d49b8-8d7e-44d3-abfe-473ebc8ecee7/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"bb12cdb1-a0eb-4abc-bc04-11339bbddeb2\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/bb12cdb1-a0eb-4abc-bc04-11339bbddeb2\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/bb12cdb1-a0eb-4abc-bc04-11339bbddeb2/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \   </disk>\n    <disk id=\"bb12cdb1-a0eb-4abc-bc04-11339bbddeb2\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/bb12cdb1-a0eb-4abc-bc04-11339bbddeb2\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/bb12cdb1-a0eb-4abc-bc04-11339bbddeb2/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"94d47557-be19-4d46-bd8f-3288dd81de96\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/94d47557-be19-4d46-bd8f-3288dd81de96\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/94d47557-be19-4d46-bd8f-3288dd81de96/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \   </disk>\n    <disk id=\"94d47557-be19-4d46-bd8f-3288dd81de96\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/94d47557-be19-4d46-bd8f-3288dd81de96\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/94d47557-be19-4d46-bd8f-3288dd81de96/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -3840,7 +3829,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:41 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3877,18 +3866,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"54866547-e7ce-4a9b-93b9-dfcb4c2eb067\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots/54866547-e7ce-4a9b-93b9-dfcb4c2eb067\">\n
+        \   <snapshot id=\"54866547-e7ce-4a9b-93b9-dfcb4c2eb067\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots/54866547-e7ce-4a9b-93b9-dfcb4c2eb067\">\n
         \       <description>_ActiveImage_EVM-V50017_Mon Oct 08 22:31:32 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots/54866547-e7ce-4a9b-93b9-dfcb4c2eb067/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/snapshots/54866547-e7ce-4a9b-93b9-dfcb4c2eb067/restore\"/>\n
         \       </actions>\n        <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\"
-        href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n        <disk id=\"852765a3-7c12-4366-b10d-6e97954958b6\"
-        href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6\"/>\n
+        href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n        <disk id=\"852765a3-7c12-4366-b10d-6e97954958b6\"
+        href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/disks/852765a3-7c12-4366-b10d-6e97954958b6\"/>\n
         \       <date>2012-10-08T18:37:30.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:41 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3925,17 +3914,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"1bfeffe6-1e6a-4bc7-9099-827e6df3be3e\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics/1bfeffe6-1e6a-4bc7-9099-827e6df3be3e\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics/1bfeffe6-1e6a-4bc7-9099-827e6df3be3e/statistics\"/>\n
-        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"1bfeffe6-1e6a-4bc7-9099-827e6df3be3e\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics/1bfeffe6-1e6a-4bc7-9099-827e6df3be3e\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630/nics/1bfeffe6-1e6a-4bc7-9099-827e6df3be3e/statistics\"/>\n
+        \       <vm id=\"bb8e1c05-0722-405e-967d-00b142cae630\" href=\"/ovirt-engine/api/vms/bb8e1c05-0722-405e-967d-00b142cae630\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:2b\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:41 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3972,41 +3961,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"08761baa-bbcb-4d25-919c-420652520e43\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \   <disk id=\"08761baa-bbcb-4d25-919c-420652520e43\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"d64cfbb4-60c3-475d-a62d-b26110ac98c4\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \   </disk>\n    <disk id=\"d64cfbb4-60c3-475d-a62d-b26110ac98c4\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \   </disk>\n    <disk id=\"2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \   </disk>\n    <disk id=\"589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"efc1be6d-3847-4c2b-a997-72ffe970abd9\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \   </disk>\n    <disk id=\"efc1be6d-3847-4c2b-a997-72ffe970abd9\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4017,7 +4006,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:42 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4054,46 +4043,46 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"aeb5104d-2b14-4bde-b656-2b48728c3855\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/aeb5104d-2b14-4bde-b656-2b48728c3855\">\n
+        \   <snapshot id=\"aeb5104d-2b14-4bde-b656-2b48728c3855\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/aeb5104d-2b14-4bde-b656-2b48728c3855\">\n
         \       <description>_ActiveImage_EVM-v5005_Tue Feb 07 13:46:00 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/aeb5104d-2b14-4bde-b656-2b48728c3855/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/aeb5104d-2b14-4bde-b656-2b48728c3855/restore\"/>\n
         \       </actions>\n        <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"08761baa-bbcb-4d25-919c-420652520e43\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"08761baa-bbcb-4d25-919c-420652520e43\"
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/08761baa-bbcb-4d25-919c-420652520e43\"/>\n
         \       <date>2012-02-07T13:43:05.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"b45b0b25-84f4-4112-85a5-054ccf3bee78\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b45b0b25-84f4-4112-85a5-054ccf3bee78\">\n
+        id=\"b45b0b25-84f4-4112-85a5-054ccf3bee78\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b45b0b25-84f4-4112-85a5-054ccf3bee78\">\n
         \       <description>_ActiveImage_EVM-v5005_Tue Feb 07 13:46:24 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b45b0b25-84f4-4112-85a5-054ccf3bee78/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b45b0b25-84f4-4112-85a5-054ccf3bee78/restore\"/>\n
         \       </actions>\n        <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"d64cfbb4-60c3-475d-a62d-b26110ac98c4\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"d64cfbb4-60c3-475d-a62d-b26110ac98c4\"
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/d64cfbb4-60c3-475d-a62d-b26110ac98c4\"/>\n
         \       <date>2012-02-07T13:43:29.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"53795e6c-f5a1-4478-a754-f23e5e644c5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/53795e6c-f5a1-4478-a754-f23e5e644c5b\">\n
+        id=\"53795e6c-f5a1-4478-a754-f23e5e644c5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/53795e6c-f5a1-4478-a754-f23e5e644c5b\">\n
         \       <description>_ActiveImage_EVM-v5005_Tue Feb 07 13:45:15 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/53795e6c-f5a1-4478-a754-f23e5e644c5b/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/53795e6c-f5a1-4478-a754-f23e5e644c5b/restore\"/>\n
         \       </actions>\n        <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\"
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/2006c5b7-6165-494f-9bc6-97c8cbf6dbb4\"/>\n
         \       <date>2012-02-07T13:42:18.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"b4553f8e-9795-4202-b1d9-fd13ee4eb28a\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b4553f8e-9795-4202-b1d9-fd13ee4eb28a\">\n
+        id=\"b4553f8e-9795-4202-b1d9-fd13ee4eb28a\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b4553f8e-9795-4202-b1d9-fd13ee4eb28a\">\n
         \       <description>_ActiveImage_EVM-v5005_Tue Feb 07 13:45:46 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b4553f8e-9795-4202-b1d9-fd13ee4eb28a/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/b4553f8e-9795-4202-b1d9-fd13ee4eb28a/restore\"/>\n
         \       </actions>\n        <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\"
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/589dd0fe-9d5f-4f7f-9661-31ac1b1c7a3f\"/>\n
         \       <date>2012-02-07T13:42:51.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"cdff61f6-7887-4614-a2e3-9cd795fc70bc\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/cdff61f6-7887-4614-a2e3-9cd795fc70bc\">\n
+        id=\"cdff61f6-7887-4614-a2e3-9cd795fc70bc\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/cdff61f6-7887-4614-a2e3-9cd795fc70bc\">\n
         \       <description>_ActiveImage_EVM-v5005_Tue Feb 07 13:45:32 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/cdff61f6-7887-4614-a2e3-9cd795fc70bc/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/snapshots/cdff61f6-7887-4614-a2e3-9cd795fc70bc/restore\"/>\n
         \       </actions>\n        <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"efc1be6d-3847-4c2b-a997-72ffe970abd9\"
-        href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9\"/>\n
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n        <disk id=\"efc1be6d-3847-4c2b-a997-72ffe970abd9\"
+        href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/disks/efc1be6d-3847-4c2b-a997-72ffe970abd9\"/>\n
         \       <date>2012-02-07T13:42:36.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:42 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4130,17 +4119,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"e1f6c658-87c3-45d7-9efe-f527823ed3b7\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics/e1f6c658-87c3-45d7-9efe-f527823ed3b7\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics/e1f6c658-87c3-45d7-9efe-f527823ed3b7/statistics\"/>\n
-        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
-        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
+        \   <nic id=\"e1f6c658-87c3-45d7-9efe-f527823ed3b7\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics/e1f6c658-87c3-45d7-9efe-f527823ed3b7\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b/nics/e1f6c658-87c3-45d7-9efe-f527823ed3b7/statistics\"/>\n
+        \       <vm id=\"dba8a234-08b8-4639-a047-1dd072ff6e5b\" href=\"/ovirt-engine/api/vms/dba8a234-08b8-4639-a047-1dd072ff6e5b\"/>\n
+        \       <network id=\"41f0f0c6-dc66-4b47-9f60-bd0f68318e79\" href=\"/ovirt-engine/api/networks/41f0f0c6-dc66-4b47-9f60-bd0f68318e79\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:09\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:42 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4177,17 +4166,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8/statistics\"/>\n
-        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
+        \   <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8/statistics\"/>\n
+        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"dcbeb4f8-831c-4e34-a45a-8242a5b06ca1\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/dcbeb4f8-831c-4e34-a45a-8242a5b06ca1\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/dcbeb4f8-831c-4e34-a45a-8242a5b06ca1/statistics\"/>\n
-        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
+        \   </disk>\n    <disk id=\"dcbeb4f8-831c-4e34-a45a-8242a5b06ca1\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/dcbeb4f8-831c-4e34-a45a-8242a5b06ca1\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/dcbeb4f8-831c-4e34-a45a-8242a5b06ca1/statistics\"/>\n
+        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4198,7 +4187,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:42 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4235,25 +4224,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"36b9b974-06ac-4a8e-af50-2e1d9128a04e\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/36b9b974-06ac-4a8e-af50-2e1d9128a04e\">\n
+        \   <snapshot id=\"36b9b974-06ac-4a8e-af50-2e1d9128a04e\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/36b9b974-06ac-4a8e-af50-2e1d9128a04e\">\n
         \       <description>_ActiveImage_GM-Ubuntu-1_Fri Jan 20 12:59:55 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/36b9b974-06ac-4a8e-af50-2e1d9128a04e/restore\"/>\n
-        \       </actions>\n        <link rel=\"prev\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c\"/>\n
-        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
-        \       <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/36b9b974-06ac-4a8e-af50-2e1d9128a04e/restore\"/>\n
+        \       </actions>\n        <link rel=\"prev\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c\"/>\n
+        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
+        \       <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\"/>\n
         \       <date>2012-01-20T12:58:34.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"ed9df509-3cfc-46e9-8dce-35c86a143a0c\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c\">\n
+        id=\"ed9df509-3cfc-46e9-8dce-35c86a143a0c\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c\">\n
         \       <description>Snap 1</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c/restore\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/snapshots/ed9df509-3cfc-46e9-8dce-35c86a143a0c/restore\"/>\n
         \       </actions>\n        <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\"
-        href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n        <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\"
-        href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\"/>\n
+        href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n        <disk id=\"3685c850-948b-47be-ac9a-cf93f1f0c6f8\"
+        href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/disks/3685c850-948b-47be-ac9a-cf93f1f0c6f8\"/>\n
         \       <date>2012-01-20T12:33:09.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:42 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4290,17 +4279,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"a1e7b277-36a9-4da9-b449-f787883a12f5\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics/a1e7b277-36a9-4da9-b449-f787883a12f5\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics/a1e7b277-36a9-4da9-b449-f787883a12f5/statistics\"/>\n
-        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"a1e7b277-36a9-4da9-b449-f787883a12f5\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics/a1e7b277-36a9-4da9-b449-f787883a12f5\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226/nics/a1e7b277-36a9-4da9-b449-f787883a12f5/statistics\"/>\n
+        \       <vm id=\"935a9856-b8e7-43c3-ad93-e10df0a29226\" href=\"/ovirt-engine/api/vms/935a9856-b8e7-43c3-ad93-e10df0a29226\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:02\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:43 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4337,9 +4326,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"33ce0787-a83d-4dcc-a224-6b4766ce643a\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a/statistics\"/>\n
-        \       <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n
+        \   <disk id=\"33ce0787-a83d-4dcc-a224-6b4766ce643a\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a/statistics\"/>\n
+        \       <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4350,7 +4339,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:43 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4387,18 +4376,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"a189bdd2-3b64-40d9-a1dc-5429c01687ef\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots/a189bdd2-3b64-40d9-a1dc-5429c01687ef\">\n
+        \   <snapshot id=\"a189bdd2-3b64-40d9-a1dc-5429c01687ef\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots/a189bdd2-3b64-40d9-a1dc-5429c01687ef\">\n
         \       <description>_ActiveImage_kmwin2k8a_Wed Aug 29 22:49:31 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots/a189bdd2-3b64-40d9-a1dc-5429c01687ef/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/snapshots/a189bdd2-3b64-40d9-a1dc-5429c01687ef/restore\"/>\n
         \       </actions>\n        <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\"
-        href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n        <disk id=\"33ce0787-a83d-4dcc-a224-6b4766ce643a\"
-        href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a\"/>\n
+        href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n        <disk id=\"33ce0787-a83d-4dcc-a224-6b4766ce643a\"
+        href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/disks/33ce0787-a83d-4dcc-a224-6b4766ce643a\"/>\n
         \       <date>2012-08-29T23:09:57.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:43 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4435,17 +4424,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"d496d232-5344-499a-9ff3-a1b84555e794\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics/d496d232-5344-499a-9ff3-a1b84555e794\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics/d496d232-5344-499a-9ff3-a1b84555e794/statistics\"/>\n
-        \       <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\" href=\"/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"d496d232-5344-499a-9ff3-a1b84555e794\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics/d496d232-5344-499a-9ff3-a1b84555e794\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33/nics/d496d232-5344-499a-9ff3-a1b84555e794/statistics\"/>\n
+        \       <vm id=\"980bb541-261d-4d11-8782-86848f35cf33\" href=\"/ovirt-engine/api/vms/980bb541-261d-4d11-8782-86848f35cf33\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:25\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:43 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4482,17 +4471,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"2e93dff9-d9fd-4372-9bed-d6bfba5d700d\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d/statistics\"/>\n
-        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
+        \   <disk id=\"2e93dff9-d9fd-4372-9bed-d6bfba5d700d\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d/statistics\"/>\n
+        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>6442450944</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"cb92669c-6081-4303-9c4f-ae7d43a79dd8\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8/statistics\"/>\n
-        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
+        \   </disk>\n    <disk id=\"cb92669c-6081-4303-9c4f-ae7d43a79dd8\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8/statistics\"/>\n
+        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4503,7 +4492,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:43 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4540,25 +4529,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"b063bbc0-5331-4c1b-a5a2-04f2b35719f7\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/b063bbc0-5331-4c1b-a5a2-04f2b35719f7\">\n
+        \   <snapshot id=\"b063bbc0-5331-4c1b-a5a2-04f2b35719f7\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/b063bbc0-5331-4c1b-a5a2-04f2b35719f7\">\n
         \       <description>_ActiveImage_MIQ-PXE_Thu Aug 09 16:21:07 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/b063bbc0-5331-4c1b-a5a2-04f2b35719f7/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/b063bbc0-5331-4c1b-a5a2-04f2b35719f7/restore\"/>\n
         \       </actions>\n        <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <disk id=\"2e93dff9-d9fd-4372-9bed-d6bfba5d700d\"
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d\"/>\n
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <disk id=\"2e93dff9-d9fd-4372-9bed-d6bfba5d700d\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2e93dff9-d9fd-4372-9bed-d6bfba5d700d\"/>\n
         \       <date>2012-08-09T16:39:02.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"18d94ec9-1175-477a-93f3-7732bf717dd7\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/18d94ec9-1175-477a-93f3-7732bf717dd7\">\n
+        id=\"18d94ec9-1175-477a-93f3-7732bf717dd7\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/18d94ec9-1175-477a-93f3-7732bf717dd7\">\n
         \       <description>_ActiveImage_MIQ-PXE_Tue Aug 21 12:31:48 EDT 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/18d94ec9-1175-477a-93f3-7732bf717dd7/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/18d94ec9-1175-477a-93f3-7732bf717dd7/restore\"/>\n
         \       </actions>\n        <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <disk id=\"cb92669c-6081-4303-9c4f-ae7d43a79dd8\"
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8\"/>\n
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <disk id=\"cb92669c-6081-4303-9c4f-ae7d43a79dd8\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/cb92669c-6081-4303-9c4f-ae7d43a79dd8\"/>\n
         \       <date>2012-08-21T12:51:11.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:44 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4595,22 +4584,22 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"aadad447-ff89-4a52-87b5-4993948fada1\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/aadad447-ff89-4a52-87b5-4993948fada1\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/aadad447-ff89-4a52-87b5-4993948fada1/statistics\"/>\n
-        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"aadad447-ff89-4a52-87b5-4993948fada1\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/aadad447-ff89-4a52-87b5-4993948fada1\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/aadad447-ff89-4a52-87b5-4993948fada1/statistics\"/>\n
+        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:0b\"/>\n
-        \   </nic>\n    <nic id=\"b0e11959-40f1-4b3b-b3bd-18c59f0e52e2\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/b0e11959-40f1-4b3b-b3bd-18c59f0e52e2\">\n
-        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/b0e11959-40f1-4b3b-b3bd-18c59f0e52e2/statistics\"/>\n
-        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   </nic>\n    <nic id=\"b0e11959-40f1-4b3b-b3bd-18c59f0e52e2\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/b0e11959-40f1-4b3b-b3bd-18c59f0e52e2\">\n
+        \       <name>nic2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/b0e11959-40f1-4b3b-b3bd-18c59f0e52e2/statistics\"/>\n
+        \       <vm id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\" href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:17\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:44 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4647,9 +4636,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"78cd3f01-35c9-4500-be65-f60532a360a3\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3/statistics\"/>\n
-        \       <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n
+        \   <disk id=\"78cd3f01-35c9-4500-be65-f60532a360a3\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3/statistics\"/>\n
+        \       <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4660,7 +4649,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:44 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4697,18 +4686,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"d893370c-1723-4582-8e80-a1ac007f0d94\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots/d893370c-1723-4582-8e80-a1ac007f0d94\">\n
+        \   <snapshot id=\"d893370c-1723-4582-8e80-a1ac007f0d94\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots/d893370c-1723-4582-8e80-a1ac007f0d94\">\n
         \       <description>_ActiveImage_new-server_Tue Dec 27 17:16:31 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots/d893370c-1723-4582-8e80-a1ac007f0d94/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/snapshots/d893370c-1723-4582-8e80-a1ac007f0d94/restore\"/>\n
         \       </actions>\n        <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\"
-        href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n        <disk id=\"78cd3f01-35c9-4500-be65-f60532a360a3\"
-        href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3\"/>\n
+        href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n        <disk id=\"78cd3f01-35c9-4500-be65-f60532a360a3\"
+        href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/disks/78cd3f01-35c9-4500-be65-f60532a360a3\"/>\n
         \       <date>2011-12-27T17:16:36.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:44 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4745,17 +4734,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"87cb8ea3-3f14-4a5e-a459-e01d3841ae87\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics/87cb8ea3-3f14-4a5e-a459-e01d3841ae87\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics/87cb8ea3-3f14-4a5e-a459-e01d3841ae87/statistics\"/>\n
-        \       <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\" href=\"/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n
-        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
+        \   <nic id=\"87cb8ea3-3f14-4a5e-a459-e01d3841ae87\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics/87cb8ea3-3f14-4a5e-a459-e01d3841ae87\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67/nics/87cb8ea3-3f14-4a5e-a459-e01d3841ae87/statistics\"/>\n
+        \       <vm id=\"2ada2b89-9345-42fb-a179-fbed002fff67\" href=\"/ovirt-engine/api/vms/2ada2b89-9345-42fb-a179-fbed002fff67\"/>\n
+        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:05\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:44 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4792,9 +4781,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1/statistics\"/>\n
-        \       <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n
+        \   <disk id=\"cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1/statistics\"/>\n
+        \       <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4805,7 +4794,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:45 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4842,18 +4831,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"7cad3c94-9a4d-4f2f-92a3-16aa8519aa00\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots/7cad3c94-9a4d-4f2f-92a3-16aa8519aa00\">\n
+        \   <snapshot id=\"7cad3c94-9a4d-4f2f-92a3-16aa8519aa00\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots/7cad3c94-9a4d-4f2f-92a3-16aa8519aa00\">\n
         \       <description>_ActiveImage_obarenboim_test_01_Mon Nov 26 13:01:00 EST
-        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots/7cad3c94-9a4d-4f2f-92a3-16aa8519aa00/restore\"/>\n
+        2012</description>\n        <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/snapshots/7cad3c94-9a4d-4f2f-92a3-16aa8519aa00/restore\"/>\n
         \       </actions>\n        <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\"
-        href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n        <disk id=\"cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\"
-        href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\"/>\n
+        href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n        <disk id=\"cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\"
+        href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/disks/cebcd82e-e4f2-4c0b-ad8b-0051d7a1f4a1\"/>\n
         \       <date>2012-11-26T09:20:13.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:45 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4890,17 +4879,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"d6624c6c-bd23-461e-bf01-f07b3309f202\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics/d6624c6c-bd23-461e-bf01-f07b3309f202\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics/d6624c6c-bd23-461e-bf01-f07b3309f202/statistics\"/>\n
-        \       <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\" href=\"/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"d6624c6c-bd23-461e-bf01-f07b3309f202\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics/d6624c6c-bd23-461e-bf01-f07b3309f202\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0/nics/d6624c6c-bd23-461e-bf01-f07b3309f202/statistics\"/>\n
+        \       <vm id=\"ee3670c0-152b-4106-89b2-4eda71bea8d0\" href=\"/ovirt-engine/api/vms/ee3670c0-152b-4106-89b2-4eda71bea8d0\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:16\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:45 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4937,9 +4926,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"9ab199b4-d43d-4091-ba39-1d70b13c4a4a\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a/statistics\"/>\n
-        \       <vm id=\"31d7505f-e739-4024-84da-2d8df1db9b39\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\"/>\n
+        \   <disk id=\"9ab199b4-d43d-4091-ba39-1d70b13c4a4a\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a/statistics\"/>\n
+        \       <vm id=\"31d7505f-e739-4024-84da-2d8df1db9b39\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -4950,7 +4939,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:46 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4987,18 +4976,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"028d7529-98bd-472b-b339-46f035d3bbe1\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots/028d7529-98bd-472b-b339-46f035d3bbe1\">\n
+        \   <snapshot id=\"028d7529-98bd-472b-b339-46f035d3bbe1\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots/028d7529-98bd-472b-b339-46f035d3bbe1\">\n
         \       <description>_ActiveImage_RHEL_Tue Dec 20 13:20:51 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots/028d7529-98bd-472b-b339-46f035d3bbe1/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/snapshots/028d7529-98bd-472b-b339-46f035d3bbe1/restore\"/>\n
         \       </actions>\n        <vm id=\"31d7505f-e739-4024-84da-2d8df1db9b39\"
-        href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\"/>\n        <disk id=\"9ab199b4-d43d-4091-ba39-1d70b13c4a4a\"
-        href=\"/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a\"/>\n
+        href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39\"/>\n        <disk id=\"9ab199b4-d43d-4091-ba39-1d70b13c4a4a\"
+        href=\"/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/disks/9ab199b4-d43d-4091-ba39-1d70b13c4a4a\"/>\n
         \       <date>2011-12-20T13:19:19.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:46 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/31d7505f-e739-4024-84da-2d8df1db9b39/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5043,7 +5032,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:46 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5080,41 +5069,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"43adfc13-f1a4-4f7a-9388-6e5049be6323\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \   <disk id=\"43adfc13-f1a4-4f7a-9388-6e5049be6323\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"cda71de2-657c-4818-8c03-411471f5fcad\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/cda71de2-657c-4818-8c03-411471f5fcad\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/cda71de2-657c-4818-8c03-411471f5fcad/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \   </disk>\n    <disk id=\"cda71de2-657c-4818-8c03-411471f5fcad\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/cda71de2-657c-4818-8c03-411471f5fcad\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/cda71de2-657c-4818-8c03-411471f5fcad/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"f17aabfa-4a1b-41ae-ae97-5bf43cb2106d\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/f17aabfa-4a1b-41ae-ae97-5bf43cb2106d\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/f17aabfa-4a1b-41ae-ae97-5bf43cb2106d/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \   </disk>\n    <disk id=\"f17aabfa-4a1b-41ae-ae97-5bf43cb2106d\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/f17aabfa-4a1b-41ae-ae97-5bf43cb2106d\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/f17aabfa-4a1b-41ae-ae97-5bf43cb2106d/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"2e942bec-13c4-4f80-87e5-ed605ddaed0c\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/2e942bec-13c4-4f80-87e5-ed605ddaed0c\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/2e942bec-13c4-4f80-87e5-ed605ddaed0c/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \   </disk>\n    <disk id=\"2e942bec-13c4-4f80-87e5-ed605ddaed0c\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/2e942bec-13c4-4f80-87e5-ed605ddaed0c\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/2e942bec-13c4-4f80-87e5-ed605ddaed0c/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"b409b29f-d403-47ac-ba65-9893ac6c369b\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/b409b29f-d403-47ac-ba65-9893ac6c369b\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/b409b29f-d403-47ac-ba65-9893ac6c369b/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \   </disk>\n    <disk id=\"b409b29f-d403-47ac-ba65-9893ac6c369b\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/b409b29f-d403-47ac-ba65-9893ac6c369b\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/b409b29f-d403-47ac-ba65-9893ac6c369b/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -5125,7 +5114,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:46 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5162,18 +5151,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"46b5c70c-8baf-4693-b106-7efc4588974e\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots/46b5c70c-8baf-4693-b106-7efc4588974e\">\n
+        \   <snapshot id=\"46b5c70c-8baf-4693-b106-7efc4588974e\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots/46b5c70c-8baf-4693-b106-7efc4588974e\">\n
         \       <description>_ActiveImage_rpo-evm_Thu Mar 28 11:44:24 EDT 2013</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots/46b5c70c-8baf-4693-b106-7efc4588974e/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/snapshots/46b5c70c-8baf-4693-b106-7efc4588974e/restore\"/>\n
         \       </actions>\n        <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"
-        href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n        <disk id=\"43adfc13-f1a4-4f7a-9388-6e5049be6323\"
-        href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323\"/>\n
+        href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n        <disk id=\"43adfc13-f1a4-4f7a-9388-6e5049be6323\"
+        href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/disks/43adfc13-f1a4-4f7a-9388-6e5049be6323\"/>\n
         \       <date>2013-03-28T08:36:57.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:47 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5210,17 +5199,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"695190de-631c-4bc3-ae9d-e141ac2d3f8e\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics/695190de-631c-4bc3-ae9d-e141ac2d3f8e\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics/695190de-631c-4bc3-ae9d-e141ac2d3f8e/statistics\"/>\n
-        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"695190de-631c-4bc3-ae9d-e141ac2d3f8e\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics/695190de-631c-4bc3-ae9d-e141ac2d3f8e\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0/nics/695190de-631c-4bc3-ae9d-e141ac2d3f8e/statistics\"/>\n
+        \       <vm id=\"554c9e02-0f7f-4f79-8fcd-5d5049e437a0\" href=\"/ovirt-engine/api/vms/554c9e02-0f7f-4f79-8fcd-5d5049e437a0\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:07\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:47 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5257,41 +5246,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \   <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"633d813d-e28e-4b3a-bd9a-3c31a11f58c8\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/633d813d-e28e-4b3a-bd9a-3c31a11f58c8\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/633d813d-e28e-4b3a-bd9a-3c31a11f58c8/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \   </disk>\n    <disk id=\"633d813d-e28e-4b3a-bd9a-3c31a11f58c8\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/633d813d-e28e-4b3a-bd9a-3c31a11f58c8\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/633d813d-e28e-4b3a-bd9a-3c31a11f58c8/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"ff51f773-3c52-4840-ad93-38697e1f69da\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/ff51f773-3c52-4840-ad93-38697e1f69da\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/ff51f773-3c52-4840-ad93-38697e1f69da/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \   </disk>\n    <disk id=\"ff51f773-3c52-4840-ad93-38697e1f69da\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/ff51f773-3c52-4840-ad93-38697e1f69da\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/ff51f773-3c52-4840-ad93-38697e1f69da/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"097fc432-acbe-48c3-b874-05a91b0310af\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/097fc432-acbe-48c3-b874-05a91b0310af\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/097fc432-acbe-48c3-b874-05a91b0310af/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \   </disk>\n    <disk id=\"097fc432-acbe-48c3-b874-05a91b0310af\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/097fc432-acbe-48c3-b874-05a91b0310af\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/097fc432-acbe-48c3-b874-05a91b0310af/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"4ccca278-306c-44e4-8220-5cf3c7c92e67\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/4ccca278-306c-44e4-8220-5cf3c7c92e67\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/4ccca278-306c-44e4-8220-5cf3c7c92e67/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \   </disk>\n    <disk id=\"4ccca278-306c-44e4-8220-5cf3c7c92e67\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/4ccca278-306c-44e4-8220-5cf3c7c92e67\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/4ccca278-306c-44e4-8220-5cf3c7c92e67/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -5302,7 +5291,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:47 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5339,25 +5328,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"916d479e-5c2a-4958-b03b-33f6771e2b87\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/916d479e-5c2a-4958-b03b-33f6771e2b87\">\n
+        \   <snapshot id=\"916d479e-5c2a-4958-b03b-33f6771e2b87\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/916d479e-5c2a-4958-b03b-33f6771e2b87\">\n
         \       <description>_ActiveImage_rpo-test_Mon Mar 11 12:07:45 EDT 2013</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/916d479e-5c2a-4958-b03b-33f6771e2b87/restore\"/>\n
-        \       </actions>\n        <link rel=\"prev\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
-        \       <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/916d479e-5c2a-4958-b03b-33f6771e2b87/restore\"/>\n
+        \       </actions>\n        <link rel=\"prev\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \       <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\"/>\n
         \       <date>2013-03-11T08:55:30.000-04:00</date>\n    </snapshot>\n    <snapshot
-        id=\"9671245f-51af-42f5-b0d0-aae46a5c65ef\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef\">\n
+        id=\"9671245f-51af-42f5-b0d0-aae46a5c65ef\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef\">\n
         \       <description>test snap</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef/restore\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/snapshots/9671245f-51af-42f5-b0d0-aae46a5c65ef/restore\"/>\n
         \       </actions>\n        <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\"
-        href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n        <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\"
-        href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\"/>\n
+        href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n        <disk id=\"d07c8761-9934-4db8-9197-7f95f845688a\"
+        href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/disks/d07c8761-9934-4db8-9197-7f95f845688a\"/>\n
         \       <date>2013-03-11T08:54:56.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:48 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5394,17 +5383,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"d1e2e8e6-e696-4288-9bbd-787daed61a48\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics/d1e2e8e6-e696-4288-9bbd-787daed61a48\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics/d1e2e8e6-e696-4288-9bbd-787daed61a48/statistics\"/>\n
-        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
-        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
+        \   <nic id=\"d1e2e8e6-e696-4288-9bbd-787daed61a48\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics/d1e2e8e6-e696-4288-9bbd-787daed61a48\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e/nics/d1e2e8e6-e696-4288-9bbd-787daed61a48/statistics\"/>\n
+        \       <vm id=\"9a5bec68-7d96-4c40-b918-9f137b95fc3e\" href=\"/ovirt-engine/api/vms/9a5bec68-7d96-4c40-b918-9f137b95fc3e\"/>\n
+        \       <network id=\"00000000-0000-0000-0000-000000000009\" href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:03\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:48 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5441,9 +5430,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef/statistics\"/>\n
-        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
+        \   <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef/statistics\"/>\n
+        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -5454,7 +5443,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:48 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5491,25 +5480,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"f9b6a2b4-6e98-45af-964a-c7d0476a1b67\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/f9b6a2b4-6e98-45af-964a-c7d0476a1b67\">\n
+        \   <snapshot id=\"f9b6a2b4-6e98-45af-964a-c7d0476a1b67\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/f9b6a2b4-6e98-45af-964a-c7d0476a1b67\">\n
         \       <description>_ActiveImage_ULin1_Tue Dec 27 17:57:38 EST 2011</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/f9b6a2b4-6e98-45af-964a-c7d0476a1b67/restore\"/>\n
-        \       </actions>\n        <link rel=\"prev\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9\"/>\n
-        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
-        \       <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/f9b6a2b4-6e98-45af-964a-c7d0476a1b67/restore\"/>\n
+        \       </actions>\n        <link rel=\"prev\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9\"/>\n
+        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
+        \       <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\"/>\n
         \       <date>2011-12-27T17:57:46.000-05:00</date>\n    </snapshot>\n    <snapshot
-        id=\"e45c88be-65fc-4ad2-b988-938dacd135c9\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9\">\n
+        id=\"e45c88be-65fc-4ad2-b988-938dacd135c9\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9\">\n
         \       <description>Snap 1</description>\n        <actions>\n            <link
-        rel=\"restore\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9/restore\"/>\n
+        rel=\"restore\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/snapshots/e45c88be-65fc-4ad2-b988-938dacd135c9/restore\"/>\n
         \       </actions>\n        <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"
-        href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n        <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\"
-        href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\"/>\n
+        href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n        <disk id=\"5052e0f4-130f-4048-99a2-63c5fd1646ef\"
+        href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/disks/5052e0f4-130f-4048-99a2-63c5fd1646ef\"/>\n
         \       <date>2011-09-27T15:30:05.000-04:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:48 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5546,17 +5535,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"a670cb98-4865-4197-9aca-2090bbcfcf2e\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics/a670cb98-4865-4197-9aca-2090bbcfcf2e\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics/a670cb98-4865-4197-9aca-2090bbcfcf2e/statistics\"/>\n
-        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
-        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
+        \   <nic id=\"a670cb98-4865-4197-9aca-2090bbcfcf2e\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics/a670cb98-4865-4197-9aca-2090bbcfcf2e\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49/nics/a670cb98-4865-4197-9aca-2090bbcfcf2e/statistics\"/>\n
+        \       <vm id=\"22e1a0b0-06af-4e84-8789-07e6a7f6cc49\" href=\"/ovirt-engine/api/vms/22e1a0b0-06af-4e84-8789-07e6a7f6cc49\"/>\n
+        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
         \       <interface>e1000</interface>\n        <mac address=\"00:1a:4a:a8:fc:00\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:48 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5593,41 +5582,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"ddde3a31-fe96-41a4-91e7-8d76c9ff3270\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270\">\n
-        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \   <disk id=\"ddde3a31-fe96-41a4-91e7-8d76c9ff3270\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270\">\n
+        \       <name>Disk 4</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"e9ab8df1-b510-44c5-8ef1-ad117a64ecbc\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/e9ab8df1-b510-44c5-8ef1-ad117a64ecbc\">\n
-        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/e9ab8df1-b510-44c5-8ef1-ad117a64ecbc/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \   </disk>\n    <disk id=\"e9ab8df1-b510-44c5-8ef1-ad117a64ecbc\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/e9ab8df1-b510-44c5-8ef1-ad117a64ecbc\">\n
+        \       <name>Disk 3</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/e9ab8df1-b510-44c5-8ef1-ad117a64ecbc/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"7cfdf2cd-c372-4c66-8f4c-b70c748efa6a\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/7cfdf2cd-c372-4c66-8f4c-b70c748efa6a\">\n
-        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/7cfdf2cd-c372-4c66-8f4c-b70c748efa6a/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \   </disk>\n    <disk id=\"7cfdf2cd-c372-4c66-8f4c-b70c748efa6a\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/7cfdf2cd-c372-4c66-8f4c-b70c748efa6a\">\n
+        \       <name>Disk 2</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/7cfdf2cd-c372-4c66-8f4c-b70c748efa6a/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"aa55779c-d5e5-4a73-b85e-30522676e610\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/aa55779c-d5e5-4a73-b85e-30522676e610\">\n
-        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/aa55779c-d5e5-4a73-b85e-30522676e610/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \   </disk>\n    <disk id=\"aa55779c-d5e5-4a73-b85e-30522676e610\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/aa55779c-d5e5-4a73-b85e-30522676e610\">\n
+        \       <name>Disk 1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/aa55779c-d5e5-4a73-b85e-30522676e610/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"20b17a6c-1e98-498c-8373-c666a39fe262\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/20b17a6c-1e98-498c-8373-c666a39fe262\">\n
-        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/20b17a6c-1e98-498c-8373-c666a39fe262/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \   </disk>\n    <disk id=\"20b17a6c-1e98-498c-8373-c666a39fe262\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/20b17a6c-1e98-498c-8373-c666a39fe262\">\n
+        \       <name>Disk 5</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/20b17a6c-1e98-498c-8373-c666a39fe262/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
         \       <storage_domains>\n            <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -5638,7 +5627,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:49 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5675,18 +5664,18 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot id=\"84fbd998-7865-45c3-9c2e-59323058d412\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots/84fbd998-7865-45c3-9c2e-59323058d412\">\n
+        \   <snapshot id=\"84fbd998-7865-45c3-9c2e-59323058d412\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots/84fbd998-7865-45c3-9c2e-59323058d412\">\n
         \       <description>_ActiveImage_V5-test_Wed Jan 04 14:04:35 EST 2012</description>\n
-        \       <actions>\n            <link rel=\"restore\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots/84fbd998-7865-45c3-9c2e-59323058d412/restore\"/>\n
+        \       <actions>\n            <link rel=\"restore\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/snapshots/84fbd998-7865-45c3-9c2e-59323058d412/restore\"/>\n
         \       </actions>\n        <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"
-        href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n        <disk id=\"ddde3a31-fe96-41a4-91e7-8d76c9ff3270\"
-        href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270\"/>\n
+        href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n        <disk id=\"ddde3a31-fe96-41a4-91e7-8d76c9ff3270\"
+        href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/disks/ddde3a31-fe96-41a4-91e7-8d76c9ff3270\"/>\n
         \       <date>2012-01-04T14:06:52.000-05:00</date>\n    </snapshot>\n</snapshots>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:49 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5723,17 +5712,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic id=\"fc1293c2-55ef-43bf-b0dd-9244779f3823\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics/fc1293c2-55ef-43bf-b0dd-9244779f3823\">\n
-        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics/fc1293c2-55ef-43bf-b0dd-9244779f3823/statistics\"/>\n
-        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
-        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
+        \   <nic id=\"fc1293c2-55ef-43bf-b0dd-9244779f3823\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics/fc1293c2-55ef-43bf-b0dd-9244779f3823\">\n
+        \       <name>nic1</name>\n        <link rel=\"statistics\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f/nics/fc1293c2-55ef-43bf-b0dd-9244779f3823/statistics\"/>\n
+        \       <vm id=\"aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\" href=\"/ovirt-engine/api/vms/aee6bd5e-9f12-4384-8fe5-4b0b8e15268f\"/>\n
+        \       <network id=\"2f17d722-a330-4861-959e-699af75ff608\" href=\"/ovirt-engine/api/networks/2f17d722-a330-4861-959e-699af75ff608\"/>\n
         \       <interface>virtio</interface>\n        <mac address=\"00:1a:4a:a8:fc:06\"/>\n
         \   </nic>\n</nics>\n"
     http_version: 
   recorded_at: Tue, 07 Oct 2014 17:58:49 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/00000000-0000-0000-0000-000000000000/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5778,7 +5767,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:49 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5815,9 +5804,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"2ed230e0-c2cc-4027-8ae1-f41cf2283674\" href=\"/api/vms/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks/2ed230e0-c2cc-4027-8ae1-f41cf2283674\">\n
+        \   <disk id=\"2ed230e0-c2cc-4027-8ae1-f41cf2283674\" href=\"/ovirt-engine/api/vms/e3af998a-7104-4a10-a7c0-bc90c4250bf5/disks/2ed230e0-c2cc-4027-8ae1-f41cf2283674\">\n
         \       <name>Disk 1</name>\n        <vm id=\"e3af998a-7104-4a10-a7c0-bc90c4250bf5\"
-        href=\"/api/vms/e3af998a-7104-4a10-a7c0-bc90c4250bf5\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/e3af998a-7104-4a10-a7c0-bc90c4250bf5\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -5828,7 +5817,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:50 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5865,17 +5854,17 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"6b7e9778-e92a-4e08-b4f4-3887e81a226b\" href=\"/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/6b7e9778-e92a-4e08-b4f4-3887e81a226b\">\n
+        \   <disk id=\"6b7e9778-e92a-4e08-b4f4-3887e81a226b\" href=\"/ovirt-engine/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/6b7e9778-e92a-4e08-b4f4-3887e81a226b\">\n
         \       <name>Disk 1</name>\n        <vm id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\"
-        href=\"/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"1e736810-0dff-42f2-aede-bc68ce8625d0\" href=\"/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/1e736810-0dff-42f2-aede-bc68ce8625d0\">\n
+        \   </disk>\n    <disk id=\"1e736810-0dff-42f2-aede-bc68ce8625d0\" href=\"/ovirt-engine/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/1e736810-0dff-42f2-aede-bc68ce8625d0\">\n
         \       <name>Disk 2</name>\n        <vm id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\"
-        href=\"/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>1073741824</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
@@ -5886,7 +5875,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:50 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5923,41 +5912,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"85f2eaaa-cb9b-4bf4-a175-30c357adde0b\" href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/85f2eaaa-cb9b-4bf4-a175-30c357adde0b\">\n
+        \   <disk id=\"85f2eaaa-cb9b-4bf4-a175-30c357adde0b\" href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/85f2eaaa-cb9b-4bf4-a175-30c357adde0b\">\n
         \       <name>Disk 2</name>\n        <vm id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\"
-        href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"afe8bdee-7adb-4dbd-93ea-29436ca3f2ae\" href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/afe8bdee-7adb-4dbd-93ea-29436ca3f2ae\">\n
+        \   </disk>\n    <disk id=\"afe8bdee-7adb-4dbd-93ea-29436ca3f2ae\" href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/afe8bdee-7adb-4dbd-93ea-29436ca3f2ae\">\n
         \       <name>Disk 3</name>\n        <vm id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\"
-        href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"e6fe617d-b7c6-4249-b7bb-5e8f4a37f5c3\" href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/e6fe617d-b7c6-4249-b7bb-5e8f4a37f5c3\">\n
+        \   </disk>\n    <disk id=\"e6fe617d-b7c6-4249-b7bb-5e8f4a37f5c3\" href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/e6fe617d-b7c6-4249-b7bb-5e8f4a37f5c3\">\n
         \       <name>Disk 4</name>\n        <vm id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\"
-        href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"0b017018-3871-4d24-82d3-8eb9ded85f1c\" href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/0b017018-3871-4d24-82d3-8eb9ded85f1c\">\n
+        \   </disk>\n    <disk id=\"0b017018-3871-4d24-82d3-8eb9ded85f1c\" href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/0b017018-3871-4d24-82d3-8eb9ded85f1c\">\n
         \       <name>Disk 5</name>\n        <vm id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\"
-        href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"0001e0a0-ab3b-4efa-98f3-175b5b9030de\" href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/0001e0a0-ab3b-4efa-98f3-175b5b9030de\">\n
+        \   </disk>\n    <disk id=\"0001e0a0-ab3b-4efa-98f3-175b5b9030de\" href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf/disks/0001e0a0-ab3b-4efa-98f3-175b5b9030de\">\n
         \       <name>Disk 1</name>\n        <vm id=\"d473fb6b-96a5-4667-a2d4-60b195603bbf\"
-        href=\"/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/d473fb6b-96a5-4667-a2d4-60b195603bbf\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
@@ -5968,7 +5957,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:50 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6005,41 +5994,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"26d1e590-553f-4ca4-b781-b2c2891983c8\" href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/26d1e590-553f-4ca4-b781-b2c2891983c8\">\n
+        \   <disk id=\"26d1e590-553f-4ca4-b781-b2c2891983c8\" href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/26d1e590-553f-4ca4-b781-b2c2891983c8\">\n
         \       <name>Disk 4</name>\n        <vm id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"9de151de-a95e-4327-8eec-19a17a6dfe08\" href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/9de151de-a95e-4327-8eec-19a17a6dfe08\">\n
+        \   </disk>\n    <disk id=\"9de151de-a95e-4327-8eec-19a17a6dfe08\" href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/9de151de-a95e-4327-8eec-19a17a6dfe08\">\n
         \       <name>Disk 3</name>\n        <vm id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"9ea47ed1-9789-4fe7-a9ad-bdf309d48415\" href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/9ea47ed1-9789-4fe7-a9ad-bdf309d48415\">\n
+        \   </disk>\n    <disk id=\"9ea47ed1-9789-4fe7-a9ad-bdf309d48415\" href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/9ea47ed1-9789-4fe7-a9ad-bdf309d48415\">\n
         \       <name>Disk 2</name>\n        <vm id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"957819b6-3600-417d-9dc2-eb3ef3820c0a\" href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/957819b6-3600-417d-9dc2-eb3ef3820c0a\">\n
+        \   </disk>\n    <disk id=\"957819b6-3600-417d-9dc2-eb3ef3820c0a\" href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/957819b6-3600-417d-9dc2-eb3ef3820c0a\">\n
         \       <name>Disk 5</name>\n        <vm id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"fa3bee60-356b-4004-8f7d-f3f38844131a\" href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/fa3bee60-356b-4004-8f7d-f3f38844131a\">\n
+        \   </disk>\n    <disk id=\"fa3bee60-356b-4004-8f7d-f3f38844131a\" href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356/disks/fa3bee60-356b-4004-8f7d-f3f38844131a\">\n
         \       <name>Disk 1</name>\n        <vm id=\"ce9b44cb-8253-4153-ad4b-c53039dd9356\"
-        href=\"/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/ce9b44cb-8253-4153-ad4b-c53039dd9356\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
@@ -6050,7 +6039,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:50 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6087,41 +6076,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"a6797a06-894c-475f-bb0c-6b43cdfaeb06\" href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/a6797a06-894c-475f-bb0c-6b43cdfaeb06\">\n
+        \   <disk id=\"a6797a06-894c-475f-bb0c-6b43cdfaeb06\" href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/a6797a06-894c-475f-bb0c-6b43cdfaeb06\">\n
         \       <name>Disk 1</name>\n        <vm id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"e0039e10-30be-4ee9-9804-98931eed1e74\" href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/e0039e10-30be-4ee9-9804-98931eed1e74\">\n
+        \   </disk>\n    <disk id=\"e0039e10-30be-4ee9-9804-98931eed1e74\" href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/e0039e10-30be-4ee9-9804-98931eed1e74\">\n
         \       <name>Disk 4</name>\n        <vm id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"8614b994-952a-4a3a-91a2-28c771b3c167\" href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/8614b994-952a-4a3a-91a2-28c771b3c167\">\n
+        \   </disk>\n    <disk id=\"8614b994-952a-4a3a-91a2-28c771b3c167\" href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/8614b994-952a-4a3a-91a2-28c771b3c167\">\n
         \       <name>Disk 3</name>\n        <vm id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"994c2ed5-bb4e-4e02-ae8b-1906113e7c20\" href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/994c2ed5-bb4e-4e02-ae8b-1906113e7c20\">\n
+        \   </disk>\n    <disk id=\"994c2ed5-bb4e-4e02-ae8b-1906113e7c20\" href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/994c2ed5-bb4e-4e02-ae8b-1906113e7c20\">\n
         \       <name>Disk 5</name>\n        <vm id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"4a52caf8-afbd-47f3-b984-fb09a6c7f71a\" href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/4a52caf8-afbd-47f3-b984-fb09a6c7f71a\">\n
+        \   </disk>\n    <disk id=\"4a52caf8-afbd-47f3-b984-fb09a6c7f71a\" href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc/disks/4a52caf8-afbd-47f3-b984-fb09a6c7f71a\">\n
         \       <name>Disk 2</name>\n        <vm id=\"7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"
-        href=\"/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/7120b19a-1b39-4bd4-afa8-6393fc4cd3dc\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6132,7 +6121,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:51 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/1845ad70-c097-42f8-acb6-c3ac8c410572/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6169,41 +6158,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"aef0323d-7d43-4c45-85ed-078f1a3e1a5a\" href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/aef0323d-7d43-4c45-85ed-078f1a3e1a5a\">\n
+        \   <disk id=\"aef0323d-7d43-4c45-85ed-078f1a3e1a5a\" href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/aef0323d-7d43-4c45-85ed-078f1a3e1a5a\">\n
         \       <name>Disk 3</name>\n        <vm id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"7ab7455c-ac32-4aaa-a64f-d0a908a81146\" href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/7ab7455c-ac32-4aaa-a64f-d0a908a81146\">\n
+        \   </disk>\n    <disk id=\"7ab7455c-ac32-4aaa-a64f-d0a908a81146\" href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/7ab7455c-ac32-4aaa-a64f-d0a908a81146\">\n
         \       <name>Disk 2</name>\n        <vm id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"77a51c98-09cd-4ded-be22-94c187b5d2dd\" href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/77a51c98-09cd-4ded-be22-94c187b5d2dd\">\n
+        \   </disk>\n    <disk id=\"77a51c98-09cd-4ded-be22-94c187b5d2dd\" href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/77a51c98-09cd-4ded-be22-94c187b5d2dd\">\n
         \       <name>Disk 1</name>\n        <vm id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"343e89fe-d495-4dcd-851f-b6c858c15076\" href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/343e89fe-d495-4dcd-851f-b6c858c15076\">\n
+        \   </disk>\n    <disk id=\"343e89fe-d495-4dcd-851f-b6c858c15076\" href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/343e89fe-d495-4dcd-851f-b6c858c15076\">\n
         \       <name>Disk 5</name>\n        <vm id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"b0090927-0112-4713-abd7-ff1e7adbb6fa\" href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/b0090927-0112-4713-abd7-ff1e7adbb6fa\">\n
+        \   </disk>\n    <disk id=\"b0090927-0112-4713-abd7-ff1e7adbb6fa\" href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572/disks/b0090927-0112-4713-abd7-ff1e7adbb6fa\">\n
         \       <name>Disk 4</name>\n        <vm id=\"1845ad70-c097-42f8-acb6-c3ac8c410572\"
-        href=\"/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1845ad70-c097-42f8-acb6-c3ac8c410572\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6214,7 +6203,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:51 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6251,41 +6240,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"74f7da39-9f1d-497a-b9c5-24b29f582ca6\" href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/74f7da39-9f1d-497a-b9c5-24b29f582ca6\">\n
+        \   <disk id=\"74f7da39-9f1d-497a-b9c5-24b29f582ca6\" href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/74f7da39-9f1d-497a-b9c5-24b29f582ca6\">\n
         \       <name>Disk 3</name>\n        <vm id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"1f08780f-70e2-4cde-8773-62bbdaea3488\" href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/1f08780f-70e2-4cde-8773-62bbdaea3488\">\n
+        \   </disk>\n    <disk id=\"1f08780f-70e2-4cde-8773-62bbdaea3488\" href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/1f08780f-70e2-4cde-8773-62bbdaea3488\">\n
         \       <name>Disk 2</name>\n        <vm id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"458a2b3e-ffa0-474f-b1aa-f2aaf15a6043\" href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/458a2b3e-ffa0-474f-b1aa-f2aaf15a6043\">\n
+        \   </disk>\n    <disk id=\"458a2b3e-ffa0-474f-b1aa-f2aaf15a6043\" href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/458a2b3e-ffa0-474f-b1aa-f2aaf15a6043\">\n
         \       <name>Disk 1</name>\n        <vm id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"3eafdb4e-60dc-4427-a81a-9fbacd6b4010\" href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/3eafdb4e-60dc-4427-a81a-9fbacd6b4010\">\n
+        \   </disk>\n    <disk id=\"3eafdb4e-60dc-4427-a81a-9fbacd6b4010\" href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/3eafdb4e-60dc-4427-a81a-9fbacd6b4010\">\n
         \       <name>Disk 5</name>\n        <vm id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"79c492f0-008a-4e8f-93e3-7ea20aff6fd0\" href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/79c492f0-008a-4e8f-93e3-7ea20aff6fd0\">\n
+        \   </disk>\n    <disk id=\"79c492f0-008a-4e8f-93e3-7ea20aff6fd0\" href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff/disks/79c492f0-008a-4e8f-93e3-7ea20aff6fd0\">\n
         \       <name>Disk 4</name>\n        <vm id=\"a9ac3d74-eb66-437b-85c8-e83099edf9ff\"
-        href=\"/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/a9ac3d74-eb66-437b-85c8-e83099edf9ff\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6296,7 +6285,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:51 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6333,41 +6322,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"5521b6bf-184e-4a84-b82d-921fa4ef901d\" href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/5521b6bf-184e-4a84-b82d-921fa4ef901d\">\n
+        \   <disk id=\"5521b6bf-184e-4a84-b82d-921fa4ef901d\" href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/5521b6bf-184e-4a84-b82d-921fa4ef901d\">\n
         \       <name>Disk 3</name>\n        <vm id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"75812179-eeb8-4d8c-a733-7e0bf0e137ad\" href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/75812179-eeb8-4d8c-a733-7e0bf0e137ad\">\n
+        \   </disk>\n    <disk id=\"75812179-eeb8-4d8c-a733-7e0bf0e137ad\" href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/75812179-eeb8-4d8c-a733-7e0bf0e137ad\">\n
         \       <name>Disk 5</name>\n        <vm id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"b9294516-4341-4008-aea9-63d8ed85e36b\" href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/b9294516-4341-4008-aea9-63d8ed85e36b\">\n
+        \   </disk>\n    <disk id=\"b9294516-4341-4008-aea9-63d8ed85e36b\" href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/b9294516-4341-4008-aea9-63d8ed85e36b\">\n
         \       <name>Disk 2</name>\n        <vm id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"b7cedfa8-ac5a-4c3c-977c-76899e45291d\" href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/b7cedfa8-ac5a-4c3c-977c-76899e45291d\">\n
+        \   </disk>\n    <disk id=\"b7cedfa8-ac5a-4c3c-977c-76899e45291d\" href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/b7cedfa8-ac5a-4c3c-977c-76899e45291d\">\n
         \       <name>Disk 1</name>\n        <vm id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"91eadb54-02d1-49ec-a3df-f901180f616e\" href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91eadb54-02d1-49ec-a3df-f901180f616e\">\n
+        \   </disk>\n    <disk id=\"91eadb54-02d1-49ec-a3df-f901180f616e\" href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91eadb54-02d1-49ec-a3df-f901180f616e\">\n
         \       <name>Disk 4</name>\n        <vm id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"
-        href=\"/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6378,7 +6367,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:51 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/c9ee91ff-41af-48f5-8734-953f865c83b9/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6415,41 +6404,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"478efffc-9f97-4a1f-95d7-9dc57f3ee672\" href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/478efffc-9f97-4a1f-95d7-9dc57f3ee672\">\n
+        \   <disk id=\"478efffc-9f97-4a1f-95d7-9dc57f3ee672\" href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/478efffc-9f97-4a1f-95d7-9dc57f3ee672\">\n
         \       <name>Disk 4</name>\n        <vm id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"12b4f490-3629-4bdf-9100-7d46b615edd5\" href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/12b4f490-3629-4bdf-9100-7d46b615edd5\">\n
+        \   </disk>\n    <disk id=\"12b4f490-3629-4bdf-9100-7d46b615edd5\" href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/12b4f490-3629-4bdf-9100-7d46b615edd5\">\n
         \       <name>Disk 1</name>\n        <vm id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"eacf2ac9-275b-4d4f-a467-92fdef1f7d9f\" href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/eacf2ac9-275b-4d4f-a467-92fdef1f7d9f\">\n
+        \   </disk>\n    <disk id=\"eacf2ac9-275b-4d4f-a467-92fdef1f7d9f\" href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/eacf2ac9-275b-4d4f-a467-92fdef1f7d9f\">\n
         \       <name>Disk 2</name>\n        <vm id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>4294967296</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"20b8bbb8-3f71-4c18-bc94-d4cc92deac3c\" href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/20b8bbb8-3f71-4c18-bc94-d4cc92deac3c\">\n
+        \   </disk>\n    <disk id=\"20b8bbb8-3f71-4c18-bc94-d4cc92deac3c\" href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/20b8bbb8-3f71-4c18-bc94-d4cc92deac3c\">\n
         \       <name>Disk 3</name>\n        <vm id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>raw</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"9dea8701-bb58-49b5-b634-8f6df3c98187\" href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/9dea8701-bb58-49b5-b634-8f6df3c98187\">\n
+        \   </disk>\n    <disk id=\"9dea8701-bb58-49b5-b634-8f6df3c98187\" href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9/disks/9dea8701-bb58-49b5-b634-8f6df3c98187\">\n
         \       <name>Disk 5</name>\n        <vm id=\"c9ee91ff-41af-48f5-8734-953f865c83b9\"
-        href=\"/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/c9ee91ff-41af-48f5-8734-953f865c83b9\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6460,7 +6449,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:52 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6497,41 +6486,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"813bd258-a5a8-4e64-a47b-01c0edeb7592\" href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/813bd258-a5a8-4e64-a47b-01c0edeb7592\">\n
+        \   <disk id=\"813bd258-a5a8-4e64-a47b-01c0edeb7592\" href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/813bd258-a5a8-4e64-a47b-01c0edeb7592\">\n
         \       <name>Disk 2</name>\n        <vm id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"a7958e65-121b-4231-ab05-abd7f9957c6a\" href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/a7958e65-121b-4231-ab05-abd7f9957c6a\">\n
+        \   </disk>\n    <disk id=\"a7958e65-121b-4231-ab05-abd7f9957c6a\" href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/a7958e65-121b-4231-ab05-abd7f9957c6a\">\n
         \       <name>Disk 3</name>\n        <vm id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"6888ab61-14f5-4031-a823-915ec37b16bc\" href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/6888ab61-14f5-4031-a823-915ec37b16bc\">\n
+        \   </disk>\n    <disk id=\"6888ab61-14f5-4031-a823-915ec37b16bc\" href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/6888ab61-14f5-4031-a823-915ec37b16bc\">\n
         \       <name>Disk 4</name>\n        <vm id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"840c335a-a205-4f69-801e-d4e5d826a28b\" href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/840c335a-a205-4f69-801e-d4e5d826a28b\">\n
+        \   </disk>\n    <disk id=\"840c335a-a205-4f69-801e-d4e5d826a28b\" href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/840c335a-a205-4f69-801e-d4e5d826a28b\">\n
         \       <name>Disk 5</name>\n        <vm id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"ca987bb6-6932-4784-93fa-952c7caa8305\" href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/ca987bb6-6932-4784-93fa-952c7caa8305\">\n
+        \   </disk>\n    <disk id=\"ca987bb6-6932-4784-93fa-952c7caa8305\" href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8/disks/ca987bb6-6932-4784-93fa-952c7caa8305\">\n
         \       <name>Disk 1</name>\n        <vm id=\"1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"
-        href=\"/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/1d92768f-bbbb-4eb4-90f5-a3ae6c205ec8\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
@@ -6542,7 +6531,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:52 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/83f76598-4797-40ff-b0ec-433eb74db8be/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6579,9 +6568,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"7e253a67-9666-4e3b-b3b4-1c07eadde0bc\" href=\"/api/vms/83f76598-4797-40ff-b0ec-433eb74db8be/disks/7e253a67-9666-4e3b-b3b4-1c07eadde0bc\">\n
+        \   <disk id=\"7e253a67-9666-4e3b-b3b4-1c07eadde0bc\" href=\"/ovirt-engine/api/vms/83f76598-4797-40ff-b0ec-433eb74db8be/disks/7e253a67-9666-4e3b-b3b4-1c07eadde0bc\">\n
         \       <name>Disk 1</name>\n        <vm id=\"83f76598-4797-40ff-b0ec-433eb74db8be\"
-        href=\"/api/vms/83f76598-4797-40ff-b0ec-433eb74db8be\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/83f76598-4797-40ff-b0ec-433eb74db8be\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"6efaa0f3-d832-4e8f-846f-aacdc974e6d0\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6592,7 +6581,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:52 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6629,9 +6618,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"e98f57e0-5f1c-4e2c-a435-fcf365211227\" href=\"/api/vms/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks/e98f57e0-5f1c-4e2c-a435-fcf365211227\">\n
+        \   <disk id=\"e98f57e0-5f1c-4e2c-a435-fcf365211227\" href=\"/ovirt-engine/api/vms/57eb8fef-58ea-4f40-a308-f88b05d18f5d/disks/e98f57e0-5f1c-4e2c-a435-fcf365211227\">\n
         \       <name>Disk 1</name>\n        <vm id=\"57eb8fef-58ea-4f40-a308-f88b05d18f5d\"
-        href=\"/api/vms/57eb8fef-58ea-4f40-a308-f88b05d18f5d\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/57eb8fef-58ea-4f40-a308-f88b05d18f5d\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6642,7 +6631,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:52 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6679,9 +6668,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"3571b143-56e5-4c6f-94c7-95a7912ac89b\" href=\"/api/vms/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks/3571b143-56e5-4c6f-94c7-95a7912ac89b\">\n
+        \   <disk id=\"3571b143-56e5-4c6f-94c7-95a7912ac89b\" href=\"/ovirt-engine/api/vms/bb3289d7-6dce-4cfc-9973-c01f3abfe13f/disks/3571b143-56e5-4c6f-94c7-95a7912ac89b\">\n
         \       <name>Disk 1</name>\n        <vm id=\"bb3289d7-6dce-4cfc-9973-c01f3abfe13f\"
-        href=\"/api/vms/bb3289d7-6dce-4cfc-9973-c01f3abfe13f\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/bb3289d7-6dce-4cfc-9973-c01f3abfe13f\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"65ca9577-0d95-4909-8532-4c45201fbfe4\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6692,7 +6681,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:52 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/disks
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api/templates/276fcf44-afeb-4591-b3a6-82544124f898/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6729,41 +6718,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk id=\"cab97df4-7e8f-423d-beb6-3782f5196347\" href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/cab97df4-7e8f-423d-beb6-3782f5196347\">\n
+        \   <disk id=\"cab97df4-7e8f-423d-beb6-3782f5196347\" href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/cab97df4-7e8f-423d-beb6-3782f5196347\">\n
         \       <name>Disk 1</name>\n        <vm id=\"276fcf44-afeb-4591-b3a6-82544124f898\"
-        href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>7516192768</size>\n        <type>system</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>ide</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>true</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"6127913a-d300-4bd7-8695-1ebdc09491ef\" href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/6127913a-d300-4bd7-8695-1ebdc09491ef\">\n
+        \   </disk>\n    <disk id=\"6127913a-d300-4bd7-8695-1ebdc09491ef\" href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/6127913a-d300-4bd7-8695-1ebdc09491ef\">\n
         \       <name>Disk 3</name>\n        <vm id=\"276fcf44-afeb-4591-b3a6-82544124f898\"
-        href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>5368709120</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"f59f3076-28e8-4cac-8920-65cd09484e14\" href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/f59f3076-28e8-4cac-8920-65cd09484e14\">\n
+        \   </disk>\n    <disk id=\"f59f3076-28e8-4cac-8920-65cd09484e14\" href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/f59f3076-28e8-4cac-8920-65cd09484e14\">\n
         \       <name>Disk 2</name>\n        <vm id=\"276fcf44-afeb-4591-b3a6-82544124f898\"
-        href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>3221225472</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"5a53adbb-c4f5-42d8-b463-3e8e53514882\" href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/5a53adbb-c4f5-42d8-b463-3e8e53514882\">\n
+        \   </disk>\n    <disk id=\"5a53adbb-c4f5-42d8-b463-3e8e53514882\" href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/5a53adbb-c4f5-42d8-b463-3e8e53514882\">\n
         \       <name>Disk 4</name>\n        <vm id=\"276fcf44-afeb-4591-b3a6-82544124f898\"
-        href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>8589934592</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
         \       <format>cow</format>\n        <sparse>true</sparse>\n        <bootable>false</bootable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
-        \   </disk>\n    <disk id=\"be0f5c8a-62a7-45c4-9230-ae6ff4382eea\" href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/be0f5c8a-62a7-45c4-9230-ae6ff4382eea\">\n
+        \   </disk>\n    <disk id=\"be0f5c8a-62a7-45c4-9230-ae6ff4382eea\" href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898/disks/be0f5c8a-62a7-45c4-9230-ae6ff4382eea\">\n
         \       <name>Disk 5</name>\n        <vm id=\"276fcf44-afeb-4591-b3a6-82544124f898\"
-        href=\"/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
+        href=\"/ovirt-engine/api/vms/276fcf44-afeb-4591-b3a6-82544124f898\"/>\n        <storage_domains>\n
         \           <storage_domain id=\"40f45969-31e9-4db6-9c9c-9a683c3755aa\"/>\n
         \       </storage_domains>\n        <size>21474836480</size>\n        <type>data</type>\n
         \       <status>\n            <state>ok</state>\n        </status>\n        <interface>virtio</interface>\n
@@ -6774,7 +6763,7 @@ http_interactions:
   recorded_at: Tue, 07 Oct 2014 17:58:53 GMT
 - request:
     method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/api
+    uri: https://evm%40manageiq.com:password@192.168.252.231:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -6803,20 +6792,20 @@ http_interactions:
       X-Powered-By:
       - Servlet 2.5; JBoss-5.0/JBossWeb-2.1
       Link:
-      - <https://192.168.252.231:8443/api/capabilities>; rel=capabilities,<https://192.168.252.231:8443/api/clusters>;
-        rel=clusters,<https://192.168.252.231:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.231:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.252.231:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.252.231:8443/api/events>; rel=events,<https://192.168.252.231:8443/api/events?search={query}&from={event_id}>;
-        rel=events/search,<https://192.168.252.231:8443/api/hosts>; rel=hosts,<https://192.168.252.231:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.252.231:8443/api/networks>; rel=networks,<https://192.168.252.231:8443/api/roles>;
-        rel=roles,<https://192.168.252.231:8443/api/storagedomains>; rel=storagedomains,<https://192.168.252.231:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.252.231:8443/api/tags>; rel=tags,<https://192.168.252.231:8443/api/templates>;
-        rel=templates,<https://192.168.252.231:8443/api/templates?search={query}>;
-        rel=templates/search,<https://192.168.252.231:8443/api/users>; rel=users,<https://192.168.252.231:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.252.231:8443/api/groups>; rel=groups,<https://192.168.252.231:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.252.231:8443/api/domains>; rel=domains,<https://192.168.252.231:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.252.231:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.252.231:8443/api/vms>;
-        rel=vms,<https://192.168.252.231:8443/api/vms?search={query}>; rel=vms/search
+      - <https://192.168.252.231:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.252.231:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.252.231:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.231:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.252.231:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.252.231:8443/ovirt-engine/api/events>; rel=events,<https://192.168.252.231:8443/ovirt-engine/api/events?search={query}&from={event_id}>;
+        rel=events/search,<https://192.168.252.231:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.252.231:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.252.231:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.252.231:8443/ovirt-engine/api/roles>;
+        rel=roles,<https://192.168.252.231:8443/ovirt-engine/api/storagedomains>; rel=storagedomains,<https://192.168.252.231:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.252.231:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.252.231:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.252.231:8443/ovirt-engine/api/templates?search={query}>;
+        rel=templates/search,<https://192.168.252.231:8443/ovirt-engine/api/users>; rel=users,<https://192.168.252.231:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.252.231:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.252.231:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.252.231:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.252.231:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.252.231:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.252.231:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.252.231:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search
       Content-Type:
       - application/xml
       Content-Length:
@@ -6826,25 +6815,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<api>\n
-        \   <link rel=\"capabilities\" href=\"/api/capabilities\"/>\n    <link rel=\"clusters\"
-        href=\"/api/clusters\"/>\n    <link rel=\"clusters/search\" href=\"/api/clusters?search={query}\"/>\n
-        \   <link rel=\"datacenters\" href=\"/api/datacenters\"/>\n    <link rel=\"datacenters/search\"
-        href=\"/api/datacenters?search={query}\"/>\n    <link rel=\"events\" href=\"/api/events\"/>\n
-        \   <link rel=\"events/search\" href=\"/api/events?search={query}&amp;from={event_id}\"/>\n
-        \   <link rel=\"hosts\" href=\"/api/hosts\"/>\n    <link rel=\"hosts/search\"
-        href=\"/api/hosts?search={query}\"/>\n    <link rel=\"networks\" href=\"/api/networks\"/>\n
-        \   <link rel=\"roles\" href=\"/api/roles\"/>\n    <link rel=\"storagedomains\"
-        href=\"/api/storagedomains\"/>\n    <link rel=\"storagedomains/search\" href=\"/api/storagedomains?search={query}\"/>\n
-        \   <link rel=\"tags\" href=\"/api/tags\"/>\n    <link rel=\"templates\" href=\"/api/templates\"/>\n
-        \   <link rel=\"templates/search\" href=\"/api/templates?search={query}\"/>\n
-        \   <link rel=\"users\" href=\"/api/users\"/>\n    <link rel=\"users/search\"
-        href=\"/api/users?search={query}\"/>\n    <link rel=\"groups\" href=\"/api/groups\"/>\n
-        \   <link rel=\"groups/search\" href=\"/api/groups?search={query}\"/>\n    <link
-        rel=\"domains\" href=\"/api/domains\"/>\n    <link rel=\"vmpools\" href=\"/api/vmpools\"/>\n
-        \   <link rel=\"vmpools/search\" href=\"/api/vmpools?search={query}\"/>\n
-        \   <link rel=\"vms\" href=\"/api/vms\"/>\n    <link rel=\"vms/search\" href=\"/api/vms?search={query}\"/>\n
-        \   <special_objects>\n        <link rel=\"templates/blank\" href=\"/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
-        \       <link rel=\"tags/root\" href=\"/api/tags/00000000-0000-0000-0000-000000000000\"/>\n
+        \   <link rel=\"capabilities\" href=\"/ovirt-engine/api/capabilities\"/>\n    <link rel=\"clusters\"
+        href=\"/ovirt-engine/api/clusters\"/>\n    <link rel=\"clusters/search\" href=\"/ovirt-engine/api/clusters?search={query}\"/>\n
+        \   <link rel=\"datacenters\" href=\"/ovirt-engine/api/datacenters\"/>\n    <link rel=\"datacenters/search\"
+        href=\"/ovirt-engine/api/datacenters?search={query}\"/>\n    <link rel=\"events\" href=\"/ovirt-engine/api/events\"/>\n
+        \   <link rel=\"events/search\" href=\"/ovirt-engine/api/events?search={query}&amp;from={event_id}\"/>\n
+        \   <link rel=\"hosts\" href=\"/ovirt-engine/api/hosts\"/>\n    <link rel=\"hosts/search\"
+        href=\"/ovirt-engine/api/hosts?search={query}\"/>\n    <link rel=\"networks\" href=\"/ovirt-engine/api/networks\"/>\n
+        \   <link rel=\"roles\" href=\"/ovirt-engine/api/roles\"/>\n    <link rel=\"storagedomains\"
+        href=\"/ovirt-engine/api/storagedomains\"/>\n    <link rel=\"storagedomains/search\" href=\"/ovirt-engine/api/storagedomains?search={query}\"/>\n
+        \   <link rel=\"tags\" href=\"/ovirt-engine/api/tags\"/>\n    <link rel=\"templates\" href=\"/ovirt-engine/api/templates\"/>\n
+        \   <link rel=\"templates/search\" href=\"/ovirt-engine/api/templates?search={query}\"/>\n
+        \   <link rel=\"users\" href=\"/ovirt-engine/api/users\"/>\n    <link rel=\"users/search\"
+        href=\"/ovirt-engine/api/users?search={query}\"/>\n    <link rel=\"groups\" href=\"/ovirt-engine/api/groups\"/>\n
+        \   <link rel=\"groups/search\" href=\"/ovirt-engine/api/groups?search={query}\"/>\n    <link
+        rel=\"domains\" href=\"/ovirt-engine/api/domains\"/>\n    <link rel=\"vmpools\" href=\"/ovirt-engine/api/vmpools\"/>\n
+        \   <link rel=\"vmpools/search\" href=\"/ovirt-engine/api/vmpools?search={query}\"/>\n
+        \   <link rel=\"vms\" href=\"/ovirt-engine/api/vms\"/>\n    <link rel=\"vms/search\" href=\"/ovirt-engine/api/vms?search={query}\"/>\n
+        \   <special_objects>\n        <link rel=\"templates/blank\" href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"/>\n
+        \       <link rel=\"tags/root\" href=\"/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000\"/>\n
         \   </special_objects>\n    <product_info>\n        <name>Red Hat Enterprise
         Virtualization</name>\n        <vendor>Red Hat</vendor>\n        <version
         revision=\"0\" build=\"0\" minor=\"0\" major=\"3\"/>\n    </product_info>\n

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_3_1.yml
@@ -2,18 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.252.230/api
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      WWW-Authenticate:
-      - Basic realm="RESTAPI"
-  recorded_at: Tue, 26 Apr 2016 11:15:00 GMT
-- request:
-    method: get
-    uri: https://evm%40manageiq.com:password@192.168.252.230/api
+    uri: https://evm%40manageiq.com:password@192.168.252.230/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -42,20 +31,20 @@ http_interactions:
       Set-Cookie:
       - JSESSIONID=eyaOaNBaQj8SyEdzJeVk0Iyb; Path=/api; Secure
       Link:
-      - <https://192.168.252.230/api/capabilities>; rel=capabilities,<https://192.168.252.230/api/clusters>;
-        rel=clusters,<https://192.168.252.230/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.230/api/datacenters>;
-        rel=datacenters,<https://192.168.252.230/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.252.230/api/events>; rel=events,<https://192.168.252.230/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.252.230/api/hosts>; rel=hosts,<https://192.168.252.230/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.252.230/api/networks>; rel=networks,<https://192.168.252.230/api/roles>;
-        rel=roles,<https://192.168.252.230/api/storagedomains>; rel=storagedomains,<https://192.168.252.230/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.252.230/api/tags>; rel=tags,<https://192.168.252.230/api/templates>;
-        rel=templates,<https://192.168.252.230/api/templates?search={query}>; rel=templates/search,<https://192.168.252.230/api/users>;
-        rel=users,<https://192.168.252.230/api/users?search={query}>; rel=users/search,<https://192.168.252.230/api/groups>;
-        rel=groups,<https://192.168.252.230/api/groups?search={query}>; rel=groups/search,<https://192.168.252.230/api/domains>;
-        rel=domains,<https://192.168.252.230/api/vmpools>; rel=vmpools,<https://192.168.252.230/api/vmpools?search={query}>;
-        rel=vmpools/search,<https://192.168.252.230/api/vms>; rel=vms,<https://192.168.252.230/api/vms?search={query}>;
-        rel=vms/search,<https://192.168.252.230/api/disks>; rel=disks,<https://192.168.252.230/api/disks?search={query}>;
+      - <https://192.168.252.230/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.252.230/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.252.230/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.230/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.252.230/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.252.230/ovirt-engine/api/events>; rel=events,<https://192.168.252.230/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.252.230/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.252.230/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.252.230/ovirt-engine/api/networks>; rel=networks,<https://192.168.252.230/ovirt-engine/api/roles>;
+        rel=roles,<https://192.168.252.230/ovirt-engine/api/storagedomains>; rel=storagedomains,<https://192.168.252.230/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.252.230/ovirt-engine/api/tags>; rel=tags,<https://192.168.252.230/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.252.230/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.252.230/ovirt-engine/api/users>;
+        rel=users,<https://192.168.252.230/ovirt-engine/api/users?search={query}>; rel=users/search,<https://192.168.252.230/ovirt-engine/api/groups>;
+        rel=groups,<https://192.168.252.230/ovirt-engine/api/groups?search={query}>; rel=groups/search,<https://192.168.252.230/ovirt-engine/api/domains>;
+        rel=domains,<https://192.168.252.230/ovirt-engine/api/vmpools>; rel=vmpools,<https://192.168.252.230/ovirt-engine/api/vmpools?search={query}>;
+        rel=vmpools/search,<https://192.168.252.230/ovirt-engine/api/vms>; rel=vms,<https://192.168.252.230/ovirt-engine/api/vms?search={query}>;
+        rel=vms/search,<https://192.168.252.230/ovirt-engine/api/disks>; rel=disks,<https://192.168.252.230/ovirt-engine/api/disks?search={query}>;
         rel=disks/search
       Content-Type:
       - application/xml
@@ -66,27 +55,27 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<api>\n
-        \   <link href=\"/api/capabilities\" rel=\"capabilities\"/>\n    <link href=\"/api/clusters\"
-        rel=\"clusters\"/>\n    <link href=\"/api/clusters?search={query}\" rel=\"clusters/search\"/>\n
-        \   <link href=\"/api/datacenters\" rel=\"datacenters\"/>\n    <link href=\"/api/datacenters?search={query}\"
-        rel=\"datacenters/search\"/>\n    <link href=\"/api/events\" rel=\"events\"/>\n
-        \   <link href=\"/api/events;from={event_id}?search={query}\" rel=\"events/search\"/>\n
-        \   <link href=\"/api/hosts\" rel=\"hosts\"/>\n    <link href=\"/api/hosts?search={query}\"
-        rel=\"hosts/search\"/>\n    <link href=\"/api/networks\" rel=\"networks\"/>\n
-        \   <link href=\"/api/roles\" rel=\"roles\"/>\n    <link href=\"/api/storagedomains\"
-        rel=\"storagedomains\"/>\n    <link href=\"/api/storagedomains?search={query}\"
-        rel=\"storagedomains/search\"/>\n    <link href=\"/api/tags\" rel=\"tags\"/>\n
-        \   <link href=\"/api/templates\" rel=\"templates\"/>\n    <link href=\"/api/templates?search={query}\"
-        rel=\"templates/search\"/>\n    <link href=\"/api/users\" rel=\"users\"/>\n
-        \   <link href=\"/api/users?search={query}\" rel=\"users/search\"/>\n    <link
-        href=\"/api/groups\" rel=\"groups\"/>\n    <link href=\"/api/groups?search={query}\"
-        rel=\"groups/search\"/>\n    <link href=\"/api/domains\" rel=\"domains\"/>\n
-        \   <link href=\"/api/vmpools\" rel=\"vmpools\"/>\n    <link href=\"/api/vmpools?search={query}\"
-        rel=\"vmpools/search\"/>\n    <link href=\"/api/vms\" rel=\"vms\"/>\n    <link
-        href=\"/api/vms?search={query}\" rel=\"vms/search\"/>\n    <link href=\"/api/disks\"
-        rel=\"disks\"/>\n    <link href=\"/api/disks?search={query}\" rel=\"disks/search\"/>\n
-        \   <special_objects>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
-        rel=\"templates/blank\"/>\n        <link href=\"/api/tags/00000000-0000-0000-0000-000000000000\"
+        \   <link href=\"/ovirt-engine/api/capabilities\" rel=\"capabilities\"/>\n    <link href=\"/ovirt-engine/api/clusters\"
+        rel=\"clusters\"/>\n    <link href=\"/ovirt-engine/api/clusters?search={query}\" rel=\"clusters/search\"/>\n
+        \   <link href=\"/ovirt-engine/api/datacenters\" rel=\"datacenters\"/>\n    <link href=\"/ovirt-engine/api/datacenters?search={query}\"
+        rel=\"datacenters/search\"/>\n    <link href=\"/ovirt-engine/api/events\" rel=\"events\"/>\n
+        \   <link href=\"/ovirt-engine/api/events;from={event_id}?search={query}\" rel=\"events/search\"/>\n
+        \   <link href=\"/ovirt-engine/api/hosts\" rel=\"hosts\"/>\n    <link href=\"/ovirt-engine/api/hosts?search={query}\"
+        rel=\"hosts/search\"/>\n    <link href=\"/ovirt-engine/api/networks\" rel=\"networks\"/>\n
+        \   <link href=\"/ovirt-engine/api/roles\" rel=\"roles\"/>\n    <link href=\"/ovirt-engine/api/storagedomains\"
+        rel=\"storagedomains\"/>\n    <link href=\"/ovirt-engine/api/storagedomains?search={query}\"
+        rel=\"storagedomains/search\"/>\n    <link href=\"/ovirt-engine/api/tags\" rel=\"tags\"/>\n
+        \   <link href=\"/ovirt-engine/api/templates\" rel=\"templates\"/>\n    <link href=\"/ovirt-engine/api/templates?search={query}\"
+        rel=\"templates/search\"/>\n    <link href=\"/ovirt-engine/api/users\" rel=\"users\"/>\n
+        \   <link href=\"/ovirt-engine/api/users?search={query}\" rel=\"users/search\"/>\n    <link
+        href=\"/ovirt-engine/api/groups\" rel=\"groups\"/>\n    <link href=\"/ovirt-engine/api/groups?search={query}\"
+        rel=\"groups/search\"/>\n    <link href=\"/ovirt-engine/api/domains\" rel=\"domains\"/>\n
+        \   <link href=\"/ovirt-engine/api/vmpools\" rel=\"vmpools\"/>\n    <link href=\"/ovirt-engine/api/vmpools?search={query}\"
+        rel=\"vmpools/search\"/>\n    <link href=\"/ovirt-engine/api/vms\" rel=\"vms\"/>\n    <link
+        href=\"/ovirt-engine/api/vms?search={query}\" rel=\"vms/search\"/>\n    <link href=\"/ovirt-engine/api/disks\"
+        rel=\"disks\"/>\n    <link href=\"/ovirt-engine/api/disks?search={query}\" rel=\"disks/search\"/>\n
+        \   <special_objects>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
+        rel=\"templates/blank\"/>\n        <link href=\"/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000\"
         rel=\"tags/root\"/>\n    </special_objects>\n    <product_info>\n        <name>Red
         Hat Enterprise Virtualization</name>\n        <vendor>Red Hat</vendor>\n        <version
         major=\"3\" minor=\"1\" build=\"0\" revision=\"0\"/>\n    </product_info>\n
@@ -100,7 +89,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:21 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/clusters
+    uri: https://192.168.252.230/ovirt-engine/api/clusters
     body:
       encoding: US-ASCII
       string: ''
@@ -137,46 +126,46 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<clusters>\n
-        \   <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\" id=\"99408929-82cf-4dc7-a532-9d998063fa95\">\n
+        \   <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\" id=\"99408929-82cf-4dc7-a532-9d998063fa95\">\n
         \       <name>iSCSI</name>\n        <description>The default server cluster</description>\n
-        \       <link href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/networks\"
-        rel=\"networks\"/>\n        <link href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/glustervolumes\"
+        \       <link href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/networks\"
+        rel=\"networks\"/>\n        <link href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95/glustervolumes\"
         rel=\"glustervolumes\"/>\n        <cpu id=\"Intel Nehalem Family\"/>\n        <data_center
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
         \       <memory_policy>\n            <overcommit percent=\"150\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version major=\"3\"
         minor=\"1\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n        <virt_service>true</virt_service>\n        <gluster_service>false</gluster_service>\n
-        \   </cluster>\n    <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \   </cluster>\n    <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\">\n        <name>NFS</name>\n        <description>NFS</description>\n
-        \       <link href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/networks\"
-        rel=\"networks\"/>\n        <link href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/glustervolumes\"
+        \       <link href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/networks\"
+        rel=\"networks\"/>\n        <link href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db/glustervolumes\"
         rel=\"glustervolumes\"/>\n        <cpu id=\"Intel Conroe Family\"/>\n        <data_center
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
         \       <memory_policy>\n            <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version major=\"3\"
         minor=\"1\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n        <virt_service>true</virt_service>\n        <gluster_service>false</gluster_service>\n
-        \   </cluster>\n    <cluster href=\"/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db\"
+        \   </cluster>\n    <cluster href=\"/ovirt-engine/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db\"
         id=\"07926cf6-dcd3-11e2-abf5-005056a217db\">\n        <name>rhelh-nfs-Local</name>\n
-        \       <link href=\"/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/networks\"
-        rel=\"networks\"/>\n        <link href=\"/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/glustervolumes\"
+        \       <link href=\"/ovirt-engine/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/networks\"
+        rel=\"networks\"/>\n        <link href=\"/ovirt-engine/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/clusters/07926cf6-dcd3-11e2-abf5-005056a217db/glustervolumes\"
         rel=\"glustervolumes\"/>\n        <cpu id=\"Intel Conroe Family\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
         \       </memory_policy>\n        <scheduling_policy/>\n        <version major=\"3\"
         minor=\"1\"/>\n        <error_handling>\n            <on_error>migrate</on_error>\n
         \       </error_handling>\n        <virt_service>true</virt_service>\n        <gluster_service>false</gluster_service>\n
-        \   </cluster>\n    <cluster href=\"/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db\"
+        \   </cluster>\n    <cluster href=\"/ovirt-engine/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db\"
         id=\"b22c39c6-e06b-11e2-99d1-005056a217db\">\n        <name>temp</name>\n
-        \       <link href=\"/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/networks\"
-        rel=\"networks\"/>\n        <link href=\"/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/glustervolumes\"
+        \       <link href=\"/ovirt-engine/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/networks\"
+        rel=\"networks\"/>\n        <link href=\"/ovirt-engine/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/clusters/b22c39c6-e06b-11e2-99d1-005056a217db/glustervolumes\"
         rel=\"glustervolumes\"/>\n        <cpu id=\"Intel Conroe Family\"/>\n        <memory_policy>\n
         \           <overcommit percent=\"100\"/>\n            <transparent_hugepages>\n
         \               <enabled>true</enabled>\n            </transparent_hugepages>\n
@@ -188,7 +177,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:21 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vmpools
+    uri: https://192.168.252.230/ovirt-engine/api/vmpools
     body:
       encoding: US-ASCII
       string: ''
@@ -233,7 +222,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:21 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/networks
+    uri: https://192.168.252.230/ovirt-engine/api/networks
     body:
       encoding: US-ASCII
       string: ''
@@ -270,32 +259,32 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<networks>\n
-        \   <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\" id=\"00000000-0000-0000-0000-000000000009\">\n
+        \   <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\" id=\"00000000-0000-0000-0000-000000000009\">\n
         \       <name>rhevm</name>\n        <description>Management Network</description>\n
-        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <stp>false</stp>\n
         \       <mtu>0</mtu>\n        <usages>\n            <usage>vm</usage>\n        </usages>\n
-        \   </network>\n    <network href=\"/api/networks/5fdbd265-0ead-4038-ba68-39ef4deafcd6\"
+        \   </network>\n    <network href=\"/ovirt-engine/api/networks/5fdbd265-0ead-4038-ba68-39ef4deafcd6\"
         id=\"5fdbd265-0ead-4038-ba68-39ef4deafcd6\">\n        <name>iSCSI</name>\n
-        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <stp>false</stp>\n
-        \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
+        \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/ovirt-engine/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
         id=\"249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\">\n        <name>vmnet</name>\n
-        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <stp>false</stp>\n
-        \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
+        \       <mtu>0</mtu>\n        <usages/>\n    </network>\n    <network href=\"/ovirt-engine/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\">\n        <name>rhevm</name>\n
         \       <description>Management Network</description>\n        <data_center
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
         \       <stp>false</stp>\n        <mtu>0</mtu>\n        <usages>\n            <usage>vm</usage>\n
-        \       </usages>\n    </network>\n    <network href=\"/api/networks/73eceed7-efbc-4d24-acb5-1d89f0b5f670\"
+        \       </usages>\n    </network>\n    <network href=\"/ovirt-engine/api/networks/73eceed7-efbc-4d24-acb5-1d89f0b5f670\"
         id=\"73eceed7-efbc-4d24-acb5-1d89f0b5f670\">\n        <name>Storage</name>\n
-        \       <data_center href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
         id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n        <stp>false</stp>\n
         \       <mtu>0</mtu>\n        <usages>\n            <usage>vm</usage>\n        </usages>\n
-        \   </network>\n    <network href=\"/api/networks/b167e5b4-1c68-429c-8c82-14fe668739af\"
+        \   </network>\n    <network href=\"/ovirt-engine/api/networks/b167e5b4-1c68-429c-8c82-14fe668739af\"
         id=\"b167e5b4-1c68-429c-8c82-14fe668739af\">\n        <name>invalid</name>\n
-        \       <data_center href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
         id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n        <stp>false</stp>\n
         \       <mtu>0</mtu>\n        <usages>\n            <usage>vm</usage>\n        </usages>\n
         \   </network>\n</networks>\n"
@@ -303,7 +292,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/storagedomains?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.252.230/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -340,26 +329,26 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\"
+        \   <storage_domain href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\"
         id=\"f291819d-6f09-4a5b-9e48-0bc40898362b\">\n        <name>Export</name>\n
-        \       <link href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/templates\"
-        rel=\"templates\"/>\n        <link href=\"/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/vms\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/templates\"
+        rel=\"templates\"/>\n        <link href=\"/ovirt-engine/api/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/vms\"
         rel=\"vms\"/>\n        <type>export</type>\n        <master>false</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.65</address>\n
         \           <path>/srv/export</path>\n        </storage>\n        <available>25769803776</available>\n
         \       <used>37580963840</used>\n        <committed>0</committed>\n        <storage_format>v1</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
         id=\"73072271-11c3-41aa-af23-37bf2fa185cd\">\n        <name>ISO</name>\n        <link
-        href=\"/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/files\"
+        href=\"/ovirt-engine/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/files\"
         rel=\"files\"/>\n        <type>iso</type>\n        <master>false</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.230</address>\n
         \           <path>/srv/ISO</path>\n        </storage>\n        <available>27917287424</available>\n
         \       <used>30064771072</used>\n        <committed>0</committed>\n        <storage_format>v1</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f\"
         id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\">\n        <name>NetApp01Lun2</name>\n
-        \       <link href=\"/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/permissions\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>true</master>\n
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
         id=\"CqCwC9-3V1p-WIwg-R5H5-zdid-10dP-o2GhyJ\">\n                <logical_unit
@@ -374,39 +363,39 @@ http_interactions:
         \               </logical_unit>\n            </volume_group>\n        </storage>\n
         \       <available>57982058496</available>\n        <used>48318382080</used>\n
         \       <committed>69793218560</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96\"
         id=\"d0a7d751-46bc-495a-a312-e5d010059f96\">\n        <name>RHEVM31-1</name>\n
-        \       <link href=\"/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/permissions\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>false</master>\n
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
         id=\"TKVvjS-2L08-F19O-Pewh-f9nl-xiKD-lfXzh7\"/>\n        </storage>\n        <available>137438953472</available>\n
         \       <used>136365211648</used>\n        <committed>228707008512</committed>\n
         \       <storage_format>v3</storage_format>\n    </storage_domain>\n    <storage_domain
-        href=\"/api/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8\" id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\">\n
-        \       <name>RHEVM31-NFS1</name>\n        <link href=\"/api/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/permissions\"
+        href=\"/ovirt-engine/api/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8\" id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\">\n
+        \       <name>RHEVM31-NFS1</name>\n        <link href=\"/ovirt-engine/api/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>false</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.30</address>\n
         \           <path>/vol/rhev31share1/rhevm-data</path>\n        </storage>\n
         \       <available>76235669504</available>\n        <used>10737418240</used>\n
         \       <committed>199715979264</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229\"
         id=\"62f9cdc1-5473-49f8-8128-e4db5d84d229\">\n        <name>RHEVM31-NFS2</name>\n
-        \       <link href=\"/api/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/permissions\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>true</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.30</address>\n
         \           <path>/vol/rhev31share2/rhevm-data</path>\n        </storage>\n
         \       <available>16106127360</available>\n        <used>1073741824</used>\n
         \       <committed>0</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b\"
         id=\"244bf930-fe4c-4458-81b1-c1cf33d4081b\">\n        <name>RHEVM31-Rspec1</name>\n
-        \       <link href=\"/api/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/permissions\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>false</master>\n
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
         id=\"FXdwmR-2eBU-wyhv-Pbxn-XECC-kdRC-KjXk31\"/>\n        </storage>\n        <available>10737418240</available>\n
         \       <used>4294967296</used>\n        <committed>0</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f\"
         id=\"efbe372b-7634-49f0-901e-0c05d526181f\">\n        <name>RHEVM31-gluster</name>\n
-        \       <link href=\"/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f/permissions\"
+        \       <link href=\"/ovirt-engine/api/storagedomains/efbe372b-7634-49f0-901e-0c05d526181f/permissions\"
         rel=\"permissions\"/>\n        <type>data</type>\n        <master>false</master>\n
         \       <storage>\n            <address>example.gluster.server.com</address>        <type>glusterfs</type>\n
         \        <path>/gv0</path>        </storage>\n        <available>16106127360</available>\n
@@ -416,7 +405,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/storagedomains?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.252.230/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -461,7 +450,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/datacenters
+    uri: https://192.168.252.230/ovirt-engine/api/datacenters
     body:
       encoding: US-ASCII
       string: ''
@@ -498,20 +487,20 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<data_centers>\n
-        \   <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \   <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\">\n        <name>Default</name>\n
-        \       <description>iSCSI</description>\n        <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains\"
-        rel=\"storagedomains\"/>\n        <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/quotas\"
+        \       <description>iSCSI</description>\n        <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains\"
+        rel=\"storagedomains\"/>\n        <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/quotas\"
         rel=\"quotas\"/>\n        <storage_type>iscsi</storage_type>\n        <storage_format>v3</storage_format>\n
         \       <version major=\"3\" minor=\"1\"/>\n        <supported_versions>\n
         \           <version major=\"3\" minor=\"1\"/>\n        </supported_versions>\n
         \       <status>\n            <state>up</state>\n        </status>\n    </data_center>\n
-        \   <data_center href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
+        \   <data_center href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
         id=\"773f2ddf-7765-42fc-85d6-673b718541cd\">\n        <name>NFS</name>\n        <link
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains\"
-        rel=\"storagedomains\"/>\n        <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/quotas\"
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains\"
+        rel=\"storagedomains\"/>\n        <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/quotas\"
         rel=\"quotas\"/>\n        <storage_type>nfs</storage_type>\n        <storage_format>v3</storage_format>\n
         \       <version major=\"3\" minor=\"1\"/>\n        <supported_versions>\n
         \           <version major=\"3\" minor=\"1\"/>\n        </supported_versions>\n
@@ -520,7 +509,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.252.230/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -557,25 +546,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<hosts>\n
-        \   <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\">\n
-        \       <actions>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/iscsilogin\"
-        rel=\"iscsilogin\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/iscsidiscover\"
-        rel=\"iscsidiscover\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/commitnetconfig\"
-        rel=\"commitnetconfig\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/approve\"
-        rel=\"approve\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/fence\"
-        rel=\"fence\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/install\"
-        rel=\"install\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/activate\"
+        \   <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/iscsilogin\"
+        rel=\"iscsilogin\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/iscsidiscover\"
+        rel=\"iscsidiscover\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/commitnetconfig\"
+        rel=\"commitnetconfig\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/approve\"
+        rel=\"approve\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/fence\"
+        rel=\"fence\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/install\"
+        rel=\"install\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>per410-rh1</name>\n
-        \       <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/storage\"
-        rel=\"storage\"/>\n        <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics\"
+        \       <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/storage\"
+        rel=\"storage\"/>\n        <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics\"
         rel=\"statistics\"/>\n        <address>192.168.252.232</address>\n        <certificate>\n
         \           <organization>manageiq.com</organization>\n            <subject>O=manageiq.com,CN=192.168.252.232</subject>\n
         \       </certificate>\n        <status>\n            <state>up</state>\n
-        \       </status>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \       </status>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <port>54321</port>\n
         \       <type>rhel</type>\n        <storage_manager priority=\"5\">true</storage_manager>\n
         \       <power_management>\n            <enabled>false</enabled>\n            <options>\n
@@ -588,26 +577,26 @@ http_interactions:
         Xeon(R) CPU           E5504  @ 2.00GHz</name>\n            <speed>1995</speed>\n
         \       </cpu>\n        <memory>59069431808</memory>\n        <max_scheduling_memory>87125131264</max_scheduling_memory>\n
         \       <summary>\n            <active>1</active>\n            <migrating>0</migrating>\n
-        \           <total>1</total>\n        </summary>\n    </host>\n    <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
+        \           <total>1</total>\n        </summary>\n    </host>\n    <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
         id=\"6ab50456-d4f9-11e2-931e-005056a217db\">\n        <actions>\n            <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/deactivate\" rel=\"deactivate\"/>\n
-        \           <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/iscsilogin\"
-        rel=\"iscsilogin\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/iscsidiscover\"
-        rel=\"iscsidiscover\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/commitnetconfig\"
-        rel=\"commitnetconfig\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/approve\"
-        rel=\"approve\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/fence\"
-        rel=\"fence\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/install\"
-        rel=\"install\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/activate\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/deactivate\" rel=\"deactivate\"/>\n
+        \           <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/iscsilogin\"
+        rel=\"iscsilogin\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/iscsidiscover\"
+        rel=\"iscsidiscover\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/commitnetconfig\"
+        rel=\"commitnetconfig\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/approve\"
+        rel=\"approve\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/fence\"
+        rel=\"fence\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/install\"
+        rel=\"install\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rhelh-nfs</name>\n        <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/storage\" rel=\"storage\"/>\n
-        \       <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/storage\" rel=\"storage\"/>\n
+        \       <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics\"
         rel=\"statistics\"/>\n        <address>192.168.252.233</address>\n        <certificate>\n
         \           <organization>manageiq.com</organization>\n            <subject>O=manageiq.com,CN=192.168.252.233</subject>\n
         \       </certificate>\n        <status>\n            <state>up</state>\n
-        \       </status>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \       </status>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <port>54321</port>\n
         \       <type>rhel</type>\n        <storage_manager priority=\"5\">true</storage_manager>\n
         \       <power_management>\n            <enabled>false</enabled>\n            <options>\n
@@ -625,7 +614,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:22 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.252.230/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -670,7 +659,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:23 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.252.230/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -707,25 +696,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<vms>\n
-        \   <vm href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7\" id=\"8e58fa33-8026-4a01-9802-4ee1850bb9f7\">\n
-        \       <actions>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7\" id=\"8e58fa33-8026-4a01-9802-4ee1850bb9f7\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/move\"
         rel=\"move\"/>\n        </actions>\n        <name>aab_demo_vm</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -733,33 +722,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-01T10:51:58.562-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <host id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b\" id=\"32de8c66-3c57-490e-8f4c-6bacaad1243b\">\n
-        \       <actions>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b\" id=\"32de8c66-3c57-490e-8f4c-6bacaad1243b\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/move\"
         rel=\"move\"/>\n        </actions>\n        <name>aab_test_vm</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -767,33 +756,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-01T09:20:14.321-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <host id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\" id=\"d5ff6544-89ab-4f27-b92c-ae900e3dfe12\">\n
-        \       <actions>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\" id=\"d5ff6544-89ab-4f27-b92c-ae900e3dfe12\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/move\"
         rel=\"move\"/>\n        </actions>\n        <name>abc123</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -801,33 +790,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-15T11:15:46.506-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\" id=\"bde561cd-0ce4-444f-9480-5e51a4e963f3\">\n
-        \       <actions>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\" id=\"bde561cd-0ce4-444f-9480-5e51a4e963f3\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/move\"
         rel=\"move\"/>\n        </actions>\n        <name>abc1234</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -835,33 +824,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-15T11:16:20.987-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7\" id=\"c6f023ac-f06e-4723-9047-6a61a802bef7\">\n
-        \       <actions>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7\" id=\"c6f023ac-f06e-4723-9047-6a61a802bef7\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd1</name>\n        <description>bd1</description>\n
-        \       <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -870,33 +859,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-05T10:24:00.586-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\" id=\"fa5a0cbc-b671-48de-beba-56babcbae127\">\n
-        \       <actions>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\" id=\"fa5a0cbc-b671-48de-beba-56babcbae127\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/move\"
         rel=\"move\"/>\n        </actions>\n        <name>BD-F17-Desktop</name>\n
-        \       <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/statistics\"
         rel=\"statistics\"/>\n        <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -905,33 +894,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-08T17:14:46.048-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\" id=\"243bdb1e-f460-432b-868f-4a5f8a7a3c96\">\n
-        \       <actions>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\" id=\"243bdb1e-f460-432b-868f-4a5f8a7a3c96\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd-isotest-14-ir</name>\n
-        \       <description></description>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/statistics\"
+        \       <description></description>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -939,33 +928,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-14T18:11:34.131-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\" id=\"9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\">\n
-        \       <actions>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\" id=\"9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd-isotest-14-pr</name>\n
-        \       <description></description>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/statistics\"
+        \       <description></description>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -973,33 +962,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-14T17:48:20.837-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac\" id=\"222f6caa-9956-4103-8356-013c98be17ac\">\n
-        \       <actions>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac\" id=\"222f6caa-9956-4103-8356-013c98be17ac\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd-testiso1</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1007,33 +996,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-05-08T14:11:15.992-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <host id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\" id=\"695cfd4d-23a5-4328-abb0-8d92dd1a5386\">\n
-        \       <actions>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\" id=\"695cfd4d-23a5-4328-abb0-8d92dd1a5386\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd-wintest</name>\n        <link
-        href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/statistics\"
+        href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>8589934592</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1042,33 +1031,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-16T18:15:40.472-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>1431306240</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\" id=\"9bfc3fd5-ce6a-4ba2-87aa-571955f03884\">\n
-        \       <actions>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\" id=\"9bfc3fd5-ce6a-4ba2-87aa-571955f03884\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bd-wintest-01-18-c</name>\n
-        \       <description></description>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/statistics\"
+        \       <description></description>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1076,33 +1065,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-18T12:46:07.349-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2147483648</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9\" id=\"a9c8a38e-c458-4d00-af1b-67feff947ac9\">\n
-        \       <actions>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9\" id=\"a9c8a38e-c458-4d00-af1b-67feff947ac9\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/move\"
         rel=\"move\"/>\n        </actions>\n        <name>bill-t1</name>\n        <link
-        href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/statistics\"
+        href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>805306368</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1111,34 +1100,34 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-05-30T17:16:53.922-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>357564416</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5\" id=\"999fa9c0-f708-4850-b825-c0e22041d0b5\">\n
-        \       <actions>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5\" id=\"999fa9c0-f708-4850-b825-c0e22041d0b5\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/move\"
         rel=\"move\"/>\n        </actions>\n        <name>EmsRefreshSpec-NoDisks-NoNics</name>\n
         \       <description>EmsRefreshSpec-NoDisks-NoNics</description>\n        <link
-        href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/statistics\"
+        href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1147,34 +1136,34 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-06-24T14:06:42.156-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>357564416</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\" id=\"26a050fb-62c3-4645-9088-be6efec860e1\">\n
-        \       <actions>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\" id=\"26a050fb-62c3-4645-9088-be6efec860e1\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/move\"
         rel=\"move\"/>\n        </actions>\n        <name>EmsRefreshSpec-PoweredOff</name>\n
         \       <description>Powered Off VM for EmsRefresh testing</description>\n
-        \       <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1183,34 +1172,34 @@ http_interactions:
         \       <high_availability>\n            <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2012-12-05T10:30:15.289-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\" id=\"fe052832-2350-48ce-8e56-c24b4cd91876\">\n
-        \       <actions>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\" id=\"fe052832-2350-48ce-8e56-c24b4cd91876\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/move\"
         rel=\"move\"/>\n        </actions>\n        <name>EmsRefreshSpec-PoweredOn</name>\n
         \       <description>Powered On VM for EmsRefresh testing with DirectLUN Disk</description>\n
-        \       <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>up</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1221,9 +1210,9 @@ http_interactions:
         \           <address>192.168.252.232</address>\n            <port>5900</port>\n
         \           <secure_port>5901</secure_port>\n            <monitors>1</monitors>\n
         \           <allow_override>false</allow_override>\n        </display>\n        <host
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \       <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \       <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <start_time>2014-10-07T17:01:24.183-04:00</start_time>\n
         \       <creation_time>2012-12-05T10:29:47.707-05:00</creation_time>\n        <origin>rhev</origin>\n
         \       <stateless>false</stateless>\n        <placement_policy>\n            <affinity>migratable</affinity>\n
@@ -1231,26 +1220,26 @@ http_interactions:
         \       </memory_policy>\n        <guest_info>\n            <ips>\n                <ip
         address=\"192.168.253.45\"/>\n            </ips>\n        </guest_info>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n        <usb>\n
-        \           <enabled>false</enabled>\n        </usb>\n    </vm>\n    <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \           <enabled>false</enabled>\n        </usb>\n    </vm>\n    <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/cancelmigration\" rel=\"cancelmigration\"/>\n
-        \           <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/move\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/cancelmigration\" rel=\"cancelmigration\"/>\n
+        \           <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/move\"
         rel=\"move\"/>\n        </actions>\n        <name>evm-5012</name>\n        <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/statistics\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1259,33 +1248,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-12T10:38:18.310-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\" id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\">\n
-        \       <actions>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\" id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/move\"
         rel=\"move\"/>\n        </actions>\n        <name>EVM-DHS-Test</name>\n        <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/statistics\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1294,33 +1283,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2012-12-06T11:51:08.497-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44\" id=\"64c1e578-8859-4ea7-a0f6-f294580d7d44\">\n
-        \       <actions>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44\" id=\"64c1e578-8859-4ea7-a0f6-f294580d7d44\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/move\"
         rel=\"move\"/>\n        </actions>\n        <name>lucy_cpu</name>\n        <link
-        href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/statistics\"
+        href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"16\" cores=\"4\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1329,33 +1318,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-18T15:53:39.455-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5\" id=\"4d24cc69-5257-4efa-b610-ce43ce1884f5\">\n
-        \       <actions>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5\" id=\"4d24cc69-5257-4efa-b610-ce43ce1884f5\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/move\"
         rel=\"move\"/>\n        </actions>\n        <name>lucy_cpu7</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"16\" cores=\"4\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1364,33 +1353,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-18T17:24:03.755-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <host id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\" id=\"5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\">\n
-        \       <actions>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\" id=\"5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/move\"
         rel=\"move\"/>\n        </actions>\n        <name>lucy_cpu8</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2122317824</memory>\n        <cpu>\n            <topology
         sockets=\"3\" cores=\"2\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1398,33 +1387,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-18T17:27:24.807-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <host id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n            <affinity>migratable</affinity>\n
         \       </placement_policy>\n        <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\" id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\">\n
-        \       <actions>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\" id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/move\"
         rel=\"move\"/>\n        </actions>\n        <name>lucy-test</name>\n        <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/statistics\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/statistics\"
         rel=\"statistics\"/>\n        <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>2122317824</memory>\n        <cpu>\n            <topology
         sockets=\"5\" cores=\"4\"/>\n        </cpu>\n        <os type=\"rhel_6\">\n
@@ -1433,33 +1422,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>vnc</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-09-17T16:24:26.136-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>357564416</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\" id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\">\n
-        \       <actions>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\" id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/move\"
         rel=\"move\"/>\n        </actions>\n        <name>miqutil</name>\n        <description>MIQ
-        Utility Server (Do NOT Power Off)</description>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/statistics\"
+        Utility Server (Do NOT Power Off)</description>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
@@ -1468,33 +1457,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2012-12-20T13:26:00.822-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>536870912</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\" id=\"b6a1aa0d-a057-482d-8bff-1d2036f889fd\">\n
-        \       <actions>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\" id=\"b6a1aa0d-a057-482d-8bff-1d2036f889fd\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/move\"
         rel=\"move\"/>\n        </actions>\n        <name>MK_AUG_05_003_DELETE</name>\n
-        \       <description></description>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/statistics\"
+        \       <description></description>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
@@ -1503,33 +1492,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2014-08-05T10:15:26.371-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\" id=\"f2cd9e78-15f7-47a3-94a6-137c36958bea\">\n
-        \       <actions>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\" id=\"f2cd9e78-15f7-47a3-94a6-137c36958bea\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/move\"
         rel=\"move\"/>\n        </actions>\n        <name>rmtest06</name>\n        <description></description>\n
-        \       <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/statistics\"
+        \       <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
@@ -1537,33 +1526,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-01-16T17:23:15.786-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>1073741824</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\" id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\">\n
-        \       <actions>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\" id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/move\"
         rel=\"move\"/>\n        </actions>\n        <name>rpo-evm-iscsi</name>\n        <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/statistics\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/statistics\"
         rel=\"statistics\"/>\n        <type>server</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
@@ -1572,33 +1561,33 @@ http_interactions:
         \           <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>true</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-04-22T15:52:40.767-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>2862612480</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\" id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\">\n
-        \       <actions>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\" id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/move\"
         rel=\"move\"/>\n        </actions>\n        <name>rpo-test1</name>\n        <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/statistics\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/statistics\"
         rel=\"statistics\"/>\n        <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
@@ -1607,33 +1596,33 @@ http_interactions:
         \       <high_availability>\n            <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
-        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-04-25T17:04:06.570-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
         \       <memory_policy>\n            <guaranteed>715128832</guaranteed>\n
         \       </memory_policy>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
         \       <usb>\n            <enabled>false</enabled>\n        </usb>\n    </vm>\n
-        \   <vm href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\" id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\">\n
-        \       <actions>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/cancelmigration\"
-        rel=\"cancelmigration\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/ticket\"
-        rel=\"ticket\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/migrate\"
-        rel=\"migrate\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/shutdown\"
-        rel=\"shutdown\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/start\"
-        rel=\"start\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/stop\"
-        rel=\"stop\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/suspend\"
-        rel=\"suspend\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/detach\"
-        rel=\"detach\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/export\"
-        rel=\"export\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/move\"
+        \   <vm href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\" id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/cancelmigration\"
+        rel=\"cancelmigration\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/ticket\"
+        rel=\"ticket\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/migrate\"
+        rel=\"migrate\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/shutdown\"
+        rel=\"shutdown\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/start\"
+        rel=\"start\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/stop\"
+        rel=\"stop\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/suspend\"
+        rel=\"suspend\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/detach\"
+        rel=\"detach\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/export\"
+        rel=\"export\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/move\"
         rel=\"move\"/>\n        </actions>\n        <name>rpo-test2</name>\n        <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots\"
-        rel=\"snapshots\"/>\n        <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/tags\"
-        rel=\"tags\"/>\n        <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/permissions\"
-        rel=\"permissions\"/>\n        <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/statistics\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots\"
+        rel=\"snapshots\"/>\n        <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/tags\"
+        rel=\"tags\"/>\n        <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/permissions\"
+        rel=\"permissions\"/>\n        <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/statistics\"
         rel=\"statistics\"/>\n        <type>desktop</type>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"other_linux\">\n
@@ -1642,8 +1631,8 @@ http_interactions:
         \       <high_availability>\n            <enabled>false</enabled>\n            <priority>1</priority>\n
         \       </high_availability>\n        <display>\n            <type>spice</type>\n
         \           <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
-        \       </display>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
-        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
+        \       </display>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <template href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
         id=\"00000000-0000-0000-0000-000000000000\"/>\n        <creation_time>2013-06-19T11:32:42.460-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <stateless>false</stateless>\n        <placement_policy>\n
         \           <affinity>migratable</affinity>\n        </placement_policy>\n
@@ -1654,7 +1643,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:23 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.252.230/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -1699,7 +1688,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:23 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates
+    uri: https://192.168.252.230/ovirt-engine/api/templates
     body:
       encoding: US-ASCII
       string: ''
@@ -1736,214 +1725,214 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<templates>\n
-        \   <template href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23\"
+        \   <template href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23\"
         id=\"b14e3c9f-a171-4d23-b3e2-da423d1d2a23\">\n        <actions>\n            <link
-        href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/export\" rel=\"export\"/>\n
+        href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/export\" rel=\"export\"/>\n
         \       </actions>\n        <name>757e824d-6d97-4568-be29-9346c354e802</name>\n
-        \       <description>RedHat CloudForms 3.0</description>\n        <link href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/permissions\"
+        \       <description>ManageIQ</description>\n        <link href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>6442450944</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"4\"/>\n        </cpu>\n        <os type=\"rhel_6\">\n
         \           <boot dev=\"cdrom\"/>\n            <boot dev=\"hd\"/>\n        </os>\n
-        \       <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \       <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <creation_time>2013-12-19T15:58:45.000-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264\" id=\"54f1b9f4-0e89-4c72-9a26-f94dcb857264\">\n
-        \       <actions>\n            <link href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/export\"
+        href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264\" id=\"54f1b9f4-0e89-4c72-9a26-f94dcb857264\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/export\"
         rel=\"export\"/>\n        </actions>\n        <name>bd-clone-template</name>\n
-        \       <link href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/permissions\"
+        \       <link href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
-        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <creation_time>2013-08-27T12:44:45.072-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\" id=\"e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\">\n
-        \       <actions>\n            <link href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/export\"
+        href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\" id=\"e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/export\"
         rel=\"export\"/>\n        </actions>\n        <name>bd-temp1</name>\n        <link
-        href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/permissions\"
+        href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"2\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <creation_time>2013-11-02T00:33:26.393-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/00000000-0000-0000-0000-000000000000\" id=\"00000000-0000-0000-0000-000000000000\">\n
-        \       <actions>\n            <link href=\"/api/templates/00000000-0000-0000-0000-000000000000/export\"
+        href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\" id=\"00000000-0000-0000-0000-000000000000\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/export\"
         rel=\"export\"/>\n        </actions>\n        <name>Blank</name>\n        <description>Blank
-        template</description>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000/permissions\"
+        template</description>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/permissions\"
         rel=\"permissions\"/>\n        <type>desktop</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>536870912</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2008-04-01T00:00:00.000-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\" id=\"f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\">\n
-        \       <actions>\n            <link href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/export\"
+        href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\" id=\"f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/export\"
         rel=\"export\"/>\n        </actions>\n        <name>CFME_Base</name>\n        <link
-        href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/permissions\"
+        href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"2\"/>\n        </cpu>\n        <os type=\"unassigned\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2013-05-23T14:54:18.118-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\" id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\">\n
-        \       <actions>\n            <link href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/export\"
+        href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\" id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/export\"
         rel=\"export\"/>\n        </actions>\n        <name>EmsRefreshSpec-Template</name>\n
         \       <description>Template for EmsRefresh testing</description>\n        <link
-        href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks\" rel=\"disks\"/>\n
-        \       <link href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/permissions\"
+        href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks\" rel=\"disks\"/>\n
+        \       <link href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <boot dev=\"cdrom\"/>\n            <kernel></kernel>\n
         \           <initrd></initrd>\n            <cmdline></cmdline>\n        </os>\n
-        \       <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \       <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2012-09-26T14:43:23.000-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\" id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\">\n
-        \       <actions>\n            <link href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/export\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\" id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/export\"
         rel=\"export\"/>\n        </actions>\n        <name>EVM-v50017</name>\n        <description>EVM
-        v5.0.0.17 RedHat Appliance</description>\n        <link href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/permissions\"
+        v5.0.0.17 RedHat Appliance</description>\n        <link href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2012-10-09T09:21:58.000-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\" id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\">\n
-        \       <actions>\n            <link href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/export\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\" id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/export\"
         rel=\"export\"/>\n        </actions>\n        <name>EVM-v50025</name>\n        <description>EVM
-        appliance v5.0.0.25</description>\n        <link href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/permissions\"
+        appliance v5.0.0.25</description>\n        <link href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2012-12-18T16:59:24.000-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\" id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\">\n
-        \       <actions>\n            <link href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/export\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\" id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/export\"
         rel=\"export\"/>\n        </actions>\n        <name>evm-v5012</name>\n        <description>EVM
-        5.0.1.2</description>\n        <link href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/permissions\"
+        5.0.1.2</description>\n        <link href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>4294967296</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_5x64\">\n
-        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <boot dev=\"hd\"/>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2013-01-15T21:53:21.000-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>0</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8\" id=\"ce04bf8d-70d7-489a-9107-b294211636c8\">\n
-        \       <actions>\n            <link href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/export\"
+        href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8\" id=\"ce04bf8d-70d7-489a-9107-b294211636c8\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/export\"
         rel=\"export\"/>\n        </actions>\n        <name>prov-template</name>\n
-        \       <link href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/permissions\"
+        \       <link href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
-        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
+        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/5be5d08a-a60b-11e2-bee6-005056a217db\"
         id=\"5be5d08a-a60b-11e2-bee6-005056a217db\"/>\n        <creation_time>2013-07-29T12:31:01.139-04:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b\" id=\"63d4a24f-0f57-46fe-b918-063f476a5d8b\">\n
-        \       <actions>\n            <link href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/export\"
+        href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b\" id=\"63d4a24f-0f57-46fe-b918-063f476a5d8b\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/export\"
         rel=\"export\"/>\n        </actions>\n        <name>PxeRhelRhevm31</name>\n
         \       <description>PXE Template for RHEL 6 Server on RHEVM 3.1</description>\n
-        \       <link href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/permissions\"
+        \       <link href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>2147483648</memory>\n        <cpu>\n            <topology
         sockets=\"2\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
-        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2012-12-06T15:59:56.722-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
         \           <type>spice</type>\n            <monitors>1</monitors>\n            <allow_override>false</allow_override>\n
         \       </display>\n        <stateless>false</stateless>\n        <usb>\n
         \           <enabled>false</enabled>\n        </usb>\n    </template>\n    <template
-        href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544\" id=\"cee7feb4-5112-42ed-97c5-9db37d332544\">\n
-        \       <actions>\n            <link href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/export\"
+        href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544\" id=\"cee7feb4-5112-42ed-97c5-9db37d332544\">\n
+        \       <actions>\n            <link href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/export\"
         rel=\"export\"/>\n        </actions>\n        <name>rmrhel</name>\n        <description>rod
-        test</description>\n        <link href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks\"
-        rel=\"disks\"/>\n        <link href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/nics\"
-        rel=\"nics\"/>\n        <link href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/cdroms\"
-        rel=\"cdroms\"/>\n        <link href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/permissions\"
+        test</description>\n        <link href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks\"
+        rel=\"disks\"/>\n        <link href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/nics\"
+        rel=\"nics\"/>\n        <link href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/cdroms\"
+        rel=\"cdroms\"/>\n        <link href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/permissions\"
         rel=\"permissions\"/>\n        <type>server</type>\n        <status>\n            <state>ok</state>\n
         \       </status>\n        <memory>1073741824</memory>\n        <cpu>\n            <topology
         sockets=\"1\" cores=\"1\"/>\n        </cpu>\n        <os type=\"rhel_6x64\">\n
         \           <boot dev=\"hd\"/>\n            <kernel></kernel>\n            <initrd></initrd>\n
-        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
+        \           <cmdline></cmdline>\n        </os>\n        <cluster href=\"/ovirt-engine/api/clusters/99408929-82cf-4dc7-a532-9d998063fa95\"
         id=\"99408929-82cf-4dc7-a532-9d998063fa95\"/>\n        <creation_time>2013-01-16T16:59:29.027-05:00</creation_time>\n
         \       <origin>rhev</origin>\n        <high_availability>\n            <enabled>false</enabled>\n
         \           <priority>1</priority>\n        </high_availability>\n        <display>\n
@@ -1954,7 +1943,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:24 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains
+    uri: https://192.168.252.230/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -1991,45 +1980,45 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96\"
+        \   <storage_domain href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96\"
         id=\"d0a7d751-46bc-495a-a312-e5d010059f96\">\n        <actions>\n            <link
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/activate\"
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/d0a7d751-46bc-495a-a312-e5d010059f96/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>RHEVM31-1</name>\n        <data_center
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
         \       <type>data</type>\n        <status>\n            <state>active</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>iscsi</type>\n
         \           <volume_group id=\"TKVvjS-2L08-F19O-Pewh-f9nl-xiKD-lfXzh7\"/>\n
         \       </storage>\n        <available>137438953472</available>\n        <used>136365211648</used>\n
         \       <committed>228707008512</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b\"
         id=\"244bf930-fe4c-4458-81b1-c1cf33d4081b\">\n        <actions>\n            <link
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/activate\"
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/244bf930-fe4c-4458-81b1-c1cf33d4081b/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>RHEVM31-Rspec1</name>\n
-        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <type>data</type>\n
         \       <status>\n            <state>active</state>\n        </status>\n        <master>false</master>\n
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
         id=\"FXdwmR-2eBU-wyhv-Pbxn-XECC-kdRC-KjXk31\"/>\n        </storage>\n        <available>10737418240</available>\n
         \       <used>4294967296</used>\n        <committed>0</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
         id=\"73072271-11c3-41aa-af23-37bf2fa185cd\">\n        <actions>\n            <link
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/activate\"
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>ISO</name>\n        <data_center
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\" id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n
         \       <type>iso</type>\n        <status>\n            <state>maintenance</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.230</address>\n            <path>/srv/ISO</path>\n
         \       </storage>\n        <available>27917287424</available>\n        <used>30064771072</used>\n
         \       <committed>0</committed>\n        <storage_format>v1</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f\"
         id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\">\n        <actions>\n            <link
-        href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/activate\"
+        href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db/storagedomains/6284e934-9f11-486a-b9d8-aaacfa4f226f/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>NetApp01Lun2</name>\n
-        \       <data_center href=\"/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/45b5a710-eccd-11e1-bc2c-005056a217db\"
         id=\"45b5a710-eccd-11e1-bc2c-005056a217db\"/>\n        <type>data</type>\n
         \       <status>\n            <state>active</state>\n        </status>\n        <master>true</master>\n
         \       <storage>\n            <type>iscsi</type>\n            <volume_group
@@ -2050,7 +2039,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:24 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains
+    uri: https://192.168.252.230/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -2087,47 +2076,47 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<storage_domains>\n
-        \   <storage_domain href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\"
+        \   <storage_domain href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b\"
         id=\"f291819d-6f09-4a5b-9e48-0bc40898362b\">\n        <actions>\n            <link
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/activate\"
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/f291819d-6f09-4a5b-9e48-0bc40898362b/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>Export</name>\n        <data_center
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
         \       <type>export</type>\n        <status>\n            <state>active</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.65</address>\n            <path>/srv/export</path>\n
         \       </storage>\n        <available>25769803776</available>\n        <used>37580963840</used>\n
         \       <committed>0</committed>\n        <storage_format>v1</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229\"
         id=\"62f9cdc1-5473-49f8-8128-e4db5d84d229\">\n        <actions>\n            <link
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/activate\"
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/62f9cdc1-5473-49f8-8128-e4db5d84d229/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>RHEVM31-NFS2</name>\n
-        \       <data_center href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
         id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n        <type>data</type>\n
         \       <status>\n            <state>active</state>\n        </status>\n        <master>true</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.30</address>\n
         \           <path>/vol/rhev31share2/rhevm-data</path>\n        </storage>\n
         \       <available>16106127360</available>\n        <used>1073741824</used>\n
         \       <committed>0</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"
         id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\">\n        <actions>\n            <link
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/activate\"
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>RHEVM31-NFS1</name>\n
-        \       <data_center href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
+        \       <data_center href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\"
         id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n        <type>data</type>\n
         \       <status>\n            <state>active</state>\n        </status>\n        <master>false</master>\n
         \       <storage>\n            <type>nfs</type>\n            <address>192.168.252.30</address>\n
         \           <path>/vol/rhev31share1/rhevm-data</path>\n        </storage>\n
         \       <available>76235669504</available>\n        <used>10737418240</used>\n
         \       <committed>199715979264</committed>\n        <storage_format>v3</storage_format>\n
-        \   </storage_domain>\n    <storage_domain href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
+        \   </storage_domain>\n    <storage_domain href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd\"
         id=\"73072271-11c3-41aa-af23-37bf2fa185cd\">\n        <actions>\n            <link
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/activate\"
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd/storagedomains/73072271-11c3-41aa-af23-37bf2fa185cd/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>ISO</name>\n        <data_center
-        href=\"/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
+        href=\"/ovirt-engine/api/datacenters/773f2ddf-7765-42fc-85d6-673b718541cd\" id=\"773f2ddf-7765-42fc-85d6-673b718541cd\"/>\n
         \       <type>iso</type>\n        <status>\n            <state>active</state>\n
         \       </status>\n        <master>false</master>\n        <storage>\n            <type>nfs</type>\n
         \           <address>192.168.252.230</address>\n            <path>/srv/ISO</path>\n
@@ -2138,7 +2127,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:24 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics
+    uri: https://192.168.252.230/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics
     body:
       encoding: US-ASCII
       string: ''
@@ -2175,102 +2164,102 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<statistics>\n
-        \   <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\"
+        \   <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\"
         id=\"7816602b-c05c-3db7-a4da-3769f7ad8896\">\n        <name>memory.total</name>\n
         \       <description>Total memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>59069431808</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\"
         id=\"b7499508-c1c3-32f0-8174-c1783e57bb08\">\n        <name>memory.used</name>\n
         \       <description>Used memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>2953471590</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\"
         id=\"5a0fba9d-33d7-3cbf-addd-ba462040c946\">\n        <name>memory.free</name>\n
         \       <description>Free memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>56115960218</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc\"
         id=\"ffc0e1fd-fa34-3f85-9862-8a841c1658bc\">\n        <name>memory.shared</name>\n
         \       <description>Shared memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\"
         id=\"c81c86f0-bc61-3c78-a543-898b8339d03f\">\n        <name>memory.buffers</name>\n
         \       <description>IO buffers</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\"
         id=\"1b6244ee-8dbd-365d-8762-482ddc05ee11\">\n        <name>memory.cached</name>\n
         \       <description>OS caches</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\"
         id=\"c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\">\n        <name>swap.total</name>\n
         \       <description>Total swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>52427751424</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\"
         id=\"1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\">\n        <name>swap.free</name>\n
         \       <description>Free swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>52427751424</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\"
         id=\"27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\">\n        <name>swap.used</name>\n
         \       <description>Used swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\"
         id=\"ea00da15-de2d-3393-a7cb-810c4b19ed07\">\n        <name>swap.cached</name>\n
         \       <description>Swap also in memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\"
         id=\"f740b9ad-14a7-3f6c-9b80-efff44777169\">\n        <name>ksm.cpu.current</name>\n
         \       <description>KSM CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\"
         id=\"a1fab379-66e2-3b1d-9914-81a9e79cb719\">\n        <name>cpu.current.user</name>\n
         \       <description>User CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>1</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\"
         id=\"a98c1e11-078c-3593-a57e-4b12c1ce9815\">\n        <name>cpu.current.system</name>\n
         \       <description>System CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>1</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\"
         id=\"4ae97794-f56d-3f05-a9e7-8798887cd1ac\">\n        <name>cpu.current.idle</name>\n
         \       <description>Idle CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>99</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/65860dae-c890-312e-9314-5c01f31225ab\"
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/statistics/65860dae-c890-312e-9314-5c01f31225ab\"
         id=\"65860dae-c890-312e-9314-5c01f31225ab\">\n        <name>cpu.load.avg.5m</name>\n
         \       <description>CPU 5 minute load average</description>\n        <values
         type=\"DECIMAL\">\n            <value>\n                <datum>0.14</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
+        \       <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\" id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n
         \   </statistic>\n</statistics>\n"
     http_version: 
   recorded_at: Wed, 08 Oct 2014 01:27:24 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics
+    uri: https://192.168.252.230/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2307,41 +2296,41 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<host_nics>\n
-        \   <actions>\n        <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/setupnetworks\"
-        rel=\"setupnetworks\"/>\n    </actions>\n    <host_nic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c\"
+        \   <actions>\n        <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/setupnetworks\"
+        rel=\"setupnetworks\"/>\n    </actions>\n    <host_nic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c\"
         id=\"1e783be8-fe80-456e-9a19-42329b03f28c\">\n        <actions>\n            <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/attach\"
-        rel=\"attach\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/detach\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/attach\"
+        rel=\"attach\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/detach\"
         rel=\"detach\"/>\n        </actions>\n        <name>em1</name>\n        <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/statistics\"
-        rel=\"statistics\"/>\n        <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
-        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/1e783be8-fe80-456e-9a19-42329b03f28c/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
+        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <mac address=\"00:24:e8:69:f0:b5\"/>\n
         \       <ip address=\"192.168.252.232\" netmask=\"255.255.254.0\" gateway=\"192.168.252.1\"/>\n
         \       <boot_protocol>static</boot_protocol>\n        <speed>1000000000</speed>\n
         \       <status>\n            <state>up</state>\n        </status>\n        <mtu>1500</mtu>\n
         \       <bridged>true</bridged>\n        <custom_configuration>false</custom_configuration>\n
-        \   </host_nic>\n    <host_nic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793\"
+        \   </host_nic>\n    <host_nic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793\"
         id=\"9790f7a9-d2ec-42dd-9d19-b52b1f96a793\">\n        <actions>\n            <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/attach\"
-        rel=\"attach\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/detach\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/attach\"
+        rel=\"attach\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/detach\"
         rel=\"detach\"/>\n        </actions>\n        <name>em2</name>\n        <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/statistics\"
-        rel=\"statistics\"/>\n        <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
-        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/api/networks/5fdbd265-0ead-4038-ba68-39ef4deafcd6\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/9790f7a9-d2ec-42dd-9d19-b52b1f96a793/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
+        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/ovirt-engine/api/networks/5fdbd265-0ead-4038-ba68-39ef4deafcd6\"
         id=\"5fdbd265-0ead-4038-ba68-39ef4deafcd6\"/>\n        <mac address=\"00:24:e8:69:f0:b6\"/>\n
         \       <ip address=\"\" netmask=\"\"/>\n        <boot_protocol>static</boot_protocol>\n
         \       <speed>1000000000</speed>\n        <status>\n            <state>up</state>\n
         \       </status>\n        <mtu>1500</mtu>\n        <bridged>false</bridged>\n
         \       <custom_configuration>false</custom_configuration>\n    </host_nic>\n
-        <host_nic href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92\"
+        <host_nic href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92\"
         id=\"f2585809-3563-483a-8b62-e9976c7d1d92\">\n        <actions>\n        <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/attach\"
-        rel=\"attach\"/>\n            <link href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/detach\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/attach\"
+        rel=\"attach\"/>\n            <link href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/detach\"
         rel=\"detach\"/>\n        </actions>\n        <name>em3</name>\n        <link
-        href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/statistics\"
-        rel=\"statistics\"/>\n        <host href=\"/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
-        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
+        href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db/nics/f2585809-3563-483a-8b62-e9976c7d1d92/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/ovirt-engine/api/hosts/2f1d11cc-e269-11e2-839c-005056a217db\"
+        id=\"2f1d11cc-e269-11e2-839c-005056a217db\"/>\n        <network href=\"/ovirt-engine/api/networks/249d49d3-e0e6-444d-a1f1-f62a1c5d69b0\"
         id=\"b167e5b4-1c68-429c-8c82-14fe668739af\"/>\n        <mac address=\"00:24:e8:69:f0:cc\"/>\n
         \       <speed>1000000000</speed>\n        <status>\n            <state>down</state>\n
         \       </status>\n        <mtu>1500</mtu>\n        <bridged>false</bridged>\n
@@ -2350,7 +2339,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:24 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics
+    uri: https://192.168.252.230/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics
     body:
       encoding: US-ASCII
       string: ''
@@ -2387,102 +2376,102 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<statistics>\n
-        \   <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\"
+        \   <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/7816602b-c05c-3db7-a4da-3769f7ad8896\"
         id=\"7816602b-c05c-3db7-a4da-3769f7ad8896\">\n        <name>memory.total</name>\n
         \       <description>Total memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>8185184256</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/b7499508-c1c3-32f0-8174-c1783e57bb08\"
         id=\"b7499508-c1c3-32f0-8174-c1783e57bb08\">\n        <name>memory.used</name>\n
         \       <description>Used memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>491111055</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/5a0fba9d-33d7-3cbf-addd-ba462040c946\"
         id=\"5a0fba9d-33d7-3cbf-addd-ba462040c946\">\n        <name>memory.free</name>\n
         \       <description>Free memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>7694073201</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/ffc0e1fd-fa34-3f85-9862-8a841c1658bc\"
         id=\"ffc0e1fd-fa34-3f85-9862-8a841c1658bc\">\n        <name>memory.shared</name>\n
         \       <description>Shared memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/c81c86f0-bc61-3c78-a543-898b8339d03f\"
         id=\"c81c86f0-bc61-3c78-a543-898b8339d03f\">\n        <name>memory.buffers</name>\n
         \       <description>IO buffers</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/1b6244ee-8dbd-365d-8762-482ddc05ee11\"
         id=\"1b6244ee-8dbd-365d-8762-482ddc05ee11\">\n        <name>memory.cached</name>\n
         \       <description>OS caches</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\"
         id=\"c43847d7-3bc1-3aaf-b92c-902e64bbdb5b\">\n        <name>swap.total</name>\n
         \       <description>Total swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>8320450560</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\"
         id=\"1a4c1c9b-f3cc-301e-82ce-47d4b9fb5a46\">\n        <name>swap.free</name>\n
         \       <description>Free swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>8320450560</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\"
         id=\"27686b4e-ba8d-3576-bc70-d68cbd8a2ba9\">\n        <name>swap.used</name>\n
         \       <description>Used swap</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/ea00da15-de2d-3393-a7cb-810c4b19ed07\"
         id=\"ea00da15-de2d-3393-a7cb-810c4b19ed07\">\n        <name>swap.cached</name>\n
         \       <description>Swap also in memory</description>\n        <values type=\"INTEGER\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>BYTES</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/f740b9ad-14a7-3f6c-9b80-efff44777169\"
         id=\"f740b9ad-14a7-3f6c-9b80-efff44777169\">\n        <name>ksm.cpu.current</name>\n
         \       <description>KSM CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/a1fab379-66e2-3b1d-9914-81a9e79cb719\"
         id=\"a1fab379-66e2-3b1d-9914-81a9e79cb719\">\n        <name>cpu.current.user</name>\n
         \       <description>User CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/a98c1e11-078c-3593-a57e-4b12c1ce9815\"
         id=\"a98c1e11-078c-3593-a57e-4b12c1ce9815\">\n        <name>cpu.current.system</name>\n
         \       <description>System CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>0</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/4ae97794-f56d-3f05-a9e7-8798887cd1ac\"
         id=\"4ae97794-f56d-3f05-a9e7-8798887cd1ac\">\n        <name>cpu.current.idle</name>\n
         \       <description>Idle CPU usage</description>\n        <values type=\"DECIMAL\">\n
         \           <value>\n                <datum>100</datum>\n            </value>\n
         \       </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
-        \   </statistic>\n    <statistic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/65860dae-c890-312e-9314-5c01f31225ab\"
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \   </statistic>\n    <statistic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/statistics/65860dae-c890-312e-9314-5c01f31225ab\"
         id=\"65860dae-c890-312e-9314-5c01f31225ab\">\n        <name>cpu.load.avg.5m</name>\n
         \       <description>CPU 5 minute load average</description>\n        <values
         type=\"DECIMAL\">\n            <value>\n                <datum>0.020</datum>\n
         \           </value>\n        </values>\n        <type>GAUGE</type>\n        <unit>PERCENT</unit>\n
-        \       <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
+        \       <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\" id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n
         \   </statistic>\n</statistics>\n"
     http_version: 
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics
+    uri: https://192.168.252.230/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2519,25 +2508,25 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<host_nics>\n
-        \   <actions>\n        <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/setupnetworks\"
-        rel=\"setupnetworks\"/>\n    </actions>\n    <host_nic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3\"
+        \   <actions>\n        <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/setupnetworks\"
+        rel=\"setupnetworks\"/>\n    </actions>\n    <host_nic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3\"
         id=\"b95a36ef-fb73-4bc9-86b2-6707efb4d2f3\">\n        <actions>\n            <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/attach\"
-        rel=\"attach\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/detach\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/attach\"
+        rel=\"attach\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/detach\"
         rel=\"detach\"/>\n        </actions>\n        <name>eth1</name>\n        <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/statistics\"
-        rel=\"statistics\"/>\n        <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/b95a36ef-fb73-4bc9-86b2-6707efb4d2f3/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
         id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n        <mac address=\"e0:91:f5:1b:66:5b\"/>\n
         \       <ip address=\"\" netmask=\"\"/>\n        <boot_protocol>none</boot_protocol>\n
         \       <status>\n            <state>down</state>\n        </status>\n        <mtu>1500</mtu>\n
-        \       <bridged>false</bridged>\n    </host_nic>\n    <host_nic href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c\"
+        \       <bridged>false</bridged>\n    </host_nic>\n    <host_nic href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c\"
         id=\"920ae1ea-88d8-4005-ab69-f9595c6ddd6c\">\n        <actions>\n            <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/attach\"
-        rel=\"attach\"/>\n            <link href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/detach\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/attach\"
+        rel=\"attach\"/>\n            <link href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/detach\"
         rel=\"detach\"/>\n        </actions>\n        <name>eth0</name>\n        <link
-        href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/statistics\"
-        rel=\"statistics\"/>\n        <host href=\"/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
-        id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n        <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
+        href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db/nics/920ae1ea-88d8-4005-ab69-f9595c6ddd6c/statistics\"
+        rel=\"statistics\"/>\n        <host href=\"/ovirt-engine/api/hosts/6ab50456-d4f9-11e2-931e-005056a217db\"
+        id=\"6ab50456-d4f9-11e2-931e-005056a217db\"/>\n        <network href=\"/ovirt-engine/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"/>\n        <mac address=\"00:1d:09:06:9a:3c\"/>\n
         \       <ip address=\"192.168.252.233\" netmask=\"255.255.254.0\" gateway=\"192.168.252.1\"/>\n
         \       <boot_protocol>static</boot_protocol>\n        <speed>1000000000</speed>\n
@@ -2548,7 +2537,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2585,13 +2574,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d\"
+        \   <disk href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d\"
         id=\"1dad18e0-e7f0-4722-97f3-c36b48cec12d\">\n        <actions>\n            <link
-        href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/activate\"
+        href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>bd-clone_Disk1</name>\n
-        \       <link href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7\"
+        \       <link href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/disks/1dad18e0-e7f0-4722-97f3-c36b48cec12d/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7\"
         id=\"8e58fa33-8026-4a01-9802-4ee1850bb9f7\"/>\n        <alias>bd-clone_Disk1</alias>\n
         \       <image_id>3acbf2f1-7ea4-447a-9747-452c42b1515c</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -2606,7 +2595,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2643,9 +2632,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots/a9d2e78c-3c47-4ac1-9e41-28e65a7aa986\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots/a9d2e78c-3c47-4ac1-9e41-28e65a7aa986\"
         id=\"a9d2e78c-3c47-4ac1-9e41-28e65a7aa986\">\n        <actions>\n            <link
-        href=\"/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots/a9d2e78c-3c47-4ac1-9e41-28e65a7aa986/restore\"
+        href=\"/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/snapshots/a9d2e78c-3c47-4ac1-9e41-28e65a7aa986/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-01T10:51:58.569-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -2653,7 +2642,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8e58fa33-8026-4a01-9802-4ee1850bb9f7/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2698,7 +2687,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2735,13 +2724,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef\"
+        \   <disk href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef\"
         id=\"225dfbdd-b17a-4a4c-b845-5f345b1236ef\">\n        <actions>\n            <link
-        href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/activate\"
+        href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>bd-clone_Disk1</name>\n
-        \       <link href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b\"
+        \       <link href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/disks/225dfbdd-b17a-4a4c-b845-5f345b1236ef/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b\"
         id=\"32de8c66-3c57-490e-8f4c-6bacaad1243b\"/>\n        <alias>bd-clone_Disk1</alias>\n
         \       <image_id>157b1088-6e39-4ac9-aadb-564f5bd58cf0</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -2756,7 +2745,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:25 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2793,9 +2782,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots/e6bbe186-a704-416a-b3be-d3121cb01e74\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots/e6bbe186-a704-416a-b3be-d3121cb01e74\"
         id=\"e6bbe186-a704-416a-b3be-d3121cb01e74\">\n        <actions>\n            <link
-        href=\"/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots/e6bbe186-a704-416a-b3be-d3121cb01e74/restore\"
+        href=\"/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/snapshots/e6bbe186-a704-416a-b3be-d3121cb01e74/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-01T09:20:14.331-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -2803,7 +2792,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/32de8c66-3c57-490e-8f4c-6bacaad1243b/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2848,7 +2837,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2885,13 +2874,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878\"
+        \   <disk href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878\"
         id=\"701a4076-2290-46cc-bafa-93482ccb5878\">\n        <actions>\n            <link
-        href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/activate\"
+        href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"
+        \       <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/disks/701a4076-2290-46cc-bafa-93482ccb5878/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"
         id=\"d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>b78aa283-666b-4b63-95af-c5cd19527b7c</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -2906,7 +2895,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -2943,9 +2932,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots/216715aa-8705-48cc-8587-f8659379cde9\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots/216715aa-8705-48cc-8587-f8659379cde9\"
         id=\"216715aa-8705-48cc-8587-f8659379cde9\">\n        <actions>\n            <link
-        href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots/216715aa-8705-48cc-8587-f8659379cde9/restore\"
+        href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/snapshots/216715aa-8705-48cc-8587-f8659379cde9/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-15T11:15:46.536-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -2953,7 +2942,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -2990,14 +2979,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4\"
+        \   <nic href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4\"
         id=\"944f5d92-b2ff-4380-ac6c-85e0e30708b4\">\n        <actions>\n            <link
-        href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/activate\"
+        href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"
-        id=\"d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12/nics/944f5d92-b2ff-4380-ac6c-85e0e30708b4/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"
+        id=\"d5ff6544-89ab-4f27-b92c-ae900e3dfe12\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:60\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3005,7 +2994,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3042,13 +3031,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8\"
+        \   <disk href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8\"
         id=\"81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8\">\n        <actions>\n            <link
-        href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/activate\"
+        href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\"
+        \       <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/disks/81107fb7-a4f3-4e11-9d21-ac7bbc3d89f8/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\"
         id=\"bde561cd-0ce4-444f-9480-5e51a4e963f3\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>881a2988-3340-4957-90d3-c9c196cdd2af</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -3063,7 +3052,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3100,9 +3089,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots/52358208-f26c-4ede-b7ff-8c6d08b25169\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots/52358208-f26c-4ede-b7ff-8c6d08b25169\"
         id=\"52358208-f26c-4ede-b7ff-8c6d08b25169\">\n        <actions>\n            <link
-        href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots/52358208-f26c-4ede-b7ff-8c6d08b25169/restore\"
+        href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/snapshots/52358208-f26c-4ede-b7ff-8c6d08b25169/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-15T11:16:20.996-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3110,7 +3099,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3147,14 +3136,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c\"
+        \   <nic href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c\"
         id=\"b2a1ad70-8678-4071-8d28-bad38f05103c\">\n        <actions>\n            <link
-        href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/activate\"
+        href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\"
-        id=\"bde561cd-0ce4-444f-9480-5e51a4e963f3\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3/nics/b2a1ad70-8678-4071-8d28-bad38f05103c/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/bde561cd-0ce4-444f-9480-5e51a4e963f3\"
+        id=\"bde561cd-0ce4-444f-9480-5e51a4e963f3\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:ec\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3162,7 +3151,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:26 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3199,13 +3188,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e\"
+        \   <disk href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e\"
         id=\"f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e\">\n        <actions>\n            <link
-        href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/activate\"
+        href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>bd1_Disk1</name>\n        <link
-        href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7\"
+        href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/disks/f10d379e-fdf3-4e5d-bbcd-e44cf7546e2e/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7\"
         id=\"c6f023ac-f06e-4723-9047-6a61a802bef7\"/>\n        <alias>bd1_Disk1</alias>\n
         \       <image_id>cffb9fd8-ecb0-4b11-89ae-365a04b2080c</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -3220,7 +3209,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3257,9 +3246,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots/37cfea3b-6e6f-47f1-8569-e0bf4035afe1\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots/37cfea3b-6e6f-47f1-8569-e0bf4035afe1\"
         id=\"37cfea3b-6e6f-47f1-8569-e0bf4035afe1\">\n        <actions>\n            <link
-        href=\"/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots/37cfea3b-6e6f-47f1-8569-e0bf4035afe1/restore\"
+        href=\"/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/snapshots/37cfea3b-6e6f-47f1-8569-e0bf4035afe1/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-05T10:24:00.593-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3267,7 +3256,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/c6f023ac-f06e-4723-9047-6a61a802bef7/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3312,7 +3301,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3349,13 +3338,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2\"
+        \   <disk href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2\"
         id=\"d5e38b2f-2a1d-463d-aeb3-60a61248ffd2\">\n        <actions>\n            <link
-        href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/activate\"
+        href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>BD-F17-Desktop_Disk1</name>\n
-        \       <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\"
+        \       <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/disks/d5e38b2f-2a1d-463d-aeb3-60a61248ffd2/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\"
         id=\"fa5a0cbc-b671-48de-beba-56babcbae127\"/>\n        <alias>BD-F17-Desktop_Disk1</alias>\n
         \       <image_id>dedd8401-0fbe-4634-8d28-9eb1de80ca54</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -3370,7 +3359,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3407,9 +3396,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots/13ae9648-f716-4331-ba47-77b3ec1f77ac\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots/13ae9648-f716-4331-ba47-77b3ec1f77ac\"
         id=\"13ae9648-f716-4331-ba47-77b3ec1f77ac\">\n        <actions>\n            <link
-        href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots/13ae9648-f716-4331-ba47-77b3ec1f77ac/restore\"
+        href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/snapshots/13ae9648-f716-4331-ba47-77b3ec1f77ac/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-08T17:14:46.202-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3417,7 +3406,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3454,14 +3443,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6\"
+        \   <nic href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6\"
         id=\"e6a10a8f-8776-47e6-88fc-857945ac28c6\">\n        <actions>\n            <link
-        href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/activate\"
+        href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\"
-        id=\"fa5a0cbc-b671-48de-beba-56babcbae127\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127/nics/e6a10a8f-8776-47e6-88fc-857945ac28c6/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fa5a0cbc-b671-48de-beba-56babcbae127\"
+        id=\"fa5a0cbc-b671-48de-beba-56babcbae127\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:ed\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3469,7 +3458,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3506,13 +3495,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86\"
+        \   <disk href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86\"
         id=\"a8a2d3ca-d37a-4437-8a21-a7749c607d86\">\n        <actions>\n            <link
-        href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/activate\"
+        href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\"
+        \       <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/disks/a8a2d3ca-d37a-4437-8a21-a7749c607d86/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\"
         id=\"243bdb1e-f460-432b-868f-4a5f8a7a3c96\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>23e587c9-122e-4d83-8950-a1cd2382d1f2</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -3527,7 +3516,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:27 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3564,9 +3553,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots/a8a1e6dc-d4a5-414a-a1f3-fcf76cd853ce\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots/a8a1e6dc-d4a5-414a-a1f3-fcf76cd853ce\"
         id=\"a8a1e6dc-d4a5-414a-a1f3-fcf76cd853ce\">\n        <actions>\n            <link
-        href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots/a8a1e6dc-d4a5-414a-a1f3-fcf76cd853ce/restore\"
+        href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/snapshots/a8a1e6dc-d4a5-414a-a1f3-fcf76cd853ce/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-14T18:11:34.141-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3574,7 +3563,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3611,14 +3600,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282\"
+        \   <nic href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282\"
         id=\"69a8d626-4982-4f62-b806-7552a1b32282\">\n        <actions>\n            <link
-        href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/activate\"
+        href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\"
-        id=\"243bdb1e-f460-432b-868f-4a5f8a7a3c96\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96/nics/69a8d626-4982-4f62-b806-7552a1b32282/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/243bdb1e-f460-432b-868f-4a5f8a7a3c96\"
+        id=\"243bdb1e-f460-432b-868f-4a5f8a7a3c96\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:62\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3626,7 +3615,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3663,13 +3652,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79\"
+        \   <disk href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79\"
         id=\"8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79\">\n        <actions>\n            <link
-        href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/activate\"
+        href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"
+        \       <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/disks/8e6033f7-6e02-4c6a-b3c2-6f8b8fac9f79/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"
         id=\"9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>e7bc6956-fce8-444f-8e24-9c76e6ba625b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -3684,7 +3673,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3721,9 +3710,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots/3c841ae1-24e9-4938-845f-0068b3bf2506\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots/3c841ae1-24e9-4938-845f-0068b3bf2506\"
         id=\"3c841ae1-24e9-4938-845f-0068b3bf2506\">\n        <actions>\n            <link
-        href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots/3c841ae1-24e9-4938-845f-0068b3bf2506/restore\"
+        href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/snapshots/3c841ae1-24e9-4938-845f-0068b3bf2506/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-14T17:48:20.849-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3731,7 +3720,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3768,14 +3757,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d\"
+        \   <nic href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d\"
         id=\"a6edc4c0-8425-4874-9b4c-8079b707e60d\">\n        <actions>\n            <link
-        href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/activate\"
+        href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"
-        id=\"9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28/nics/a6edc4c0-8425-4874-9b4c-8079b707e60d/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"
+        id=\"9a17c2b2-5c6c-4dac-b5e7-9cb5843ebc28\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:67\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3783,7 +3772,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3820,13 +3809,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238\"
+        \   <disk href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238\"
         id=\"7cca8072-5e8a-41a4-9176-a7c68bbc9238\">\n        <actions>\n            <link
-        href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/activate\"
+        href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac\"
+        \       <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/disks/7cca8072-5e8a-41a4-9176-a7c68bbc9238/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac\"
         id=\"222f6caa-9956-4103-8356-013c98be17ac\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>fc7bfbaf-7017-4750-848f-46080628ee27</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -3841,7 +3830,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -3878,9 +3867,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots/f7181dd1-598b-4bdb-9aa3-042eb9544add\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots/f7181dd1-598b-4bdb-9aa3-042eb9544add\"
         id=\"f7181dd1-598b-4bdb-9aa3-042eb9544add\">\n        <actions>\n            <link
-        href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots/f7181dd1-598b-4bdb-9aa3-042eb9544add/restore\"
+        href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/snapshots/f7181dd1-598b-4bdb-9aa3-042eb9544add/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-05-08T14:11:16.027-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -3888,7 +3877,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:28 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -3925,14 +3914,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a\"
+        \   <nic href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a\"
         id=\"5171677a-c1ab-4818-9f51-67e8c85bcd0a\">\n        <actions>\n            <link
-        href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/activate\"
+        href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/222f6caa-9956-4103-8356-013c98be17ac\"
-        id=\"222f6caa-9956-4103-8356-013c98be17ac\"/>\n        <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
+        href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac/nics/5171677a-c1ab-4818-9f51-67e8c85bcd0a/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/222f6caa-9956-4103-8356-013c98be17ac\"
+        id=\"222f6caa-9956-4103-8356-013c98be17ac\"/>\n        <network href=\"/ovirt-engine/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:ef\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -3940,7 +3929,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -3977,13 +3966,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683\"
+        \   <disk href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683\"
         id=\"4528a149-e125-4b85-aeff-3e96a394c683\">\n        <actions>\n            <link
-        href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/activate\"
+        href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\"
+        \       <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/disks/4528a149-e125-4b85-aeff-3e96a394c683/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\"
         id=\"695cfd4d-23a5-4328-abb0-8d92dd1a5386\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>6f3eb79b-5ad9-4143-9a5f-3c559af361c0</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -3998,7 +3987,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4035,9 +4024,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots/e64a2cb5-bd02-43b6-ab16-b8b60d543048\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots/e64a2cb5-bd02-43b6-ab16-b8b60d543048\"
         id=\"e64a2cb5-bd02-43b6-ab16-b8b60d543048\">\n        <actions>\n            <link
-        href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots/e64a2cb5-bd02-43b6-ab16-b8b60d543048/restore\"
+        href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/snapshots/e64a2cb5-bd02-43b6-ab16-b8b60d543048/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-16T18:15:40.488-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -4045,7 +4034,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4082,14 +4071,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78\"
+        \   <nic href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78\"
         id=\"749dcd7c-77c6-40f4-9f0d-076416fafc78\">\n        <actions>\n            <link
-        href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/activate\"
+        href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\"
-        id=\"695cfd4d-23a5-4328-abb0-8d92dd1a5386\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386/nics/749dcd7c-77c6-40f4-9f0d-076416fafc78/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/695cfd4d-23a5-4328-abb0-8d92dd1a5386\"
+        id=\"695cfd4d-23a5-4328-abb0-8d92dd1a5386\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:ee\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -4097,7 +4086,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4134,13 +4123,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c\"
+        \   <disk href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c\"
         id=\"3d55fdb4-b404-4ef8-aa91-7b3001fca50c\">\n        <actions>\n            <link
-        href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/activate\"
+        href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"
+        \       <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/disks/3d55fdb4-b404-4ef8-aa91-7b3001fca50c/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"
         id=\"9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>f2bad0ae-b7d5-4568-8067-e966954905cd</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -4155,7 +4144,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4192,9 +4181,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots/b3f4ad63-7fe0-406c-b1b6-89a44ec084ad\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots/b3f4ad63-7fe0-406c-b1b6-89a44ec084ad\"
         id=\"b3f4ad63-7fe0-406c-b1b6-89a44ec084ad\">\n        <actions>\n            <link
-        href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots/b3f4ad63-7fe0-406c-b1b6-89a44ec084ad/restore\"
+        href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/snapshots/b3f4ad63-7fe0-406c-b1b6-89a44ec084ad/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-18T12:46:07.389-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -4202,7 +4191,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:29 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4239,14 +4228,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a\"
+        \   <nic href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a\"
         id=\"557a6462-1bbe-4ac2-81b1-fb6b5e28525a\">\n        <actions>\n            <link
-        href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/activate\"
+        href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"
-        id=\"9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884/nics/557a6462-1bbe-4ac2-81b1-fb6b5e28525a/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"
+        id=\"9bfc3fd5-ce6a-4ba2-87aa-571955f03884\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:66\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -4254,7 +4243,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4291,13 +4280,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a\"
+        \   <disk href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a\"
         id=\"2467950c-9757-438e-a0fa-1ffd3f9d351a\">\n        <actions>\n            <link
-        href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/activate\"
+        href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>bill-t1_Disk1</name>\n
-        \       <link href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9\"
+        \       <link href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/disks/2467950c-9757-438e-a0fa-1ffd3f9d351a/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9\"
         id=\"a9c8a38e-c458-4d00-af1b-67feff947ac9\"/>\n        <alias>bill-t1_Disk1</alias>\n
         \       <image_id>ec51a1af-9f0e-46d5-8832-9cb9019e44b9</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -4312,7 +4301,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4349,9 +4338,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots/f74e122f-7063-4e4b-9662-4d44e9182132\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots/f74e122f-7063-4e4b-9662-4d44e9182132\"
         id=\"f74e122f-7063-4e4b-9662-4d44e9182132\">\n        <actions>\n            <link
-        href=\"/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots/f74e122f-7063-4e4b-9662-4d44e9182132/restore\"
+        href=\"/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/snapshots/f74e122f-7063-4e4b-9662-4d44e9182132/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-05-30T17:16:53.945-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -4359,7 +4348,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/a9c8a38e-c458-4d00-af1b-67feff947ac9/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4404,7 +4393,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4449,7 +4438,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4486,9 +4475,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots/0438635e-cbdc-4c99-8dbb-c854b44776ea\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots/0438635e-cbdc-4c99-8dbb-c854b44776ea\"
         id=\"0438635e-cbdc-4c99-8dbb-c854b44776ea\">\n        <actions>\n            <link
-        href=\"/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots/0438635e-cbdc-4c99-8dbb-c854b44776ea/restore\"
+        href=\"/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/snapshots/0438635e-cbdc-4c99-8dbb-c854b44776ea/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-06-24T14:06:42.210-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -4496,7 +4485,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/999fa9c0-f708-4850-b825-c0e22041d0b5/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4541,7 +4530,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:30 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4578,13 +4567,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc\"
+        \   <disk href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc\"
         id=\"21fc55f7-2775-4fec-8442-fa546e06fabc\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/activate\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>Disk 1</name>\n        <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/21fc55f7-2775-4fec-8442-fa546e06fabc/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
         id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <alias>Disk 1</alias>\n
         \       <image_id>aa7f4f16-1875-4951-af43-3a27b3e3658a</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -4594,13 +4583,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01\"
         id=\"e46e16a8-530e-4144-84fe-6ed612d25d01\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/activate\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>Disk 2</name>\n        <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/disks/e46e16a8-530e-4144-84fe-6ed612d25d01/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
         id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <alias>Disk 2</alias>\n
         \       <image_id>aae6040d-1fd5-4370-864b-874f1a616b67</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -4615,7 +4604,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:31 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4652,21 +4641,21 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/a49102de-1e2a-45b7-b464-185f959dbfbb\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/a49102de-1e2a-45b7-b464-185f959dbfbb\"
         id=\"a49102de-1e2a-45b7-b464-185f959dbfbb\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/a49102de-1e2a-45b7-b464-185f959dbfbb/restore\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/a49102de-1e2a-45b7-b464-185f959dbfbb/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2012-12-05T10:30:15.346-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n    <snapshot
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec\"
         id=\"edbc4501-23a6-45c9-a736-b378f45a2aec\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/restore\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Snapshot1</description>\n
         \       <type>regular</type>\n        <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\">\n
         \           <name>EmsRefreshSpec-PoweredOff</name>\n            <description>Powered
-        Off VM for EmsRefresh testing</description>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/cdroms\"
-        rel=\"cdroms\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/disks\"
-        rel=\"disks\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/nics\"
+        Off VM for EmsRefresh testing</description>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/cdroms\"
+        rel=\"cdroms\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/disks\"
+        rel=\"disks\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/edbc4501-23a6-45c9-a736-b378f45a2aec/nics\"
         rel=\"nics\"/>\n            <type>server</type>\n            <status>\n                <state>down</state>\n
         \           </status>\n            <memory>1073741824</memory>\n            <cpu>\n
         \               <topology sockets=\"2\" cores=\"1\"/>\n            </cpu>\n
@@ -4684,15 +4673,15 @@ http_interactions:
         \           <usb>\n                <enabled>true</enabled>\n                <type>legacy</type>\n
         \           </usb>\n        </vm>\n        <date>2012-12-05T10:52:11.111-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n    <snapshot
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757\"
         id=\"f5990c3f-c608-4fc7-b50d-17fe1d389757\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/restore\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Snapshot2</description>\n
         \       <type>regular</type>\n        <vm id=\"26a050fb-62c3-4645-9088-be6efec860e1\">\n
         \           <name>EmsRefreshSpec-PoweredOff</name>\n            <description>Powered
-        Off VM for EmsRefresh testing</description>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/cdroms\"
-        rel=\"cdroms\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/disks\"
-        rel=\"disks\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/nics\"
+        Off VM for EmsRefresh testing</description>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/cdroms\"
+        rel=\"cdroms\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/disks\"
+        rel=\"disks\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/snapshots/f5990c3f-c608-4fc7-b50d-17fe1d389757/nics\"
         rel=\"nics\"/>\n            <type>server</type>\n            <status>\n                <state>down</state>\n
         \           </status>\n            <memory>1073741824</memory>\n            <cpu>\n
         \               <topology sockets=\"2\" cores=\"1\"/>\n            </cpu>\n
@@ -4714,7 +4703,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:31 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4751,34 +4740,34 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18\"
+        \   <nic href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18\"
         id=\"f2b9d3dc-e948-4ec9-a746-b03c409cfd18\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/activate\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
-        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/f2b9d3dc-e948-4ec9-a746-b03c409cfd18/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
+        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:0c\"/>\n        <active>true</active>\n
-        \   </nic>\n    <nic href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801\"
+        \   </nic>\n    <nic href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801\"
         id=\"6be9b35c-e1b0-4111-8425-3e0fd63eb801\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/activate\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic2</name>\n        <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
-        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/6be9b35c-e1b0-4111-8425-3e0fd63eb801/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
+        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:0e\"/>\n        <active>true</active>\n
-        \   </nic>\n    <nic href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5\"
+        \   </nic>\n    <nic href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5\"
         id=\"8885ea68-6f17-4c34-9849-98f6854547c5\">\n        <actions>\n            <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/activate\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic3</name>\n        <link
-        href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
-        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1/nics/8885ea68-6f17-4c34-9849-98f6854547c5/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/26a050fb-62c3-4645-9088-be6efec860e1\"
+        id=\"26a050fb-62c3-4645-9088-be6efec860e1\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>rtl8139</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:0f\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -4786,7 +4775,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:31 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -4823,13 +4812,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a\"
+        \   <disk href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a\"
         id=\"5fc5484d-1730-42bc-adc3-262592ea595a\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EmsRefreshSpec-PoweredOn_Disk1</name>\n
-        \       <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        \       <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/5fc5484d-1730-42bc-adc3-262592ea595a/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
         id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <alias>EmsRefreshSpec-PoweredOn_Disk1</alias>\n
         \       <image_id>caf41fcb-97ff-4bac-a7f2-083e3e72338b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -4839,13 +4828,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b\"
         id=\"b7139a48-854b-49b4-b4a0-92ef88261b7b\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EmsRefreshSpec-PoweredOn_Disk3</name>\n
-        \       <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        \       <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/b7139a48-854b-49b4-b4a0-92ef88261b7b/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
         id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <alias>EmsRefreshSpec-PoweredOn_Disk3</alias>\n
         \       <image_id>b368185e-ca4e-4ec1-8032-2a74d5807450</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -4855,13 +4844,13 @@ http_interactions:
         \       <sparse>false</sparse>\n        <bootable>false</bootable>\n        <shareable>true</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c\"
         id=\"fba89cd9-efca-4f10-90f2-40d66771ae9c\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EmsRefreshSpec-PoweredOn_Disk2</name>\n
-        \       <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        \       <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/disks/fba89cd9-efca-4f10-90f2-40d66771ae9c/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
         id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <alias>EmsRefreshSpec-PoweredOn_Disk2</alias>\n
         \       <image_id>bacd4c90-d526-4ecd-9df4-92a073450cc9</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -4876,7 +4865,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:31 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -4913,9 +4902,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/d7db04c1-9030-4c39-8618-3978787c3278\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/d7db04c1-9030-4c39-8618-3978787c3278\"
         id=\"d7db04c1-9030-4c39-8618-3978787c3278\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/d7db04c1-9030-4c39-8618-3978787c3278/restore\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/snapshots/d7db04c1-9030-4c39-8618-3978787c3278/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2012-12-05T10:29:47.818-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -4923,7 +4912,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:31 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -4960,34 +4949,34 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9\"
+        \   <nic href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9\"
         id=\"33178349-d55b-4243-95b8-cb432ed6e4f9\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic3</name>\n        <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
-        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/33178349-d55b-4243-95b8-cb432ed6e4f9/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>rtl8139</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:10\"/>\n        <active>true</active>\n
-        \   </nic>\n    <nic href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494\"
+        \   </nic>\n    <nic href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494\"
         id=\"cd940355-5b78-46e1-8e19-073e3f1e7494\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic2</name>\n        <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
-        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/cd940355-5b78-46e1-8e19-073e3f1e7494/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:11\"/>\n        <active>true</active>\n
-        \   </nic>\n    <nic href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d\"
+        \   </nic>\n    <nic href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d\"
         id=\"98610918-86f6-45a9-b96f-b9849ab3ad7d\">\n        <actions>\n            <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/activate\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
-        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876/nics/98610918-86f6-45a9-b96f-b9849ab3ad7d/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fe052832-2350-48ce-8e56-c24b4cd91876\"
+        id=\"fe052832-2350-48ce-8e56-c24b4cd91876\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:12\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -4995,7 +4984,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5032,13 +5021,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41\"
+        \   <disk href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41\"
         id=\"3ac1059e-e979-4815-b234-9fe8f0579a41\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-5012_Disk5</name>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/3ac1059e-e979-4815-b234-9fe8f0579a41/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <alias>evm-5012_Disk5</alias>\n
         \       <image_id>37527554-c1a7-46d9-bc35-dfb88f3c3092</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5048,13 +5037,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7\"
         id=\"50901247-0cae-45ae-b92e-bf718e3546c7\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-5012_Disk4</name>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/50901247-0cae-45ae-b92e-bf718e3546c7/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <alias>evm-5012_Disk4</alias>\n
         \       <image_id>5e81d797-d69c-45e5-bdc9-0c9d05f46739</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5064,13 +5053,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24\"
         id=\"c4c3486d-6742-4df7-8e77-dd1d51204e24\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-5012_Disk2</name>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/c4c3486d-6742-4df7-8e77-dd1d51204e24/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <alias>evm-5012_Disk2</alias>\n
         \       <image_id>1d5623e5-e1fb-450a-80a5-cf3b0519bf8e</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5080,13 +5069,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702\"
         id=\"e063e231-bf78-4b40-a88f-e8e5d661f702\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-5012_Disk3</name>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/e063e231-bf78-4b40-a88f-e8e5d661f702/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <alias>evm-5012_Disk3</alias>\n
         \       <image_id>6bdbe46c-1e90-4808-9474-f751c0baa68b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5096,13 +5085,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774\"
         id=\"f8920bac-af99-4686-ac82-44d3b33c6774\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-5012_Disk1</name>\n
-        \       <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        \       <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/disks/f8920bac-af99-4686-ac82-44d3b33c6774/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
         id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <alias>evm-5012_Disk1</alias>\n
         \       <image_id>09801dea-e4bc-41a4-a4c2-5095ffa6be6b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5117,7 +5106,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5154,9 +5143,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots/0e22c494-1654-4493-85b6-0e8c7d3046c3\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots/0e22c494-1654-4493-85b6-0e8c7d3046c3\"
         id=\"0e22c494-1654-4493-85b6-0e8c7d3046c3\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots/0e22c494-1654-4493-85b6-0e8c7d3046c3/restore\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/snapshots/0e22c494-1654-4493-85b6-0e8c7d3046c3/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-12T10:38:18.336-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -5164,7 +5153,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5201,14 +5190,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf\"
+        \   <nic href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf\"
         id=\"f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf\">\n        <actions>\n            <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/activate\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
-        id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b/nics/f2f6a86a-4d5e-45e4-a26b-aaaace7ce7cf/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"
+        id=\"4c5ecdbb-5b52-4578-a619-3b9a4bf2024b\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:61\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -5216,7 +5205,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5253,13 +5242,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597\"
+        \   <disk href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597\"
         id=\"3499a3da-5af0-4722-9cfd-2c2099ab9597\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EVM-v50017_Disk1</name>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/3499a3da-5af0-4722-9cfd-2c2099ab9597/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
         id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <alias>EVM-v50017_Disk1</alias>\n
         \       <image_id>167cd4b7-9f7e-4cbf-93a1-11780982b174</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5269,13 +5258,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec\"
         id=\"397dfde1-7fcb-44b9-a737-f7ec023ad3ec\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EVM-v50017_Disk4</name>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/397dfde1-7fcb-44b9-a737-f7ec023ad3ec/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
         id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <alias>EVM-v50017_Disk4</alias>\n
         \       <image_id>0a0e493a-2116-4aea-a5ce-0af056e91d51</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5285,13 +5274,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86\"
         id=\"404d92b1-06ba-488d-91a6-7a3df5da9a86\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EVM-v50017_Disk5</name>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/404d92b1-06ba-488d-91a6-7a3df5da9a86/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
         id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <alias>EVM-v50017_Disk5</alias>\n
         \       <image_id>c8cc3f3d-4432-4f27-86c0-d7c39a0e2cb8</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5301,13 +5290,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61\"
         id=\"b4c42556-5bb1-4514-8721-929f23c4ac61\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EVM-v50017_Disk2</name>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/b4c42556-5bb1-4514-8721-929f23c4ac61/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
         id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <alias>EVM-v50017_Disk2</alias>\n
         \       <image_id>4c69e4a8-9b7d-4f6d-a651-a94d737ac410</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5317,13 +5306,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8\"
         id=\"c4e38eea-341f-406e-9214-17bb59b175b8\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>EVM-v50017_Disk3</name>\n
-        \       <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        \       <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/disks/c4e38eea-341f-406e-9214-17bb59b175b8/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
         id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <alias>EVM-v50017_Disk3</alias>\n
         \       <image_id>e819b187-806c-4155-8e9a-e8ea351f4612</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -5338,7 +5327,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5375,9 +5364,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots/0aa5eda4-9823-411e-b26c-8c0af74508f4\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots/0aa5eda4-9823-411e-b26c-8c0af74508f4\"
         id=\"0aa5eda4-9823-411e-b26c-8c0af74508f4\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots/0aa5eda4-9823-411e-b26c-8c0af74508f4/restore\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/snapshots/0aa5eda4-9823-411e-b26c-8c0af74508f4/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2012-12-06T11:51:08.516-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -5385,7 +5374,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5422,14 +5411,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0\"
+        \   <nic href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0\"
         id=\"e9730ce7-0340-41d9-9b50-6520b4636ca0\">\n        <actions>\n            <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/activate\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
-        id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67/nics/e9730ce7-0340-41d9-9b50-6520b4636ca0/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/cb55e963-4951-4edd-b3c6-29f3f4338c67\"
+        id=\"cb55e963-4951-4edd-b3c6-29f3f4338c67\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:68\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -5437,7 +5426,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:32 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5482,7 +5471,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5519,9 +5508,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots/8397f76a-e719-42cf-98c6-afa2e8f8eede\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots/8397f76a-e719-42cf-98c6-afa2e8f8eede\"
         id=\"8397f76a-e719-42cf-98c6-afa2e8f8eede\">\n        <actions>\n            <link
-        href=\"/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots/8397f76a-e719-42cf-98c6-afa2e8f8eede/restore\"
+        href=\"/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/snapshots/8397f76a-e719-42cf-98c6-afa2e8f8eede/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-18T15:53:39.468-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -5529,7 +5518,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/64c1e578-8859-4ea7-a0f6-f294580d7d44/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5574,7 +5563,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5611,13 +5600,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0\"
+        \   <disk href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0\"
         id=\"b6bd9984-c76f-4fb5-8500-13388fc05cd0\">\n        <actions>\n            <link
-        href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/activate\"
+        href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rmrhel_Disk1</name>\n
-        \       <link href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5\"
+        \       <link href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/disks/b6bd9984-c76f-4fb5-8500-13388fc05cd0/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5\"
         id=\"4d24cc69-5257-4efa-b610-ce43ce1884f5\"/>\n        <alias>rmrhel_Disk1</alias>\n
         \       <image_id>291aaea4-0d6f-44b0-90fa-418cfb8905ce</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -5632,7 +5621,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5669,9 +5658,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots/1a70cdcb-d8c3-462b-acb6-d97f3b712ad8\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots/1a70cdcb-d8c3-462b-acb6-d97f3b712ad8\"
         id=\"1a70cdcb-d8c3-462b-acb6-d97f3b712ad8\">\n        <actions>\n            <link
-        href=\"/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots/1a70cdcb-d8c3-462b-acb6-d97f3b712ad8/restore\"
+        href=\"/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/snapshots/1a70cdcb-d8c3-462b-acb6-d97f3b712ad8/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-18T17:24:03.792-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -5679,7 +5668,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/4d24cc69-5257-4efa-b610-ce43ce1884f5/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5724,7 +5713,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5761,13 +5750,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9\"
+        \   <disk href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9\"
         id=\"0c6c578a-824f-4067-87b3-1db00c1bb2c9\">\n        <actions>\n            <link
-        href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/activate\"
+        href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rmrhel_Disk1</name>\n
-        \       <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"
+        \       <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/disks/0c6c578a-824f-4067-87b3-1db00c1bb2c9/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"
         id=\"5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"/>\n        <alias>rmrhel_Disk1</alias>\n
         \       <image_id>681024c4-a18e-4e2c-b065-7f11b2dede09</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -5782,7 +5771,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5819,9 +5808,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots/94ab8f9f-2371-4809-9a28-c6034edae326\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots/94ab8f9f-2371-4809-9a28-c6034edae326\"
         id=\"94ab8f9f-2371-4809-9a28-c6034edae326\">\n        <actions>\n            <link
-        href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots/94ab8f9f-2371-4809-9a28-c6034edae326/restore\"
+        href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/snapshots/94ab8f9f-2371-4809-9a28-c6034edae326/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-18T17:27:24.845-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -5829,7 +5818,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:33 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -5866,14 +5855,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229\"
+        \   <nic href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229\"
         id=\"5f6b6fba-4acb-406a-a856-fc5adb205229\">\n        <actions>\n            <link
-        href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/activate\"
+        href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"
-        id=\"5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1/nics/5f6b6fba-4acb-406a-a856-fc5adb205229/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"
+        id=\"5a9efb71-310b-4c9c-ba1a-94a036ffdcc1\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:63\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -5881,7 +5870,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5918,13 +5907,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc\"
+        \   <disk href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc\"
         id=\"e58fb10d-e058-4586-898e-5aaaec9b09fc\">\n        <actions>\n            <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/activate\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>lucy-test_Disk1</name>\n
-        \       <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\"
+        \       <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/disks/e58fb10d-e058-4586-898e-5aaaec9b09fc/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\"
         id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\"/>\n        <alias>lucy-test_Disk1</alias>\n
         \       <image_id>11bce9b5-40d6-483d-b237-7e01c7c95597</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -5939,7 +5928,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -5976,21 +5965,21 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/ce1e36f6-eefa-4d97-81f9-bc2eb1a7668f\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/ce1e36f6-eefa-4d97-81f9-bc2eb1a7668f\"
         id=\"ce1e36f6-eefa-4d97-81f9-bc2eb1a7668f\">\n        <actions>\n            <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/ce1e36f6-eefa-4d97-81f9-bc2eb1a7668f/restore\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/ce1e36f6-eefa-4d97-81f9-bc2eb1a7668f/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-09-17T16:24:26.276-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n    <snapshot
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5\"
         id=\"a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5\">\n        <actions>\n            <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/restore\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>GM Test</description>\n
         \       <type>regular</type>\n        <vm id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\">\n
         \           <name>lucy-test</name>\n            <description></description>\n
-        \           <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/cdroms\"
-        rel=\"cdroms\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/disks\"
-        rel=\"disks\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/nics\"
+        \           <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/cdroms\"
+        rel=\"cdroms\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/disks\"
+        rel=\"disks\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/snapshots/a47adb59-71dc-4fc0-b5cb-fca6ae7eeab5/nics\"
         rel=\"nics\"/>\n            <type>desktop</type>\n            <status>\n                <state>down</state>\n
         \           </status>\n            <memory>2122317824</memory>\n            <cpu>\n
         \               <topology sockets=\"5\" cores=\"4\"/>\n            </cpu>\n
@@ -6012,7 +6001,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6049,14 +6038,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047\"
+        \   <nic href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047\"
         id=\"9a184d2d-d746-4a89-ba9c-280ac4156047\">\n        <actions>\n            <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/activate\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\"
-        id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483/nics/9a184d2d-d746-4a89-ba9c-280ac4156047/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/abf8096c-90ba-4372-b7e5-c935c37dc483\"
+        id=\"abf8096c-90ba-4372-b7e5-c935c37dc483\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:f1\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6064,7 +6053,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6101,13 +6090,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5\"
+        \   <disk href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5\"
         id=\"2a0445bb-9317-4981-9bf4-958647575ef5\">\n        <actions>\n            <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/activate\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>miqutil_Disk3</name>\n
-        \       <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
+        \       <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/2a0445bb-9317-4981-9bf4-958647575ef5/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
         id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <alias>miqutil_Disk3</alias>\n
         \       <image_id>cb92669c-6081-4303-9c4f-ae7d43a79dd8</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -6117,13 +6106,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908\"
         id=\"609bcb4f-7c31-46cb-93e1-e682890f1908\">\n        <actions>\n            <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/activate\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>miqutil_Disk3</name>\n
-        \       <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
+        \       <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/disks/609bcb4f-7c31-46cb-93e1-e682890f1908/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
         id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <alias>miqutil_Disk3</alias>\n
         \       <image_id>2e93dff9-d9fd-4372-9bed-d6bfba5d700d</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -6138,7 +6127,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -6175,9 +6164,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/f090fa1c-8f67-432c-b071-16aa3ba7b4fd\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/f090fa1c-8f67-432c-b071-16aa3ba7b4fd\"
         id=\"f090fa1c-8f67-432c-b071-16aa3ba7b4fd\">\n        <actions>\n            <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/f090fa1c-8f67-432c-b071-16aa3ba7b4fd/restore\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/snapshots/f090fa1c-8f67-432c-b071-16aa3ba7b4fd/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2012-12-20T13:26:00.995-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -6185,7 +6174,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:34 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6222,24 +6211,24 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871\"
+        \   <nic href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871\"
         id=\"f60a6611-f77b-4b8f-853b-10f468a74871\">\n        <actions>\n            <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/activate\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
-        id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/f60a6611-f77b-4b8f-853b-10f468a74871/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
+        id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:0b\"/>\n        <active>true</active>\n
-        \   </nic>\n    <nic href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311\"
+        \   </nic>\n    <nic href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311\"
         id=\"4712aaf0-cbb4-4e11-a3cf-81783f24b311\">\n        <actions>\n            <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/activate\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic2</name>\n        <link
-        href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
-        id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141/nics/4712aaf0-cbb4-4e11-a3cf-81783f24b311/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/fff83bf7-9dcb-4845-b85b-ff855b9fb141\"
+        id=\"fff83bf7-9dcb-4845-b85b-ff855b9fb141\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:17\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6247,7 +6236,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6284,13 +6273,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91\"
+        \   <disk href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91\"
         id=\"95ea75cd-4d5b-422a-a33e-d6a16a5ffc91\">\n        <actions>\n            <link
-        href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/activate\"
+        href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>prov-template_Disk1</name>\n
-        \       <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\"
+        \       <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/disks/95ea75cd-4d5b-422a-a33e-d6a16a5ffc91/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\"
         id=\"b6a1aa0d-a057-482d-8bff-1d2036f889fd\"/>\n        <alias>prov-template_Disk1</alias>\n
         \       <image_id>d6726be4-aae0-4fe3-9773-be040bf9a2f1</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -6305,7 +6294,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -6342,9 +6331,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots/2dcdd312-ac01-4b56-8409-b3c730db848e\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots/2dcdd312-ac01-4b56-8409-b3c730db848e\"
         id=\"2dcdd312-ac01-4b56-8409-b3c730db848e\">\n        <actions>\n            <link
-        href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots/2dcdd312-ac01-4b56-8409-b3c730db848e/restore\"
+        href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/snapshots/2dcdd312-ac01-4b56-8409-b3c730db848e/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2014-08-05T10:15:26.382-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -6352,7 +6341,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6389,14 +6378,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302\"
+        \   <nic href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302\"
         id=\"37469488-8f97-4f3e-9793-990d78818302\">\n        <actions>\n            <link
-        href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/activate\"
+        href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\"
-        id=\"b6a1aa0d-a057-482d-8bff-1d2036f889fd\"/>\n        <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
+        href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd/nics/37469488-8f97-4f3e-9793-990d78818302/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/b6a1aa0d-a057-482d-8bff-1d2036f889fd\"
+        id=\"b6a1aa0d-a057-482d-8bff-1d2036f889fd\"/>\n        <network href=\"/ovirt-engine/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:eb\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6404,7 +6393,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6441,13 +6430,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1\"
+        \   <disk href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1\"
         id=\"58f1f555-0415-47c2-bbd9-89940ad259e1\">\n        <actions>\n            <link
-        href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/activate\"
+        href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rmrhel_Disk1</name>\n
-        \       <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\"
+        \       <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/disks/58f1f555-0415-47c2-bbd9-89940ad259e1/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\"
         id=\"f2cd9e78-15f7-47a3-94a6-137c36958bea\"/>\n        <alias>rmrhel_Disk1</alias>\n
         \       <image_id>32b58fc8-7165-41df-b15e-96fe508fca9d</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -6462,7 +6451,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -6499,9 +6488,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots/e74399de-e5eb-4be0-ac32-14adade9de34\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots/e74399de-e5eb-4be0-ac32-14adade9de34\"
         id=\"e74399de-e5eb-4be0-ac32-14adade9de34\">\n        <actions>\n            <link
-        href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots/e74399de-e5eb-4be0-ac32-14adade9de34/restore\"
+        href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/snapshots/e74399de-e5eb-4be0-ac32-14adade9de34/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-01-16T17:23:15.795-05:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -6509,7 +6498,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:35 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6546,14 +6535,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017\"
+        \   <nic href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017\"
         id=\"81ff75ae-a378-4749-bc6f-cadc829d5017\">\n        <actions>\n            <link
-        href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/activate\"
+        href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\"
-        id=\"f2cd9e78-15f7-47a3-94a6-137c36958bea\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea/nics/81ff75ae-a378-4749-bc6f-cadc829d5017/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/f2cd9e78-15f7-47a3-94a6-137c36958bea\"
+        id=\"f2cd9e78-15f7-47a3-94a6-137c36958bea\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>e1000</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:69\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6561,7 +6550,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6598,13 +6587,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa\"
+        \   <disk href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa\"
         id=\"52b4ab2c-5e96-46f9-b764-7cad2b7c30aa\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rpo-evm-iscsi_Disk6</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/52b4ab2c-5e96-46f9-b764-7cad2b7c30aa/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>rpo-evm-iscsi_Disk6</alias>\n
         \       <interface>virtio</interface>\n        <bootable>false</bootable>\n
         \       <shareable>false</shareable>\n        <wipe_after_delete>false</wipe_after_delete>\n
@@ -6616,13 +6605,13 @@ http_interactions:
         \               <paths>0</paths>\n                <volume_group_id>CqCwC9-3V1p-WIwg-R5H5-zdid-10dP-o2GhyJ</volume_group_id>\n
         \               <disk_id>52b4ab2c-5e96-46f9-b764-7cad2b7c30aa</disk_id>\n
         \           </logical_unit>\n        </lun_storage>\n    </disk>\n    <disk
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0\"
         id=\"5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-v5012_Disk3</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/5ac5635f-4a5d-4533-8ac8-abf6e1b6b0a0/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>evm-v5012_Disk3</alias>\n
         \       <image_id>e964c4f5-f693-459f-8ff3-3914a638581f</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6632,13 +6621,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6\"
         id=\"912935d9-9582-4416-a61e-924b869bbed6\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-v5012_Disk1</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/912935d9-9582-4416-a61e-924b869bbed6/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>evm-v5012_Disk1</alias>\n
         \       <image_id>b876acd3-5606-41c3-bd40-e70739bca977</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6648,13 +6637,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e\"
         id=\"c52be438-e8ca-4874-a85c-a03ce721050e\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-v5012_Disk2</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/c52be438-e8ca-4874-a85c-a03ce721050e/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>evm-v5012_Disk2</alias>\n
         \       <image_id>82901806-9869-4603-9d18-97468c1ea9ce</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6664,13 +6653,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6\"
         id=\"d8a534c0-2b60-44e0-9f89-f1052681eaf6\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-v5012_Disk4</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/d8a534c0-2b60-44e0-9f89-f1052681eaf6/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>evm-v5012_Disk4</alias>\n
         \       <image_id>13ba6215-1ba4-49b7-888b-9693a52cb265</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6680,13 +6669,13 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <active>true</active>\n        <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n
-        \   </disk>\n    <disk href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd\"
+        \   </disk>\n    <disk href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd\"
         id=\"e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>evm-v5012_Disk5</name>\n
-        \       <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        \       <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/disks/e46eb24d-7b1e-4b04-8343-3b5c3f03a3bd/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
         id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <alias>evm-v5012_Disk5</alias>\n
         \       <image_id>b92c078a-2503-4ce3-adf1-e17c7e5cac35</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6701,7 +6690,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -6738,9 +6727,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots/269eb60d-3daf-4719-a3fa-0e48129ad3fe\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots/269eb60d-3daf-4719-a3fa-0e48129ad3fe\"
         id=\"269eb60d-3daf-4719-a3fa-0e48129ad3fe\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots/269eb60d-3daf-4719-a3fa-0e48129ad3fe/restore\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/snapshots/269eb60d-3daf-4719-a3fa-0e48129ad3fe/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-04-22T15:52:41.810-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n</snapshots>\n"
@@ -6748,7 +6737,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6785,14 +6774,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537\"
+        \   <nic href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537\"
         id=\"8138ff1d-1a9a-4c32-951b-f46fe9bf9537\">\n        <actions>\n            <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/activate\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
-        id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21/nics/8138ff1d-1a9a-4c32-951b-f46fe9bf9537/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/1116d87e-0900-459d-bb1c-96a8086f4f21\"
+        id=\"1116d87e-0900-459d-bb1c-96a8086f4f21\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:ea\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6800,7 +6789,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -6837,13 +6826,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be\"
+        \   <disk href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be\"
         id=\"ad10ce14-d72d-4556-aaa4-09f98c1325be\">\n        <actions>\n            <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/activate\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rpo-test1_Disk1</name>\n
-        \       <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\"
+        \       <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/disks/ad10ce14-d72d-4556-aaa4-09f98c1325be/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\"
         id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\"/>\n        <alias>rpo-test1_Disk1</alias>\n
         \       <image_id>0e770733-667e-4654-b915-6307a1dfc1c5</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"6284e934-9f11-486a-b9d8-aaacfa4f226f\"/>\n
@@ -6858,7 +6847,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -6895,21 +6884,21 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/32741ee7-d38f-4ece-9dfd-ea71c7136f50\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/32741ee7-d38f-4ece-9dfd-ea71c7136f50\"
         id=\"32741ee7-d38f-4ece-9dfd-ea71c7136f50\">\n        <actions>\n            <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/32741ee7-d38f-4ece-9dfd-ea71c7136f50/restore\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/32741ee7-d38f-4ece-9dfd-ea71c7136f50/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-04-25T17:04:06.602-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n    <snapshot
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c\"
         id=\"fccf9020-b4bf-4d60-9423-c242bc73445c\">\n        <actions>\n            <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/restore\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>snap1</description>\n
         \       <type>regular</type>\n        <vm id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\">\n
         \           <name>rpo-test1</name>\n            <description></description>\n
-        \           <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/cdroms\"
-        rel=\"cdroms\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/disks\"
-        rel=\"disks\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/nics\"
+        \           <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/cdroms\"
+        rel=\"cdroms\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/disks\"
+        rel=\"disks\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/snapshots/fccf9020-b4bf-4d60-9423-c242bc73445c/nics\"
         rel=\"nics\"/>\n            <type>desktop</type>\n            <status>\n                <state>down</state>\n
         \           </status>\n            <memory>1073741824</memory>\n            <cpu>\n
         \               <topology sockets=\"1\" cores=\"1\"/>\n            </cpu>\n
@@ -6931,7 +6920,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:36 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -6968,14 +6957,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f\"
+        \   <nic href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f\"
         id=\"f96790b6-7195-44c9-80b3-527c4779730f\">\n        <actions>\n            <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/activate\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\"
-        id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\"/>\n        <network href=\"/api/networks/00000000-0000-0000-0000-000000000009\"
+        href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f/nics/f96790b6-7195-44c9-80b3-527c4779730f/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/8fe61fec-b374-4151-b92a-2cdb603bcb3f\"
+        id=\"8fe61fec-b374-4151-b92a-2cdb603bcb3f\"/>\n        <network href=\"/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009\"
         id=\"00000000-0000-0000-0000-000000000009\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:65\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -6983,7 +6972,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks
+    uri: https://192.168.252.230/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7020,13 +7009,13 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df\"
+        \   <disk href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df\"
         id=\"19449cf8-1905-4b8a-b45a-e845a693a3df\">\n        <actions>\n            <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/activate\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>rpo-test2_Disk1</name>\n
-        \       <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\"
+        \       <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/disks/19449cf8-1905-4b8a-b45a-e845a693a3df/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\"
         id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\"/>\n        <alias>rpo-test2_Disk1</alias>\n
         \       <image_id>ee5c7736-a034-4e39-b863-a1fd965c6b97</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -7041,7 +7030,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots
+    uri: https://192.168.252.230/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -7078,21 +7067,21 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<snapshots>\n
-        \   <snapshot href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/5c113fd5-247d-4a5b-a903-75e3be45201a\"
+        \   <snapshot href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/5c113fd5-247d-4a5b-a903-75e3be45201a\"
         id=\"5c113fd5-247d-4a5b-a903-75e3be45201a\">\n        <actions>\n            <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/5c113fd5-247d-4a5b-a903-75e3be45201a/restore\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/5c113fd5-247d-4a5b-a903-75e3be45201a/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>Active VM</description>\n
         \       <type>active</type>\n        <date>2013-06-19T11:32:42.896-04:00</date>\n
         \       <snapshot_status>ok</snapshot_status>\n    </snapshot>\n    <snapshot
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb\"
         id=\"b9b92c44-494a-44fa-b0ce-fecbffa64aeb\">\n        <actions>\n            <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/restore\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/restore\"
         rel=\"restore\"/>\n        </actions>\n        <description>snap1</description>\n
         \       <type>regular</type>\n        <vm id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\">\n
         \           <name>rpo-test2</name>\n            <description></description>\n
-        \           <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/cdroms\"
-        rel=\"cdroms\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/disks\"
-        rel=\"disks\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/nics\"
+        \           <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/cdroms\"
+        rel=\"cdroms\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/disks\"
+        rel=\"disks\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/snapshots/b9b92c44-494a-44fa-b0ce-fecbffa64aeb/nics\"
         rel=\"nics\"/>\n            <type>desktop</type>\n            <status>\n                <state>down</state>\n
         \           </status>\n            <memory>536870912</memory>\n            <cpu>\n
         \               <topology sockets=\"1\" cores=\"1\"/>\n            </cpu>\n
@@ -7114,7 +7103,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics
+    uri: https://192.168.252.230/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -7151,14 +7140,14 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<nics>\n
-        \   <nic href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c\"
+        \   <nic href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c\"
         id=\"8d393332-7b96-4c0e-bd96-c59b1ec23f0c\">\n        <actions>\n            <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/deactivate\"
-        rel=\"deactivate\"/>\n            <link href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/activate\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/deactivate\"
+        rel=\"deactivate\"/>\n            <link href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/activate\"
         rel=\"activate\"/>\n        </actions>\n        <name>nic1</name>\n        <link
-        href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/statistics\"
-        rel=\"statistics\"/>\n        <vm href=\"/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\"
-        id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\"/>\n        <network href=\"/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
+        href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc/nics/8d393332-7b96-4c0e-bd96-c59b1ec23f0c/statistics\"
+        rel=\"statistics\"/>\n        <vm href=\"/ovirt-engine/api/vms/adb58c4b-32af-41c8-823f-1e83317c52fc\"
+        id=\"adb58c4b-32af-41c8-823f-1e83317c52fc\"/>\n        <network href=\"/ovirt-engine/api/networks/bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"
         id=\"bf717cad-b3fd-4dea-a7d5-c56778dc70fa\"/>\n        <interface>virtio</interface>\n
         \       <mac address=\"00:1a:4a:a8:fc:64\"/>\n        <active>true</active>\n
         \   </nic>\n</nics>\n"
@@ -7166,7 +7155,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7203,11 +7192,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks/1c32dc34-c72d-48f1-a980-51e54b270acd\"
+        \   <disk href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks/1c32dc34-c72d-48f1-a980-51e54b270acd\"
         id=\"1c32dc34-c72d-48f1-a980-51e54b270acd\">\n        <actions>\n            <link
-        href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks/1c32dc34-c72d-48f1-a980-51e54b270acd/copy\"
+        href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23/disks/1c32dc34-c72d-48f1-a980-51e54b270acd/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>757e824d-6d97-4568-be29-9346c354e802_Disk1</name>\n
-        \       <template href=\"/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23\"
+        \       <template href=\"/ovirt-engine/api/templates/b14e3c9f-a171-4d23-b3e2-da423d1d2a23\"
         id=\"b14e3c9f-a171-4d23-b3e2-da423d1d2a23\"/>\n        <alias>757e824d-6d97-4568-be29-9346c354e802_Disk1</alias>\n
         \       <image_id>8d1a5a87-2693-4011-820f-53b1a38293b7</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -7221,7 +7210,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7258,11 +7247,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks/01eae62b-90df-424d-978c-beaa7eb2f7f6\"
+        \   <disk href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks/01eae62b-90df-424d-978c-beaa7eb2f7f6\"
         id=\"01eae62b-90df-424d-978c-beaa7eb2f7f6\">\n        <actions>\n            <link
-        href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks/01eae62b-90df-424d-978c-beaa7eb2f7f6/copy\"
+        href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264/disks/01eae62b-90df-424d-978c-beaa7eb2f7f6/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>bd-clone_Disk1</name>\n
-        \       <template href=\"/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264\"
+        \       <template href=\"/ovirt-engine/api/templates/54f1b9f4-0e89-4c72-9a26-f94dcb857264\"
         id=\"54f1b9f4-0e89-4c72-9a26-f94dcb857264\"/>\n        <alias>bd-clone_Disk1</alias>\n
         \       <image_id>a791ba77-8cc1-44de-9945-69f0a291cc47</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -7276,7 +7265,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:37 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7313,11 +7302,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks/d6af4e03-1142-4aeb-a346-a592ae64ef10\"
+        \   <disk href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks/d6af4e03-1142-4aeb-a346-a592ae64ef10\"
         id=\"d6af4e03-1142-4aeb-a346-a592ae64ef10\">\n        <actions>\n            <link
-        href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks/d6af4e03-1142-4aeb-a346-a592ae64ef10/copy\"
+        href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3/disks/d6af4e03-1142-4aeb-a346-a592ae64ef10/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>cfme_Disk1</name>\n        <template
-        href=\"/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\" id=\"e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\"/>\n
+        href=\"/ovirt-engine/api/templates/e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\" id=\"e6ec2b96-dd2e-4fa3-94f1-b9a2c27eeff3\"/>\n
         \       <alias>cfme_Disk1</alias>\n        <image_id>7d905b70-3d01-434d-887e-2a5db9662b91</image_id>\n
         \       <storage_domains>\n            <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
         \       </storage_domains>\n        <size>53687091200</size>\n        <provisioned_size>53687091200</provisioned_size>\n
@@ -7330,7 +7319,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/00000000-0000-0000-0000-000000000000/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7375,7 +7364,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7412,11 +7401,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks/1224d085-93b3-49d6-b15a-2c7d231de50a\"
+        \   <disk href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks/1224d085-93b3-49d6-b15a-2c7d231de50a\"
         id=\"1224d085-93b3-49d6-b15a-2c7d231de50a\">\n        <actions>\n            <link
-        href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks/1224d085-93b3-49d6-b15a-2c7d231de50a/copy\"
+        href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68/disks/1224d085-93b3-49d6-b15a-2c7d231de50a/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>cfme_Disk1</name>\n        <template
-        href=\"/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\" id=\"f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\"/>\n
+        href=\"/ovirt-engine/api/templates/f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\" id=\"f3c7accb-8d1a-4977-a3c3-e5d9f6a7dc68\"/>\n
         \       <alias>cfme_Disk1</alias>\n        <image_id>e06742a5-8516-4dd1-82c9-381f81117dbb</image_id>\n
         \       <storage_domains>\n            <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
         \       </storage_domains>\n        <size>53687091200</size>\n        <provisioned_size>53687091200</provisioned_size>\n
@@ -7429,7 +7418,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7466,11 +7455,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/95a35764-4e49-4d6c-895f-33948f30ea69\"
+        \   <disk href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/95a35764-4e49-4d6c-895f-33948f30ea69\"
         id=\"95a35764-4e49-4d6c-895f-33948f30ea69\">\n        <actions>\n            <link
-        href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/95a35764-4e49-4d6c-895f-33948f30ea69/copy\"
+        href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/95a35764-4e49-4d6c-895f-33948f30ea69/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EmsRefreshSpec_Disk1</name>\n
-        \       <template href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\"
+        \       <template href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\"
         id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <alias>EmsRefreshSpec_Disk1</alias>\n
         \       <image_id>6b7e9778-e92a-4e08-b4f4-3887e81a226b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7480,11 +7469,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/c8ace089-1c41-4ec3-97ad-c454827030b5\"
+        \   <disk href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/c8ace089-1c41-4ec3-97ad-c454827030b5\"
         id=\"c8ace089-1c41-4ec3-97ad-c454827030b5\">\n        <actions>\n            <link
-        href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/c8ace089-1c41-4ec3-97ad-c454827030b5/copy\"
+        href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613/disks/c8ace089-1c41-4ec3-97ad-c454827030b5/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EmsRefreshSpec_Disk2</name>\n
-        \       <template href=\"/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\"
+        \       <template href=\"/ovirt-engine/api/templates/7a6db798-9df9-40ca-8cc3-3baab32e7613\"
         id=\"7a6db798-9df9-40ca-8cc3-3baab32e7613\"/>\n        <alias>EmsRefreshSpec_Disk2</alias>\n
         \       <image_id>1e736810-0dff-42f2-aede-bc68ce8625d0</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7498,7 +7487,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7535,11 +7524,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/310f1820-f910-47e4-8eb3-0e93c668ad77\"
+        \   <disk href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/310f1820-f910-47e4-8eb3-0e93c668ad77\"
         id=\"310f1820-f910-47e4-8eb3-0e93c668ad77\">\n        <actions>\n            <link
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/310f1820-f910-47e4-8eb3-0e93c668ad77/copy\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/310f1820-f910-47e4-8eb3-0e93c668ad77/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50017_Disk1</name>\n
-        \       <template href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
+        \       <template href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
         id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <alias>EVM-v50017_Disk1</alias>\n
         \       <image_id>5521b6bf-184e-4a84-b82d-921fa4ef901d</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7549,11 +7538,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/74c8b3a8-bd46-465d-878d-6c88a22c6b6e\"
+        \   <disk href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/74c8b3a8-bd46-465d-878d-6c88a22c6b6e\"
         id=\"74c8b3a8-bd46-465d-878d-6c88a22c6b6e\">\n        <actions>\n            <link
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/74c8b3a8-bd46-465d-878d-6c88a22c6b6e/copy\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/74c8b3a8-bd46-465d-878d-6c88a22c6b6e/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50017_Disk5</name>\n
-        \       <template href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
+        \       <template href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
         id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <alias>EVM-v50017_Disk5</alias>\n
         \       <image_id>91eadb54-02d1-49ec-a3df-f901180f616e</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7563,11 +7552,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91bb2725-5ea1-4bd7-93b1-95b34a4fbb8f\"
+        \   <disk href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91bb2725-5ea1-4bd7-93b1-95b34a4fbb8f\"
         id=\"91bb2725-5ea1-4bd7-93b1-95b34a4fbb8f\">\n        <actions>\n            <link
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91bb2725-5ea1-4bd7-93b1-95b34a4fbb8f/copy\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/91bb2725-5ea1-4bd7-93b1-95b34a4fbb8f/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50017_Disk4</name>\n
-        \       <template href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
+        \       <template href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
         id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <alias>EVM-v50017_Disk4</alias>\n
         \       <image_id>b7cedfa8-ac5a-4c3c-977c-76899e45291d</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7577,11 +7566,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/bc18b18d-804c-4e8d-810e-3cf59976e948\"
+        \   <disk href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/bc18b18d-804c-4e8d-810e-3cf59976e948\"
         id=\"bc18b18d-804c-4e8d-810e-3cf59976e948\">\n        <actions>\n            <link
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/bc18b18d-804c-4e8d-810e-3cf59976e948/copy\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/bc18b18d-804c-4e8d-810e-3cf59976e948/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50017_Disk2</name>\n
-        \       <template href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
+        \       <template href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
         id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <alias>EVM-v50017_Disk2</alias>\n
         \       <image_id>75812179-eeb8-4d8c-a733-7e0bf0e137ad</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7591,11 +7580,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/ebd53bf0-20d0-4a4e-a39f-3726d0a51836\"
+        \   <disk href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/ebd53bf0-20d0-4a4e-a39f-3726d0a51836\"
         id=\"ebd53bf0-20d0-4a4e-a39f-3726d0a51836\">\n        <actions>\n            <link
-        href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/ebd53bf0-20d0-4a4e-a39f-3726d0a51836/copy\"
+        href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676/disks/ebd53bf0-20d0-4a4e-a39f-3726d0a51836/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50017_Disk3</name>\n
-        \       <template href=\"/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
+        \       <template href=\"/ovirt-engine/api/templates/6bd4eec5-0135-4cd0-ae16-71905ba76676\"
         id=\"6bd4eec5-0135-4cd0-ae16-71905ba76676\"/>\n        <alias>EVM-v50017_Disk3</alias>\n
         \       <image_id>b9294516-4341-4008-aea9-63d8ed85e36b</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7609,7 +7598,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7646,11 +7635,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/1d1b0e6f-6de1-4cd1-bb39-89ac117f79bd\"
+        \   <disk href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/1d1b0e6f-6de1-4cd1-bb39-89ac117f79bd\"
         id=\"1d1b0e6f-6de1-4cd1-bb39-89ac117f79bd\">\n        <actions>\n            <link
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/1d1b0e6f-6de1-4cd1-bb39-89ac117f79bd/copy\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/1d1b0e6f-6de1-4cd1-bb39-89ac117f79bd/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50025_Disk2</name>\n
-        \       <template href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
+        \       <template href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
         id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\"/>\n        <alias>EVM-v50025_Disk2</alias>\n
         \       <image_id>8b882795-579e-45a9-9b89-7a760b4fe9b1</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7660,11 +7649,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/462b01eb-8123-44f8-893e-1bebfff89f00\"
+        \   <disk href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/462b01eb-8123-44f8-893e-1bebfff89f00\"
         id=\"462b01eb-8123-44f8-893e-1bebfff89f00\">\n        <actions>\n            <link
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/462b01eb-8123-44f8-893e-1bebfff89f00/copy\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/462b01eb-8123-44f8-893e-1bebfff89f00/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50025_Disk4</name>\n
-        \       <template href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
+        \       <template href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
         id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\"/>\n        <alias>EVM-v50025_Disk4</alias>\n
         \       <image_id>63875572-e7da-480f-b585-c3b3641ed77d</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7674,11 +7663,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/aae247e7-457a-4097-ac81-5191f778c573\"
+        \   <disk href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/aae247e7-457a-4097-ac81-5191f778c573\"
         id=\"aae247e7-457a-4097-ac81-5191f778c573\">\n        <actions>\n            <link
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/aae247e7-457a-4097-ac81-5191f778c573/copy\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/aae247e7-457a-4097-ac81-5191f778c573/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50025_Disk3</name>\n
-        \       <template href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
+        \       <template href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
         id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\"/>\n        <alias>EVM-v50025_Disk3</alias>\n
         \       <image_id>5069ca88-e684-4e62-9cbc-3d8241f00590</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7688,11 +7677,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/b922126e-2ab7-4862-bdb3-7041ff54dadf\"
+        \   <disk href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/b922126e-2ab7-4862-bdb3-7041ff54dadf\"
         id=\"b922126e-2ab7-4862-bdb3-7041ff54dadf\">\n        <actions>\n            <link
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/b922126e-2ab7-4862-bdb3-7041ff54dadf/copy\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/b922126e-2ab7-4862-bdb3-7041ff54dadf/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50025_Disk1</name>\n
-        \       <template href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
+        \       <template href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
         id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\"/>\n        <alias>EVM-v50025_Disk1</alias>\n
         \       <image_id>4da764d3-1abb-4b69-832e-245fe24516f8</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7702,11 +7691,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/e5ffe385-740a-4e49-9cdf-6a478192290a\"
+        \   <disk href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/e5ffe385-740a-4e49-9cdf-6a478192290a\"
         id=\"e5ffe385-740a-4e49-9cdf-6a478192290a\">\n        <actions>\n            <link
-        href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/e5ffe385-740a-4e49-9cdf-6a478192290a/copy\"
+        href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2/disks/e5ffe385-740a-4e49-9cdf-6a478192290a/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>EVM-v50025_Disk5</name>\n
-        \       <template href=\"/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
+        \       <template href=\"/ovirt-engine/api/templates/63600a6f-0c12-445e-bc92-093bfb0e2aa2\"
         id=\"63600a6f-0c12-445e-bc92-093bfb0e2aa2\"/>\n        <alias>EVM-v50025_Disk5</alias>\n
         \       <image_id>b6b9c75a-a7c4-42b3-8407-5de07cc41e1e</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7720,7 +7709,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7757,11 +7746,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/20e634a3-59eb-4494-bd13-809539bfffbf\"
+        \   <disk href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/20e634a3-59eb-4494-bd13-809539bfffbf\"
         id=\"20e634a3-59eb-4494-bd13-809539bfffbf\">\n        <actions>\n            <link
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/20e634a3-59eb-4494-bd13-809539bfffbf/copy\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/20e634a3-59eb-4494-bd13-809539bfffbf/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>evm-v5012_Disk1</name>\n
-        \       <template href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
+        \       <template href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
         id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\"/>\n        <alias>evm-v5012_Disk1</alias>\n
         \       <image_id>31ee9949-2b0c-466f-b44a-780edb41bce7</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7771,11 +7760,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/2bf2c79e-4ca4-4b30-9943-e5aac584a9c3\"
+        \   <disk href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/2bf2c79e-4ca4-4b30-9943-e5aac584a9c3\"
         id=\"2bf2c79e-4ca4-4b30-9943-e5aac584a9c3\">\n        <actions>\n            <link
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/2bf2c79e-4ca4-4b30-9943-e5aac584a9c3/copy\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/2bf2c79e-4ca4-4b30-9943-e5aac584a9c3/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>evm-v5012_Disk3</name>\n
-        \       <template href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
+        \       <template href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
         id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\"/>\n        <alias>evm-v5012_Disk3</alias>\n
         \       <image_id>07a6550a-81ae-4fa9-b99a-751270abee95</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7785,11 +7774,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/3d13e921-c1ca-4add-b90e-a22708e20a9a\"
+        \   <disk href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/3d13e921-c1ca-4add-b90e-a22708e20a9a\"
         id=\"3d13e921-c1ca-4add-b90e-a22708e20a9a\">\n        <actions>\n            <link
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/3d13e921-c1ca-4add-b90e-a22708e20a9a/copy\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/3d13e921-c1ca-4add-b90e-a22708e20a9a/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>evm-v5012_Disk4</name>\n
-        \       <template href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
+        \       <template href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
         id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\"/>\n        <alias>evm-v5012_Disk4</alias>\n
         \       <image_id>39be5a61-1b56-4e9f-ad22-5b6723ecbf15</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7799,11 +7788,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>false</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/7bd103c6-4526-4e59-8b8c-505a753e2dd7\"
+        \   <disk href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/7bd103c6-4526-4e59-8b8c-505a753e2dd7\"
         id=\"7bd103c6-4526-4e59-8b8c-505a753e2dd7\">\n        <actions>\n            <link
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/7bd103c6-4526-4e59-8b8c-505a753e2dd7/copy\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/7bd103c6-4526-4e59-8b8c-505a753e2dd7/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>evm-v5012_Disk5</name>\n
-        \       <template href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
+        \       <template href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
         id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\"/>\n        <alias>evm-v5012_Disk5</alias>\n
         \       <image_id>0c6a5e48-a63d-4841-96df-fb7ffdc0eb16</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7813,11 +7802,11 @@ http_interactions:
         \       <sparse>true</sparse>\n        <bootable>true</bootable>\n        <shareable>false</shareable>\n
         \       <wipe_after_delete>false</wipe_after_delete>\n        <propagate_errors>false</propagate_errors>\n
         \       <quota id=\"00000000-0000-0000-0000-000000000000\"/>\n    </disk>\n
-        \   <disk href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/9a62fd96-be3a-44fc-949b-7bc1483b3af5\"
+        \   <disk href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/9a62fd96-be3a-44fc-949b-7bc1483b3af5\"
         id=\"9a62fd96-be3a-44fc-949b-7bc1483b3af5\">\n        <actions>\n            <link
-        href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/9a62fd96-be3a-44fc-949b-7bc1483b3af5/copy\"
+        href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4/disks/9a62fd96-be3a-44fc-949b-7bc1483b3af5/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>evm-v5012_Disk2</name>\n
-        \       <template href=\"/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
+        \       <template href=\"/ovirt-engine/api/templates/c0874381-c63e-48ad-aaa7-cece26c22ba4\"
         id=\"c0874381-c63e-48ad-aaa7-cece26c22ba4\"/>\n        <alias>evm-v5012_Disk2</alias>\n
         \       <image_id>0f6d26ff-7566-4ff9-b321-11ad8dc70ed9</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7831,7 +7820,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:38 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7868,11 +7857,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks/c1333ae8-5c74-4452-a3ea-9528b8a102f1\"
+        \   <disk href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks/c1333ae8-5c74-4452-a3ea-9528b8a102f1\"
         id=\"c1333ae8-5c74-4452-a3ea-9528b8a102f1\">\n        <actions>\n            <link
-        href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks/c1333ae8-5c74-4452-a3ea-9528b8a102f1/copy\"
+        href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8/disks/c1333ae8-5c74-4452-a3ea-9528b8a102f1/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>prov-template_Disk1</name>\n
-        \       <template href=\"/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8\"
+        \       <template href=\"/ovirt-engine/api/templates/ce04bf8d-70d7-489a-9107-b294211636c8\"
         id=\"ce04bf8d-70d7-489a-9107-b294211636c8\"/>\n        <alias>prov-template_Disk1</alias>\n
         \       <image_id>09be86e4-78e0-426b-862b-84adc4825649</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"aa7e70e5-40d0-43e2-a605-92ce6ba652a8\"/>\n
@@ -7886,7 +7875,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:39 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7923,11 +7912,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks/67b2556f-bd9f-49b5-80b7-6606b58e50e5\"
+        \   <disk href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks/67b2556f-bd9f-49b5-80b7-6606b58e50e5\"
         id=\"67b2556f-bd9f-49b5-80b7-6606b58e50e5\">\n        <actions>\n            <link
-        href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks/67b2556f-bd9f-49b5-80b7-6606b58e50e5/copy\"
+        href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b/disks/67b2556f-bd9f-49b5-80b7-6606b58e50e5/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>PxeRhelRhev31_Disk1</name>\n
-        \       <template href=\"/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b\"
+        \       <template href=\"/ovirt-engine/api/templates/63d4a24f-0f57-46fe-b918-063f476a5d8b\"
         id=\"63d4a24f-0f57-46fe-b918-063f476a5d8b\"/>\n        <alias>PxeRhelRhev31_Disk1</alias>\n
         \       <image_id>8616a639-b254-4532-b82d-82ae8bd4f7cf</image_id>\n        <storage_domains>\n
         \           <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
@@ -7941,7 +7930,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:39 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks
+    uri: https://192.168.252.230/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -7978,11 +7967,11 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<disks>\n
-        \   <disk href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks/4cbda98f-6561-4813-93d7-862695434f52\"
+        \   <disk href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks/4cbda98f-6561-4813-93d7-862695434f52\"
         id=\"4cbda98f-6561-4813-93d7-862695434f52\">\n        <actions>\n            <link
-        href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks/4cbda98f-6561-4813-93d7-862695434f52/copy\"
+        href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544/disks/4cbda98f-6561-4813-93d7-862695434f52/copy\"
         rel=\"copy\"/>\n        </actions>\n        <name>rmrhel_Disk1</name>\n        <template
-        href=\"/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544\" id=\"cee7feb4-5112-42ed-97c5-9db37d332544\"/>\n
+        href=\"/ovirt-engine/api/templates/cee7feb4-5112-42ed-97c5-9db37d332544\" id=\"cee7feb4-5112-42ed-97c5-9db37d332544\"/>\n
         \       <alias>rmrhel_Disk1</alias>\n        <image_id>a6967806-7717-4e46-bc78-2a8af9165e35</image_id>\n
         \       <storage_domains>\n            <storage_domain id=\"d0a7d751-46bc-495a-a312-e5d010059f96\"/>\n
         \       </storage_domains>\n        <size>10737418240</size>\n        <provisioned_size>10737418240</provisioned_size>\n
@@ -7995,7 +7984,7 @@ http_interactions:
   recorded_at: Wed, 08 Oct 2014 01:27:39 GMT
 - request:
     method: get
-    uri: https://192.168.252.230/api
+    uri: https://192.168.252.230/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -8024,20 +8013,20 @@ http_interactions:
       Expires:
       - Wed, 31 Dec 1969 19:00:00 EST
       Link:
-      - <https://192.168.252.230/api/capabilities>; rel=capabilities,<https://192.168.252.230/api/clusters>;
-        rel=clusters,<https://192.168.252.230/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.230/api/datacenters>;
-        rel=datacenters,<https://192.168.252.230/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.252.230/api/events>; rel=events,<https://192.168.252.230/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.252.230/api/hosts>; rel=hosts,<https://192.168.252.230/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.252.230/api/networks>; rel=networks,<https://192.168.252.230/api/roles>;
-        rel=roles,<https://192.168.252.230/api/storagedomains>; rel=storagedomains,<https://192.168.252.230/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.252.230/api/tags>; rel=tags,<https://192.168.252.230/api/templates>;
-        rel=templates,<https://192.168.252.230/api/templates?search={query}>; rel=templates/search,<https://192.168.252.230/api/users>;
-        rel=users,<https://192.168.252.230/api/users?search={query}>; rel=users/search,<https://192.168.252.230/api/groups>;
-        rel=groups,<https://192.168.252.230/api/groups?search={query}>; rel=groups/search,<https://192.168.252.230/api/domains>;
-        rel=domains,<https://192.168.252.230/api/vmpools>; rel=vmpools,<https://192.168.252.230/api/vmpools?search={query}>;
-        rel=vmpools/search,<https://192.168.252.230/api/vms>; rel=vms,<https://192.168.252.230/api/vms?search={query}>;
-        rel=vms/search,<https://192.168.252.230/api/disks>; rel=disks,<https://192.168.252.230/api/disks?search={query}>;
+      - <https://192.168.252.230/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.252.230/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.252.230/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.252.230/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.252.230/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.252.230/ovirt-engine/api/events>; rel=events,<https://192.168.252.230/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.252.230/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.252.230/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.252.230/ovirt-engine/api/networks>; rel=networks,<https://192.168.252.230/ovirt-engine/api/roles>;
+        rel=roles,<https://192.168.252.230/ovirt-engine/api/storagedomains>; rel=storagedomains,<https://192.168.252.230/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.252.230/ovirt-engine/api/tags>; rel=tags,<https://192.168.252.230/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.252.230/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.252.230/ovirt-engine/api/users>;
+        rel=users,<https://192.168.252.230/ovirt-engine/api/users?search={query}>; rel=users/search,<https://192.168.252.230/ovirt-engine/api/groups>;
+        rel=groups,<https://192.168.252.230/ovirt-engine/api/groups?search={query}>; rel=groups/search,<https://192.168.252.230/ovirt-engine/api/domains>;
+        rel=domains,<https://192.168.252.230/ovirt-engine/api/vmpools>; rel=vmpools,<https://192.168.252.230/ovirt-engine/api/vmpools?search={query}>;
+        rel=vmpools/search,<https://192.168.252.230/ovirt-engine/api/vms>; rel=vms,<https://192.168.252.230/ovirt-engine/api/vms?search={query}>;
+        rel=vms/search,<https://192.168.252.230/ovirt-engine/api/disks>; rel=disks,<https://192.168.252.230/ovirt-engine/api/disks?search={query}>;
         rel=disks/search
       Content-Type:
       - application/xml
@@ -8048,27 +8037,27 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<api>\n
-        \   <link href=\"/api/capabilities\" rel=\"capabilities\"/>\n    <link href=\"/api/clusters\"
-        rel=\"clusters\"/>\n    <link href=\"/api/clusters?search={query}\" rel=\"clusters/search\"/>\n
-        \   <link href=\"/api/datacenters\" rel=\"datacenters\"/>\n    <link href=\"/api/datacenters?search={query}\"
-        rel=\"datacenters/search\"/>\n    <link href=\"/api/events\" rel=\"events\"/>\n
-        \   <link href=\"/api/events;from={event_id}?search={query}\" rel=\"events/search\"/>\n
-        \   <link href=\"/api/hosts\" rel=\"hosts\"/>\n    <link href=\"/api/hosts?search={query}\"
-        rel=\"hosts/search\"/>\n    <link href=\"/api/networks\" rel=\"networks\"/>\n
-        \   <link href=\"/api/roles\" rel=\"roles\"/>\n    <link href=\"/api/storagedomains\"
-        rel=\"storagedomains\"/>\n    <link href=\"/api/storagedomains?search={query}\"
-        rel=\"storagedomains/search\"/>\n    <link href=\"/api/tags\" rel=\"tags\"/>\n
-        \   <link href=\"/api/templates\" rel=\"templates\"/>\n    <link href=\"/api/templates?search={query}\"
-        rel=\"templates/search\"/>\n    <link href=\"/api/users\" rel=\"users\"/>\n
-        \   <link href=\"/api/users?search={query}\" rel=\"users/search\"/>\n    <link
-        href=\"/api/groups\" rel=\"groups\"/>\n    <link href=\"/api/groups?search={query}\"
-        rel=\"groups/search\"/>\n    <link href=\"/api/domains\" rel=\"domains\"/>\n
-        \   <link href=\"/api/vmpools\" rel=\"vmpools\"/>\n    <link href=\"/api/vmpools?search={query}\"
-        rel=\"vmpools/search\"/>\n    <link href=\"/api/vms\" rel=\"vms\"/>\n    <link
-        href=\"/api/vms?search={query}\" rel=\"vms/search\"/>\n    <link href=\"/api/disks\"
-        rel=\"disks\"/>\n    <link href=\"/api/disks?search={query}\" rel=\"disks/search\"/>\n
-        \   <special_objects>\n        <link href=\"/api/templates/00000000-0000-0000-0000-000000000000\"
-        rel=\"templates/blank\"/>\n        <link href=\"/api/tags/00000000-0000-0000-0000-000000000000\"
+        \   <link href=\"/ovirt-engine/api/capabilities\" rel=\"capabilities\"/>\n    <link href=\"/ovirt-engine/api/clusters\"
+        rel=\"clusters\"/>\n    <link href=\"/ovirt-engine/api/clusters?search={query}\" rel=\"clusters/search\"/>\n
+        \   <link href=\"/ovirt-engine/api/datacenters\" rel=\"datacenters\"/>\n    <link href=\"/ovirt-engine/api/datacenters?search={query}\"
+        rel=\"datacenters/search\"/>\n    <link href=\"/ovirt-engine/api/events\" rel=\"events\"/>\n
+        \   <link href=\"/ovirt-engine/api/events;from={event_id}?search={query}\" rel=\"events/search\"/>\n
+        \   <link href=\"/ovirt-engine/api/hosts\" rel=\"hosts\"/>\n    <link href=\"/ovirt-engine/api/hosts?search={query}\"
+        rel=\"hosts/search\"/>\n    <link href=\"/ovirt-engine/api/networks\" rel=\"networks\"/>\n
+        \   <link href=\"/ovirt-engine/api/roles\" rel=\"roles\"/>\n    <link href=\"/ovirt-engine/api/storagedomains\"
+        rel=\"storagedomains\"/>\n    <link href=\"/ovirt-engine/api/storagedomains?search={query}\"
+        rel=\"storagedomains/search\"/>\n    <link href=\"/ovirt-engine/api/tags\" rel=\"tags\"/>\n
+        \   <link href=\"/ovirt-engine/api/templates\" rel=\"templates\"/>\n    <link href=\"/ovirt-engine/api/templates?search={query}\"
+        rel=\"templates/search\"/>\n    <link href=\"/ovirt-engine/api/users\" rel=\"users\"/>\n
+        \   <link href=\"/ovirt-engine/api/users?search={query}\" rel=\"users/search\"/>\n    <link
+        href=\"/ovirt-engine/api/groups\" rel=\"groups\"/>\n    <link href=\"/ovirt-engine/api/groups?search={query}\"
+        rel=\"groups/search\"/>\n    <link href=\"/ovirt-engine/api/domains\" rel=\"domains\"/>\n
+        \   <link href=\"/ovirt-engine/api/vmpools\" rel=\"vmpools\"/>\n    <link href=\"/ovirt-engine/api/vmpools?search={query}\"
+        rel=\"vmpools/search\"/>\n    <link href=\"/ovirt-engine/api/vms\" rel=\"vms\"/>\n    <link
+        href=\"/ovirt-engine/api/vms?search={query}\" rel=\"vms/search\"/>\n    <link href=\"/ovirt-engine/api/disks\"
+        rel=\"disks\"/>\n    <link href=\"/ovirt-engine/api/disks?search={query}\" rel=\"disks/search\"/>\n
+        \   <special_objects>\n        <link href=\"/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000\"
+        rel=\"templates/blank\"/>\n        <link href=\"/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000\"
         rel=\"tags/root\"/>\n    </special_objects>\n    <product_info>\n        <name>Red
         Hat Enterprise Virtualization</name>\n        <vendor>Red Hat</vendor>\n        <version
         major=\"3\" minor=\"1\" build=\"0\" revision=\"0\"/>\n    </product_info>\n

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_after_migration.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_after_migration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://10.35.161.51/api
+    uri: https://10.35.161.51/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -33,33 +33,33 @@ http_interactions:
       Expires:
       - Thu, 01 Jan 1970 02:00:00 IST
       Link:
-      - "<https://10.35.161.51/api/capabilities>; rel=capabilities,<https://10.35.161.51/api/clusters>;
-        rel=clusters,<https://10.35.161.51/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/api/datacenters>;
-        rel=datacenters,<https://10.35.161.51/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/api/events>;
-        rel=events,<https://10.35.161.51/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://10.35.161.51/api/hosts>; rel=hosts,<https://10.35.161.51/api/hosts?search={query}>;
-        rel=hosts/search,<https://10.35.161.51/api/networks>; rel=networks,<https://10.35.161.51/api/networks?search={query}>;
-        rel=networks/search,<https://10.35.161.51/api/roles>; rel=roles,<https://10.35.161.51/api/storagedomains>;
-        rel=storagedomains,<https://10.35.161.51/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://10.35.161.51/api/tags>; rel=tags,<https://10.35.161.51/api/bookmarks>;
-        rel=bookmarks,<https://10.35.161.51/api/icons>; rel=icons,<https://10.35.161.51/api/templates>;
-        rel=templates,<https://10.35.161.51/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/api/instancetypes>;
-        rel=instancetypes,<https://10.35.161.51/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://10.35.161.51/api/users>; rel=users,<https://10.35.161.51/api/users?search={query}>;
-        rel=users/search,<https://10.35.161.51/api/groups>; rel=groups,<https://10.35.161.51/api/groups?search={query}>;
-        rel=groups/search,<https://10.35.161.51/api/domains>; rel=domains,<https://10.35.161.51/api/vmpools>;
-        rel=vmpools,<https://10.35.161.51/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/api/vms>;
-        rel=vms,<https://10.35.161.51/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/api/disks>;
-        rel=disks,<https://10.35.161.51/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/api/jobs>;
-        rel=jobs,<https://10.35.161.51/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/api/vnicprofiles>;
-        rel=vnicprofiles,<https://10.35.161.51/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/api/cpuprofiles>;
-        rel=cpuprofiles,<https://10.35.161.51/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://10.35.161.51/api/permissions>; rel=permissions,<https://10.35.161.51/api/macpools>;
-        rel=macpools,<https://10.35.161.51/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/api/externalhostproviders>;
-        rel=externalhostproviders,<https://10.35.161.51/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://10.35.161.51/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://10.35.161.51/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://10.35.161.51/api/katelloerrata>; rel=katelloerrata"
+      - "<https://10.35.161.51/ovirt-engine/api/capabilities>; rel=capabilities,<https://10.35.161.51/ovirt-engine/api/clusters>;
+        rel=clusters,<https://10.35.161.51/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://10.35.161.51/ovirt-engine/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/ovirt-engine/api/events>;
+        rel=events,<https://10.35.161.51/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://10.35.161.51/ovirt-engine/api/hosts>; rel=hosts,<https://10.35.161.51/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://10.35.161.51/ovirt-engine/api/networks>; rel=networks,<https://10.35.161.51/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://10.35.161.51/ovirt-engine/api/roles>; rel=roles,<https://10.35.161.51/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://10.35.161.51/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://10.35.161.51/ovirt-engine/api/tags>; rel=tags,<https://10.35.161.51/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://10.35.161.51/ovirt-engine/api/icons>; rel=icons,<https://10.35.161.51/ovirt-engine/api/templates>;
+        rel=templates,<https://10.35.161.51/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://10.35.161.51/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://10.35.161.51/ovirt-engine/api/users>; rel=users,<https://10.35.161.51/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://10.35.161.51/ovirt-engine/api/groups>; rel=groups,<https://10.35.161.51/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://10.35.161.51/ovirt-engine/api/domains>; rel=domains,<https://10.35.161.51/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://10.35.161.51/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/ovirt-engine/api/vms>;
+        rel=vms,<https://10.35.161.51/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/ovirt-engine/api/disks>;
+        rel=disks,<https://10.35.161.51/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/ovirt-engine/api/jobs>;
+        rel=jobs,<https://10.35.161.51/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://10.35.161.51/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://10.35.161.51/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://10.35.161.51/ovirt-engine/api/permissions>; rel=permissions,<https://10.35.161.51/ovirt-engine/api/macpools>;
+        rel=macpools,<https://10.35.161.51/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://10.35.161.51/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://10.35.161.51/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://10.35.161.51/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://10.35.161.51/ovirt-engine/api/katelloerrata>; rel=katelloerrata"
       Jsessionid:
       - PjLhwAkmc850YyVOZjPCA9Kk
       Content-Type:
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:51 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/clusters?search=sortby%20name%20asc%20page%201
+    uri: https://10.35.161.51/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:51 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/clusters?search=sortby%20name%20asc%20page%202
+    uri: https://10.35.161.51/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:51 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/datacenters?search=sortby%20name%20asc%20page%201
+    uri: https://10.35.161.51/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -276,7 +276,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:51 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/datacenters?search=sortby%20name%20asc%20page%202
+    uri: https://10.35.161.51/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -328,7 +328,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:51 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae
     body:
       encoding: US-ASCII
       string: ''
@@ -413,7 +413,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:52 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/templates?search=vm.id=13054ffb-ae62-49e3-9ec7-9ad426f62fae
+    uri: https://10.35.161.51/ovirt-engine/api/templates?search=vm.id=13054ffb-ae62-49e3-9ec7-9ad426f62fae
     body:
       encoding: US-ASCII
       string: ''
@@ -485,7 +485,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:52 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/storagedomains/2ef34a5b-2046-4707-9180-7723aad1b8ce
+    uri: https://10.35.161.51/ovirt-engine/api/storagedomains/2ef34a5b-2046-4707-9180-7723aad1b8ce
     body:
       encoding: US-ASCII
       string: ''
@@ -548,7 +548,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:52 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/disks
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -612,7 +612,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:52 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/snapshots
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -669,7 +669,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:09:53 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/nics
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/nics
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_before_migration.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_before_migration.yml
@@ -2,59 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://10.35.161.51/api
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Date:
-      - Mon, 16 Jan 2017 08:20:18 GMT
-      Pragma:
-      - No-cache
-      Cache-Control:
-      - no-cache
-      Expires:
-      - Thu, 01 Jan 1970 02:00:00 IST
-      Www-Authenticate:
-      - Basic realm="ENGINE"
-      Content-Type:
-      - text/html;charset=utf-8
-      Vary:
-      - Accept-Encoding
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '377'
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA7WTXU+DMBSG/0qdt+v42Ma0VJItMyHeuCiJ8bJANxqBYlui
-        uOy/W+i+4i6miSMhbU7f85xz4C3OVJEHOKMkDbBiKqfBw+zlfmbrxxsjEEbR
-        AjwromoJRrYDIMCWkWGpmna5gjB0wHrJSwWXpGB5gyKS8YL0p4KRvC9JKaGk
-        gi39hOdcoI+MKerHJHlbCV6XKTTh67E7nk88vwNJ9kWR61af/gaE7kXojmfo
-        w8vQRx199jh//Qs/zjX6lG/Katw/9roBi9/RDoQt8rjVo4m7vzUF6+4YIGAE
-        m+mgJAU9CYdPh9C+JQgDbBlfaZ8ZU8Y8bbRBnfO+1BqssW03dz2nB0ouM5Lq
-        /XbTC3CleXvQ0L5FQDUVxVYcgAN+gnZkQSsuFLaqH5m2d4NAQaUkK5OMa914
-        +54qdY2UykSwSjFe7tS7c8d1EIgy1tZ6r6lU3coElWZEUquMloolpM0e7Iuc
-        mdMyX83qbvc35+Dx2eQDAAA=
-    http_version:
-  recorded_at: Mon, 16 Jan 2017 13:08:34 GMT
-- request:
-    method: get
-    uri: https://admin%40internal:password@10.35.161.51/api
+    uri: https://admin%40internal:password@10.35.161.51/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -85,33 +33,33 @@ http_interactions:
       Set-Cookie:
       - JSESSIONID=PjLhwAkmc850YyVOZjPCA9Kk; Path=/api; Secure; HttpOnly
       Link:
-      - "<https://10.35.161.51/api/capabilities>; rel=capabilities,<https://10.35.161.51/api/clusters>;
-        rel=clusters,<https://10.35.161.51/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/api/datacenters>;
-        rel=datacenters,<https://10.35.161.51/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/api/events>;
-        rel=events,<https://10.35.161.51/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://10.35.161.51/api/hosts>; rel=hosts,<https://10.35.161.51/api/hosts?search={query}>;
-        rel=hosts/search,<https://10.35.161.51/api/networks>; rel=networks,<https://10.35.161.51/api/networks?search={query}>;
-        rel=networks/search,<https://10.35.161.51/api/roles>; rel=roles,<https://10.35.161.51/api/storagedomains>;
-        rel=storagedomains,<https://10.35.161.51/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://10.35.161.51/api/tags>; rel=tags,<https://10.35.161.51/api/bookmarks>;
-        rel=bookmarks,<https://10.35.161.51/api/icons>; rel=icons,<https://10.35.161.51/api/templates>;
-        rel=templates,<https://10.35.161.51/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/api/instancetypes>;
-        rel=instancetypes,<https://10.35.161.51/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://10.35.161.51/api/users>; rel=users,<https://10.35.161.51/api/users?search={query}>;
-        rel=users/search,<https://10.35.161.51/api/groups>; rel=groups,<https://10.35.161.51/api/groups?search={query}>;
-        rel=groups/search,<https://10.35.161.51/api/domains>; rel=domains,<https://10.35.161.51/api/vmpools>;
-        rel=vmpools,<https://10.35.161.51/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/api/vms>;
-        rel=vms,<https://10.35.161.51/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/api/disks>;
-        rel=disks,<https://10.35.161.51/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/api/jobs>;
-        rel=jobs,<https://10.35.161.51/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/api/vnicprofiles>;
-        rel=vnicprofiles,<https://10.35.161.51/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/api/cpuprofiles>;
-        rel=cpuprofiles,<https://10.35.161.51/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://10.35.161.51/api/permissions>; rel=permissions,<https://10.35.161.51/api/macpools>;
-        rel=macpools,<https://10.35.161.51/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/api/externalhostproviders>;
-        rel=externalhostproviders,<https://10.35.161.51/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://10.35.161.51/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://10.35.161.51/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://10.35.161.51/api/katelloerrata>; rel=katelloerrata"
+      - "<https://10.35.161.51/ovirt-engine/api/capabilities>; rel=capabilities,<https://10.35.161.51/ovirt-engine/api/clusters>;
+        rel=clusters,<https://10.35.161.51/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://10.35.161.51/ovirt-engine/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/ovirt-engine/api/events>;
+        rel=events,<https://10.35.161.51/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://10.35.161.51/ovirt-engine/api/hosts>; rel=hosts,<https://10.35.161.51/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://10.35.161.51/ovirt-engine/api/networks>; rel=networks,<https://10.35.161.51/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://10.35.161.51/ovirt-engine/api/roles>; rel=roles,<https://10.35.161.51/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://10.35.161.51/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://10.35.161.51/ovirt-engine/api/tags>; rel=tags,<https://10.35.161.51/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://10.35.161.51/ovirt-engine/api/icons>; rel=icons,<https://10.35.161.51/ovirt-engine/api/templates>;
+        rel=templates,<https://10.35.161.51/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://10.35.161.51/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://10.35.161.51/ovirt-engine/api/users>; rel=users,<https://10.35.161.51/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://10.35.161.51/ovirt-engine/api/groups>; rel=groups,<https://10.35.161.51/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://10.35.161.51/ovirt-engine/api/domains>; rel=domains,<https://10.35.161.51/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://10.35.161.51/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/ovirt-engine/api/vms>;
+        rel=vms,<https://10.35.161.51/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/ovirt-engine/api/disks>;
+        rel=disks,<https://10.35.161.51/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/ovirt-engine/api/jobs>;
+        rel=jobs,<https://10.35.161.51/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://10.35.161.51/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://10.35.161.51/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://10.35.161.51/ovirt-engine/api/permissions>; rel=permissions,<https://10.35.161.51/ovirt-engine/api/macpools>;
+        rel=macpools,<https://10.35.161.51/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://10.35.161.51/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://10.35.161.51/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://10.35.161.51/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://10.35.161.51/ovirt-engine/api/katelloerrata>; rel=katelloerrata"
       Jsessionid:
       - PjLhwAkmc850YyVOZjPCA9Kk
       Content-Type:
@@ -150,7 +98,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/clusters
+    uri: https://10.35.161.51/ovirt-engine/api/clusters
     body:
       encoding: US-ASCII
       string: ''
@@ -219,7 +167,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vmpools
+    uri: https://10.35.161.51/ovirt-engine/api/vmpools
     body:
       encoding: US-ASCII
       string: ''
@@ -270,7 +218,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/networks
+    uri: https://10.35.161.51/ovirt-engine/api/networks
     body:
       encoding: US-ASCII
       string: ''
@@ -328,7 +276,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/storagedomains?search=sortby%20name%20asc%20page%201
+    uri: https://10.35.161.51/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -400,7 +348,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/storagedomains?search=sortby%20name%20asc%20page%202
+    uri: https://10.35.161.51/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -452,7 +400,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:35 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/datacenters
+    uri: https://10.35.161.51/ovirt-engine/api/datacenters
     body:
       encoding: US-ASCII
       string: ''
@@ -510,7 +458,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:36 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts?search=sortby%20name%20asc%20page%201
+    uri: https://10.35.161.51/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -602,7 +550,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:36 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts?search=sortby%20name%20asc%20page%202
+    uri: https://10.35.161.51/ovirt-engine/api/hosts?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -653,7 +601,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:36 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms?search=sortby%20name%20asc%20page%201
+    uri: https://10.35.161.51/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -759,7 +707,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:36 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms?search=sortby%20name%20asc%20page%202
+    uri: https://10.35.161.51/ovirt-engine/api/vms?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -810,7 +758,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:36 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/templates
+    uri: https://10.35.161.51/ovirt-engine/api/templates
     body:
       encoding: US-ASCII
       string: ''
@@ -888,7 +836,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/datacenters/00000001-0001-0001-0001-0000000003bb/storagedomains
+    uri: https://10.35.161.51/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000003bb/storagedomains
     body:
       encoding: US-ASCII
       string: ''
@@ -949,7 +897,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts/bfb0c0b4-8616-4bbf-9210-9de48892adc6/statistics
+    uri: https://10.35.161.51/ovirt-engine/api/hosts/bfb0c0b4-8616-4bbf-9210-9de48892adc6/statistics
     body:
       encoding: US-ASCII
       string: ''
@@ -1021,7 +969,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts/bfb0c0b4-8616-4bbf-9210-9de48892adc6/nics
+    uri: https://10.35.161.51/ovirt-engine/api/hosts/bfb0c0b4-8616-4bbf-9210-9de48892adc6/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1085,7 +1033,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts/0b4c3cf3-3b51-479a-bd36-ab968151a9a9/statistics
+    uri: https://10.35.161.51/ovirt-engine/api/hosts/0b4c3cf3-3b51-479a-bd36-ab968151a9a9/statistics
     body:
       encoding: US-ASCII
       string: ''
@@ -1157,7 +1105,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/hosts/0b4c3cf3-3b51-479a-bd36-ab968151a9a9/nics
+    uri: https://10.35.161.51/ovirt-engine/api/hosts/0b4c3cf3-3b51-479a-bd36-ab968151a9a9/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1223,7 +1171,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:37 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/disks
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -1287,7 +1235,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/snapshots
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -1344,7 +1292,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/nics
+    uri: https://10.35.161.51/ovirt-engine/api/vms/13054ffb-ae62-49e3-9ec7-9ad426f62fae/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1395,7 +1343,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/disks
+    uri: https://10.35.161.51/ovirt-engine/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -1446,7 +1394,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/snapshots
+    uri: https://10.35.161.51/ovirt-engine/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -1503,7 +1451,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/nics
+    uri: https://10.35.161.51/ovirt-engine/api/vms/ccda1fdd-852e-4e7f-939d-5598bc8fcbb3/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1554,7 +1502,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:38 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/disks
+    uri: https://10.35.161.51/ovirt-engine/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -1619,7 +1567,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:39 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/snapshots
+    uri: https://10.35.161.51/ovirt-engine/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -1676,7 +1624,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:39 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/nics
+    uri: https://10.35.161.51/ovirt-engine/api/vms/9ada55c8-71b8-4e76-9b5e-d9a3f31f8c84/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1738,7 +1686,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:39 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/disks
+    uri: https://10.35.161.51/ovirt-engine/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -1801,7 +1749,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:39 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/snapshots
+    uri: https://10.35.161.51/ovirt-engine/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -1858,7 +1806,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:39 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/nics
+    uri: https://10.35.161.51/ovirt-engine/api/vms/5e61c5a1-c877-4a93-8c3b-01838e073167/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -1916,7 +1864,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:40 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/templates/00000000-0000-0000-0000-000000000000/disks
+    uri: https://10.35.161.51/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -1967,7 +1915,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:40 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api/templates/749236d0-6320-46d2-bd0a-8a9989bb607a/disks
+    uri: https://10.35.161.51/ovirt-engine/api/templates/749236d0-6320-46d2-bd0a-8a9989bb607a/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -2030,7 +1978,7 @@ http_interactions:
   recorded_at: Mon, 16 Jan 2017 13:08:40 GMT
 - request:
     method: get
-    uri: https://10.35.161.51/api
+    uri: https://10.35.161.51/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -2061,33 +2009,33 @@ http_interactions:
       Expires:
       - Thu, 01 Jan 1970 02:00:00 IST
       Link:
-      - "<https://10.35.161.51/api/capabilities>; rel=capabilities,<https://10.35.161.51/api/clusters>;
-        rel=clusters,<https://10.35.161.51/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/api/datacenters>;
-        rel=datacenters,<https://10.35.161.51/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/api/events>;
-        rel=events,<https://10.35.161.51/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://10.35.161.51/api/hosts>; rel=hosts,<https://10.35.161.51/api/hosts?search={query}>;
-        rel=hosts/search,<https://10.35.161.51/api/networks>; rel=networks,<https://10.35.161.51/api/networks?search={query}>;
-        rel=networks/search,<https://10.35.161.51/api/roles>; rel=roles,<https://10.35.161.51/api/storagedomains>;
-        rel=storagedomains,<https://10.35.161.51/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://10.35.161.51/api/tags>; rel=tags,<https://10.35.161.51/api/bookmarks>;
-        rel=bookmarks,<https://10.35.161.51/api/icons>; rel=icons,<https://10.35.161.51/api/templates>;
-        rel=templates,<https://10.35.161.51/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/api/instancetypes>;
-        rel=instancetypes,<https://10.35.161.51/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://10.35.161.51/api/users>; rel=users,<https://10.35.161.51/api/users?search={query}>;
-        rel=users/search,<https://10.35.161.51/api/groups>; rel=groups,<https://10.35.161.51/api/groups?search={query}>;
-        rel=groups/search,<https://10.35.161.51/api/domains>; rel=domains,<https://10.35.161.51/api/vmpools>;
-        rel=vmpools,<https://10.35.161.51/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/api/vms>;
-        rel=vms,<https://10.35.161.51/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/api/disks>;
-        rel=disks,<https://10.35.161.51/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/api/jobs>;
-        rel=jobs,<https://10.35.161.51/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/api/vnicprofiles>;
-        rel=vnicprofiles,<https://10.35.161.51/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/api/cpuprofiles>;
-        rel=cpuprofiles,<https://10.35.161.51/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://10.35.161.51/api/permissions>; rel=permissions,<https://10.35.161.51/api/macpools>;
-        rel=macpools,<https://10.35.161.51/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/api/externalhostproviders>;
-        rel=externalhostproviders,<https://10.35.161.51/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://10.35.161.51/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://10.35.161.51/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://10.35.161.51/api/katelloerrata>; rel=katelloerrata"
+      - "<https://10.35.161.51/ovirt-engine/api/capabilities>; rel=capabilities,<https://10.35.161.51/ovirt-engine/api/clusters>;
+        rel=clusters,<https://10.35.161.51/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://10.35.161.51/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://10.35.161.51/ovirt-engine/api/datacenters?search={query}>; rel=datacenters/search,<https://10.35.161.51/ovirt-engine/api/events>;
+        rel=events,<https://10.35.161.51/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://10.35.161.51/ovirt-engine/api/hosts>; rel=hosts,<https://10.35.161.51/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://10.35.161.51/ovirt-engine/api/networks>; rel=networks,<https://10.35.161.51/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://10.35.161.51/ovirt-engine/api/roles>; rel=roles,<https://10.35.161.51/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://10.35.161.51/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://10.35.161.51/ovirt-engine/api/tags>; rel=tags,<https://10.35.161.51/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://10.35.161.51/ovirt-engine/api/icons>; rel=icons,<https://10.35.161.51/ovirt-engine/api/templates>;
+        rel=templates,<https://10.35.161.51/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://10.35.161.51/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://10.35.161.51/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://10.35.161.51/ovirt-engine/api/users>; rel=users,<https://10.35.161.51/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://10.35.161.51/ovirt-engine/api/groups>; rel=groups,<https://10.35.161.51/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://10.35.161.51/ovirt-engine/api/domains>; rel=domains,<https://10.35.161.51/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://10.35.161.51/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://10.35.161.51/ovirt-engine/api/vms>;
+        rel=vms,<https://10.35.161.51/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://10.35.161.51/ovirt-engine/api/disks>;
+        rel=disks,<https://10.35.161.51/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://10.35.161.51/ovirt-engine/api/jobs>;
+        rel=jobs,<https://10.35.161.51/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://10.35.161.51/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://10.35.161.51/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://10.35.161.51/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://10.35.161.51/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://10.35.161.51/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://10.35.161.51/ovirt-engine/api/permissions>; rel=permissions,<https://10.35.161.51/ovirt-engine/api/macpools>;
+        rel=macpools,<https://10.35.161.51/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://10.35.161.51/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://10.35.161.51/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://10.35.161.51/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://10.35.161.51/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://10.35.161.51/ovirt-engine/api/katelloerrata>; rel=katelloerrata"
       Jsessionid:
       - PjLhwAkmc850YyVOZjPCA9Kk
       Content-Type:

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_new_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_new_vm.yml
@@ -2,40 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Connection:
-      - keep-alive
-      Www-Authenticate:
-      - Basic realm="ENGINE"
-      Content-Type:
-      - text/html;charset=UTF-8
-      Content-Length:
-      - '71'
-      Date:
-      - Mon, 22 Aug 2016 09:57:57 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
-    http_version:
-  recorded_at: Mon, 22 Aug 2016 09:57:56 GMT
-- request:
-    method: get
-    uri: https://admin%40internal:engine@192.168.1.31:8443/api
+    uri: https://admin%40internal:engine@192.168.1.31:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -66,33 +33,33 @@ http_interactions:
       Jsessionid:
       - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
       Link:
-      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
-        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
-        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
-        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
-        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
-        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
-        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
-        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
-        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
-        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
-        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
-        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
-        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
-        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+      - "<https://192.168.1.31:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/ovirt-engine/api/events>; rel=events,<https://192.168.1.31:8443/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.1.31:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.1.31:8443/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/ovirt-engine/api/roles>; rel=roles,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.1.31:8443/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/ovirt-engine/api/icons>; rel=icons,<https://192.168.1.31:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/ovirt-engine/api/users>; rel=users,<https://192.168.1.31:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.1.31:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.1.31:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/ovirt-engine/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/ovirt-engine/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/ovirt-engine/api/permissions>; rel=permissions,<https://192.168.1.31:8443/ovirt-engine/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/ovirt-engine/api/katelloerrata>;
         rel=katelloerrata"
       Date:
       - Mon, 22 Aug 2016 09:57:57 GMT
@@ -101,56 +68,56 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <api>
-            <link href="/api/capabilities" rel="capabilities"/>
-            <link href="/api/clusters" rel="clusters"/>
-            <link href="/api/clusters?search={query}" rel="clusters/search"/>
-            <link href="/api/datacenters" rel="datacenters"/>
-            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
-            <link href="/api/events" rel="events"/>
-            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
-            <link href="/api/hosts" rel="hosts"/>
-            <link href="/api/hosts?search={query}" rel="hosts/search"/>
-            <link href="/api/networks" rel="networks"/>
-            <link href="/api/networks?search={query}" rel="networks/search"/>
-            <link href="/api/roles" rel="roles"/>
-            <link href="/api/storagedomains" rel="storagedomains"/>
-            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
-            <link href="/api/tags" rel="tags"/>
-            <link href="/api/bookmarks" rel="bookmarks"/>
-            <link href="/api/icons" rel="icons"/>
-            <link href="/api/templates" rel="templates"/>
-            <link href="/api/templates?search={query}" rel="templates/search"/>
-            <link href="/api/instancetypes" rel="instancetypes"/>
-            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
-            <link href="/api/users" rel="users"/>
-            <link href="/api/users?search={query}" rel="users/search"/>
-            <link href="/api/groups" rel="groups"/>
-            <link href="/api/groups?search={query}" rel="groups/search"/>
-            <link href="/api/domains" rel="domains"/>
-            <link href="/api/vmpools" rel="vmpools"/>
-            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
-            <link href="/api/vms" rel="vms"/>
-            <link href="/api/vms?search={query}" rel="vms/search"/>
-            <link href="/api/disks" rel="disks"/>
-            <link href="/api/disks?search={query}" rel="disks/search"/>
-            <link href="/api/jobs" rel="jobs"/>
-            <link href="/api/storageconnections" rel="storageconnections"/>
-            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
-            <link href="/api/diskprofiles" rel="diskprofiles"/>
-            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
-            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
-            <link href="/api/permissions" rel="permissions"/>
-            <link href="/api/macpools" rel="macpools"/>
-            <link href="/api/operatingsystems" rel="operatingsystems"/>
-            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
-            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
-            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
-            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
-            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/capabilities" rel="capabilities"/>
+            <link href="/ovirt-engine/api/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/ovirt-engine/api/datacenters" rel="datacenters"/>
+            <link href="/ovirt-engine/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/ovirt-engine/api/events" rel="events"/>
+            <link href="/ovirt-engine/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/ovirt-engine/api/hosts" rel="hosts"/>
+            <link href="/ovirt-engine/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/ovirt-engine/api/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/networks?search={query}" rel="networks/search"/>
+            <link href="/ovirt-engine/api/roles" rel="roles"/>
+            <link href="/ovirt-engine/api/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/ovirt-engine/api/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/bookmarks" rel="bookmarks"/>
+            <link href="/ovirt-engine/api/icons" rel="icons"/>
+            <link href="/ovirt-engine/api/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/templates?search={query}" rel="templates/search"/>
+            <link href="/ovirt-engine/api/instancetypes" rel="instancetypes"/>
+            <link href="/ovirt-engine/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/ovirt-engine/api/users" rel="users"/>
+            <link href="/ovirt-engine/api/users?search={query}" rel="users/search"/>
+            <link href="/ovirt-engine/api/groups" rel="groups"/>
+            <link href="/ovirt-engine/api/groups?search={query}" rel="groups/search"/>
+            <link href="/ovirt-engine/api/domains" rel="domains"/>
+            <link href="/ovirt-engine/api/vmpools" rel="vmpools"/>
+            <link href="/ovirt-engine/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/ovirt-engine/api/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/vms?search={query}" rel="vms/search"/>
+            <link href="/ovirt-engine/api/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/disks?search={query}" rel="disks/search"/>
+            <link href="/ovirt-engine/api/jobs" rel="jobs"/>
+            <link href="/ovirt-engine/api/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/ovirt-engine/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/ovirt-engine/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/ovirt-engine/api/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/macpools" rel="macpools"/>
+            <link href="/ovirt-engine/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/ovirt-engine/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/ovirt-engine/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/ovirt-engine/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/ovirt-engine/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/ovirt-engine/api/katelloerrata" rel="katelloerrata"/>
             <special_objects>
-                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
-                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
             </special_objects>
             <product_info>
                 <name>oVirt Engine</name>
@@ -182,7 +149,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:56 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/clusters?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.1.31:8443/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -219,29 +186,29 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <clusters>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
                 <actions>
-                    <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
+                    <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
                 </actions>
                 <name>Default</name>
                 <description>The default server cluster</description>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
                 <cpu id="Intel SandyBridge Family">
                     <architecture>X86_64</architecture>
                 </cpu>
-                <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
+                <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
                 <memory_policy>
                     <overcommit percent="100"/>
                     <transparent_hugepages>
                         <enabled>true</enabled>
                     </transparent_hugepages>
                 </memory_policy>
-                <scheduling_policy href="/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
+                <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
                     <name>none</name>
                     <policy>none</policy>
                 </scheduling_policy>
@@ -285,7 +252,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:33 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/clusters?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.1.31:8443/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -326,7 +293,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:33 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/datacenters?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.1.31:8443/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -363,16 +330,16 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <data_centers>
-            <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
+            <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
                 <name>Default</name>
                 <description>The default Data Center</description>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
                 <local>false</local>
                 <storage_format>v3</storage_format>
                 <version major="3" minor="6"/>
@@ -382,7 +349,7 @@ http_interactions:
                 <status>
                     <state>up</state>
                 </status>
-                <mac_pool href="/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
+                <mac_pool href="/ovirt-engine/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
                 <quota_mode>disabled</quota_mode>
             </data_center>
         </data_centers>
@@ -390,7 +357,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:34 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/datacenters?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.1.31:8443/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -431,7 +398,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:34 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
     body:
       encoding: US-ASCII
       string: ''
@@ -467,45 +434,45 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
+        <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
             <actions>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
             </actions>
             <name>123</name>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
             <type>desktop</type>
             <status>
                 <state>down</state>
@@ -524,7 +491,7 @@ http_interactions:
             <os type="other">
                 <boot dev="hd"/>
             </os>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
             <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
             <origin>ovirt</origin>
             <stateless>false</stateless>
@@ -554,7 +521,7 @@ http_interactions:
             </usb>
             <migration_downtime>-1</migration_downtime>
             <start_paused>false</start_paused>
-            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
             <migration>
                 <auto_converge>inherit</auto_converge>
                 <compressed>inherit</compressed>
@@ -565,13 +532,13 @@ http_interactions:
             <time_zone>
                 <name>Etc/GMT</name>
             </time_zone>
-            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+            <small_icon href="/ovirt-engine/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+            <large_icon href="/ovirt-engine/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
             <memory_policy>
                 <guaranteed>1073741824</guaranteed>
                 <ballooning>false</ballooning>
             </memory_policy>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+            <template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
             <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
             <placement_policy>
                 <affinity>migratable</affinity>
@@ -583,7 +550,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    uri: https://192.168.1.31:8443/ovirt-engine/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
     body:
       encoding: US-ASCII
       string: ''
@@ -620,19 +587,19 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <templates>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
+            <template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
                 <actions>
-                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
+                    <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
                 </actions>
                 <name>GlanceTemplate-7bb26f9</name>
                 <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
                 <type>desktop</type>
                 <status>
                     <state>ok</state>
@@ -651,7 +618,7 @@ http_interactions:
                 <os type="other">
                     <boot dev="hd"/>
                 </os>
-                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+                <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
                 <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
                 <origin>ovirt</origin>
                 <stateless>false</stateless>
@@ -681,7 +648,7 @@ http_interactions:
                 </usb>
                 <migration_downtime>-1</migration_downtime>
                 <start_paused>false</start_paused>
-                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+                <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
                 <migration>
                     <auto_converge>inherit</auto_converge>
                     <compressed>inherit</compressed>
@@ -692,13 +659,13 @@ http_interactions:
                 <time_zone>
                     <name>Etc/GMT</name>
                 </time_zone>
-                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+                <small_icon href="/ovirt-engine/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+                <large_icon href="/ovirt-engine/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
                 <memory_policy>
                     <guaranteed>1073741824</guaranteed>
                 </memory_policy>
                 <version>
-                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+                    <base_template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
                     <version_number>1</version_number>
                     <version_name>base version</version_name>
                 </version>
@@ -708,7 +675,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/storagedomains?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -745,19 +712,19 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <storage_domains>
-            <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
+            <storage_domain href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
                 <actions>
-                    <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
-                    <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
+                    <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
+                    <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
                 </actions>
                 <name>data</name>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
                 <data_centers>
                     <data_center id="00000001-0001-0001-0001-0000000002c0"/>
                 </data_centers>
@@ -785,7 +752,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/storagedomains?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -826,7 +793,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -863,18 +830,18 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <disks>
-            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+            <disk href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
                 </actions>
                 <name>GlanceDisk-73786f4</name>
                 <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
+                <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
                 <alias>GlanceDisk-73786f4</alias>
                 <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
                 <storage_domains>
@@ -895,7 +862,7 @@ http_interactions:
                 <propagate_errors>false</propagate_errors>
                 <active>true</active>
                 <read_only>false</read_only>
-                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+                <disk_profile href="/ovirt-engine/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
                 <storage_type>image</storage_type>
             </disk>
         </disks>
@@ -903,7 +870,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -940,9 +907,9 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <snapshots>
-            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
+            <snapshot href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
                 </actions>
                 <description>Active VM</description>
                 <type>active</type>
@@ -955,7 +922,7 @@ http_interactions:
   recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -992,28 +959,28 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <nics>
-            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
+            <nic href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
                 </actions>
                 <name>nic1</name>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
+                <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
                 <linked>true</linked>
                 <interface>virtio</interface>
                 <mac address="00:1a:4a:16:01:52"/>
                 <active>true</active>
                 <plugged>true</plugged>
-                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
+                <vnic_profile href="/ovirt-engine/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
             </nic>
         </nics>
     http_version:
   recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
+    uri: https://192.168.1.31:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -1044,33 +1011,33 @@ http_interactions:
       Jsessionid:
       - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
       Link:
-      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
-        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
-        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
-        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
-        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
-        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
-        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
-        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
-        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
-        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
-        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
-        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
-        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
-        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+      - "<https://192.168.1.31:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/ovirt-engine/api/events>; rel=events,<https://192.168.1.31:8443/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.1.31:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.1.31:8443/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/ovirt-engine/api/roles>; rel=roles,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.1.31:8443/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/ovirt-engine/api/icons>; rel=icons,<https://192.168.1.31:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/ovirt-engine/api/users>; rel=users,<https://192.168.1.31:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.1.31:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.1.31:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/ovirt-engine/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/ovirt-engine/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/ovirt-engine/api/permissions>; rel=permissions,<https://192.168.1.31:8443/ovirt-engine/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/ovirt-engine/api/katelloerrata>;
         rel=katelloerrata"
       Date:
       - Wed, 30 Nov 2016 15:43:35 GMT
@@ -1079,56 +1046,56 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <api>
-            <link href="/api/capabilities" rel="capabilities"/>
-            <link href="/api/clusters" rel="clusters"/>
-            <link href="/api/clusters?search={query}" rel="clusters/search"/>
-            <link href="/api/datacenters" rel="datacenters"/>
-            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
-            <link href="/api/events" rel="events"/>
-            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
-            <link href="/api/hosts" rel="hosts"/>
-            <link href="/api/hosts?search={query}" rel="hosts/search"/>
-            <link href="/api/networks" rel="networks"/>
-            <link href="/api/networks?search={query}" rel="networks/search"/>
-            <link href="/api/roles" rel="roles"/>
-            <link href="/api/storagedomains" rel="storagedomains"/>
-            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
-            <link href="/api/tags" rel="tags"/>
-            <link href="/api/bookmarks" rel="bookmarks"/>
-            <link href="/api/icons" rel="icons"/>
-            <link href="/api/templates" rel="templates"/>
-            <link href="/api/templates?search={query}" rel="templates/search"/>
-            <link href="/api/instancetypes" rel="instancetypes"/>
-            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
-            <link href="/api/users" rel="users"/>
-            <link href="/api/users?search={query}" rel="users/search"/>
-            <link href="/api/groups" rel="groups"/>
-            <link href="/api/groups?search={query}" rel="groups/search"/>
-            <link href="/api/domains" rel="domains"/>
-            <link href="/api/vmpools" rel="vmpools"/>
-            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
-            <link href="/api/vms" rel="vms"/>
-            <link href="/api/vms?search={query}" rel="vms/search"/>
-            <link href="/api/disks" rel="disks"/>
-            <link href="/api/disks?search={query}" rel="disks/search"/>
-            <link href="/api/jobs" rel="jobs"/>
-            <link href="/api/storageconnections" rel="storageconnections"/>
-            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
-            <link href="/api/diskprofiles" rel="diskprofiles"/>
-            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
-            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
-            <link href="/api/permissions" rel="permissions"/>
-            <link href="/api/macpools" rel="macpools"/>
-            <link href="/api/operatingsystems" rel="operatingsystems"/>
-            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
-            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
-            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
-            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
-            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/capabilities" rel="capabilities"/>
+            <link href="/ovirt-engine/api/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/ovirt-engine/api/datacenters" rel="datacenters"/>
+            <link href="/ovirt-engine/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/ovirt-engine/api/events" rel="events"/>
+            <link href="/ovirt-engine/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/ovirt-engine/api/hosts" rel="hosts"/>
+            <link href="/ovirt-engine/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/ovirt-engine/api/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/networks?search={query}" rel="networks/search"/>
+            <link href="/ovirt-engine/api/roles" rel="roles"/>
+            <link href="/ovirt-engine/api/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/ovirt-engine/api/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/bookmarks" rel="bookmarks"/>
+            <link href="/ovirt-engine/api/icons" rel="icons"/>
+            <link href="/ovirt-engine/api/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/templates?search={query}" rel="templates/search"/>
+            <link href="/ovirt-engine/api/instancetypes" rel="instancetypes"/>
+            <link href="/ovirt-engine/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/ovirt-engine/api/users" rel="users"/>
+            <link href="/ovirt-engine/api/users?search={query}" rel="users/search"/>
+            <link href="/ovirt-engine/api/groups" rel="groups"/>
+            <link href="/ovirt-engine/api/groups?search={query}" rel="groups/search"/>
+            <link href="/ovirt-engine/api/domains" rel="domains"/>
+            <link href="/ovirt-engine/api/vmpools" rel="vmpools"/>
+            <link href="/ovirt-engine/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/ovirt-engine/api/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/vms?search={query}" rel="vms/search"/>
+            <link href="/ovirt-engine/api/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/disks?search={query}" rel="disks/search"/>
+            <link href="/ovirt-engine/api/jobs" rel="jobs"/>
+            <link href="/ovirt-engine/api/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/ovirt-engine/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/ovirt-engine/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/ovirt-engine/api/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/macpools" rel="macpools"/>
+            <link href="/ovirt-engine/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/ovirt-engine/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/ovirt-engine/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/ovirt-engine/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/ovirt-engine/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/ovirt-engine/api/katelloerrata" rel="katelloerrata"/>
             <special_objects>
-                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
-                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
             </special_objects>
             <product_info>
                 <name>oVirt Engine</name>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_vm.yml
@@ -2,40 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Connection:
-      - keep-alive
-      Www-Authenticate:
-      - Basic realm="ENGINE"
-      Content-Type:
-      - text/html;charset=UTF-8
-      Content-Length:
-      - '71'
-      Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
-- request:
-    method: get
-    uri: https://admin%40internal:engine@192.168.1.31:8443/api
+    uri: https://admin%40internal:engine@192.168.1.31:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +25,7 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18; path=/api; HttpOnly
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18; path=/ovirt-engine/api; HttpOnly
       Content-Type:
       - application/xml
       Content-Length:
@@ -66,33 +33,33 @@ http_interactions:
       Jsessionid:
       - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
       Link:
-      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
-        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
-        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
-        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
-        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
-        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
-        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
-        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
-        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
-        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
-        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
-        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
-        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
-        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+      - "<https://192.168.1.31:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/ovirt-engine/api/events>; rel=events,<https://192.168.1.31:8443/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.1.31:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.1.31:8443/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/ovirt-engine/api/roles>; rel=roles,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.1.31:8443/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/ovirt-engine/api/icons>; rel=icons,<https://192.168.1.31:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/ovirt-engine/api/users>; rel=users,<https://192.168.1.31:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.1.31:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.1.31:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/ovirt-engine/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/ovirt-engine/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/ovirt-engine/api/permissions>; rel=permissions,<https://192.168.1.31:8443/ovirt-engine/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/ovirt-engine/api/katelloerrata>;
         rel=katelloerrata"
       Date:
       - Fri, 19 Aug 2016 09:43:43 GMT
@@ -101,56 +68,56 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <api>
-            <link href="/api/capabilities" rel="capabilities"/>
-            <link href="/api/clusters" rel="clusters"/>
-            <link href="/api/clusters?search={query}" rel="clusters/search"/>
-            <link href="/api/datacenters" rel="datacenters"/>
-            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
-            <link href="/api/events" rel="events"/>
-            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
-            <link href="/api/hosts" rel="hosts"/>
-            <link href="/api/hosts?search={query}" rel="hosts/search"/>
-            <link href="/api/networks" rel="networks"/>
-            <link href="/api/networks?search={query}" rel="networks/search"/>
-            <link href="/api/roles" rel="roles"/>
-            <link href="/api/storagedomains" rel="storagedomains"/>
-            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
-            <link href="/api/tags" rel="tags"/>
-            <link href="/api/bookmarks" rel="bookmarks"/>
-            <link href="/api/icons" rel="icons"/>
-            <link href="/api/templates" rel="templates"/>
-            <link href="/api/templates?search={query}" rel="templates/search"/>
-            <link href="/api/instancetypes" rel="instancetypes"/>
-            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
-            <link href="/api/users" rel="users"/>
-            <link href="/api/users?search={query}" rel="users/search"/>
-            <link href="/api/groups" rel="groups"/>
-            <link href="/api/groups?search={query}" rel="groups/search"/>
-            <link href="/api/domains" rel="domains"/>
-            <link href="/api/vmpools" rel="vmpools"/>
-            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
-            <link href="/api/vms" rel="vms"/>
-            <link href="/api/vms?search={query}" rel="vms/search"/>
-            <link href="/api/disks" rel="disks"/>
-            <link href="/api/disks?search={query}" rel="disks/search"/>
-            <link href="/api/jobs" rel="jobs"/>
-            <link href="/api/storageconnections" rel="storageconnections"/>
-            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
-            <link href="/api/diskprofiles" rel="diskprofiles"/>
-            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
-            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
-            <link href="/api/permissions" rel="permissions"/>
-            <link href="/api/macpools" rel="macpools"/>
-            <link href="/api/operatingsystems" rel="operatingsystems"/>
-            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
-            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
-            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
-            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
-            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/capabilities" rel="capabilities"/>
+            <link href="/ovirt-engine/api/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/ovirt-engine/api/datacenters" rel="datacenters"/>
+            <link href="/ovirt-engine/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/ovirt-engine/api/events" rel="events"/>
+            <link href="/ovirt-engine/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/ovirt-engine/api/hosts" rel="hosts"/>
+            <link href="/ovirt-engine/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/ovirt-engine/api/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/networks?search={query}" rel="networks/search"/>
+            <link href="/ovirt-engine/api/roles" rel="roles"/>
+            <link href="/ovirt-engine/api/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/ovirt-engine/api/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/bookmarks" rel="bookmarks"/>
+            <link href="/ovirt-engine/api/icons" rel="icons"/>
+            <link href="/ovirt-engine/api/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/templates?search={query}" rel="templates/search"/>
+            <link href="/ovirt-engine/api/instancetypes" rel="instancetypes"/>
+            <link href="/ovirt-engine/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/ovirt-engine/api/users" rel="users"/>
+            <link href="/ovirt-engine/api/users?search={query}" rel="users/search"/>
+            <link href="/ovirt-engine/api/groups" rel="groups"/>
+            <link href="/ovirt-engine/api/groups?search={query}" rel="groups/search"/>
+            <link href="/ovirt-engine/api/domains" rel="domains"/>
+            <link href="/ovirt-engine/api/vmpools" rel="vmpools"/>
+            <link href="/ovirt-engine/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/ovirt-engine/api/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/vms?search={query}" rel="vms/search"/>
+            <link href="/ovirt-engine/api/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/disks?search={query}" rel="disks/search"/>
+            <link href="/ovirt-engine/api/jobs" rel="jobs"/>
+            <link href="/ovirt-engine/api/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/ovirt-engine/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/ovirt-engine/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/ovirt-engine/api/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/macpools" rel="macpools"/>
+            <link href="/ovirt-engine/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/ovirt-engine/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/ovirt-engine/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/ovirt-engine/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/ovirt-engine/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/ovirt-engine/api/katelloerrata" rel="katelloerrata"/>
             <special_objects>
-                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
-                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
             </special_objects>
             <product_info>
                 <name>oVirt Engine</name>
@@ -182,7 +149,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/clusters?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.1.31:8443/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -219,29 +186,29 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <clusters>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
                 <actions>
-                    <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
+                    <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
                 </actions>
                 <name>Default</name>
                 <description>The default server cluster</description>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
-                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
+                <link href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
                 <cpu id="Intel SandyBridge Family">
                     <architecture>X86_64</architecture>
                 </cpu>
-                <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
+                <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
                 <memory_policy>
                     <overcommit percent="100"/>
                     <transparent_hugepages>
                         <enabled>true</enabled>
                     </transparent_hugepages>
                 </memory_policy>
-                <scheduling_policy href="/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
+                <scheduling_policy href="/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
                     <name>none</name>
                     <policy>none</policy>
                 </scheduling_policy>
@@ -285,7 +252,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:35 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/clusters?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.1.31:8443/ovirt-engine/api/clusters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -326,7 +293,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:35 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/datacenters?search=sortby%20name%20asc%20page%201
+    uri: https://192.168.1.31:8443/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%201
     body:
       encoding: US-ASCII
       string: ''
@@ -363,16 +330,16 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <data_centers>
-            <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
+            <data_center href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
                 <name>Default</name>
                 <description>The default Data Center</description>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
-                <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
+                <link href="/ovirt-engine/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
                 <local>false</local>
                 <storage_format>v3</storage_format>
                 <version major="3" minor="6"/>
@@ -382,7 +349,7 @@ http_interactions:
                 <status>
                     <state>up</state>
                 </status>
-                <mac_pool href="/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
+                <mac_pool href="/ovirt-engine/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
                 <quota_mode>disabled</quota_mode>
             </data_center>
         </data_centers>
@@ -390,7 +357,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:36 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/datacenters?search=sortby%20name%20asc%20page%202
+    uri: https://192.168.1.31:8443/ovirt-engine/api/datacenters?search=sortby%20name%20asc%20page%202
     body:
       encoding: US-ASCII
       string: ''
@@ -431,7 +398,7 @@ http_interactions:
   recorded_at: Wed, 30 Nov 2016 15:43:36 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
     body:
       encoding: US-ASCII
       string: ''
@@ -467,45 +434,45 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
+        <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
             <actions>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
             </actions>
             <name>123</name>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
             <type>desktop</type>
             <status>
                 <state>down</state>
@@ -524,7 +491,7 @@ http_interactions:
             <os type="other">
                 <boot dev="hd"/>
             </os>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+            <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
             <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
             <origin>ovirt</origin>
             <stateless>false</stateless>
@@ -554,7 +521,7 @@ http_interactions:
             </usb>
             <migration_downtime>-1</migration_downtime>
             <start_paused>false</start_paused>
-            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+            <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
             <migration>
                 <auto_converge>inherit</auto_converge>
                 <compressed>inherit</compressed>
@@ -565,13 +532,13 @@ http_interactions:
             <time_zone>
                 <name>Etc/GMT</name>
             </time_zone>
-            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+            <small_icon href="/ovirt-engine/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+            <large_icon href="/ovirt-engine/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
             <memory_policy>
                 <guaranteed>1073741824</guaranteed>
                 <ballooning>false</ballooning>
             </memory_policy>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+            <template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
             <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
             <placement_policy>
                 <affinity>migratable</affinity>
@@ -583,7 +550,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    uri: https://192.168.1.31:8443/ovirt-engine/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
     body:
       encoding: US-ASCII
       string: ''
@@ -620,19 +587,19 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <templates>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
+            <template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
                 <actions>
-                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
+                    <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
                 </actions>
                 <name>GlanceTemplate-7bb26f9</name>
                 <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
+                <link href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
                 <type>desktop</type>
                 <status>
                     <state>ok</state>
@@ -651,7 +618,7 @@ http_interactions:
                 <os type="other">
                     <boot dev="hd"/>
                 </os>
-                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+                <cluster href="/ovirt-engine/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
                 <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
                 <origin>ovirt</origin>
                 <stateless>false</stateless>
@@ -681,7 +648,7 @@ http_interactions:
                 </usb>
                 <migration_downtime>-1</migration_downtime>
                 <start_paused>false</start_paused>
-                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+                <cpu_profile href="/ovirt-engine/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
                 <migration>
                     <auto_converge>inherit</auto_converge>
                     <compressed>inherit</compressed>
@@ -692,13 +659,13 @@ http_interactions:
                 <time_zone>
                     <name>Etc/GMT</name>
                 </time_zone>
-                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+                <small_icon href="/ovirt-engine/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+                <large_icon href="/ovirt-engine/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
                 <memory_policy>
                     <guaranteed>1073741824</guaranteed>
                 </memory_policy>
                 <version>
-                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+                    <base_template href="/ovirt-engine/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
                     <version_number>1</version_number>
                     <version_name>base version</version_name>
                 </version>
@@ -708,7 +675,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0
+    uri: https://192.168.1.31:8443/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0
     body:
       encoding: US-ASCII
       string: ''
@@ -744,19 +711,19 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
+        <storage_domain href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
             <actions>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
             </actions>
             <name>data</name>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
-            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
+            <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
             <data_centers>
                 <data_center id="00000001-0001-0001-0001-0000000002c0"/>
             </data_centers>
@@ -783,7 +750,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -820,18 +787,18 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <disks>
-            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+            <disk href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
                 </actions>
                 <name>GlanceDisk-73786f4</name>
                 <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
+                <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
                 <alias>GlanceDisk-73786f4</alias>
                 <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
                 <storage_domains>
@@ -852,7 +819,7 @@ http_interactions:
                 <propagate_errors>false</propagate_errors>
                 <active>true</active>
                 <read_only>false</read_only>
-                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+                <disk_profile href="/ovirt-engine/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
                 <storage_type>image</storage_type>
             </disk>
         </disks>
@@ -860,7 +827,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
     body:
       encoding: US-ASCII
       string: ''
@@ -897,9 +864,9 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <snapshots>
-            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
+            <snapshot href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
                 </actions>
                 <description>Active VM</description>
                 <type>active</type>
@@ -912,7 +879,7 @@ http_interactions:
   recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
+    uri: https://192.168.1.31:8443/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
     body:
       encoding: US-ASCII
       string: ''
@@ -949,28 +916,28 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <nics>
-            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
+            <nic href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
                 <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
+                    <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
                 </actions>
                 <name>nic1</name>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+                <link href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
+                <vm href="/ovirt-engine/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
                 <linked>true</linked>
                 <interface>virtio</interface>
                 <mac address="00:1a:4a:16:01:52"/>
                 <active>true</active>
                 <plugged>true</plugged>
-                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
+                <vnic_profile href="/ovirt-engine/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
             </nic>
         </nics>
     http_version:
   recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
+    uri: https://192.168.1.31:8443/ovirt-engine/api
     body:
       encoding: US-ASCII
       string: ''
@@ -1001,33 +968,33 @@ http_interactions:
       Jsessionid:
       - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
       Link:
-      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
-        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
-        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
-        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
-        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
-        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
-        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
-        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
-        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
-        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
-        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
-        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
-        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
-        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
-        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
-        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
-        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
-        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
-        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
-        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
-        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
-        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
-        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
-        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
-        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
-        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
-        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+      - "<https://192.168.1.31:8443/ovirt-engine/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/ovirt-engine/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/ovirt-engine/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/ovirt-engine/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/ovirt-engine/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/ovirt-engine/api/events>; rel=events,<https://192.168.1.31:8443/ovirt-engine/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/ovirt-engine/api/hosts>; rel=hosts,<https://192.168.1.31:8443/ovirt-engine/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/ovirt-engine/api/networks>; rel=networks,<https://192.168.1.31:8443/ovirt-engine/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/ovirt-engine/api/roles>; rel=roles,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/ovirt-engine/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/ovirt-engine/api/tags>; rel=tags,<https://192.168.1.31:8443/ovirt-engine/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/ovirt-engine/api/icons>; rel=icons,<https://192.168.1.31:8443/ovirt-engine/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/ovirt-engine/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/ovirt-engine/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/ovirt-engine/api/users>; rel=users,<https://192.168.1.31:8443/ovirt-engine/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/ovirt-engine/api/groups>; rel=groups,<https://192.168.1.31:8443/ovirt-engine/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/ovirt-engine/api/domains>; rel=domains,<https://192.168.1.31:8443/ovirt-engine/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/ovirt-engine/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/ovirt-engine/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/ovirt-engine/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/ovirt-engine/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/ovirt-engine/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/ovirt-engine/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/ovirt-engine/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/ovirt-engine/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/ovirt-engine/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/ovirt-engine/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/ovirt-engine/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/ovirt-engine/api/permissions>; rel=permissions,<https://192.168.1.31:8443/ovirt-engine/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/ovirt-engine/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/ovirt-engine/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/ovirt-engine/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/ovirt-engine/api/katelloerrata>;
         rel=katelloerrata"
       Date:
       - Fri, 19 Aug 2016 09:43:44 GMT
@@ -1036,56 +1003,56 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <api>
-            <link href="/api/capabilities" rel="capabilities"/>
-            <link href="/api/clusters" rel="clusters"/>
-            <link href="/api/clusters?search={query}" rel="clusters/search"/>
-            <link href="/api/datacenters" rel="datacenters"/>
-            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
-            <link href="/api/events" rel="events"/>
-            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
-            <link href="/api/hosts" rel="hosts"/>
-            <link href="/api/hosts?search={query}" rel="hosts/search"/>
-            <link href="/api/networks" rel="networks"/>
-            <link href="/api/networks?search={query}" rel="networks/search"/>
-            <link href="/api/roles" rel="roles"/>
-            <link href="/api/storagedomains" rel="storagedomains"/>
-            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
-            <link href="/api/tags" rel="tags"/>
-            <link href="/api/bookmarks" rel="bookmarks"/>
-            <link href="/api/icons" rel="icons"/>
-            <link href="/api/templates" rel="templates"/>
-            <link href="/api/templates?search={query}" rel="templates/search"/>
-            <link href="/api/instancetypes" rel="instancetypes"/>
-            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
-            <link href="/api/users" rel="users"/>
-            <link href="/api/users?search={query}" rel="users/search"/>
-            <link href="/api/groups" rel="groups"/>
-            <link href="/api/groups?search={query}" rel="groups/search"/>
-            <link href="/api/domains" rel="domains"/>
-            <link href="/api/vmpools" rel="vmpools"/>
-            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
-            <link href="/api/vms" rel="vms"/>
-            <link href="/api/vms?search={query}" rel="vms/search"/>
-            <link href="/api/disks" rel="disks"/>
-            <link href="/api/disks?search={query}" rel="disks/search"/>
-            <link href="/api/jobs" rel="jobs"/>
-            <link href="/api/storageconnections" rel="storageconnections"/>
-            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
-            <link href="/api/diskprofiles" rel="diskprofiles"/>
-            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
-            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
-            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
-            <link href="/api/permissions" rel="permissions"/>
-            <link href="/api/macpools" rel="macpools"/>
-            <link href="/api/operatingsystems" rel="operatingsystems"/>
-            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
-            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
-            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
-            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
-            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <link href="/ovirt-engine/api/capabilities" rel="capabilities"/>
+            <link href="/ovirt-engine/api/clusters" rel="clusters"/>
+            <link href="/ovirt-engine/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/ovirt-engine/api/datacenters" rel="datacenters"/>
+            <link href="/ovirt-engine/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/ovirt-engine/api/events" rel="events"/>
+            <link href="/ovirt-engine/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/ovirt-engine/api/hosts" rel="hosts"/>
+            <link href="/ovirt-engine/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/ovirt-engine/api/networks" rel="networks"/>
+            <link href="/ovirt-engine/api/networks?search={query}" rel="networks/search"/>
+            <link href="/ovirt-engine/api/roles" rel="roles"/>
+            <link href="/ovirt-engine/api/storagedomains" rel="storagedomains"/>
+            <link href="/ovirt-engine/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/ovirt-engine/api/tags" rel="tags"/>
+            <link href="/ovirt-engine/api/bookmarks" rel="bookmarks"/>
+            <link href="/ovirt-engine/api/icons" rel="icons"/>
+            <link href="/ovirt-engine/api/templates" rel="templates"/>
+            <link href="/ovirt-engine/api/templates?search={query}" rel="templates/search"/>
+            <link href="/ovirt-engine/api/instancetypes" rel="instancetypes"/>
+            <link href="/ovirt-engine/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/ovirt-engine/api/users" rel="users"/>
+            <link href="/ovirt-engine/api/users?search={query}" rel="users/search"/>
+            <link href="/ovirt-engine/api/groups" rel="groups"/>
+            <link href="/ovirt-engine/api/groups?search={query}" rel="groups/search"/>
+            <link href="/ovirt-engine/api/domains" rel="domains"/>
+            <link href="/ovirt-engine/api/vmpools" rel="vmpools"/>
+            <link href="/ovirt-engine/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/ovirt-engine/api/vms" rel="vms"/>
+            <link href="/ovirt-engine/api/vms?search={query}" rel="vms/search"/>
+            <link href="/ovirt-engine/api/disks" rel="disks"/>
+            <link href="/ovirt-engine/api/disks?search={query}" rel="disks/search"/>
+            <link href="/ovirt-engine/api/jobs" rel="jobs"/>
+            <link href="/ovirt-engine/api/storageconnections" rel="storageconnections"/>
+            <link href="/ovirt-engine/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/ovirt-engine/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/ovirt-engine/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/ovirt-engine/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/ovirt-engine/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/ovirt-engine/api/permissions" rel="permissions"/>
+            <link href="/ovirt-engine/api/macpools" rel="macpools"/>
+            <link href="/ovirt-engine/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/ovirt-engine/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/ovirt-engine/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/ovirt-engine/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/ovirt-engine/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/ovirt-engine/api/katelloerrata" rel="katelloerrata"/>
             <special_objects>
-                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
-                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+                <link href="/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
             </special_objects>
             <product_info>
                 <name>oVirt Engine</name>

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/vm_fetch_disks.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/vm_fetch_disks.yml
@@ -2,40 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Connection:
-      - keep-alive
-      Www-Authenticate:
-      - Basic realm="ENGINE"
-      Content-Type:
-      - text/html;charset=UTF-8
-      Content-Length:
-      - '71'
-      Date:
-      - Thu, 01 Dec 2016 12:28:30 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
-    http_version:
-  recorded_at: Thu, 01 Dec 2016 12:28:30 GMT
-- request:
-    method: get
-    uri: https://admin%40internal:engine@192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
+    uri: https://admin%40internal:engine@192.168.1.31:8443/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +25,7 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - JSESSIONID=VlxUPb99qJPwMA_BW1X6Rib8vi8ceeu2JQIpa_3V.f18; path=/api; HttpOnly
+      - JSESSIONID=VlxUPb99qJPwMA_BW1X6Rib8vi8ceeu2JQIpa_3V.f18; path=/ovirt-engine/api; HttpOnly
       Content-Type:
       - application/xml
       Content-Length:
@@ -71,9 +38,9 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <disk href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+        <disk href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
             <actions>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+                <link href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
             </actions>
             <name>GlanceDisk-73786f4</name>
             <description>CirrOS 0.3.1 (73786f4)</description>
@@ -82,7 +49,7 @@ http_interactions:
             </vms>
             <alias>GlanceDisk-73786f4</alias>
             <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
-            <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
+            <storage_domain href="/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
             <storage_domains>
                 <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
             </storage_domains>
@@ -99,7 +66,7 @@ http_interactions:
             <shareable>false</shareable>
             <wipe_after_delete>false</wipe_after_delete>
             <propagate_errors>false</propagate_errors>
-            <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+            <disk_profile href="/ovirt-engine/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
             <storage_type>image</storage_type>
         </disk>
     http_version:

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/vm_fetch_no_disks.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/vm_fetch_no_disks.yml
@@ -2,40 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.1.31:8443/api
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Connection:
-      - keep-alive
-      Www-Authenticate:
-      - Basic realm="ENGINE"
-      Content-Type:
-      - text/html;charset=UTF-8
-      Content-Length:
-      - '71'
-      Date:
-      - Thu, 01 Dec 2016 12:41:29 GMT
-    body:
-      encoding: UTF-8
-      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
-    http_version: 
-  recorded_at: Thu, 01 Dec 2016 12:41:28 GMT
-- request:
-    method: get
-    uri: https://admin%40internal:engine@192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
+    uri: https://admin%40internal:engine@192.168.1.31:8443/ovirt-engine/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +25,7 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - JSESSIONID=wgFKbxhmyF8DSFVWxXLBhdTTj-3c-1snGjezqC4W.f18; path=/api; HttpOnly
+      - JSESSIONID=wgFKbxhmyF8DSFVWxXLBhdTTj-3c-1snGjezqC4W.f18; path=/ovirt-engine/api; HttpOnly
       Content-Length:
       - '0'
       Jsessionid:


### PR DESCRIPTION
This is a `euwe` backport of ManageIQ/manageiq#14469.

Versions of oVirt 3.4 and older only supported the /api path for access to the
API. Since version 3.5 /ovirt-engine/api is supported as well, and /api is
deprecated. In version 4.0 /api was removed completely. The provider has
supported both paths, which caused confusion and problems during upgrades. As
we no longer need to support oVirt 3.4 or older, that support can now be
removed. That is what this patch does. The path will be still saved to the
'path' column of the 'endpoints' table, but not used at all.

https://bugzilla.redhat.com/1427653