### PR TITLE
Method for Human name of virtual custom attributes

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -2,6 +2,8 @@ module CustomAttributeMixin
   extend ActiveSupport::Concern
 
   CUSTOM_ATTRIBUTES_PREFIX = "virtual_custom_attribute_".freeze
+  SECTION_SEPARATOR        = ":SECTION:".freeze
+  DEFAULT_SECTION_NAME     = 'Custom Attribute'.freeze
 
   included do
     has_many   :custom_attributes,     :as => :resource, :dependent => :destroy
@@ -43,6 +45,11 @@ module CustomAttributeMixin
         custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
       end
     end
+  end
+
+  def self.to_human(column)
+    col_name, section = column.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, '').split(SECTION_SEPARATOR)
+    _("%{section}: %{custom_key}") % { :custom_key => col_name, :section => section.try(:titleize) || DEFAULT_SECTION_NAME}
   end
 
   def self.select_virtual_custom_attributes(cols)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1173,7 +1173,8 @@ class MiqExpression
 
     klass.custom_keys.each do |custom_key|
       custom_detail_column = [model, CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX + custom_key].join("-")
-      custom_detail_name = _("Labels: %{custom_key}") % { :custom_key => custom_key }
+      custom_detail_name = CustomAttributeMixin.to_human(custom_key)
+
       if options[:include_model]
         model_name = Dictionary.gettext(model, :type => :model, :notfound => :titleize)
         custom_detail_name = [model_name, custom_detail_name].join(" : ")

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -908,7 +908,7 @@ class MiqExpression
       dict_col = model.nil? ? col : [model, col].join(".")
       column_human = if col
                        if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
-                         col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "")
+                         CustomAttributeMixin.to_human(col)
                        else
                          Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize)
                        end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1911,15 +1911,12 @@ describe MiqExpression do
   end
 
   context "._custom_details_for" do
-    let(:klass)        { Vm }
-    let(:vm)           { FactoryGirl.create(:vm) }
-    let(:custom_attr1) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => "CATTR_1", :value => "Value 1") }
-    let(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
+    let(:klass)         { Vm }
+    let(:vm)            { FactoryGirl.create(:vm) }
+    let!(:custom_attr1) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => "CATTR_1", :value => "Value 1") }
+    let!(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
 
     it "ignores custom_attibutes with a nil name" do
-      custom_attr1
-      custom_attr2
-
       expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Labels: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
   end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1917,7 +1917,7 @@ describe MiqExpression do
     let!(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
 
     it "ignores custom_attibutes with a nil name" do
-      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Labels: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
+      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Custom Attribute: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
   end
 

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -8,6 +8,26 @@ describe CustomAttributeMixin do
     end
   end
 
+  describe '#to_human' do
+    let(:custom_attribute)                { 'virtual_custom_attribute_name' }
+    let(:custom_attribute_with_section_1) { "virtual_custom_attribute_name#{described_class::SECTION_SEPARATOR}labels" }
+    let(:custom_attribute_with_section_2) do
+      "virtual_custom_attribute_name#{described_class::SECTION_SEPARATOR}docker_labels"
+    end
+
+    it 'returns human form of virtual custom attribute with sections' do
+      expect(described_class.to_human(custom_attribute)).to eq('Custom Attribute: name')
+    end
+
+    it 'returns human form of virtual custom attribute' do
+      expect(described_class.to_human(custom_attribute_with_section_1)).to eq('Labels: name')
+    end
+
+    it 'returns human form of virtual custom attribute' do
+      expect(described_class.to_human(custom_attribute_with_section_2)).to eq('Docker Labels: name')
+    end
+  end
+
   it "defines #miq_custom_keys" do
     expect(test_class.new).to respond_to(:miq_custom_keys)
   end


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/14823

Get human name for virtual custom attribute with section

example:
```
to_human(‘virtual_custom_attribute_some_name’)
=> ‘Custom Attribute: some_name’
```
```
to_human(‘virtual_custom_attribute_some_name:SECTION:docker_labels’)
=> ‘Docker Labels: some_name’
```

This PR together with UI https://github.com/ManageIQ/manageiq-ui-classic/pull/1099 is using the method for displaying human form of virtual custom attributes in report definition:
- Available Fields
- Selected Fields (in the UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/109)
- Expression Editor

At this moment are custom attribute displayed in the format:
'Custom Attribute: some_name'

@miq-bot add_label enhacement, core
@miq-bot assign @gtanzillo 

## Links
follow up of #14391
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1434077
UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/1099
