### PR TITLE
[WIP] YAML support for CFN orchestration templates

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -22,6 +22,8 @@ class OrchestrationTemplate < ApplicationRecord
   attr_accessor :remote_proxy
   alias remote_proxy? remote_proxy
 
+  attr_accessor :format
+
   # Try to create the template if the name is not found in table
   def self.seed
     Dir.glob(TEMPLATE_DIR.join('*.yml')).each do |file|

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -21,6 +21,16 @@ FactoryGirl.define do
     content File.read(Rails.root.join('spec/fixtures/orchestration_templates/cfn_parameters.json'))
   end
 
+  factory :orchestration_template_cfn_with_json_content, :parent => :orchestration_template_cfn do
+    format "json"
+    content File.read(Rails.root.join('spec/fixtures/orchestration_templates/cfn_parameters.json'))
+  end
+
+  factory :orchestration_template_cfn_with_yaml_content, :parent => :orchestration_template_cfn do
+    format "yaml"
+    content File.read(Rails.root.join('spec/fixtures/orchestration_templates/cfn_parameters.yml'))
+  end
+
   factory :orchestration_template_hot_with_content,
           :parent => :orchestration_template,
           :class  => "OrchestrationTemplateHot" do

--- a/spec/fixtures/orchestration_templates/cfn_parameters.yml
+++ b/spec/fixtures/orchestration_templates/cfn_parameters.yml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Incomplete sample template for testing parsing of various parameters
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    Type: AWS::EC2::KeyPair::KeyName
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+  WebServerInstanceType:
+    Description: WebServer Server EC2 instance type
+    Type: String
+    Default: m1.small
+    AllowedValues:
+    - t2.small
+    - t2.medium
+    - m1.small
+    ConstraintDescription: must be a valid EC2 instance type.
+  SecondaryIPAddressCount:
+    Type: Number
+    Default: '1'
+    MinValue: '1'
+    MaxValue: '5'
+    Description: Number of secondary IP addresses to assign to the network interface
+      (1-5)
+    ConstraintDescription: must be a number from 1 to 5.
+  MasterUserPassword:
+    Description: 'The password associated with the aster user account for the redshift
+      cluster that is being created. '
+    Type: String
+    NoEcho: 'true'
+    MinLength: '1'
+    MaxLength: '41'
+    AllowedPattern: "[a-zA-Z0-9]*"
+    ConstraintDescription: must contain only alphanumeric characters.
+  Subnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
+    ConstraintDescription: must be a list of an existing subnets in the selected Virtual
+      Private Cloud.
+  AZs:
+    Type: List<String>
+    Description: The list of AvailabilityZones for your Virtual Private Cloud (VPC)
+    ConstraintDescription: must be a list if valid EC2 availability zones for the
+      selected Virtual Private Cloud
+Resources:
+  MyEC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-2f726546
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp:
+          Ref: SSHLocation
+  WebServerScaleUpPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName:
+        Ref: WebServerGroup
+      Cooldown: '60'
+      ScalingAdjustment: '1'
+  WebServerScaleDownPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName:
+        Ref: WebServerGroup
+      Cooldown: '60'
+      ScalingAdjustment: "-1"


### PR DESCRIPTION
This PR adds support for CloudFormation Orchestration Templates in YAML format. Both template validation and template parsing have been updated.

https://bugzilla.redhat.com/show_bug.cgi?id=1417021
