### PR TITLE
Gitignore public/packs - webpacker assets output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ product/automate
 public/upload
 public/pictures/
 public/ui/
+/public/packs
 
 # spec/
 spec/replication/util/data/*_migrations


### PR DESCRIPTION
[webpacker](https://github.com/rails/webpacker) puts its output in `public/packs` (and then sprockets picks that up from there and puts it in the regular place).

Gitignoring that :).

(This looks like the only change made by `rake webpacker:install` that should live in the main repo.)

@miq-bot add_label developer, ui, fine/no