### PR TITLE
Add status column to Repositories list

### DIFF
--- a/product/views/ManageIQ_Providers_EmbeddedAutomationManager_ConfigurationScriptSource.yaml
+++ b/product/views/ManageIQ_Providers_EmbeddedAutomationManager_ConfigurationScriptSource.yaml
@@ -24,6 +24,7 @@ cols:
 - total_payloads
 - created_at
 - updated_at
+- status
 
 # Included tables (joined, has_one, has_many) and columns
 
@@ -36,6 +37,7 @@ col_order:
 - total_payloads
 - created_at
 - updated_at
+- status
 
 # Column titles, in order
 headers:
@@ -44,6 +46,7 @@ headers:
 - Playbooks
 - Created On
 - Updated On
+- Status
 
 col_formats:
 -


### PR DESCRIPTION
Add status column to Repositories list.

Before:
<img width="892" alt="screen shot 2017-04-24 at 3 33 01 pm" src="https://cloud.githubusercontent.com/assets/9210860/25339530/56bb5524-2903-11e7-94d3-16dcd4bd8336.png">

After (with dummy data):
<img width="881" alt="screen shot 2017-04-24 at 3 31 42 pm" src="https://cloud.githubusercontent.com/assets/9210860/25339472/2ede3cd8-2903-11e7-9e7c-12ec5616d633.png">

@miq-bot add_labels enhancement, providers/ansible_tower, fine/yes

UI for this pivotal story:
https://www.pivotaltracker.com/story/show/143133279

@mzazrivec please have a look 