### PR TITLE
Fix sort by url for the configuration manager provider list

### DIFF
--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -4,8 +4,11 @@ class ManageIQ::Providers::ConfigurationManager < ManageIQ::Providers::BaseManag
   has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_script_sources, :dependent => :destroy, :foreign_key => "manager_id"
 
+  delegate :url, :to => :provider
+
   virtual_column  :total_configuration_profiles, :type => :integer
   virtual_column  :total_configured_systems, :type => :integer
+  virtual_column  :url, :type => :string
 
   def self.hostname_required?
     false

--- a/product/views/ManageIQ_Providers_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_ConfigurationManager.yaml
@@ -20,6 +20,7 @@ db: ManageIQ::Providers::ConfigurationManager
 # Columns to fetch from the main table
 cols:
 - name
+- url
 - type
 - last_refresh_date
 - region_description
@@ -31,7 +32,7 @@ include:
   zone:
     columns:
     - name
-  provider:
+  endpoints:
     columns:
     - url
 
@@ -41,7 +42,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
-- provider.url
+- url
 - type
 - zone.name
 - last_refresh_date

--- a/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+++ b/product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
@@ -20,6 +20,7 @@ db: ManageIQ::Providers::Foreman::ConfigurationManager
 # Columns to fetch from the main table
 cols:
 - name
+- url
 - type
 - last_refresh_date
 - region_description
@@ -32,7 +33,7 @@ include:
   zone:
     columns:
     - name
-  provider:
+  endpoints:
     columns:
     - url
 
@@ -42,7 +43,7 @@ include_for_find:
 # Order of columns (from all tables)
 col_order:
 - name
-- provider.url
+- url
 - type
 - zone.name
 - last_refresh_date


### PR DESCRIPTION
Fix sort by url for the configuration manager provider list

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1384330

Spec here: https://github.com/ManageIQ/manageiq-ui-classic/pull/1086