### PR TITLE
Fix to further check if extract method returns an empty xml node

### DIFF
--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -252,7 +252,7 @@ module ScanningMixin
         xml = extractor.extract(c) { |scan_data| update_agent_message(ost, scan_data[:msg]) }
         categories_processed += 1
         _log.info "Scanning [#{c}] information ran for [#{Time.now - st}] seconds.  TaskId:[#{ost.taskid}]  VM:[#{name}]"
-        if xml
+        if xml && xml.root
           xml.root.add_attributes("created_on" => ost.scanTime.to_i, "display_time" => ost.scanTime.iso8601)
           _log.debug "Writing scanned data to XML for [#{c}] to blackbox."
           bb.saveXmlData(xml, c)


### PR DESCRIPTION
Make sure scanning returns a xml node with root attribute. 

https://bugzilla.redhat.com/show_bug.cgi?id=1372672