### PR TITLE
MiqQueue#put_or_update don't support args_selector

### DIFF
--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -663,33 +663,6 @@ describe MiqQueue do
       expect(MiqQueue.get).to have_attributes(:args => [3, 4], :task_id => 'fun_task')
       expect(MiqQueue.get).to eq(nil)
     end
-
-    it "should use args proc to find messages on the queue" do
-      msg1 = MiqQueue.put(
-        :class_name  => 'MyClass',
-        :method_name => 'method1',
-        :args        => [1, 2],
-        :task_id     => 'first_task'
-      )
-      msg2 = MiqQueue.put(
-        :class_name  => 'MyClass',
-        :method_name => 'method1',
-        :args        => [3, 4],
-        :task_id     => 'booring_task'
-      )
-
-      MiqQueue.put_or_update(
-        :class_name    => 'MyClass',
-        :method_name   => 'method1',
-        :args_selector => ->(args) { args.kind_of?(Array) && args.last == 4 }
-      ) do |_msg, params|
-        params.merge(:task_id => 'fun_task')
-      end
-
-      expect(MiqQueue.get).to have_attributes(:args => [1, 2], :task_id => 'first_task')
-      expect(MiqQueue.get).to have_attributes(:args => [3, 4], :task_id => 'fun_task')
-      expect(MiqQueue.get).to eq(nil)
-    end
   end
 
   describe ".unqueue" do


### PR DESCRIPTION
### Goal

We currently use `put_or_update` and `put_unless_exists` to put unique messages onto the queue.
Unfortunately, this behavior prevents us from transitioning to a general purpose message queue.

As a baby step, we are transitioning away from consulting `args` to ensure a message is unique.

### How are we doing this?

In most cases, the messages have been made unique by making the method name itself more descriptive. e.g.: rename `purge("hourly", timestamp)` to `purge_hourly(timestamp)`.

But to be honest, most of the messages did not need to be unique in the first place. So we've been converting them to a `put`.

### This PR

This PR removes the last vestiges of `:args_selector`, which is not very efficient.

/cc @chessbyte 