### PR TITLE
RBAC for User model regard to allowed role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,10 @@ class User < ApplicationRecord
   serialize     :settings, Hash   # Implement settings column as a hash
   default_value_for(:settings) { Hash.new }
 
+  def self.with_allowed_roles_for(user_or_group)
+    includes(:miq_groups => :miq_user_role).where.not(:miq_user_roles => {:name => user_or_group.disallowed_roles})
+  end
+
   def self.scope_by_tenant?
     true
   end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -476,7 +476,7 @@ module Rbac
       elsif klass == MiqGroup && miq_group.try!(:self_service?)
         # Self Service users searching for groups only see their group
         scope.where(:id => miq_group.id)
-      elsif [MiqUserRole, MiqGroup].include?(klass) && (user_or_group = miq_group || user) &&
+      elsif [MiqUserRole, MiqGroup, User].include?(klass) && (user_or_group = miq_group || user) &&
             user_or_group.disallowed_roles
         scope.with_allowed_roles_for(user_or_group)
       else

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -417,6 +417,17 @@ describe Rbac::Filterer do
           expect(MiqUserRole.count).to eq(3)
           get_rbac_results_for_and_expect_objects(MiqGroup, [group])
         end
+
+        let(:super_admin_group) do
+          FactoryGirl.create(:miq_group, :tenant => default_tenant, :miq_user_role => super_administrator_user_role)
+        end
+
+        let!(:super_admin_user) { FactoryGirl.create(:user, :miq_groups => [super_admin_group]) }
+
+        it 'can see all users expect to user with group with role EvmRole-super_administrator' do
+          expect(User.count).to eq(2)
+          get_rbac_results_for_and_expect_objects(User, [user])
+        end
       end
     end
 


### PR DESCRIPTION
follow up for https://github.com/ManageIQ/manageiq/pull/13689

Hide users with role which is disallowed for logged user's role. (according to this [array](https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L64) )

@miq-bot add_label core, rbac, bug, fine/yes

@miq-bot assign @gtanzillo 
