### PR TITLE
Generate virtual custom attributes with sections

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,7 +27,10 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct
+      custom_attr_scope = CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct.pluck(:name, :section)
+      custom_attr_scope.map do |x|
+        "#{x[0]}#{x[1] ? SECTION_SEPARATOR + x[1] : ''}"
+      end
     end
 
     def self.load_custom_attributes_for(cols)

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -44,8 +44,14 @@ module CustomAttributeMixin
       virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
 
       define_method(custom_attribute.to_sym) do
-        custom_attribute_without_prefix = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
-        custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
+        custom_attribute_without_prefix           = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
+        custom_attribute_without_section, section = custom_attribute_without_prefix.split(SECTION_SEPARATOR)
+
+        where_args = {}
+        where_args[:name]    = custom_attribute_without_section
+        where_args[:section] = section if section
+
+        custom_attributes.find_by(where_args).try(:value)
       end
     end
   end

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,7 +27,7 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name).compact
+      CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct
     end
 
     def self.load_custom_attributes_for(cols)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -5,7 +5,7 @@ class MiqExpression::Field < MiqExpression::Target
 \.?(?<associations>[a-z][0-9a-z_\.]+)?
 -
 (?:
-  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[_\-.\/[:alnum:]]*)|
+  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[:_\-.\/[:alnum:]]*)|
   (?<column>[a-z]+(_[[:alnum:]]+)*)
 )
 /x

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1919,6 +1919,27 @@ describe MiqExpression do
     it "ignores custom_attibutes with a nil name" do
       expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Custom Attribute: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
+
+    let(:conatiner_image) { FactoryGirl.create(:container_image) }
+
+    let!(:custom_attribute_with_section_1) do
+      FactoryGirl.create(:custom_attribute, :resource => conatiner_image, :name => 'CATTR_3', :value => "Value 3",
+                         :section => 'section_3')
+    end
+
+    let!(:custom_attribute_with_section_2) do
+      FactoryGirl.create(:custom_attribute, :resource => conatiner_image, :name => 'CATTR_3', :value => "Value 3",
+                         :section => 'docker_labels')
+    end
+
+    it "returns human names of custom attributes with sections" do
+      expected_result = [
+        ['Docker Labels: CATTR_3', 'ContainerImage-virtual_custom_attribute_CATTR_3:SECTION:docker_labels'],
+        ['Section 3: CATTR_3', 'ContainerImage-virtual_custom_attribute_CATTR_3:SECTION:section_3']
+      ]
+
+      expect(MiqExpression._custom_details_for("ContainerImage", {})).to match_array(expected_result)
+    end
   end
 
   context ".build_relats" do

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -28,6 +28,21 @@ describe CustomAttributeMixin do
     end
   end
 
+  describe '#custom_keys' do
+    let!(:custom_attribute) { FactoryGirl.create(:custom_attribute, :name => "attr_1", :value => 'value') }
+    let!(:custom_attribute_with_section) do
+      FactoryGirl.create(:custom_attribute, :name => "attr_2", :value => 'value', :section => 'labels')
+    end
+
+    let!(:vm) do
+      FactoryGirl.create(:vm_redhat, :custom_attributes => [custom_attribute, custom_attribute_with_section])
+    end
+
+    it 'returns human form of virtual custom attribute with sections' do
+      expect(vm.class.custom_keys).to match_array(["attr_1", "attr_2#{described_class::SECTION_SEPARATOR}labels"])
+    end
+  end
+
   it "defines #miq_custom_keys" do
     expect(test_class.new).to respond_to(:miq_custom_keys)
   end


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/14823
VCA = Virtual Custom Attributes

When there are more custom_attributes with same `name` we were not able to distinguish them.

In this PR I distinguish them by column CustomAttribute#section
and I am extending format of virtual custom attributes to
`virtual_custom_attribute_NAMEOFATTR:SECTION:docker_labels`
and thanks to that it has a format in UI
`Docker Labels: NAMEOFATTR` and
when there is no section it looks like:
`Custom Attribute: NAMEOFATTR` so it
means that this also works with origin form. (part :SECTION: is not mandatory)

### Images 

let's assume that we have 3 different custom attributes with name `com.redhat.component`
but with different sections


**on the report:**
![screen shot 2017-04-20 at 16 29 20](https://cloud.githubusercontent.com/assets/14937244/25235820/9404b9ae-25e6-11e7-83b5-de253599750f.png)

**columns in report definition**
![screen shot 2017-04-20 at 16 50 56](https://cloud.githubusercontent.com/assets/14937244/25236958/8e572ba6-25e9-11e7-8759-4b2c1fa2aa17.png)

**expression**
![screen shot 2017-04-20 at 16 55 22](https://cloud.githubusercontent.com/assets/14937244/25237173/32f36940-25ea-11e7-94bc-a7f4b4911b9c.png)


## Links
follow up https://github.com/ManageIQ/manageiq/pull/14391
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1434077

## Depends on
https://github.com/ManageIQ/manageiq/pull/14835
It is a reason for WIP.

@miq-bot add_label enhancement,core, fine/yes, euwe/yes, wip

@miq-bot assign @gtanzillo 

cc @zeari @simon3z 

