### PR TITLE
[EUWE] Set database application name

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -453,6 +453,10 @@ class MiqServer < ApplicationRecord
     @who_am_i ||= "#{name} #{my_zone} #{self.class.name} #{id}"
   end
 
+  def database_application_name
+    "MIQ #{Process.pid} Server[#{compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+  end
+
   def is_local?
     guid == MiqServer.my_guid
   end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -241,6 +241,7 @@ class MiqServer < ApplicationRecord
     Vmdb::Appliance.log_config_on_startup
 
     server.ntp_reload
+    server.set_database_application_name
 
     EvmDatabase.seed_last
 
@@ -455,6 +456,10 @@ class MiqServer < ApplicationRecord
 
   def database_application_name
     "MIQ #{Process.pid} Server[#{compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+  end
+
+  def set_database_application_name
+    ArApplicationName.name = database_application_name
   end
 
   def is_local?

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -468,6 +468,21 @@ class MiqWorker < ApplicationRecord
 
   delegate :normalized_type, :to => :class
 
+  def abbreviated_class_name
+    type.sub(/^ManageIQ::Providers::/, "")
+  end
+
+  def minimal_class_name
+    abbreviated_class_name
+      .sub(/Miq/, "")
+      .sub(/Worker/, "")
+  end
+
+  def database_application_name
+    zone = MiqServer.my_server.zone
+    "MIQ #{Process.pid} #{minimal_class_name}[#{compressed_id}], s[#{miq_server.compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+  end
+
   def format_full_log_msg
     "Worker [#{self.class}] with ID: [#{id}], PID: [#{pid}], GUID: [#{guid}]"
   end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -57,12 +57,16 @@ class MiqWorker::Runner
   def worker_initialization
     starting_worker_record
     set_process_title
-
     # Sync the config and roles early since heartbeats and logging require the configuration
     sync_active_roles
     sync_config
 
     set_connection_pool_size
+  end
+
+  # More process specific stuff :-(
+  def set_database_application_name
+    ArApplicationName.name = @worker.database_application_name
   end
 
   def set_connection_pool_size
@@ -144,6 +148,7 @@ class MiqWorker::Runner
   end
 
   def prepare
+    set_database_application_name
     ObjectSpace.garbage_collect
     started_worker_record
     do_wait_for_worker_monitor if self.class.wait_for_worker_monitor?
@@ -473,12 +478,15 @@ class MiqWorker::Runner
     _log.info("#{log_prefix} Releasing any broker connections for pid: [#{Process.pid}], ERROR: #{err.message}")
   end
 
-  def set_process_title
-    type   = @worker.type.sub(/^ManageIQ::Providers::/, "")
+  def process_title
+    type   = @worker.abbreviated_class_name
     title  = "#{MiqWorker::PROCESS_TITLE_PREFIX} #{type} id: #{@worker.id}"
     title << ", queue: #{@worker.queue_name}" if @worker.queue_name
     title << ", uri: #{@worker.uri}" if @worker.uri
+    title
+  end
 
-    Process.setproctitle(title)
+  def set_process_title
+    Process.setproctitle(process_title)
   end
 end

--- a/lib/extensions/ar_application_name.rb
+++ b/lib/extensions/ar_application_name.rb
@@ -1,0 +1,16 @@
+module ArApplicationName
+  # We need to set the PGAPPNAME env variable and force the 'pg' gem objects to be
+  # recreated with this env variable set. This is done by disconnecting all of the
+  # connections in the pool.  We do this because reconnect! on an instance of the
+  # AR adapter created prior to our change to PGAPPNAME will have old connection
+  # options, which will reset our application_name.
+  #
+  # Because we fork workers from the server, if we don't disconnect the pool,
+  # any call to reconnect! on a connection will cause the worker's connection
+  # to have the server's application_name.
+  def self.name=(name)
+    # TODO: this is postgresql specific
+    ENV['PGAPPNAME'] = name
+    ActiveRecord::Base.connection_pool.disconnect!
+  end
+end

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -62,6 +62,7 @@ class EvmServer
 
     PidFile.create(MiqServer.pidfile)
     set_process_title
+    set_database_application_name
     MiqServer.start
   rescue Interrupt => e
     process_hard_signal(e.message)
@@ -76,6 +77,14 @@ class EvmServer
   # Will do nothing on ruby<2.1, because .setproctitle was introduced in 2.1
   def set_process_title
     Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
+  end
+
+  def set_database_application_name
+    ArApplicationName.name = database_application_name
+  end
+
+  def database_application_name
+    MiqServer.my_server.database_application_name
   end
 
   def self.start(*args)

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -62,7 +62,6 @@ class EvmServer
 
     PidFile.create(MiqServer.pidfile)
     set_process_title
-    set_database_application_name
     MiqServer.start
   rescue Interrupt => e
     process_hard_signal(e.message)
@@ -77,14 +76,6 @@ class EvmServer
   # Will do nothing on ruby<2.1, because .setproctitle was introduced in 2.1
   def set_process_title
     Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
-  end
-
-  def set_database_application_name
-    ArApplicationName.name = database_application_name
-  end
-
-  def database_application_name
-    MiqServer.my_server.database_application_name
   end
 
   def self.start(*args)

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -6,6 +6,8 @@ describe EvmServer do
 
     before do
       allow(MiqServer).to receive_messages(:running? => false)
+      allow(server).to receive(:set_database_application_name)
+      allow(server).to receive(:set_process_title)
       allow(PidFile).to receive(:create)
     end
 

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -26,7 +26,7 @@ describe MiqScheduleWorker::Runner do
         @worker1 = FactoryGirl.create(:miq_worker, :status => MiqWorker::STATUS_STOPPED)
         @dispatch1 = FactoryGirl.create(:miq_queue, {:zone => @zone1.name, :handler_type => @worker1.class.name, :handler_id => @worker1.id}.merge(@opts))
 
-        @zone2 = FactoryGirl.create(:zone, :name => 'zone2')
+        @zone2 = FactoryGirl.create(:zone)
         @worker2 = FactoryGirl.create(:miq_worker, :status => MiqWorker::STATUS_STOPPED)
 
         allow(MiqServer).to receive(:my_zone).and_return(@zone1.name)


### PR DESCRIPTION
This is a manual backport of:
#13856
#14904

https://bugzilla.redhat.com/show_bug.cgi?id=1445928

When we need to do database lock or connection triaging, it's really hard to tell where each connection originated from because we don't specify an application_name. It looks something like this:

vmdb_production=# select pid, application_name from pg_stat_activity;
 pid   | application_name
 ------+--------------------------------------------------
 13770 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
 13950 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
 13957 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
 13969 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
 13975 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
 13984 | /var/www/miq/vmdb/lib/workers/bin/evm_server.rb
The much debated format of the application_name now looks like this:

MIQ <worker pid> <worker class>[<worker id>], s[<server id>], <zone name>[<zone id>]
OR:
MIQ <server pid> Server[<server id>], <zone name>[<zone id>]

Note, the pg backend pid isn't needed in application_name since the pid column in pg_stat_activity is the backend pid. Plus, each of our processes can have more than one spid.

It now looks like this:

vmdb_development=# select pid, application_name from pg_stat_activity;
 pid  | application_name
------------------+------+-------------+----------------------
 5844 | MIQ 5835 Server[1r2], default[1r1]
 5888 | MIQ 5886 Generic[1r1111], s[1r2], default[1r1]
 5891 | MIQ 5889 Generic[1r1112], s[1r2], default[1r1]
 5894 | MIQ 5892 Priority[1r1113], s[1r2], default[1r1]
 5897 | MIQ 5895 Priority[1r1114], s[1r2], default[1r1]
 5900 | MIQ 5898 Schedule[1r1115], s[1r2], default[1r1]
 5928 | MIQ 5926 EventHandler[1r1116], s[1r2], default[1r1]
 5932 | MIQ 5929 Reporting[1r1117], s[1r2], default[1r1]
 5934 | MIQ 5931 Reporting[1r1118], s[1r2], default[1r1]
 5943 | MIQ 5941 Ui[1r1120], s[1r2], default[1r1]
 5940 | MIQ 5935 Websocket[1r1119], s[1r2], default[1r1]
 5946 | MIQ 5944 WebService[1r1121], s[1r2], default[1r1]
 5964 | MIQ 5935 Websocket[1r1119], s[1r2], default[1r1]
 5965 | MIQ 5941 Ui[1r1120], s[1r2], default[1r1]
 5966 | MIQ 5944 WebService[1r1121], s[1r2], default[1r1]