### PR TITLE
Google pubsub - undefined method `empty?' for nil:NilClass

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/stream.rb
@@ -51,6 +51,9 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Stream
     # If event catcher is not yet setup, then we'll get a fog error
     google.subscriptions.get(subscription_name) ||
       google.subscriptions.create(:name  => subscription_name,
+                                  # add empty config - workaround for https://github.com/fog/fog-google/issues/214
+                                  # TODO: remove once the above is resolved
+                                  :push_config => {},
                                   :topic => topic_name)
   rescue Fog::Errors::NotFound
     # Rather than expose the notfound error, we expose our own exception


### PR DESCRIPTION
workaround for regression reported https://github.com/fog/fog-google/issues/214

```
[NoMethodError]: undefined method `empty?' for nil:NilClass
/opt/rh/cfme-gemset/gems/fog-google-0.5.2/lib/fog/google/requests/pubsub/create_subscription.rb:29:in `create_subscription'
/opt/rh/cfme-gemset/gems/fog-google-0.5.2/lib/fog/google/models/pubsub/subscription.rb:71:in `save'
/opt/rh/cfme-gemset/gems/fog-core-1.43.0/lib/fog/core/collection.rb:51:in `create'
```

My guess is either https://github.com/fog/fog-google/pull/168 introduced this regression because [this line](https://github.com/fog/fog-google/blob/4ac58a77f91f4d6877d77133b6bcee33403951d8/lib/fog/google/models/pubsub/subscription.rb#L71) passes `push_config` and if it's `nil` it will pass `nil`.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1442690
@miq-bot add_labels fine/yes, bug, providers/google
@miq-bot assign @agrare 