### PR TITLE
Fixed bug: timeout was not triggered for Image Scanning Job after removing Job#agent_class

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -165,7 +165,9 @@ class Job < ApplicationRecord
 
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
           # TODO: can we add method_name, queue_name, role, instance_id to the exists?
-          next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid)
+          if job.miq_server_id
+            next if MiqQueue.exists?(:state => %w(dequeue ready), :task_id => job.guid, :class_name => "MiqServer")
+          end
           job.timeout!
         end
     rescue Exception


### PR DESCRIPTION
Bug:  Container Image Scanning Jobs do not get timeout when scanning pod fails.

**Issue**: https://github.com/ManageIQ/manageiq/issues/14788

**Fix**: put back original logic (prior to #14356) but use `MiqServer` instead of `agent_class`

@miq-bot add-label bug, smart state