### PR TITLE
Add a method to InfraManager to retrieve Hosts without EmsCluster

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -41,5 +41,9 @@ module ManageIQ::Providers
     def validate_import_vm
       false
     end
+
+    def clusterless_hosts
+      hosts.where(:ems_cluster => nil)
+    end
   end
 end


### PR DESCRIPTION
If an infra provider has clusterless hosts, they aren't displayed in the topology view. This method allows the topology service to easily map these hosts into the topology hash.
UI part: https://github.com/ManageIQ/manageiq-ui-classic/pull/1156

https://bugzilla.redhat.com/show_bug.cgi?id=1440263
