### PR TITLE
[SCVMM] Always assume a string for run_powershell_script

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/powershell.rb
@@ -13,12 +13,11 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       def run_powershell_script(connection, script)
         log_header = "MIQ(#{self.class.name}.#{__method__})"
-        script_string = IO.read(script)
         results = []
 
         begin
           with_winrm_shell(connection) do |shell|
-            results = shell.run(script_string)
+            results = shell.run(script)
             log_dos_error_results(results.stderr)
           end
         rescue Errno::ECONNREFUSED => err
@@ -119,8 +118,7 @@ class ManageIQ::Providers::Microsoft::InfraManager
 
       _result, timings = Benchmark.realtime_block(:execution) do
         with_winrm_shell do |shell|
-          script_string = IO.read(script)
-          results = shell.run(script_string)
+          results = shell.run(script)
           self.class.log_dos_error_results(results.stderr)
         end
       end

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -20,7 +20,8 @@ module ManageIQ::Providers::Microsoft
       log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
       $scvmm_log.info("#{log_header}...")
 
-      @inventory = ManageIQ::Providers::Microsoft::InfraManager.execute_powershell_json(@connection, INVENTORY_SCRIPT)
+      script = IO.read(INVENTORY_SCRIPT)
+      @inventory = ManageIQ::Providers::Microsoft::InfraManager.execute_powershell_json(@connection, script)
 
       if @inventory.empty?
         $scvmm_log.warn("#{log_header}...Empty inventory set returned from SCVMM.")


### PR DESCRIPTION
This fixes an issue where our `run_powershell_script` method was assuming a file argument, but in most cases a string (heredoc) argument was being passed instead.

This PR alters the code so that it's always assumes a string instead of a file.

https://bugzilla.redhat.com/show_bug.cgi?id=1444201