### PR TITLE
Adding openshift annotations for container images

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -24,6 +24,7 @@ class ContainerImage < ApplicationRecord
   has_many :openscap_rule_results, :through => :openscap_result
   has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
   has_many :docker_labels, -> { where(:section => "docker_labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
+  has_many :annotations, -> { where(:section => "annotations") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
 
   serialize :exposed_ports, Hash
   serialize :environment_variables, Hash

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -311,7 +311,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_images, hashes, deletes, [:image_ref, :container_image_registry_id],
-                         [:labels, :docker_labels], :container_image_registry, true)
+                         [:labels, :docker_labels, :annotations], :container_image_registry, true)
     store_ids_for_new_records(ems.container_images, hashes,
                               [:image_ref, :container_image_registry_id])
   end
@@ -412,6 +412,10 @@ module EmsRefresh::SaveInventoryContainer
 
   def save_labels_inventory(entity, hashes, target = nil)
     save_custom_attribute_attribute_inventory(entity, :labels, hashes, target)
+  end
+
+  def save_annotations_inventory(entity, hashes, target = nil)
+    save_custom_attribute_attribute_inventory(entity, :annotations, hashes, target)
   end
 
   def save_docker_labels_inventory(entity, hashes, target = nil)


### PR DESCRIPTION
Model changes to allow collecting annotations from Openshift. They will be saved as custom attributes with section "openshift_annotations", similarly to docker_lables.