### PR TITLE
InventoryObject assign_attributes should return self

### DIFF
--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -71,6 +71,7 @@ module ManagerRefresh
 
     def assign_attributes(attributes)
       attributes.each { |k, v| public_send("#{k}=", v) }
+      self
     end
 
     def to_s


### PR DESCRIPTION
InventoryObject assign_attributes should return self, it will
allow chaining and spare some lines in the refresh parser.