### PR TITLE
Set the db application_name after the server row is created

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -243,6 +243,7 @@ class MiqServer < ApplicationRecord
     Vmdb::Appliance.log_config_on_startup
 
     server.ntp_reload
+    server.set_database_application_name
 
     EvmDatabase.seed_last
 
@@ -457,6 +458,10 @@ class MiqServer < ApplicationRecord
 
   def database_application_name
     "MIQ #{Process.pid} Server[#{compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+  end
+
+  def set_database_application_name
+    ArApplicationName.name = database_application_name
   end
 
   def is_local?

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -62,7 +62,6 @@ class EvmServer
 
     PidFile.create(MiqServer.pidfile)
     set_process_title
-    set_database_application_name
     MiqServer.start
   rescue Interrupt => e
     process_hard_signal(e.message)
@@ -76,14 +75,6 @@ class EvmServer
   #
   def set_process_title
     Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
-  end
-
-  def set_database_application_name
-    ArApplicationName.name = database_application_name
-  end
-
-  def database_application_name
-    MiqServer.my_server.database_application_name
   end
 
   def self.start(*args)


### PR DESCRIPTION
Fixes a bug in #13856 when you run rake evm:start on a database without
a server row for the current server: undefined method
database_application_name for nil:NilClass.