### PR TITLE
Add chargeback to shortcuts to allow access to chargeback only.

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -4,6 +4,11 @@
   :url: /dashboard/show
   :rbac_feature_name: dashboard_view
   :startup: true
+- :name: chargeback
+  :description: Cloud Intelligence / Chargeback
+  :url: /chargeback/explorer
+  :rbac_feature_name: chargeback
+  :startup: true
 - :name: report_explorer
   :description: Cloud Intelligence / Reports
   :url: /report/explorer


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1343418

Create a role, group and then a user that has only 'chargeback' feature enabled.

Try to login (you get an error message). Expected result: you should login and see only Chargeback stuff.

To test this you might need to run ```MiqShortcut.seed``` to force reseeding the MiqShortcuts.