### PR TITLE
[FINE] Backporting assign_attributes method for Fine

### DIFF
--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -69,6 +69,10 @@ module ManagerRefresh
       attributes_for_saving
     end
 
+    def assign_attributes(attributes)
+      attributes.each { |k, v| public_send("#{k}=", v) }
+    end
+
     def to_s
       manager_uuid
     end


### PR DESCRIPTION
Backporting assign_attributes method of the InventoryObject for
Fine, to fix the manageiq-providers-amazon gem Fine CI.