### PR TITLE
Fix Migration Spec

### DIFF
--- a/spec/migrations/20150904181202_miq_groups_add_ldap_role_spec.rb
+++ b/spec/migrations/20150904181202_miq_groups_add_ldap_role_spec.rb
@@ -1,19 +1,21 @@
 require_migration
 
 describe MiqGroupsAddLdapRole do
-  let(:miq_user_role_stub) { migration_stub(:MiqUserRole) }
-  let(:miq_group_stub)     { migration_stub(:MiqGroup) }
+  migration_context :up do
+    let(:miq_user_role_stub) { migration_stub(:MiqUserRole) }
+    let(:miq_group_stub) { migration_stub(:MiqGroup) }
 
-  it "migrates ldap groups" do
-    role = miq_user_role_stub.create!("EvmRole-my_group")
-    unchanged_group = miq_group_stub.create!(:description => "EvmGroup-super_administrator", :group_type => "abc")
-    changed_group = miq_group_stub.create!(:description => "EvmGroup-my_group", :group_type => "ldap")
+    it "migrates ldap groups" do
+      role = miq_user_role_stub.create!(:name => "EvmRole-my_group")
+      unchanged_group = miq_group_stub.create!(:description => "EvmGroup-super_administrator", :group_type => "abc")
+      changed_group = miq_group_stub.create!(:description => "EvmGroup-my_group", :group_type => "ldap")
 
-    migrate
-    changed_group.reload
+      migrate
+      changed_group.reload
 
-    expect(unchanged_group.reload.group_type).to eq("abc")
-    expect(changed_group.group_type).to eq("system")
-    expect(changed_group.role).to eq(role)
+      expect(unchanged_group.reload.group_type).to eq("abc")
+      expect(changed_group.group_type).to eq("system")
+      expect(changed_group.miq_user_role_id).to eq(role.id)
+    end
   end
 end


### PR DESCRIPTION
When testing https://github.com/ManageIQ/manageiq/pull/14796 I noticed that spec `20150904181202_miq_groups_add_ldap_role_spec.rb` was broken on master (thanks to @AllenBW for checking as well).

The initial failure:
```
NoMethodError:
       undefined method `migration_stub' for #<RSpec::ExampleGroups::MiqGroupsAddLdapRole:0x007fe9018bcc60>
```
Putting the test into a `migration_context` solves that issue.

Then there was this issue:
```
 1) MiqGroupsAddLdapRole#up migrates ldap groups
     Failure/Error: role = miq_user_role_stub.create!("EvmRole-my_group")
     
     ArgumentError:
       When assigning attributes, you must pass a hash as an argument.
```

and finally, this issue:
```
1) MiqGroupsAddLdapRole#up migrates ldap groups
     Failure/Error: expect(changed_group.miq_user_role).to eq(role)
     
     NoMethodError:
       undefined method `miq_user_role' for #<MiqGroupsAddLdapRole::MiqGroup:0x007f91c70ea0f0>
     # ./spec/migrations/20150904181202_miq_groups_add_ldap_role_spec.rb:19:in `block (3 levels) in <top (required)>'
     # ./spec/support/migration_helper.rb:57:in `clearing_caches'
     # ./spec/support/migration_helper.rb:13:in `block (2 levels) in migration_context'
```

Kind of confused how this issue isn't caught all the time or what caused it... 😕 

@miq-bot add_label test, bug 