### PR TITLE
Fix StorageManagers Cross Linkers

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser/cross_linkers.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser/cross_linkers.rb
@@ -5,6 +5,10 @@ module ManageIQ::Providers::StorageManager::CinderManager::RefreshParser::CrossL
       _log.warn "Manager does not have a parent."
       return
     end
+    unless data
+      _log.warn "Manager does not have volumes, snapshots, or volume backups."
+      return
+    end
 
     parent_type = parent_manager.class.ems_type
     _log.debug "Parent type: #{parent_type}"

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser/cross_linkers.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser/cross_linkers.rb
@@ -5,6 +5,10 @@ module ManageIQ::Providers::StorageManager::SwiftManager::RefreshParser::CrossLi
       _log.warn "Manager does not have a parent."
       return
     end
+    unless data
+      _log.warn "Manager does not have any object storage."
+      return
+    end
 
     parent_type = parent_manager.class.ems_type
     _log.debug "Parent type: #{parent_type}"


### PR DESCRIPTION
Fix Cinder and Swift Cross Linkers to make sure valid data is available before
processing.  Cinder should have Volumes, Backups, or Snapshots.  Swift must
have Object Storage.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1441144.

@roliveri @hsong-rh @Fryguy please review.  Merge when appropriate.


Steps for Testing/QA
-------------------------------

Add an Openstack cloud provider that does not have any objects (for Swift) or volumes, backups, or snapshots (for Cinder).  Do a refresh of the provider after adding it.  The refresh should not result in the issue shown in the above Bugzilla.
