### PR TITLE
Do not store whole container env. in the reporting worker forever

### DIFF
--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -46,6 +46,8 @@ class ChargebackContainerImage < Chargeback
 
     @unknown_project ||= OpenStruct.new(:id => 0, :name => _('Unknown Project'), :ems_ref => _('Unknown'))
     build_results_for_report_chargeback(options)
+  ensure
+    @data_index = @containers = nil
   end
 
   def self.default_key(metric_rollup_record, ts_key)

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -42,6 +42,8 @@ class ChargebackContainerProject < Chargeback
     return [[]] if @projects.empty?
 
     build_results_for_report_chargeback(options)
+  ensure
+    @projects = nil
   end
 
   def self.where_clause(records, _options)


### PR DESCRIPTION
In big openshift environments do not use Class variables to store whole environment forever. Plugs memory leak.

https://bugzilla.redhat.com/show_bug.cgi?id=1443606