### PR TITLE
Allow descendants of Host model to use belongsto filters in RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -560,7 +560,7 @@ module Rbac
     end
 
     def get_belongsto_matches(blist, klass)
-      return get_belongsto_matches_for_host(blist) if klass == Host
+      return get_belongsto_matches_for_host(blist) if klass <= Host
       return get_belongsto_matches_for_storage(blist) if klass == Storage
       association_name = klass.base_model.to_s.tableize
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -817,6 +817,21 @@ describe Rbac::Filterer do
           expect(attrs[:auth_count]).to eq(1)
           expect(results3.length).to eq(1)
         end
+
+        it 'searches Hosts with tag and host & cluster filters' do
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([@cluster_folder_path])
+          group.entitlement.set_managed_filters([['/managed/environment/prod']])
+          group.save!
+
+          @host_1.tag_with('/managed/environment/prod', :ns => '*')
+
+          results, attrs = described_class.search(:class => "Host", :user => user)
+
+          expect(attrs[:user_filters]).to eq("managed"   => [['/managed/environment/prod']], "belongsto" => [@cluster_folder_path])
+          expect(attrs[:auth_count]).to eq(1)
+          expect(results.length).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443929

we have Host model and his descendant is only `ManageIQ::Providers::Vmware::InfraManager::HostEsx` model

but when input (Host object) to RBAC had its subclass `ManageIQ::Providers::Vmware::InfraManager::HostEsx`
then belongs to filters are not used
so in this PR it is allowed aslo for Host's subclasses.


@miq-bot add_label bug, rbac, core

@miq-bot assign @gtanzillo 
