### PR TITLE
Tag visibility for User and MiqGroup model

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -443,15 +443,21 @@ module Rbac
       klass.tenant_joins_clause(scope).where(tenant_id_clause)
     end
 
-    def scope_for_user_role_group(klass, scope, miq_group, user)
+    def scope_for_user_role_group(klass, scope, miq_group, user, managed_filters)
       user_or_group = miq_group || user
 
       if user_or_group.try!(:self_service?) && MiqUserRole != klass
         scope.where(:id => klass == User ? user.id : miq_group.id)
-      elsif user_or_group.disallowed_roles
-        scope.with_allowed_roles_for(user_or_group)
       else
-        scope
+        if user_or_group.disallowed_roles
+          scope = scope.with_allowed_roles_for(user_or_group)
+        end
+
+        if MiqUserRole != klass
+          filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, managed_filters))
+        end
+
+        scope_by_ids(scope, filtered_ids)
       end
     end
 
@@ -483,7 +489,7 @@ module Rbac
         filtered_ids = calc_filtered_ids(associated_class, rbac_filters, user, miq_group, scope_tenant_filter)
         scope_by_parent_ids(associated_class, scope, filtered_ids)
       elsif [MiqUserRole, MiqGroup, User].include?(klass)
-        scope_for_user_role_group(klass, scope, miq_group, user)
+        scope_for_user_role_group(klass, scope, miq_group, user, rbac_filters['managed'])
       else
         scope
       end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -46,7 +46,7 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder)
+    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
 
     BELONGSTO_FILTER_CLASSES = %w(
       VmOrTemplate

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -366,6 +366,44 @@ describe Rbac::Filterer do
         expect(results).to match_array(expected_objects)
       end
 
+      context 'with tags' do
+        let!(:tagged_group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }
+        let!(:user)         { FactoryGirl.create(:user, :miq_groups => [tagged_group]) }
+        let!(:other_user)   { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+        before do
+          tagged_group.entitlement = Entitlement.new
+          tagged_group.entitlement.set_belongsto_filters([])
+          tagged_group.entitlement.set_managed_filters([["/managed/environment/prod"]])
+          tagged_group.save!
+
+          tagged_group.tag_with('/managed/environment/prod', :ns => '*')
+          user.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'returns tagged users' do
+          expect(User.count).to eq(2)
+          get_rbac_results_for_and_expect_objects(User, [user])
+        end
+
+        it 'returns tagged groups' do
+          expect(MiqGroup.count).to eq(3)
+          get_rbac_results_for_and_expect_objects(MiqGroup, [tagged_group])
+        end
+
+        let(:tenant_administrator_user_role) do
+          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::DEFAULT_TENANT_ROLE_NAME)
+        end
+
+        it 'returns tagged groups when user\'s role has disallowed other roles' do
+          tagged_group.miq_user_role = tenant_administrator_user_role
+          tagged_group.save!
+
+          expect(MiqGroup.count).to eq(3)
+          get_rbac_results_for_and_expect_objects(MiqGroup, [tagged_group])
+        end
+      end
+
       it "returns all users" do
         get_rbac_results_for_and_expect_objects(User, [user, other_user])
       end


### PR DESCRIPTION
depends on (reason for WIP):
https://github.com/ManageIQ/manageiq/pull/14898
https://github.com/ManageIQ/manageiq/pull/14901

this PR is starting with [commit Add User and MiqGroup to allow be filtered by Tags](https://github.com/ManageIQ/manageiq/commit/4fd8e1b4a1e69a817c1f5d4e7a3030d232042283)  

I am using `get_managed_filter_object_ids(to determine tagged items)` because only this method is related to User and MiqGroup model in method `calc_filtered_ids`

@miq-bot add_label wip, blocker, bug, fine/yes

@miq-bot assign @gtanzillo 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1442972 (this PR is first part of two for the BZ)