### PR TITLE
Correct field names for reports

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -18,6 +18,12 @@ class MiqExpression::Field < MiqExpression::Target
         parsed_params[:virtual_custom_column])
   end
 
+  def self.get_col_name(field)
+    return field.split('.').last.tr('-', '.') unless is_field?(field)
+    parsed_field = parse(field)
+    parsed_field.associations.push(parsed_field.column).join('.')
+  end
+
   def self.is_field?(field)
     return false unless field.kind_of?(String)
     match = REGEX.match(field)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -18,12 +18,6 @@ class MiqExpression::Field < MiqExpression::Target
         parsed_params[:virtual_custom_column])
   end
 
-  def self.parse_report_field(field)
-    return field.split('.').last.tr('-', '.') unless is_field?(field)
-    parsed_field = parse(field)
-    (parsed_field.associations + [parsed_field.column]).join('.')
-  end
-
   def self.is_field?(field)
     return false unless field.kind_of?(String)
     match = REGEX.match(field)
@@ -81,6 +75,10 @@ class MiqExpression::Field < MiqExpression::Target
 
   def arel_attribute
     target.arel_attribute(column)
+  end
+
+  def report_column
+    (associations + [column]).join('.')
   end
 
   private

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -18,10 +18,10 @@ class MiqExpression::Field < MiqExpression::Target
         parsed_params[:virtual_custom_column])
   end
 
-  def self.get_col_name(field)
+  def self.parse_report_field(field)
     return field.split('.').last.tr('-', '.') unless is_field?(field)
     parsed_field = parse(field)
-    parsed_field.associations.push(parsed_field.column).join('.')
+    (parsed_field.associations + [parsed_field.column]).join('.')
   end
 
   def self.is_field?(field)

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -19,7 +19,8 @@ class MiqExpression::Tag < MiqExpression::Target
 
   def initialize(model, associations, column, managed = true)
     super(model, associations, column)
-    @namespace = "/#{managed ? MANAGED_NAMESPACE : USER_NAMESPACE}/#{column}"
+    @base_namespace = managed ? MANAGED_NAMESPACE : USER_NAMESPACE
+    @namespace = "/#{@base_namespace}/#{column}"
   end
 
   def contains(value)
@@ -41,6 +42,10 @@ class MiqExpression::Tag < MiqExpression::Target
 
   def attribute_supported_by_sql?
     false
+  end
+
+  def report_column
+    "#{@base_namespace}.#{column}"
   end
 
   private

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -77,13 +77,10 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
-  describe '#parse_report_field' do
-    it 'returns the correct format for a non field' do
-      expect(MiqExpression::Field.parse_report_field('Vm.managed-environment')).to eq('managed.environment')
-    end
-
+  describe '#report_column' do
     it 'returns the correct format for a field' do
-      expect(MiqExpression::Field.parse_report_field('Vm.miq_provision.miq_request-requester_name')).to eq('miq_provision.miq_request.requester_name')
+      field = MiqExpression::Field.parse('Vm.miq_provision.miq_request-requester_name')
+      expect(field.report_column).to eq('miq_provision.miq_request.requester_name')
     end
   end
 

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe '#parse_report_field' do
+    it 'returns the correct format for a non field' do
+      expect(MiqExpression::Field.parse_report_field('Vm.managed-environment')).to eq('managed.environment')
+    end
+
+    it 'returns the correct format for a field' do
+      expect(MiqExpression::Field.parse_report_field('Vm.miq_provision.miq_request-requester_name')).to eq('miq_provision.miq_request.requester_name')
+    end
+  end
+
   describe "#parse!" do
     it "can parse the model name" do
       field = "Vm-name"

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe MiqExpression::Tag do
     end
   end
 
+  describe '#report_column' do
+    it 'returns the correct format for a tag' do
+      tag = MiqExpression::Tag.parse('Vm.managed-environment')
+      expect(tag.report_column).to eq('managed.environment')
+    end
+  end
+
   describe "#column_type" do
     it "is always a string" do
       expect(described_class.new(Vm, [], "/host").column_type).to eq(:string)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1402547

When creating a report, the field names were not being stored properly in `col_options` because of how the UI was parsing the field. For example, the field `Vm.miq_provision.miq_request-requester_name` was being parsed as `miq_request.v_approved_by` instead of the correct `miq_provision.miq_request.v_approved_by`, causing the MiqExpression to never evaluate to true and therefore not styling the report correctly. 

This PR adds in an instance method to `MiqExpression::Field` & `MiqExpression::Tag` that the UI can leverage (https://github.com/ManageIQ/manageiq-ui-classic/pull/1170) to properly retrieve the column/field name.

@miq_bot add_label bug, reporting
@miq_bot assign @gtanzillo 
cc: @imtayadeway