### PR TITLE
move queue_name to ext_management_system

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -435,6 +435,10 @@ class ExtManagementSystem < ApplicationRecord
     resource_pools.destroy_all
   end
 
+  def queue_name
+    "ems_#{id}"
+  end
+
   def enforce_policy(target, event)
     inputs = {:ext_management_system => self}
     inputs[:vm]   = target if target.kind_of?(Vm)

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -97,7 +97,7 @@ module PerEmsWorkerMixin
       return "generic" if ems.kind_of?(Host) && ems.acts_as_ems?
 
       return ems unless ems.kind_of?(ExtManagementSystem)
-      "ems_#{ems.id}"
+      ems.queue_name
     end
 
     def ems_id_from_queue_name(queue_name)


### PR DESCRIPTION
changes requested by @jrafanie here: https://github.com/ManageIQ/manageiq/pull/14848#discussion_r113016525

make `queue_name` the responsibility of `ems_management_system`

@jrafanie Please review