### PR TITLE
Add a notification for when the embedded ansible role is activated

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -30,6 +30,8 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def setup_ansible
+    raise_role_notification(:role_activate_start)
+
     _log.info("calling EmbeddedAnsible.configure")
     EmbeddedAnsible.configure unless EmbeddedAnsible.configured?
 
@@ -37,7 +39,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     EmbeddedAnsible.start
     _log.info("calling EmbeddedAnsible.start finished")
 
-    raise_role_notification
+    raise_role_notification(:role_activate_success)
   end
 
   def update_embedded_ansible_provider
@@ -69,11 +71,11 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
   private
 
-  def raise_role_notification
+  def raise_role_notification(notification_type)
     notification_options = {
       :role_name   => ServerRole.find_by(:name => worker.class.required_roles.first).description,
       :server_name => MiqServer.my_server.name
     }
-    Notification.create(:type => :role_activate_success, :options => notification_options)
+    Notification.create(:type => notification_type, :options => notification_options)
   end
 end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -119,6 +119,11 @@
   :expires_in: 24.hours
   :level: :info
   :audience: superadmin
+- :name: role_activate_start
+  :message: 'The role %{role_name} has started activation on server %{server_name}'
+  :expires_in: 24.hours
+  :level: :info
+  :audience: superadmin
 - :name: vm_cloud_live_migrate_success
   :message: 'Live migrating Instance %{instance_name} completed successfully.'
   :expires_in: 24.hours


### PR DESCRIPTION
This allows us to bookend the possibly long-running process of configuring and starting embedded ansible on a server.

The first notification will get sent as soon as the worker is started on a server and the other will get sent as soon as the embedded ansible service is up and running.

https://bugzilla.redhat.com/show_bug.cgi?id=1444852