### PR TITLE
[EUWE] Fix spinner when creating new role

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -101,7 +101,7 @@ class OpsController
 
       node = default_node.merge(
         :key      => "#{node_id}__#{feature}",
-        :icon     => img("100/feature_#{details[:feature_type]}"),
+        :icon     => img("100/feature_#{details[:feature_type]}.png"),
         :title    => _(details[:name]),
         :tooltip  => _(details[:description]) || _(details[:name]),
         :children => {}


### PR DESCRIPTION
This fixes a missing `.png` for `100/feature_*` in `rbac_tree`. (Ops > Access Controll > Roles > Add a New Role)

Passing an image name without extension to `image_path` works, but triggers an asset-rebuild the first time the name is encountered :) .. added the extension back.

Cc @hayesr (because https://github.com/ManageIQ/manageiq/pull/13577)

https://bugzilla.redhat.com/show_bug.cgi?id=1440701