### PR TITLE
Ensure grouped generic custom buttons can be invoked

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -126,8 +126,6 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def custom_actions
-    generic_button_group = CustomButton.buttons_for("Service").select { |button| !button.parent.nil? }
-    custom_button_sets_with_generics = custom_button_sets + generic_button_group.map(&:parent).uniq.flatten
     {
       :buttons       => custom_buttons.collect(&:expanded_serializable_hash),
       :button_groups => custom_button_sets_with_generics.collect do |button_set|
@@ -137,7 +135,15 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def custom_action_buttons
-    custom_buttons + custom_button_sets.collect(&:children).flatten
+    custom_buttons + custom_button_sets_with_generics.collect(&:children).flatten
+  end
+
+  def generic_button_group
+    CustomButton.buttons_for("Service").select { |button| !button.parent.nil? }
+  end
+
+  def custom_button_sets_with_generics
+    custom_button_sets + generic_button_group.map(&:parent).uniq.flatten
   end
 
   def custom_buttons

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -174,6 +174,25 @@ describe "Custom Actions API" do
     end
   end
 
+  describe "Services with grouped generic custom buttons" do
+    it "accepts a custom action" do
+      button = FactoryGirl.create(
+        :custom_button,
+        :name             => "test button",
+        :applies_to_class => "Service",
+        :resource_action  => FactoryGirl.create(:resource_action)
+      )
+      button_group = FactoryGirl.create(:custom_button_set)
+      button_group.add_member(button)
+      service = FactoryGirl.create(:service, :service_template => FactoryGirl.create(:service_template))
+      api_basic_authorize
+
+      run_post(services_url(service.id), "action" => "test button")
+
+      expect(response.parsed_body).to include("success" => true, "message" => /Invoked custom action test button/)
+    end
+  end
+
   describe "Services with custom button dialogs" do
     it "queries for custom_actions returns expanded details for dialog buttons" do
       api_basic_authorize action_identifier(:services, :read, :resource_actions, :get)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1443691

@miq-bot add-label bug, api
@miq-bot assign @abellotti 

/cc @jjlangholtz 

@abellotti pulling this out of https://github.com/ManageIQ/manageiq/pull/14817 and marking that as WIP for now since there is a ticket associated with this bug.