### PR TITLE
Seeding dialogs should pull from all plugins, not just provider plugins

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -25,7 +25,7 @@ class Dialog < ApplicationRecord
   def self.seed
     dialog_import_service = DialogImportService.new
 
-    Vmdb::Plugins.instance.registered_provider_plugins.each do |plugin|
+    Vmdb::Plugins.instance.vmdb_plugins.each do |plugin|
       Dir.glob(plugin.root.join(DIALOG_DIR_PLUGIN, YAML_FILES_PATTERN)).each do |file|
         dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
       end

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -21,7 +21,7 @@ class MiqDialog < ApplicationRecord
   end
 
   def self.sync_from_plugins
-    Vmdb::Plugins.instance.registered_provider_plugins.each do |plugin|
+    Vmdb::Plugins.instance.vmdb_plugins.each do |plugin|
       sync_from_dir(plugin.root.join('content', 'miq_dialogs'))
     end
   end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -10,7 +10,7 @@ describe Dialog do
 
     it "seed files from plugins" do
       mock_engine = double(:root => Rails.root)
-      expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])
+      expect(Vmdb::Plugins.instance).to receive(:vmdb_plugins).and_return([mock_engine])
 
       stub_const('Dialog::DIALOG_DIR_PLUGIN', test_file_path)
       stub_const('Dialog::DIALOG_DIR_CORE', 'non-existent-dir')

--- a/spec/models/miq_dialog_spec.rb
+++ b/spec/models/miq_dialog_spec.rb
@@ -17,7 +17,7 @@ describe MiqDialog do
       mock_engine = double(:root => Pathname.new('/some/root'))
       allow(described_class).to receive(:sync_from_dir)
 
-      expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])
+      expect(Vmdb::Plugins.instance).to receive(:vmdb_plugins).and_return([mock_engine])
       expect(described_class).to receive(:sync_from_dir).once.with(
         mock_engine.root.join('content', 'miq_dialogs')
       )


### PR DESCRIPTION
@durandom Please review.  Allow pulling from manageiq-content and others.