### PR TITLE
Remove zip-zip

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -109,7 +109,7 @@ module VMDB
       zfile = zfile.to_s
 
       _log.info "Creating: [#{zfile_display}]"
-      Zip::ZipFile.open(zfile, Zip::ZipFile::CREATE) do |zip|
+      Zip::File.open(zfile, Zip::File::CREATE) do |zip|
         dirs.each do |dir|
           dir = Rails.root.join(dir) unless Pathname.new(dir).absolute?
           Dir.glob(dir).each do |file|

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -97,7 +97,7 @@ module VMDB
     end
 
     def self.zip_logs(zip_filename, dirs, userid = "system")
-      require 'zip/zipfilesystem'
+      require 'zip/filesystem'
 
       zip_dir = Rails.root.join("data", "user", userid)
       FileUtils.mkdir_p(zip_dir) unless File.exist?(zip_dir)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -117,7 +117,7 @@ describe VMDB::Util do
   end
 
   it ".add_zip_entry(private)" do
-    require 'zip/zipfilesystem'
+    require 'zip/filesystem'
     file  = "/var/log/messages.log"
     entry = "ROOT/var/log/messages.log"
     mtime = Time.parse("2013-09-24 09:00:45 -0400")


### PR DESCRIPTION
From what I can tell, the only thing holding us back from dropping our dependency on zip-zip was the usage of some aliased constants, so I changed to use the ones provided by Rubyzip.