### PR TITLE
Add native_attr to OPTIONS of Tower Credentials

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -3,9 +3,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
 
   COMMON_ATTRIBUTES = {
     :userid => {
-      :label     => N_('Access Key'),
-      :help_text => N_('AWS Access Key for this credential'),
-      :required  => true
+      :label        => N_('Access Key'),
+      :help_text    => N_('AWS Access Key for this credential'),
+      :navtive_attr => true,
+      :required     => true
     },
     :password => {
       :type      => :password,

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -3,8 +3,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
 
   COMMON_ATTRIBUTES = {
     :userid => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential')
+      :label        => N_('Username'),
+      :help_text    => N_('Username for this credential'),
+      :navtive_attr => true
     },
     :password => {
       :type      => :password,

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -3,8 +3,9 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
 
   COMMON_ATTRIBUTES = {
     :userid => {
-      :label     => N_('Access Key'),
-      :help_text => N_('AWS Access Key for this credential')
+      :label        => N_('Access Key'),
+      :help_text    => N_('AWS Access Key for this credential'),
+      :navtive_attr => true
     },
     :password => {
       :type      => :password,

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -3,9 +3,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
 
   COMMON_ATTRIBUTES = {
     :userid => {
-      :label     => N_('Username'),
-      :help_text => N_('Username for this credential'),
-      :required  => true
+      :label        => N_('Username'),
+      :help_text    => N_('Username for this credential'),
+      :navtive_attr => true,
+      :required     => true
     },
     :password => {
       :type      => :password,


### PR DESCRIPTION
As a proposed to solution to https://github.com/ManageIQ/manageiq/issues/14900

Part of bug https://bugzilla.redhat.com/show_bug.cgi?id=1444398

@miq-bot add_labels wip, bug, providers/ansible_tower