### PR TITLE
Refactor start_clone method and break up powershell functions

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
@@ -4,7 +4,8 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
     module ClassMethods
       def execute_powershell_json(connection, script)
-        parse_json_results(run_powershell_script(connection, script))
+        results = run_powershell_script(connection, script)
+        parse_json_results(results.stdout)
       end
 
       def execute_powershell(connection, script)
@@ -12,8 +13,9 @@ class ManageIQ::Providers::Microsoft::InfraManager
       end
 
       def run_powershell_script(connection, script)
+        require 'winrm'
         log_header = "MIQ(#{self.class.name}.#{__method__})"
-        results = []
+        results = ::WinRM::Output.new
 
         begin
           with_winrm_shell(connection) do |shell|
@@ -25,7 +27,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
           raise
         end
 
-        results.stdout
+        results
       end
 
       def powershell_results_to_hash(results)
@@ -108,13 +110,14 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       $scvmm_log.debug("#{log_header} Execute DOS command <#{command}>...Complete - Timings: #{timings}")
 
-      results.stdout
+      results
     end
 
     def run_powershell_script(script)
+      require 'winrm'
       log_header = "MIQ(#{self.class.name}##{__method__})"
       $scvmm_log.debug("#{log_header} Execute Powershell Script...")
-      results = []
+      results = ::WinRM::Output.new
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_winrm_shell do |shell|
@@ -125,7 +128,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       $scvmm_log.debug("#{log_header} Execute Powershell script... Complete - Timings: #{timings}")
 
-      results.stdout
+      results
     end
   end
 end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
@@ -158,7 +158,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Powershell do
       allow(connection).to receive(:shell).and_return(shell)
       allow(shell).to receive(:run).and_return(results)
 
-      expect(powershell.run_powershell_script(connection, ps_script)).to eql("stdout")
+      expect(powershell.run_powershell_script(connection, ps_script).stdout).to eql("stdout")
     end
   end
 end


### PR DESCRIPTION
This addresses an issue where an invalid provisioning attempt could fail. Instead of a helpful error message, users are getting an obscure JSON parsing error.

What is essentially happening is that the call to `New-SCVirtualMachine` inside the `build_ps_script` is failing, with the result that the method returns an empty string because there's no error checking. When JSON then tries to parse an empty string, it bombs.

This PR splits the powershell functions into two separate calls, and we check the results of the first one before moving onto the second.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1441319