### PR TITLE
Check enablement on object instead of database

### DIFF
--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -18,7 +18,7 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      all_ems_in_zone.where(:enabled => true).select(&:authentication_status_ok?)
+      all_ems_in_zone.select {|ems| ems.authentication_status_ok?  && ems.enabled == true }
     end
 
     def desired_queue_names


### PR DESCRIPTION
Fix #14804 (See exception there)
`all_ems_in_zone` calls to_a

Another possibility is eliminating `all_ems_in_zone`
```
ems_class.where(:zone_id => MiqServer.my_server.zone.id, :enabled => true).select(&:authentication_status_ok?)
```
