### PR TITLE
[EUWE] Add *_migrations to .gitnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ node_modules/
 
 # ignore included plugins in bundler.d
 bundler.d/*
+
+# specs
+spec/replication/util/data/*_migrations


### PR DESCRIPTION
This gets rid of those pesky untracked migration files when you switch to the Euwe branch.