### PR TITLE
[FINE] Fix to operation callbacks not being called correctly.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -554,7 +554,7 @@ module ManageIQ::Providers
     #
     def run_generic_operation(operation_name, ems_ref, parameters = {})
       the_operation = {
-        :operationName => operation_name,
+        :operationName => operation_name.to_s,
         :resourcePath  => ems_ref.to_s,
         :parameters    => parameters
       }


### PR DESCRIPTION
The hawkular ruby client is expecting a string as the operation name, but symbols were being used. Symbols are now converted to strings.

https://bugzilla.redhat.com/show_bug.cgi?id=1443005

This bug happens only in `fine` branch using version 2.8.0 of hawkular client gem. The `master` branch is using version 2.9.0 where the symbols are correctly handled. So, this PR should not be ported to `master` branch.