### PR TITLE
Remove UI consts from model

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -12,21 +12,6 @@ class ContainerLabelTagMapping < ApplicationRecord
   #
   # All involved tags must also have a Classification.
 
-  AUTOTAG_PREFIX = "kubernetes".freeze
-
-  MAPPABLE_ENTITIES = [
-    nil,
-    "Amazon::Vm",
-    "Amazon::Image",
-    "Kubernetes::ContainerProject",
-    "Kubernetes::ContainerRoute",
-    "Kubernetes::ContainerNode",
-    "Kubernetes::ContainerReplicator",
-    "Kubernetes::ContainerService",
-    "Kubernetes::ContainerGroup",
-    "Kubernetes::ContainerBuild"
-  ].freeze
-
   belongs_to :tag
 
   # Pass the data this returns to map_* methods.


### PR DESCRIPTION
Followup cleanup to be merged after ManageIQ/manageiq-ui-classic#1122 lands.

The model doesn't currently validate `labeled_resource_type` is one of those, 
and it's extra confusing here since UI changed to use `Foo::Bar` internally but **still store just `Bar` part in DB**.

cc @zgalor @djberg96