### PR TITLE
[EUWE] Force jasmine to 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,8 @@ unless ENV["APPLIANCE"]
     gem "brakeman",         "~>3.3",    :require => false
     gem "capybara",         "~>2.5.0",  :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "jasmine",                      :require => false
+    gem "jasmine",          "~>2.5.2",  :require => false
+    gem "jasmine-core",     "~>2.5.2",  :require => false
     gem "sqlite3",                      :require => false
   end
 


### PR DESCRIPTION
jasmine 2.6 came out, and with it, test failures :).

Forcing the version to 2.5.*.
Also adding the jasmine-core dependency, because jasmine-core is the actual jasmine, but jasmine 2.5 depends on jasmine-core >2.5 <3.0 meaning it would pick up 2.6 anyway without this.

(For `fine` and `master`, this is handled by https://github.com/ManageIQ/manageiq/pull/14870 and https://github.com/ManageIQ/manageiq-ui-classic/pull/1148)

@miq-bot add_label ui, test