### PR TITLE
Create or delete a catalog item on update

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -9,11 +9,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     'pre_with_playbook'    => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Advanced_Resource_Pre',
     'post_with_playbook'   => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Advanced_Resource_Post'
   }.freeze
-
-  CONFIG_BASIC_HASH = { :provision => {}, :retirement => {}, :reconfigure => {} }.freeze
-
   private_constant :RETIREMENT_ENTRY_POINTS
-  private_constant :CONFIG_BASIC_HASH
 
   def self.default_provisioning_entry_point(_service_type)
     '/Service/Generic/StateMachines/GenericLifecycle/provision'

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   before_destroy :check_retirement_potential, :prepend => true
-  around_destroy :around_destroy_callback
+  around_destroy :around_destroy_callback, :prepend => true
 
   RETIREMENT_ENTRY_POINTS = {
     'yes_without_playbook' => '/Service/Generic/StateMachines/GenericLifecycle/Retire_Basic_Resource',

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -235,6 +235,17 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
     end
+
+    it 'creates a new job_template if a new one is passed in' do
+      service_template = prebuild_service_template(:job_template => false)
+      catalog_item_options[:config_info][:provision].delete(:new_dialog_name)
+
+      allow(service_template).to receive(:new_job_template_required).and_return(true)
+      expect(service_template).to receive(:populate_active_config).twice
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).never
+
+      service_template.update_catalog_item(catalog_item_options, user)
+    end
   end
 
   describe '#delete_job_templates' do


### PR DESCRIPTION
When updating an existing AnsiblePlaybook catalog item - add the ability to add a new retirement playbook if one didn't previously exist before: Case A

Also, allow deleting of an existing job_template if the update does not pass in a `:playbook_id`: 
Case B

Further more:  If you create a new catalog item, delete it, and then create a new one with the same name as the old one you will no longer receive an error: Case C

Testing notes:

Case A
1. Create new Ansible Playbook Catalog item without a retirement playbook
2. Edit the above Catalog Item and add a retirement playbook.

Case B
1. Create new Ansible Playbook Catalog item without a retirement playbook
2. Edit the above Catalog Item and add a retirement playbook.
3. Edit the above Catalog Item again and delete the retirement playbook.

Case C
1. Create a new catalog item
2. Delete that catalog item
3. Create a new catalog item with the same name as in part 1.

https://www.pivotaltracker.com/story/show/141868401

https://www.pivotaltracker.com/story/show/141265431

https://bugzilla.redhat.com/show_bug.cgi?id=1438839

https://bugzilla.redhat.com/show_bug.cgi?id=1442006
