### PR TITLE
Fix to: Tower CUD failures sending success notification

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
       refresh(manager)
       find_by!(:manager_id => manager.id, :manager_ref => tower_object.id)
-    rescue AnsibleTowerClient::ClientError, ActiveRecord::RecordNotFound => error
+    rescue Exception => error
       raise
     ensure
       notify('create_in_provider', manager.id, params, error.nil?)
@@ -68,7 +68,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
     end
     self.class.send('refresh', manager)
     reload
-  rescue AnsibleTowerClient::ClientError => error
+  rescue Exception => error
     raise
   ensure
     self.class.send('notify', 'update_in_provider', manager.id, params, error.nil?)
@@ -82,7 +82,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   def delete_in_provider
     with_provider_object(&:destroy!)
     self.class.send('refresh', manager)
-  rescue AnsibleTowerClient::ClientError => error
+  rescue Exception => error
     raise
   ensure
     self.class.send('notify', 'delete_in_provider', manager.id, {:manager_ref => manager_ref}, error.nil?)

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
       refresh(manager)
       find_by!(:manager_id => manager.id, :manager_ref => tower_object.id)
-    rescue Exception => error
+    rescue StandardError => error
       raise
     ensure
       notify('create_in_provider', manager.id, params, error.nil?)
@@ -68,7 +68,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
     end
     self.class.send('refresh', manager)
     reload
-  rescue Exception => error
+  rescue StandardError => error
     raise
   ensure
     self.class.send('notify', 'update_in_provider', manager.id, params, error.nil?)
@@ -82,7 +82,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   def delete_in_provider
     with_provider_object(&:destroy!)
     self.class.send('refresh', manager)
-  rescue Exception => error
+  rescue StandardError => error
     raise
   ensure
     self.class.send('notify', 'delete_in_provider', manager.id, {:manager_ref => manager_ref}, error.nil?)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1446380

Existing code only catch specific errors (`AnsibleTowerClient::ClientError/ActiveRecord::RecordNotFound`) and send failure notifications upon them.

If the emitted error is not one of the specified, successful notification will be sent.

This PR is to fix that.

@miq-bot add_labels bug, providers/ansible_tower, fine/yes, wip