### PR TITLE
Use HashWithIndifferentAccess for job options

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -74,7 +74,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   def save_job_options(action, overrides)
-    job_options = options.fetch_path(:config_info, action.downcase.to_sym).slice(:hosts, :extra_vars)
+    job_options = options.fetch_path(:config_info, action.downcase.to_sym).slice(:hosts, :extra_vars).with_indifferent_access
     job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
     job_options.deep_merge!(overrides)
 

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -48,7 +48,7 @@ describe(ServiceAnsiblePlaybook) do
           :playbook_id   => 10,
           :extra_vars    => {
             "var1" => "default_val1",
-            "var2" => "default_val2",
+            :var2  => "default_val2",
             "var3" => "default_val3"
           },
         }
@@ -60,7 +60,7 @@ describe(ServiceAnsiblePlaybook) do
     {
       :credential_id => credential_2.id,
       :hosts         => 'host3',
-      :extra_vars    => { 'var1' => 'new_val1', 'pswd' => encrypted_val2 }
+      'extra_vars'   => { :var1 => 'new_val1', 'pswd' => encrypted_val2 }
     }
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1444107

When calling the tower API job options are converted to JSON which does not distinguish symbols vs strings. It is safe and easy to use `HashWithIndifferentAccess` that allows the overrides to freely mix symbols and strings.
