### PR TITLE
Use try for the multiplication with self["aggregate_all_vm_memory_on_disk]

### DIFF
--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -315,7 +315,7 @@ module Service::Aggregation
   def aggregate_all_vm_memory_on_disk
     if has_attribute?("aggregate_all_vm_memory_on_disk")
       # Avoids (poorly) "ERROR:  integer out of range" in postgres
-      self["aggregate_all_vm_memory_on_disk"] * 1.megabyte
+      self["aggregate_all_vm_memory_on_disk"].try(:*, 1.megabyte)
     else
       all_vms.inject(0) { |aggregate, vm| aggregate + vm.ram_size_in_bytes_by_state.to_i }
     end

--- a/spec/models/service/aggregation_spec.rb
+++ b/spec/models/service/aggregation_spec.rb
@@ -1,0 +1,11 @@
+describe "Service" do
+  before(:each) do
+    @server = EvmSpecHelper.local_miq_server
+    @service = FactoryGirl.create(:service)
+  end
+
+  it "will not crash when the attribute  is nil" do
+    allow(@service).to receive(:has_attribute?).with("aggregate_all_vm_memory_on_disk").and_return(true)
+    expect { @service.aggregate_all_vm_memory_on_disk }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Use try for the multiplication with self["aggregate_all_vm_memory_on_disk]

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1435294

Steps for Testing/QA
-------------------------------
Click on a service link in a VM summary page (or a Job)  summary page with zero memory on disk
