### PR TITLE
ansible client hack to make organization assignable for credentials

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -10,6 +10,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
   def self.provider_params(params)
+    # FIXME: workaround until https://github.com/ansible/ansible_tower_client_ruby/issues/68 is closed
+    AnsibleTowerClient::Credential.new(nil, :organization => 1)
     super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
   end
 end


### PR DESCRIPTION
make sure `organization` is in the list of known attributes for AnsibleTowerClient::Credential

```
[1] pry(main)> AnsibleTowerClient::Credential.send(:modelized_list)
=> #<Set: {}>
[2] pry(main)> a = AnsibleTowerClient::Credential.new(nil, {org_id: 1})
=> <AnsibleTowerClient::Credential org_id=1>
[3] pry(main)> a.org=1
NoMethodError: undefined method `org=' for <AnsibleTowerClient::Credential org_id=1>:AnsibleTowerClient::Credential
from (pry):3:in `<main>'
[5] pry(main)> AnsibleTowerClient::Credential.send(:modelized_list)
=> #<Set: {"org_id"}>
[6] pry(main)> b = AnsibleTowerClient::Credential.new(nil, {org: 1})
=> <AnsibleTowerClient::Credential org=1>
[7] pry(main)> AnsibleTowerClient::Credential.send(:modelized_list)
=> #<Set: {"org_id", "org"}>
[8] pry(main)> a.org=1
=> 1
```

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1444398

```
[----] E, [2017-04-21T05:30:12.275454 #2874:6ab134] ERROR -- : MIQ(MiqQueue#deliver) Message id: [12697], Error: [undefined method `organization=' for #<AnsibleTowerClient::Credential:0x0000000a7ca2b8>
Did you mean?  organization_id=
               organization_id]
[----] E, [2017-04-21T05:30:12.276080 #2874:6ab134] ERROR -- : [NoMethodError]: undefined method `organization=' for #<AnsibleTowerClient::Credential:0x0000000a7ca2b8>
Did you mean?  organization_id=
               organization_id  Method:[rescue in deliver]
[----] E, [2017-04-21T05:30:12.276227 #2874:6ab134] ERROR -- : /opt/rh/cfme-gemset/gems/ansible_tower_client-0.11.0/lib/ansible_tower_client/base_model.rb:88:in `block in update_attributes!'
/opt/rh/cfme-gemset/gems/ansible_tower_client-0.11.0/lib/ansible_tower_client/base_model.rb:84:in `each'
/opt/rh/cfme-gemset/gems/ansible_tower_client-0.11.0/lib/ansible_tower_client/base_model.rb:84:in `update_attributes!'
/var/www/miq/vmdb/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb:67:in `block in update_in_provider'
/var/www/miq/vmdb/app/models/mixins/provider_object_mixin.rb:15:in `block in with_provider_object'
/var/www/miq/vmdb/app/models/provider.rb:49:in `with_provider_connection'
/var/www/miq/vmdb/app/models/manageiq/providers/ansible_tower/shared/automation_manager.rb:5:in `with_provider_connection'
/var/www/miq/vmdb/app/models/mixins/provider_object_mixin.rb:12:in `with_provider_object'
/var/www/miq/vmdb/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb:66:in `update_in_provider'
```


@miq-bot add_labels bug, fine/yes, providers/ansible_tower
@miq-bot assign @bdunne 

cc @jameswnl 