### PR TITLE
Enable STI for middleware classes

### DIFF
--- a/app/models/middleware_datasource.rb
+++ b/app/models/middleware_datasource.rb
@@ -1,11 +1,11 @@
 class MiddlewareDatasource < ApplicationRecord
+  include NewWithTypeStiMixin
+  include LiveMetricsMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :middleware_server, :foreign_key => "server_id"
   acts_as_miq_taggable
   serialize :properties
-
-  include LiveMetricsMixin
-  include NewWithTypeStiMixin
 
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)

--- a/app/models/middleware_datasource.rb
+++ b/app/models/middleware_datasource.rb
@@ -5,6 +5,7 @@ class MiddlewareDatasource < ApplicationRecord
   serialize :properties
 
   include LiveMetricsMixin
+  include NewWithTypeStiMixin
 
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)

--- a/app/models/middleware_deployment.rb
+++ b/app/models/middleware_deployment.rb
@@ -1,10 +1,10 @@
 class MiddlewareDeployment < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :middleware_server, :foreign_key => "server_id"
   belongs_to :middleware_server_group, :foreign_key => "server_group_id", :optional => true
   acts_as_miq_taggable
 
   delegate :mutable?, :in_domain?, :to => :middleware_server
-
-  include NewWithTypeStiMixin
 end

--- a/app/models/middleware_deployment.rb
+++ b/app/models/middleware_deployment.rb
@@ -5,4 +5,6 @@ class MiddlewareDeployment < ApplicationRecord
   acts_as_miq_taggable
 
   delegate :mutable?, :in_domain?, :to => :middleware_server
+
+  include NewWithTypeStiMixin
 end

--- a/app/models/middleware_domain.rb
+++ b/app/models/middleware_domain.rb
@@ -1,8 +1,8 @@
 class MiddlewareDomain < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :middleware_server_groups, :foreign_key => "domain_id", :dependent => :destroy
   serialize :properties
   acts_as_miq_taggable
-
-  include NewWithTypeStiMixin
 end

--- a/app/models/middleware_domain.rb
+++ b/app/models/middleware_domain.rb
@@ -3,4 +3,6 @@ class MiddlewareDomain < ApplicationRecord
   has_many :middleware_server_groups, :foreign_key => "domain_id", :dependent => :destroy
   serialize :properties
   acts_as_miq_taggable
+
+  include NewWithTypeStiMixin
 end

--- a/app/models/middleware_messaging.rb
+++ b/app/models/middleware_messaging.rb
@@ -1,11 +1,11 @@
 class MiddlewareMessaging < ApplicationRecord
+  include NewWithTypeStiMixin
+  include LiveMetricsMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :middleware_server, :foreign_key => "server_id"
   acts_as_miq_taggable
   serialize :properties
-
-  include LiveMetricsMixin
-  include NewWithTypeStiMixin
 
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)

--- a/app/models/middleware_messaging.rb
+++ b/app/models/middleware_messaging.rb
@@ -5,6 +5,7 @@ class MiddlewareMessaging < ApplicationRecord
   serialize :properties
 
   include LiveMetricsMixin
+  include NewWithTypeStiMixin
 
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -1,4 +1,7 @@
 class MiddlewareServer < ApplicationRecord
+  include NewWithTypeStiMixin
+  include LiveMetricsMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :middleware_server_group, :foreign_key => "server_group_id"
   belongs_to :lives_on, :polymorphic => true
@@ -7,9 +10,6 @@ class MiddlewareServer < ApplicationRecord
   has_many :middleware_messagings, :foreign_key => "server_id", :dependent => :destroy
   serialize :properties
   acts_as_miq_taggable
-
-  include LiveMetricsMixin
-  include NewWithTypeStiMixin
 
   def properties
     super || {}

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -9,6 +9,7 @@ class MiddlewareServer < ApplicationRecord
   acts_as_miq_taggable
 
   include LiveMetricsMixin
+  include NewWithTypeStiMixin
 
   def properties
     super || {}

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -43,11 +43,11 @@ class MiddlewareServer < ApplicationRecord
 
   # Returns whether a server is immutable or not.
   #
-  # By default, we define all servers as being mutable, so that power
-  # operations are allowed, and it is the provider responsability to
+  # By default, we define all servers as being immutable, so that power
+  # operations are not allowed, and it is the provider responsability to
   # reimplement this method if necessary.
   def immutable?
-    properties['Immutable'] == 'true'
+    true
   end
 
   # Returns whether a server is immutable or not.

--- a/app/models/middleware_server_group.rb
+++ b/app/models/middleware_server_group.rb
@@ -6,4 +6,6 @@ class MiddlewareServerGroup < ApplicationRecord
   acts_as_miq_taggable
 
   delegate :ext_management_system, :to => :middleware_domain, :allow_nil => true
+
+  include NewWithTypeStiMixin
 end

--- a/app/models/middleware_server_group.rb
+++ b/app/models/middleware_server_group.rb
@@ -1,4 +1,6 @@
 class MiddlewareServerGroup < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :middleware_domain, :foreign_key => "domain_id"
   has_many :middleware_servers, :foreign_key => "server_group_id", :dependent => :destroy
   has_many :middleware_deployments, :foreign_key => "server_group_id", :dependent => :destroy
@@ -6,6 +8,4 @@ class MiddlewareServerGroup < ApplicationRecord
   acts_as_miq_taggable
 
   delegate :ext_management_system, :to => :middleware_domain, :allow_nil => true
-
-  include NewWithTypeStiMixin
 end

--- a/db/migrate/20170425154145_add_sti_to_middlewares.rb
+++ b/db/migrate/20170425154145_add_sti_to_middlewares.rb
@@ -1,0 +1,83 @@
+class AddStiToMiddlewares < ActiveRecord::Migration[5.0]
+  class MiddlewareDatasource < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiddlewareDeployment < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiddlewareDomain < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiddlewareMessaging < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiddlewareServer < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class MiddlewareServerGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    add_column :middleware_datasources, :type, :string
+    add_index  :middleware_datasources, :type
+
+    add_column :middleware_deployments, :type, :string
+    add_index  :middleware_deployments, :type
+
+    add_column :middleware_domains, :type, :string
+    add_index  :middleware_domains, :type
+
+    add_column :middleware_messagings, :type, :string
+    add_index  :middleware_messagings, :type
+
+    add_column :middleware_server_groups, :type, :string
+    add_index  :middleware_server_groups, :type
+
+    add_column :middleware_servers, :type, :string
+    add_index  :middleware_servers, :type
+
+    MiddlewareDatasource
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource')
+
+    MiddlewareDeployment
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDeployment')
+
+    MiddlewareDomain
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDomain')
+
+    MiddlewareMessaging
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareMessaging')
+
+    MiddlewareServerGroup
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerGroup')
+
+    MiddlewareServer
+      .update_all(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer')
+  end
+
+  def down
+    remove_index :middleware_datasources, :column => [:type]
+    remove_column :middleware_datasources, :type
+
+    remove_index :middleware_deployments, :column => [:type]
+    remove_column :middleware_deployments, :type
+
+    remove_index :middleware_domains, :column => [:type]
+    remove_column :middleware_domains, :type
+
+    remove_index :middleware_messagings, :column => [:type]
+    remove_column :middleware_messagings, :type
+
+    remove_index :middleware_server_groups, :column => [:type]
+    remove_column :middleware_server_groups, :type
+
+    remove_index :middleware_servers, :column => [:type]
+    remove_column :middleware_servers, :type
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4639,6 +4639,7 @@ middleware_datasources:
 - created_at
 - updated_at
 - feed
+- type
 middleware_deployments:
 - id
 - name
@@ -4652,6 +4653,7 @@ middleware_deployments:
 - feed
 - properties
 - server_group_id
+- type
 middleware_domains:
 - id
 - name
@@ -4664,6 +4666,7 @@ middleware_domains:
 - ems_id
 - created_at
 - updated_at
+- type
 middleware_messagings:
 - id
 - name
@@ -4676,6 +4679,7 @@ middleware_messagings:
 - messaging_type
 - created_at
 - updated_at
+- type
 middleware_server_groups:
 - id
 - name
@@ -4688,6 +4692,7 @@ middleware_server_groups:
 - domain_id
 - created_at
 - updated_at
+- type
 middleware_servers:
 - id
 - name
@@ -4704,6 +4709,7 @@ middleware_servers:
 - lives_on_type
 - lives_on_id
 - server_group_id
+- type
 miq_actions:
 - id
 - name

--- a/spec/migrations/20170425154145_add_sti_to_middlewares_spec.rb
+++ b/spec/migrations/20170425154145_add_sti_to_middlewares_spec.rb
@@ -1,0 +1,25 @@
+require_migration
+
+describe AddStiToMiddlewares do
+  constants = %w(
+    MiddlewareDatasource
+    MiddlewareDeployment
+    MiddlewareDomain
+    MiddlewareMessaging
+    MiddlewareServer
+    MiddlewareServerGroup
+  )
+
+  migration_context :up do
+    constants.each do |klass|
+      it "migrates all #{klass}" do
+        result = migration_stub(klass.to_sym).create!
+
+        migrate
+
+        result.reload
+        expect(result).to have_attributes(:type => "ManageIQ::Providers::Hawkular::MiddlewareManager::#{klass}")
+      end
+    end
+  end
+end

--- a/spec/models/middleware_server_spec.rb
+++ b/spec/models/middleware_server_spec.rb
@@ -27,18 +27,8 @@ describe MiddlewareServer do
   end
 
   describe '#immutable?' do
-    it 'is true if "Immutable" is set as true' do
-      subject.properties = { 'Immutable' => 'true' }
-      expect(subject).to be_immutable
-    end
-
-    it 'is false if "Immutable" is set as false' do
-      subject.properties = { 'Immutable' => 'false' }
-      expect(subject).not_to be_immutable
-    end
-
-    it 'is false if no keys are defined' do
-      expect(subject).not_to be_immutable
+    it 'is always true' do
+      expect(server).to be_immutable
     end
   end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1443094, and is a followup
to #14822. It adds a type column to all classes related to Middleware, thus
enabling Single Table Inheritance from Rails.