### PR TITLE
Added ability to add a service as a resource to another service via t…

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -87,6 +87,10 @@ class Service < ApplicationRecord
     super
   end
 
+  def add_to_service(service)
+    service.add_resource!(self)
+  end
+
   alias parent_service parent
   alias_attribute :service, :parent
   virtual_belongs_to :service

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -819,6 +819,25 @@ describe "Services API" do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'can add service resource to a service by href with an appropriate role' do
+      api_basic_authorize(collection_action_identifier(:services, :add_resource))
+      request = {
+        'action'   => 'add_resource',
+        'resource' => { 'resource' => { 'href' => services_url(svc2.id) } }
+      }
+
+      run_post(services_url(svc.id), request)
+
+      expected = {
+        'success' => true,
+        'message' => "Assigned resource services id:#{svc2.id} to Service id:#{svc.id} name:'#{svc.name}'"
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(expected)
+      expect(svc.reload.services).to eq([svc2])
+    end
   end
 
   describe 'remove_resource' do


### PR DESCRIPTION
Added ability to add a service as a resource to another service via add_resource action.

```
POST /api/services/1
{
  "action" : "add_resource",
  "resource" : { "resource" : { "href" : "/api/services/2" } }
}
```

https://bugzilla.redhat.com/show_bug.cgi?id=1441412


