### PR TITLE
Remove jasmine from Gemfile, move to ui

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ unless ENV["APPLIANCE"]
     gem "capybara",         "~>2.5.0",  :require => false
     gem "coveralls",                    :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "jasmine",                      :require => false
     gem "sqlite3",                      :require => false
     gem "timecop",          "~>0.7.3",  :require => false
     gem "vcr",              "~>3.0.0",  :require => false


### PR DESCRIPTION
jasmine is used to run JS specs, but there are no more JS specs in manageiq - moving to ui classic.

(Also current right now because jasmine 2.6.0 came out, breaking the specs, so we need to the version again, to 2.5.2.)

@miq-bot add_label ui, test, fine/yes, euwe/no
(euwe handled by #14871)

Merge only **after** https://github.com/ManageIQ/manageiq-ui-classic/pull/1148 (or together).