### PR TITLE
[DARGA] Use pid + thread id to index into the benchmark results

### DIFF
--- a/gems/pending/util/extensions/miq-benchmark.rb
+++ b/gems/pending/util/extensions/miq-benchmark.rb
@@ -34,20 +34,26 @@ module Benchmark
     end
   end
 
+  def self.thread_unique_identifier
+    # Forks inherit the @@realtime_by_tid and parent/child Thread.current.object_id
+    # are equal, so we need to index into the hash with the pid too.
+    "#{Process.pid}-#{Thread.current.object_id}"
+  end
+
   def self.in_realtime_block?
-    @@realtime_by_tid.key?(Thread.current.object_id)
+    @@realtime_by_tid.key?(thread_unique_identifier)
   end
 
   def self.current_realtime
-    @@realtime_by_tid[Thread.current.object_id] || Hash.new(0)
+    @@realtime_by_tid[thread_unique_identifier] || Hash.new(0)
   end
 
   def self.current_realtime=(hash)
-    @@realtime_by_tid[Thread.current.object_id] = hash
+    @@realtime_by_tid[thread_unique_identifier] = hash
   end
 
   def self.delete_current_realtime
-    @@realtime_by_tid.delete(Thread.current.object_id)
+    @@realtime_by_tid.delete(thread_unique_identifier)
   end
 
   @@realtime_by_tid = {}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424716

Note: This is a manual backport of:
https://github.com/ManageIQ/manageiq-gems-pending/pull/139

Forks inherit the @@realtime_by_tid and parent/child Thread.current.object_id
are equal, so we need to index into the hash with the pid too.

The following test recreates and verifies this change but because it
forks and doesn't properly bubble up exit codes, I wrote it just to
confirm the problem.

```ruby
  it "doesn't get parent's realtime_block in forked child" do
    p1_result, p1_timings = Benchmark.realtime_block(:parent_task1) do
      Timecop.travel(1000)
      p2_result, p2_timings = Benchmark.realtime_block(:parent_task2) do
        Timecop.travel(500)
      end

      expect(p2_timings[:parent_task2]).to be_within(0.5).of(500)
      expect(p2_timings.keys).to eq([:parent_task2])

      pid = fork do
        c_result, c_timings = Benchmark.realtime_block(:child_task) do
          Timecop.travel(250)
        end
        expect(c_timings[:child_task]).to be_within(0.5).of(250)
        expect(c_timings.keys).to eq([:child_task])
      end
    end

    expect(p1_timings[:parent_task1]).to be_within(0.5).of(1500)
    expect(p1_timings.keys.sort).to eq([:parent_task1, :parent_task2])
  end
```

The tests pass because I'm not handling exit codes properly, but I
see the expectation error pop up when I roll back my code change:

```
/Users/joerafaniello/.gem/ruby/2.3.4/gems/rspec-support-3.5.0/lib/rspec/support.rb:87:in
`block in <module:Support>':
(RSpec::Expectations::ExpectationNotMetError)
expected: [:child_task]
     got: [:parent_task2, :child_task]

     (compared using ==)

     Diff:
     @@ -1,2 +1,2 @@
     -[:child_task]
     +[:parent_task2, :child_task]
```