### PR TITLE
all_ems_in_zone is not a scope yet, so we can't chain 'where'

### DIFF
--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -18,7 +18,7 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      all_ems_in_zone.where(:enabled => true).select(&:authentication_status_ok?)
+      all_ems_in_zone.select {|e| e.enabled && e.authentication_status_ok?}
     end
 
     def desired_queue_names

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -15,6 +15,14 @@ describe PerEmsWorkerMixin do
     expect(@worker_class.queue_name_for_ems(@ems)).to eq(@ems_queue_name)
   end
 
+  it ".all_valid_ems_in_zone" do
+    expect(@worker_class.all_valid_ems_in_zone).to be_empty
+
+    @ems.update(:enabled => true)
+    @ems.authentications.first.validation_successful
+    expect(@worker_class.all_valid_ems_in_zone).to eq([@ems])
+  end
+
   it "#worker_options" do
     expect(@worker_record.worker_options).to eq(:guid => @worker_record.guid, :ems_id => @ems.id)
   end


### PR DESCRIPTION
Fixes a bug introduced in:
https://github.com/ManageIQ/manageiq/pull/14675

We'll do our condition checks on arrays for now, until we can properly
use scopes.  The scopes will require us to change callers to expect
scopes, which is why we're fixing this bug for now.