### PR TITLE
Remove support for seeding from product/dialogs/service_dialogs

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -1,5 +1,4 @@
 class Dialog < ApplicationRecord
-  DIALOG_DIR_CORE   = 'product/dialogs/service_dialogs'.freeze
   DIALOG_DIR_PLUGIN = 'content/service_dialogs'.freeze
 
   # The following gets around a glob symbolic link issue
@@ -25,10 +24,6 @@ class Dialog < ApplicationRecord
 
   def self.seed
     dialog_import_service = DialogImportService.new
-
-    Dir.glob(Rails.root.join(DIALOG_DIR_CORE, YAML_FILES_PATTERN)).each do |file|
-      dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
-    end
 
     Vmdb::Plugins.instance.registered_provider_plugins.each do |plugin|
       Dir.glob(plugin.root.join(DIALOG_DIR_PLUGIN, YAML_FILES_PATTERN)).each do |file|

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -8,39 +8,6 @@ describe Dialog do
       allow(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file)
     end
 
-    it "delegates to the dialog import service with a file in the default directory" do
-      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "seed_test.yaml").to_path
-      )
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "seed_test.yml").to_path
-      )
-      described_class.seed
-    end
-
-    it "delegates to the dialog import service with a file in a sub directory" do
-      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "service_dialogs", "service_seed_test.yaml").to_path
-      )
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "service_dialogs", "service_seed_test.yml").to_path
-      )
-      described_class.seed
-    end
-
-    it "delegates to the dialog import service with a symlinked file" do
-      stub_const('Dialog::DIALOG_DIR_CORE', test_file_path)
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "service_dialog_symlink", "service_seed_test.yaml").to_path
-      )
-      expect(dialog_import_service).to receive(:import_all_service_dialogs_from_yaml_file).with(
-        Rails.root.join(test_file_path, "service_dialog_symlink", "service_seed_test.yml").to_path
-      )
-      described_class.seed
-    end
-
     it "seed files from plugins" do
       mock_engine = double(:root => Rails.root)
       expect(Vmdb::Plugins.instance).to receive(:registered_provider_plugins).and_return([mock_engine])


### PR DESCRIPTION
With all service dialogs moved out of manageiq, we can drop support for seeding from product/dialogs/service_dialogs.