### PR TITLE
Join RBAC check for MiqUserRole, User and MiqGroup to one if branch

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -443,6 +443,16 @@ module Rbac
       klass.tenant_joins_clause(scope).where(tenant_id_clause)
     end
 
+    def scope_for_user_role_group(scope, miq_group, user)
+      user_or_group = miq_group || user
+
+      if user_or_group.disallowed_roles
+        scope.with_allowed_roles_for(user_or_group)
+      else
+        scope
+      end
+    end
+
     ##
     # Main scoping method
     #
@@ -472,9 +482,8 @@ module Rbac
         scope_by_parent_ids(associated_class, scope, filtered_ids)
       elsif [User, MiqGroup].include?(klass) && (miq_group || user).try!(:self_service?)
         scope.where(:id => klass == User ? user.id : miq_group.id)
-      elsif [MiqUserRole, MiqGroup, User].include?(klass) && (user_or_group = miq_group || user) &&
-            user_or_group.disallowed_roles
-        scope.with_allowed_roles_for(user_or_group)
+      elsif [MiqUserRole, MiqGroup, User].include?(klass)
+        scope_for_user_role_group(scope, miq_group, user)
       else
         scope
       end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -470,12 +470,8 @@ module Rbac
 
         filtered_ids = calc_filtered_ids(associated_class, rbac_filters, user, miq_group, scope_tenant_filter)
         scope_by_parent_ids(associated_class, scope, filtered_ids)
-      elsif klass == User && user.try!(:self_service?)
-        # Self service users searching for users only see themselves
-        scope.where(:id => user.id)
-      elsif klass == MiqGroup && miq_group.try!(:self_service?)
-        # Self Service users searching for groups only see their group
-        scope.where(:id => miq_group.id)
+      elsif [User, MiqGroup].include?(klass) && (miq_group || user).try!(:self_service?)
+        scope.where(:id => klass == User ? user.id : miq_group.id)
       elsif [MiqUserRole, MiqGroup, User].include?(klass) && (user_or_group = miq_group || user) &&
             user_or_group.disallowed_roles
         scope.with_allowed_roles_for(user_or_group)


### PR DESCRIPTION
RBAC check for MiqUserRole, User, MiqGroup models - these checks are related so
I think they should be together. This could be helpful to implement the other condition for MiqGroup and Group described in https://github.com/ManageIQ/manageiq/pull/14903

**Depends on(reason of WIP):**
https://github.com/ManageIQ/manageiq/pull/14898
**Continue in** https://github.com/ManageIQ/manageiq/pull/14903 (blocker)
Starting in [commit Join User and Group rbac check to one if branch
](https://github.com/ManageIQ/manageiq/pull/14901/commits/50f57cc2b474b7449069e4585f7270686f177bec)

@miq-bot add_label wip, fine/yes, refactoring

@miq-bot assign @gtanzillo 
cc @kbrock 
