### PR TITLE
Provide helpful warning/reminder that you're using override_gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,10 @@ def override_gem(name, *args)
     raise "Trying to override unknown gem #{name}" unless (dependency = dependencies.find { |d| d.name == name })
     dependencies.delete(dependency)
 
-    gem name, *args
+    calling_file = caller_locations.detect { |loc| !loc.path.include?("lib/bundler") }.path
+    gem(name, *args).tap do
+      Bundler::UI::Shell.new.warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" unless ENV["RAILS_ENV"] == "production"
+    end
   end
 end
 


### PR DESCRIPTION
It's easy to enable a local checkout of one of the repos in
Gemfile.dev.rb and forget about it.  Days go by and your local repo
hasn't been updated and now you get weird errors.

Let's provide a helpful warning/reminder so this is more obvious.

EDIT:  Updated screencap based on lots of helpful feedback
![screencast 2017-04-25 17-04-20](https://cloud.githubusercontent.com/assets/19339/25407857/f828b40c-29d9-11e7-86cb-cd478fe8ca7b.gif)
