### PR TITLE
Fix name of PDF summary report for Hosts

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -839,6 +839,11 @@ en:
       ManageIQ::Providers::StorageManager:                                  Storage Manager
       ManageIQ::Providers::StorageManager::CinderManager:                   Storage Manager (Cinder)
       ManageIQ::Providers::StorageManager::SwiftManager:                    Storage Manager (Swift)
+      ManageIQ::Providers::Microsoft::InfraManager::Host:                   Host (Microsoft)
+      ManageIQ::Providers::Openstack::InfraManager::Host:                   Host (OpenStack)
+      ManageIQ::Providers::Redhat::InfraManager::Host:                      Host (Redhat)
+      ManageIQ::Providers::Vmware::InfraManager::Host:                      Host (Vmware)
+      ManageIQ::Providers::Vmware::InfraManager::HostEsx:                   Host (Vmware)
       MiddlewareDatasource:     Middleware Datasource
       MiddlewareDomain:         Middleware Domain
       MiddlewareMessaging:      Middleware Messaging


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1442682

Fix name of PDF summary report for Hosts
when reaching Compute -> Infrastructure-> Hosts,
going to any hosts details and downloading
summary in PDF format.
Fix title in the downloaded PDF, remove base class
name from it.

Before:
![pdf2](https://cloud.githubusercontent.com/assets/13417815/25339327/a08e8d3e-2902-11e7-857d-9d3d728566da.png)

After:
![pdf1](https://cloud.githubusercontent.com/assets/13417815/25339182/130c39b6-2902-11e7-9a43-4b4d2a6f3555.png)