### PR TITLE
Remove the rows from schema_migrations for deleted migration files

### DIFF
--- a/db/migrate/20170419154137_remove_deleted_migration_timestamps.rb
+++ b/db/migrate/20170419154137_remove_deleted_migration_timestamps.rb
@@ -1,0 +1,9 @@
+class RemoveDeletedMigrationTimestamps < ActiveRecord::Migration[5.0]
+  class SchemaMigration < ActiveRecord::Base; end
+
+  DELETED_TIMESTAMPS = [20160106214719, 20160425161345].freeze
+
+  def up
+    SchemaMigration.where(:version => DELETED_TIMESTAMPS).delete_all
+  end
+end


### PR DESCRIPTION
These migrations were removed in #11197 and #9696 and are now causing a warning in the logs if the schema_migrations row is present, but the files are not.

https://bugzilla.redhat.com/show_bug.cgi?id=1417313

This is an alternative to #14530