### PR TITLE
Fix vendor key in physical server

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -30,6 +30,6 @@ class PhysicalServer < ApplicationRecord
   end
 
   def label_for_vendor
-    VENDOR_TYPES[vendor]
+    VENDOR_TYPES[vendor.downcase]
   end
 end


### PR DESCRIPTION
Vendor key used to return value in `label_for_vendor` method was being considered as the data was coming from database. It was causing bug if the vendor has diferente case of the Vendor hash.

The key should always be in a compliant case, which in this situation is **downcase**.