### PR TITLE
[WIP] Reconnect container images when seen again

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -310,8 +310,10 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_image_registry_id] = h[:container_image_registry][:id] unless h[:container_image_registry].nil?
     end
 
+    # We never want 2 records for same image. Reconnect old images if we see them again.
     save_inventory_multi(ems.container_images, hashes, deletes, [:image_ref, :container_image_registry_id],
-                         [:labels, :docker_labels], :container_image_registry, true)
+                         [:labels, :docker_labels], :container_image_registry, true,
+                         :reconnect_from => ContainerImage.where(:old_ems_id => ems.id))
     store_ids_for_new_records(ems.container_images, hashes,
                               [:image_ref, :container_image_registry_id])
   end


### PR DESCRIPTION
Bug: if we disconnect a container image and then encounter it again, we create a duplicate record.
Scenarios where we may disconnect an image not currently used in any container:
- Kubernetes provider
- Openshift configured `get_container_images` (#14606)
- Openshift configured `store_unused_images setting` (if #14662 lands)
- Openshift fetching used images one by one (if #14628 lands)
- Openshift eventually dropping the image from /oapi/v1/images (don't know if/when this happens?)

If then we see the image again, we'll create a duplicate record, which can confuse reports.

This PR makes refresh reconnect (ems_id) an existing image if it has the matching digest.
However, if duplicates have already been created it won't merge them, will just reuse arbitrary one of the copies.

EDIT: **TODO: this retains `old_ems_id` and `deleted_on`.  This is not OK.**
We need a more explicit API to reconnect than `assiciation.push`.  Maybe add a `reconnect_inv` method?
EDIT: as Ladas points out, loading the records back to RAM is heavy :-(
cc @Ladas @agrare @simon3z @enoodle 

Steps for Testing/QA [Optional]
-------------------------------

Refresh.  Turn off get_container_images in Advanced Settings.  Refresh.  Turn on. Refresh.
TODO: a way to actually see the dups in reports?

@miq-bot add-label bug, providers/containers

https://bugzilla.redhat.com/show_bug.cgi?id=1488072