### PR TITLE
It's _log, not log and we don't need the undefined variable prefix

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -13,7 +13,7 @@ class EmbeddedAnsibleWorker < MiqWorker
         # Because we're running in a thread on the Server
         # we need to intercept SystemExit and exit our thread,
         # not the main server thread!
-        log.info("#{log_prefix} SystemExit received, exiting monitoring Thread")
+        _log.info("SystemExit received, exiting monitoring Thread")
         Thread.exit
       end
     end


### PR DESCRIPTION
Fixes a bug introduced in:
18ffca9

Note, this shouldn't be fatal since we're just losing a log message.
The next line is exiting the Thread anyway.