### PR TITLE
Fix broken stylesheet path for PDFs

### DIFF
--- a/lib/pdf_generator.rb
+++ b/lib/pdf_generator.rb
@@ -42,8 +42,17 @@ class PdfGenerator
   end
   private_class_method :sanitize_html
 
+  # Search through plugins to find the first existing pdf stylesheet
+  #
+  # TODO: this could be refactored later to support multiple stylesheets
+  # from multiple plugins.
+  #
   def self.stylesheet_file_path(stylesheet)
-    Rails.root.join(*%W(app assets stylesheets #{stylesheet})).to_s
+    paths = Vmdb::Plugins.instance.vmdb_plugins.map do |plugin|
+      plugin.root.join("app/assets/stylesheets", stylesheet)
+    end
+
+    paths.detect { |p| File.exist?(p) }
   end
 
   private_class_method :stylesheet_file_path


### PR DESCRIPTION
The code points to the wrong place after the UI repo split. This changes it to point to the stylesheet under the UI engine.

This fixes basic PDF styles, but images remain to be addressed.

**Dependent on https://github.com/ManageIQ/manageiq-ui-classic/pull/1332 to work.**

Related: 
- https://bugzilla.redhat.com/show_bug.cgi?id=1447940
- https://github.com/ManageIQ/manageiq-ui-classic/pull/1090

**Currently**
![screen shot 2017-05-11 at 11 29 29 am](https://cloud.githubusercontent.com/assets/39493/25965886/23c6340c-363e-11e7-90d7-8b5e71a41b8c.png)

**After**
![screen shot 2017-05-11 at 11 32 58 am](https://cloud.githubusercontent.com/assets/39493/25965893/2b50fcd4-363e-11e7-9091-d4cde0818620.png)
