### PR TITLE
Wait for ems workers to finish before destroying the ems

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -431,6 +431,10 @@ class ExtManagementSystem < ApplicationRecord
     resource_pools.destroy_all
   end
 
+  def queue_name
+    "ems_#{id}"
+  end
+
   def enforce_policy(target, event)
     inputs = {:ext_management_system => self}
     inputs[:vm]   = target if target.kind_of?(Vm)

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -97,7 +97,7 @@ module PerEmsWorkerMixin
       return "generic" if ems.kind_of?(Host) && ems.acts_as_ems?
 
       return ems unless ems.kind_of?(ExtManagementSystem)
-      "ems_#{ems.id}"
+      ems.queue_name
     end
 
     def ems_id_from_queue_name(queue_name)

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -33,9 +33,9 @@ describe AsyncDeleteMixin do
     end
   end
 
-  def self.should_queue_destroy_on_instance
+  def self.should_queue_destroy_on_instance(queue_method = "destroy")
     it "should queue up destroy on instance" do
-      cond = ["class_name = ? AND instance_id = ? AND method_name = ?", @obj.class.name, @obj.id, "destroy"]
+      cond = ["class_name = ? AND instance_id = ? AND method_name = ?", @obj.class.name, @obj.id, queue_method]
 
       expect { @obj.destroy_queue }.not_to raise_error
       expect(MiqQueue.where(cond).count).to eq(1)
@@ -48,10 +48,10 @@ describe AsyncDeleteMixin do
     end
   end
 
-  def self.should_queue_destroy_on_class_with_many_ids
+  def self.should_queue_destroy_on_class_with_many_ids(queue_method = "destroy")
     it "should queue up destroy on class method with many ids" do
       ids = @objects.collect(&:id)
-      cond = ["class_name = ? AND instance_id in (?) AND method_name = ?", @obj.class.name, ids, "destroy"]
+      cond = ["class_name = ? AND instance_id in (?) AND method_name = ?", @obj.class.name, ids, queue_method]
 
       expect { @obj.class.destroy_queue(ids) }.not_to raise_error
       expect(MiqQueue.where(cond).count).to eq(ids.length)
@@ -129,8 +129,8 @@ describe AsyncDeleteMixin do
 
       should_define_destroy_queue_instance_method
       should_define_destroy_queue_class_method
-      should_queue_destroy_on_instance
-      should_queue_destroy_on_class_with_many_ids
+      should_queue_destroy_on_instance("orchestrate_destroy")
+      should_queue_destroy_on_class_with_many_ids("orchestrate_destroy")
 
       should_define_delete_queue_instance_method
       should_define_delete_queue_class_method

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -392,4 +392,19 @@ describe ExtManagementSystem do
       expect(tenant.ext_management_systems).to include(ems)
     end
   end
+
+  context "destroy" do
+    it "destroys an ems with no active workers" do
+      ems = FactoryGirl.create(:ext_management_system)
+      ems.destroy
+      expect(ExtManagementSystem.count).to eq(0)
+    end
+
+    it "does not destroy an ems with active workers" do
+      ems = FactoryGirl.create(:ext_management_system)
+      FactoryGirl.create(:miq_ems_refresh_worker, :queue_name => ems.queue_name, :status => "started")
+      ems.destroy
+      expect(ExtManagementSystem.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1437549
continue work from https://github.com/ManageIQ/manageiq/pull/14675

- [X] migration and toggling of disable flag
- [X] dont start disabled workers
- [x] orchestrate deletion ( this PR )

@durandom @Fryguy @jrafanie @kbrock ~~I have no idea whats the correct way to do this so lets discuss that here. The code added here outlines the basic functionality. `orchestrate_destroy` should replace `destroy_queue`~~ in https://github.com/manageiq/manageiq-ui-classic/blob/master/app/controllers/ems_common.rb#L898.

cc @moolitayer @cben 