### PR TITLE
Add a dummy args to storage.perf_capture

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -721,7 +721,7 @@ class Storage < ApplicationRecord
   end
 
   # TODO: See if we can reuse the main perf_capture method, and only overwrite the perf_collect_metrics method
-  def perf_capture(interval_name)
+  def perf_capture(interval_name, *_args)
     unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
       raise ArgumentError, _("invalid interval_name '%{name}'") % {:name => interval_name}
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1437644

It's being passed extra args (start/end times) due to the changes from https://github.com/ManageIQ/manageiq/pull/14332

However, it seems a better idea to change `storage.perf_capture` to conform with the other metric collection method signatures.

@miq-bot add_labels wip, bug, providers/vmware/infra