### PR TITLE
Fix for Error in re-configuring service 'undefined method `match` for Fixnum'

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -39,7 +39,7 @@ class DialogFieldTextBox < DialogField
     return if !required? && @value.blank? || !visible
 
     return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is required" if required? && @value.blank?
-    if data_type == "integer" && !@value.match(/^[0-9]+$/)
+    if data_type == "integer" && !@value.to_s.match(/^[0-9]+$/)
       return "#{dialog_tab.label}/#{dialog_group.label}/#{label} must be an integer"
     end
 

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -122,14 +122,25 @@ describe DialogFieldTextBox do
         context "when data type is integer" do
           before { df.data_type = 'integer' }
 
-          it "returns nil when the value is a number" do
-            df.value = '123'
-            expect(df.validate_field_data(dt, dg)).to be_nil
+          context "when the value is a number string" do
+            it "returns nil" do
+              df.value = '123'
+              expect(df.validate_field_data(dt, dg)).to be_nil
+            end
           end
 
-          it "returns an error when the value is not a number" do
-            df.value = 'a12'
-            expect(df.validate_field_data(dt, dg)).to eq('tab/group/test field must be an integer')
+          context "when the value is not a number string" do
+            it "returns an error" do
+              df.value = 'a12'
+              expect(df.validate_field_data(dt, dg)).to eq('tab/group/test field must be an integer')
+            end
+          end
+
+          context "when the value is an actual integer" do
+            it "returns nil" do
+              df.value = 123
+              expect(df.validate_field_data(dt, dg)).to be_nil
+            end
           end
         end
       end


### PR DESCRIPTION
This will force the use of a string before attempting to match for text field validation. The reasoning is that during order time of a dialog, all of the fields are passed in as strings, even if the `data_type` is set to integer, because it gets converted later down the line. So, it's attempting to do a `.match` to make sure that the value is all numbers, but during reconfiguration, it is actually an integer and thus `.match` is an invalid method.

https://bugzilla.redhat.com/show_bug.cgi?id=1442920

@miq-bot add_label bug, euwe/yes, fine/yes
@miq-bot assign @gmcculloug 

/cc @bzwei 