### PR TITLE
[WIP] Clear any inherited benchmarks in the forked child

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -319,6 +319,7 @@ class MiqWorker < ApplicationRecord
     close_pg_sockets_inherited_from_parent
     DRb.stop_service
     renice(Process.pid)
+    Benchmark.delete_current_realtime
   end
 
   # When we fork, the children inherits the parent's file descriptors


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424716

Our benchmark extension stores the hash of results in a class variable
indexed by the thread id [1].  Because we fork, this hash is inherited and
threads are copied so we'll inherit any benchmarks the parent process is
currently processing.

[1]
https://github.com/ManageIQ/manageiq-gems-pending/blob/34299c6baa225d0492f42e4caf61d189dc468c48/lib/gems/pending/util/extensions/miq-benchmark.rb#L53
