### PR TITLE
Use credential callback to set credentials

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -104,8 +104,8 @@ class GitRepository < ApplicationRecord
     params = {:path => directory_name}
     params[:certificate_check] = method(:self_signed_cert_cb) if verify_ssl == OpenSSL::SSL::VERIFY_NONE
     if authentications.any?
-      params[:username] = authentications.first.userid
-      params[:password] = authentications.first.password
+      params[:username] = default_authentication.userid
+      params[:password] = default_authentication.password
     end
     params
   end

--- a/lib/git_worktree_exception.rb
+++ b/lib/git_worktree_exception.rb
@@ -12,4 +12,5 @@ module GitWorktreeException
   class DirectoryAlreadyExists < RuntimeError; end
   class BranchMissing < RuntimeError; end
   class TagMissing < RuntimeError; end
+  class InvalidCredentials < RuntimeError; end
 end

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -323,4 +323,16 @@ describe GitWorktree do
       end
     end
   end
+
+  describe 'credentials_cb' do
+    let(:git_repo_path) { Rails.root.join("spec", "fixtures", "git_repos", "branch_and_tag.git") }
+    let(:test_repo) { GitWorktree.new(:path => git_repo_path.to_s) }
+
+    describe "#credentials_cb" do
+      it "call the credentials callback" do
+        expect(test_repo.credentials_cb("url", nil, nil).class).to eq(Rugged::Credentials::UserPassword)
+        expect { test_repo.credentials_cb("url", nil, nil) }.to raise_exception(GitWorktreeException::InvalidCredentials)
+      end
+    end
+  end
 end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -64,7 +64,10 @@ describe GitRepository do
       it "userid and password is set" do
         repo.update_authentication(:default => {:userid => userid, :password => password})
         expect(GitWorktree).to receive(:new).with(args).and_return(gwt)
+
         repo.refresh
+        expect(repo.default_authentication.userid).to eq(userid)
+        expect(repo.default_authentication.password).to eq(password)
       end
 
       context "self signed certifcate" do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443106

Rugged works using callbacks for credentials. The callback can be either a credential object or a callback that returns a credential object. If the credentials are invalid the callback is called again, it is designed to be used in a UI, where the UI can prompt the user for entering the updated userid/password. If the user doesn't want to enter the userid/password they can cancel it.

Since the callback is being called repeatedly it gives the feeling that the UI is stuck or the rake import command is stuck. 

We record that the credential has been set once in the callback and if called again it raises an exception which rugged sends back to the caller.

Links
-----
* https://github.com/libgit2/rugged/issues/592
* https://github.com/libgit2/libgit2/issues/3358
