### PR TITLE
It's time to deprecate Gemfile.dev.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,10 @@ end
 #   developers may not need or may not easily install, such as rails-dev-boost,
 #   any git based gem, and compiled gems like rbtrace or memprof.
 dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
-eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
+if File.exist?(dev_gemfile)
+  Bundler::UI::Shell.new.warn "** Gemfile.dev.rb deprecated, please move it to bundler.d/"
+  eval_gemfile(dev_gemfile)
+end
 
 # Load other additional Gemfiles
 Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
Based on conversations in https://github.com/ManageIQ/manageiq/pull/14875

Since we have the bundler.d directory, we can deprecate support for Gemfile.dev.rb in the root of the project.  The file can move to the bundler.d directory and we can remove some of the duplicate code found in the Gemfile.