### PR TITLE
Add default filters for the container page

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1275,3 +1275,33 @@
           value: analysis_success
     search_type: default
     db: ManageIQ::Providers::InfraManager::Vm
+- attributes:
+    name: default_State / Running
+    description: State / Running
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Container-state
+          value: "running"
+    search_type: default
+    db: Container
+- attributes:
+    name: default_State / Terminated
+    description: State / Terminated
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Container-state
+          value: "terminated"
+    search_type: default
+    db: Container
+- attributes:
+    name: default_State / Waiting
+    description: State / Waiting
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Container-state
+          value: "waiting"
+    search_type: default
+    db: Container


### PR DESCRIPTION
**Description**

Currently the containers explorer page (https:///container/explorer) crashes when there is a large number of containers (e.g. ~4000).

Add some default filters to the Container page, make the filtering more useful, after removing the tree.

PR in UI Classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/1204
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1443743

**Screenshots**

![screenshot-localhost 3000-2017-04-26-12-03-22](https://cloud.githubusercontent.com/assets/2181522/25427262/a5aa28ae-2a7a-11e7-9fbb-0dba243e8f34.png)

![screenshot-localhost 3000-2017-04-26-12-04-22](https://cloud.githubusercontent.com/assets/2181522/25427263/a5dd4fae-2a7a-11e7-9530-e97bf3c8580a.png)

