### PR TITLE
Use fetch_path to handle the case where :ws_values is nil.

### DIFF
--- a/db/fixtures/customization_templates.yml
+++ b/db/fixtures/customization_templates.yml
@@ -283,7 +283,7 @@
 
 - :name: SSH key addition template
   :description: This template enables placing ssh public key in authorized keys
-  :script: "#cloud-config\nusers:\n  - name: root\n    ssh-authorized-keys:\n      - <%= evm[:ws_values][:ssh_public_key] %>"
+  :script: "#cloud-config\nusers:\n  - name: root\n    ssh-authorized-keys:\n      - <%= evm.fetch_path(:ws_values, :ssh_public_key) %>"
   :type: CustomizationTemplateCloudInit
   :system: true
 


### PR DESCRIPTION
When :ws_values is nil, CustomizationTemplate.substitute_erb throws out [NoMethodError]: undefined method `[]' for nil:NilClass.

https://bugzilla.redhat.com/show_bug.cgi?id=1436194

