### PR TITLE
Remove stubbing in ServiceTemplate#custom_actions spec

### DIFF
--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -2,29 +2,16 @@ describe ServiceTemplate do
   include_examples "OwnershipMixin"
 
   describe "#custom_actions" do
-    let(:service_template) do
-      FactoryGirl.create(:service_template, :custom_button_sets => [assigned_group_set])
-    end
-    let(:generic_no_group) do
-      FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
-    end
-    let(:assigned_no_group) do
-      FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
-    end
-    let(:generic_group) { FactoryGirl.create(:custom_button, :name => "generic_group", :applies_to_class => "Service") }
-    let(:assigned_group) do
-      FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
-    end
-    let(:assigned_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
-    end
-    let(:generic_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
-    end
-
     it "returns the custom actions in a hash grouped by buttons and button groups" do
+      generic_no_group = FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
+      assigned_no_group = FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
+      generic_group = FactoryGirl.create(:custom_button, :name => "generic_group", :applies_to_class => "Service")
+      assigned_group = FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
+      assigned_group_set = FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
+      generic_group_set = FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
       generic_group_set.add_member(generic_group)
       assigned_group_set.add_member(assigned_group)
+      service_template = FactoryGirl.create(:service_template, :custom_button_sets => [assigned_group_set])
       allow(CustomButton).to receive(:buttons_for).with("Service").and_return(
         [generic_no_group, generic_group]
       )

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -60,12 +60,12 @@ describe ServiceTemplate do
           a_hash_including("name" => "assigned_no_group")
         ),
         :button_groups => a_collection_containing_exactly(
-          assigned_group_set.serializable_hash.reject do |key, _|
+          a_hash_including(assigned_group_set.serializable_hash.reject do |key, _|
             %w(created_on updated_on).include?(key)
-          end.merge(:buttons => [assigned_group_buttons]),
-          generic_group_set.serializable_hash.reject do |key, _|
+          end.merge(:buttons => [assigned_group_buttons])),
+          a_hash_including(generic_group_set.serializable_hash.reject do |key, _|
             %w(created_on updated_on).include?(key)
-          end.merge(:buttons => [generic_group_buttons])
+          end.merge(:buttons => [generic_group_buttons]))
         )
       }
       expect(actual).to match(expected)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -3,7 +3,7 @@ describe ServiceTemplate do
 
   describe "#custom_actions" do
     let(:service_template) do
-      described_class.create(:name => "test", :description => "test", :custom_button_sets => [assigned_group_set])
+      FactoryGirl.create(:service_template, :custom_button_sets => [assigned_group_set])
     end
     let(:generic_no_group) do
       FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -16,10 +16,10 @@ describe ServiceTemplate do
       FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
     end
     let(:assigned_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "assigned_group")
+      FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
     end
     let(:generic_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "generic_group")
+      FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
     end
 
     before do
@@ -60,8 +60,8 @@ describe ServiceTemplate do
           a_hash_including("name" => "assigned_no_group")
         ),
         :button_groups => a_collection_containing_exactly(
-          a_hash_including("name" => "assigned_group", :buttons => [assigned_group_buttons]),
-          a_hash_including("name" => "generic_group", :buttons => [generic_group_buttons])
+          a_hash_including("name" => "assigned_group_set", :buttons => [assigned_group_buttons]),
+          a_hash_including("name" => "generic_group_set", :buttons => [generic_group_buttons])
         )
       }
       expect(actual).to match(expected)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -23,9 +23,6 @@ describe ServiceTemplate do
     end
 
     before do
-      allow(generic_no_group).to receive(:expanded_serializable_hash).and_return("generic_no_group")
-      allow(assigned_no_group).to receive(:expanded_serializable_hash).and_return("assigned_no_group")
-
       generic_group_set.add_member(generic_group)
       assigned_group_set.add_member(assigned_group)
 
@@ -65,10 +62,13 @@ describe ServiceTemplate do
       actual = expected_hash_without_created_or_updated
 
       expected = {
-        :buttons       => %w(generic_no_group assigned_no_group),
+        :buttons       => a_collection_containing_exactly(
+          a_hash_including("name" => "generic_no_group"),
+          a_hash_including("name" => "assigned_no_group")
+        ),
         :button_groups => [expected_assigned_group_set, expected_generic_group_set]
       }
-      expect(actual).to eq(expected)
+      expect(actual).to match(expected)
     end
   end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -4,14 +4,17 @@ describe ServiceTemplate do
   describe "#custom_actions" do
     it "returns the custom actions in a hash grouped by buttons and button groups" do
       generic_no_group = FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
-      assigned_no_group = FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
       generic_group = FactoryGirl.create(:custom_button, :name => "generic_group", :applies_to_class => "Service")
-      assigned_group = FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
-      assigned_group_set = FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
       generic_group_set = FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
       generic_group_set.add_member(generic_group)
+
+      service_template = FactoryGirl.create(:service_template)
+      assigned_no_group = FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
+      assigned_group = FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
+      assigned_group_set = FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
       assigned_group_set.add_member(assigned_group)
-      service_template = FactoryGirl.create(:service_template, :custom_button_sets => [assigned_group_set])
+      service_template.update(:custom_button_sets => [assigned_group_set])
+
       allow(CustomButton).to receive(:buttons_for).with("Service").and_return(
         [generic_no_group, generic_group]
       )

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -40,9 +40,6 @@ describe ServiceTemplate do
         button_group.reject! do |key, _|
           %w(created_on updated_on).include?(key)
         end
-        button_group[:buttons].each do |button|
-          button.reject! { |key, _| %w(created_on updated_on).include?(key) }
-        end
       end
 
       actual = expected_hash_without_created_or_updated

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -3,13 +3,13 @@ describe ServiceTemplate do
 
   describe "#custom_actions" do
     it "returns the custom actions in a hash grouped by buttons and button groups" do
-      generic_no_group = FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
+      FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
       generic_group = FactoryGirl.create(:custom_button, :name => "generic_group", :applies_to_class => "Service")
       generic_group_set = FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
       generic_group_set.add_member(generic_group)
 
       service_template = FactoryGirl.create(:service_template)
-      assigned_no_group = FactoryGirl.create(
+      FactoryGirl.create(
         :custom_button,
         :name             => "assigned_no_group",
         :applies_to_class => "ServiceTemplate",

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -60,12 +60,8 @@ describe ServiceTemplate do
           a_hash_including("name" => "assigned_no_group")
         ),
         :button_groups => a_collection_containing_exactly(
-          a_hash_including(assigned_group_set.serializable_hash.reject do |key, _|
-            %w(created_on updated_on).include?(key)
-          end.merge(:buttons => [assigned_group_buttons])),
-          a_hash_including(generic_group_set.serializable_hash.reject do |key, _|
-            %w(created_on updated_on).include?(key)
-          end.merge(:buttons => [generic_group_buttons]))
+          a_hash_including("name" => "assigned_group", :buttons => [assigned_group_buttons]),
+          a_hash_including("name" => "generic_group", :buttons => [generic_group_buttons])
         )
       }
       expect(actual).to match(expected)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -66,7 +66,10 @@ describe ServiceTemplate do
           a_hash_including("name" => "generic_no_group"),
           a_hash_including("name" => "assigned_no_group")
         ),
-        :button_groups => [expected_assigned_group_set, expected_generic_group_set]
+        :button_groups => a_collection_containing_exactly(
+          expected_assigned_group_set,
+          expected_generic_group_set
+        )
       }
       expect(actual).to match(expected)
     end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -35,13 +35,6 @@ describe ServiceTemplate do
     end
 
     it "returns the custom actions in a hash grouped by buttons and button groups" do
-      assigned_group_buttons = assigned_group.expanded_serializable_hash.reject do |key, _|
-        %w(created_on updated_on).include?(key)
-      end
-      generic_group_buttons = generic_group.expanded_serializable_hash.reject do |key, _|
-        %w(created_on updated_on).include?(key)
-      end
-
       expected_hash_without_created_or_updated = service_template.custom_actions
       expected_hash_without_created_or_updated[:button_groups].each do |button_group|
         button_group.reject! do |key, _|
@@ -60,8 +53,18 @@ describe ServiceTemplate do
           a_hash_including("name" => "assigned_no_group")
         ),
         :button_groups => a_collection_containing_exactly(
-          a_hash_including("name" => "assigned_group_set", :buttons => [assigned_group_buttons]),
-          a_hash_including("name" => "generic_group_set", :buttons => [generic_group_buttons])
+          a_hash_including(
+            "name"   => "assigned_group_set",
+            :buttons => [
+              a_hash_including("name" => "assigned_group")
+            ]
+          ),
+          a_hash_including(
+            "name"   => "generic_group_set",
+            :buttons => [
+              a_hash_including("name" => "generic_group")
+            ]
+          )
         )
       }
       expect(actual).to match(expected)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -35,11 +35,7 @@ describe ServiceTemplate do
     end
 
     it "returns the custom actions in a hash grouped by buttons and button groups" do
-      expected_hash_without_created_or_updated = service_template.custom_actions
-      expected_hash_without_created_or_updated[:button_groups].each do |button_group|
-      end
-
-      actual = expected_hash_without_created_or_updated
+      actual = service_template.custom_actions
 
       expected = {
         :buttons       => a_collection_containing_exactly(

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -33,15 +33,11 @@ describe ServiceTemplate do
         :button_groups => a_collection_containing_exactly(
           a_hash_including(
             "name"   => "assigned_group_set",
-            :buttons => [
-              a_hash_including("name" => "assigned_group")
-            ]
+            :buttons => [a_hash_including("name" => "assigned_group")]
           ),
           a_hash_including(
             "name"   => "generic_group_set",
-            :buttons => [
-              a_hash_including("name" => "generic_group")
-            ]
+            :buttons => [a_hash_including("name" => "generic_group")]
           )
         )
       }

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -25,8 +25,6 @@ describe ServiceTemplate do
       assigned_group_set.add_member(assigned_group)
       service_template.update(:custom_button_sets => [assigned_group_set])
 
-      actual = service_template.custom_actions
-
       expected = {
         :buttons       => a_collection_containing_exactly(
           a_hash_including("name" => "generic_no_group"),
@@ -47,7 +45,7 @@ describe ServiceTemplate do
           )
         )
       }
-      expect(actual).to match(expected)
+      expect(service_template.custom_actions).to match(expected)
     end
   end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -37,9 +37,6 @@ describe ServiceTemplate do
     it "returns the custom actions in a hash grouped by buttons and button groups" do
       expected_hash_without_created_or_updated = service_template.custom_actions
       expected_hash_without_created_or_updated[:button_groups].each do |button_group|
-        button_group.reject! do |key, _|
-          %w(created_on updated_on).include?(key)
-        end
       end
 
       actual = expected_hash_without_created_or_updated

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -22,19 +22,16 @@ describe ServiceTemplate do
       FactoryGirl.create(:custom_button_set, :name => "generic_group_set")
     end
 
-    before do
+    it "returns the custom actions in a hash grouped by buttons and button groups" do
       generic_group_set.add_member(generic_group)
       assigned_group_set.add_member(assigned_group)
-
       allow(CustomButton).to receive(:buttons_for).with("Service").and_return(
         [generic_no_group, generic_group]
       )
       allow(CustomButton).to receive(:buttons_for).with(service_template).and_return(
         [assigned_no_group, assigned_group]
       )
-    end
 
-    it "returns the custom actions in a hash grouped by buttons and button groups" do
       actual = service_template.custom_actions
 
       expected = {

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -56,10 +56,13 @@ describe ServiceTemplate do
         end
       end
 
-      expect(expected_hash_without_created_or_updated).to eq(
+      actual = expected_hash_without_created_or_updated
+
+      expected = {
         :buttons       => %w(generic_no_group assigned_no_group),
         :button_groups => [expected_assigned_group_set, expected_generic_group_set]
-      )
+      }
+      expect(actual).to eq(expected)
     end
   end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -10,10 +10,10 @@ describe ServiceTemplate do
     let(:generic_group) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
     let(:assigned_group) { FactoryGirl.create(:custom_button, :applies_to_class => "ServiceTemplate") }
     let(:assigned_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "assigned_group", :description => "assigned_group")
+      FactoryGirl.create(:custom_button_set, :name => "assigned_group")
     end
     let(:generic_group_set) do
-      FactoryGirl.create(:custom_button_set, :name => "generic_group", :description => "generic_group")
+      FactoryGirl.create(:custom_button_set, :name => "generic_group")
     end
 
     before do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -9,18 +9,21 @@ describe ServiceTemplate do
       generic_group_set.add_member(generic_group)
 
       service_template = FactoryGirl.create(:service_template)
-      assigned_no_group = FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
-      assigned_group = FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
+      assigned_no_group = FactoryGirl.create(
+        :custom_button,
+        :name             => "assigned_no_group",
+        :applies_to_class => "ServiceTemplate",
+        :applies_to_id    => service_template.id
+      )
+      assigned_group = FactoryGirl.create(
+        :custom_button,
+        :name             => "assigned_group",
+        :applies_to_class => "ServiceTemplate",
+        :applies_to_id    => service_template.id
+      )
       assigned_group_set = FactoryGirl.create(:custom_button_set, :name => "assigned_group_set")
       assigned_group_set.add_member(assigned_group)
       service_template.update(:custom_button_sets => [assigned_group_set])
-
-      allow(CustomButton).to receive(:buttons_for).with("Service").and_return(
-        [generic_no_group, generic_group]
-      )
-      allow(CustomButton).to receive(:buttons_for).with(service_template).and_return(
-        [assigned_no_group, assigned_group]
-      )
 
       actual = service_template.custom_actions
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -5,10 +5,16 @@ describe ServiceTemplate do
     let(:service_template) do
       described_class.create(:name => "test", :description => "test", :custom_button_sets => [assigned_group_set])
     end
-    let(:generic_no_group) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
-    let(:assigned_no_group) { FactoryGirl.create(:custom_button, :applies_to_class => "ServiceTemplate") }
-    let(:generic_group) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
-    let(:assigned_group) { FactoryGirl.create(:custom_button, :applies_to_class => "ServiceTemplate") }
+    let(:generic_no_group) do
+      FactoryGirl.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
+    end
+    let(:assigned_no_group) do
+      FactoryGirl.create(:custom_button, :name => "assigned_no_group", :applies_to_class => "ServiceTemplate")
+    end
+    let(:generic_group) { FactoryGirl.create(:custom_button, :name => "generic_group", :applies_to_class => "Service") }
+    let(:assigned_group) do
+      FactoryGirl.create(:custom_button, :name => "assigned_group", :applies_to_class => "ServiceTemplate")
+    end
     let(:assigned_group_set) do
       FactoryGirl.create(:custom_button_set, :name => "assigned_group")
     end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -38,16 +38,9 @@ describe ServiceTemplate do
       assigned_group_buttons = assigned_group.expanded_serializable_hash.reject do |key, _|
         %w(created_on updated_on).include?(key)
       end
-      expected_assigned_group_set = assigned_group_set.serializable_hash.reject do |key, _|
-        %w(created_on updated_on).include?(key)
-      end.merge(:buttons => [assigned_group_buttons])
-
       generic_group_buttons = generic_group.expanded_serializable_hash.reject do |key, _|
         %w(created_on updated_on).include?(key)
       end
-      expected_generic_group_set = generic_group_set.serializable_hash.reject do |key, _|
-        %w(created_on updated_on).include?(key)
-      end.merge(:buttons => [generic_group_buttons])
 
       expected_hash_without_created_or_updated = service_template.custom_actions
       expected_hash_without_created_or_updated[:button_groups].each do |button_group|
@@ -67,8 +60,12 @@ describe ServiceTemplate do
           a_hash_including("name" => "assigned_no_group")
         ),
         :button_groups => a_collection_containing_exactly(
-          expected_assigned_group_set,
-          expected_generic_group_set
+          assigned_group_set.serializable_hash.reject do |key, _|
+            %w(created_on updated_on).include?(key)
+          end.merge(:buttons => [assigned_group_buttons]),
+          generic_group_set.serializable_hash.reject do |key, _|
+            %w(created_on updated_on).include?(key)
+          end.merge(:buttons => [generic_group_buttons])
         )
       }
       expect(actual).to match(expected)


### PR DESCRIPTION
The combination of stubbing out the implementation and munging results from `#serializable_hash` to form expectations here gave me poor confidence that my refactoring in https://github.com/ManageIQ/manageiq/pull/14817 had preserved this behavior.

To remedy this I:
* Inlined the lets, allowing me to set up the objects in a specific order
* Specify the `applies_to_id` for buttons assigned to service templates
* Now remove the stubbing, which was hiding the fact that the buttons weren't set up correctly
* Leverage RSpec's composable matchers more so we don't need to munge the results, and make expectations on literal values used in the setup for greater readability

The resulting test is also considerably shorter, so :scissors: 

@miq-bot add-label test, refactoring
@miq-bot assign @abellotti 