### PR TITLE
Report attributes for SUI

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -40,6 +40,9 @@ class MiqReport < ApplicationRecord
   belongs_to                :user
   has_many                  :miq_widgets, :as => :resource
 
+  virtual_column  :human_expression, :type => :string
+  virtual_column  :based_on, :type => :string
+
   alias_attribute :menu_name, :name
   attr_accessor_that_yamls :table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
@@ -87,6 +90,14 @@ class MiqReport < ApplicationRecord
   # NOTE: this can by dynamically manipulated
   def cols
     self[:cols] ||= (self[:col_order] || []).reject { |x| x.include?(".") }
+  end
+
+  def human_expression
+    conditions.to_human
+  end
+
+  def based_on
+    Dictionary.gettext(db, :type => :model, :notfound => :titleize)
   end
 
   def view_filter_columns


### PR DESCRIPTION
As per this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1442210), some fields in the SUI are not populated on the reports screen because they are not available via the API. These fields are the human readable version of the report's condition as well as the "based_on" value.

The `based_on` method in this PR uses the same call that the classic-ui uses to populate the based_on value.

This fix adds these values as virtual columns as there is currently no [method support](https://github.com/ManageIQ/manageiq/pull/14783#issuecomment-295820729) in the API

@miq-bot add_label enhancement, reporting
@miq-bot assign @gtanzillo 