### PR TITLE
[SCVMM] Allow run_powershell_script method to accept file or string

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       def run_powershell_script(connection, script)
         log_header = "MIQ(#{self.class.name}.#{__method__})"
-        script_string = IO.read(script)
+        script_string = File.exist?(script) ? IO.read(script) : script
         results = []
 
         begin
@@ -119,7 +119,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_winrm_shell do |shell|
-          script_string = IO.read(script)
+          script_string = File.exist?(script) ? IO.read(script) : script
           results = shell.run(script_string)
           self.class.log_dos_error_results(results.stderr)
         end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
@@ -1,6 +1,16 @@
 describe ManageIQ::Providers::Microsoft::InfraManager::Powershell do
   before(:all) do
     class PowershellTemp; end
+    class Connection; end
+
+    class Shell
+      def close; end
+    end
+
+    class Results
+      def stdout; "stdout"; end
+      def stderr; "stderr"; end
+    end
   end
 
   before(:each) do
@@ -108,6 +118,65 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Powershell do
     it "handles plain yaml text" do
       expect(powershell.parse_json_results(json)).to be_kind_of(Array)
       expect(powershell.parse_json_results(json).first).to be_kind_of(Hash)
+    end
+  end
+
+  context "run_powershell_script" do
+    before(:all) do
+      @connection = Connection.new
+      @shell = Shell.new
+      @results = Results.new
+    end
+
+    before do
+      @ps_file = Tempfile.new
+      @ps_file.write(ps_script)
+    end
+
+    after do
+      @ps_file.delete
+    end
+
+    let(:connection) { @connection }
+    let(:shell) { @shell }
+    let(:results) { @results }
+    let(:ps_file) { @ps_file }
+    let(:tempfile) { @tempfile }
+
+    let(:ps_script) {
+      <<-PS_SCRIPT
+        Import-Module VirtualMachineManager | Out-Null; \
+        Get-SCVMMServer localhost | Out-Null;\
+
+        $vm = New-SCVirtualMachine \
+          -Name 'foo_test-1a' \
+          -VMHost some_host \
+          -Path 'C:\\foo\\bar' \
+          -VMTemplate some_template; \
+
+        $vm | Select-Object ID | ConvertTo-Json
+      PS_SCRIPT
+    }
+
+    it "requires two arguments" do
+      expect { powershell.run_powershell_script }.to raise_error(ArgumentError)
+      expect { powershell.run_powershell_script(connection) }.to raise_error(ArgumentError)
+    end
+
+    it "accepts a string argument for a script" do
+      allow(powershell).to receive(:with_winrm_connection).and_return(connection)
+      allow(connection).to receive(:shell).and_return(shell)
+      allow(shell).to receive(:run).and_return(results)
+
+      expect(powershell.run_powershell_script(connection, ps_script)).to eql("stdout")
+    end
+
+    it "accepts a file argument for a script" do
+      allow(powershell).to receive(:with_winrm_connection).and_return(connection)
+      allow(connection).to receive(:shell).and_return(shell)
+      allow(shell).to receive(:run).and_return(results)
+
+      expect(powershell.run_powershell_script(connection, ps_file)).to eql("stdout")
     end
   end
 end


### PR DESCRIPTION
At the moment the `run_powershell_script` method in powershell.rb assumes that it's reading from a file. However, for provisioning requests the scripts are inlined as strings (heredocs), causing a `Errno::ENAMETOOLONG` error when it tries to read it as a file.

https://bugzilla.redhat.com/show_bug.cgi?id=1444201

I've updated the code to make a file check first, and assume that it's a string if it's not found as a file. I've also added some specs.

