### PR TITLE
ConfigurationScript CUD operations to use tower_api concern

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_script.rb
@@ -2,4 +2,5 @@ class ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript 
   ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScript
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -1,87 +1,13 @@
 module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScript
   extend ActiveSupport::Concern
 
+  include ProviderObjectMixin
+
   module ClassMethods
-    NAME_MAP = {
-      'create' => 'Creating',
-      'update' => 'Updating',
-      'delete' => 'Deleting'
-    }.freeze
-    private_constant :NAME_MAP
-
-    def create_in_provider(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
-      job_template = manager.with_provider_connection do |connection|
-        connection.api.job_templates.create!(params)
-      end
-
-      # Get the record in our database
-      # TODO: This needs to be targeted refresh so it doesn't take too long
-      task_ids = EmsRefresh.queue_refresh_task(manager)
-      task_ids.each { |tid| MiqTask.wait_for_taskid(tid) }
-
-      find_by!(:manager_id => manager.id, :manager_ref => job_template.id)
-    rescue AnsibleTowerClient::Error => err
-      begin
-        raise err.class, JSON.parse(err.message).values.flatten.join(", ")
-      rescue JSON::ParserError
-        raise err
-      end
-    end
-
-    def update_in_provider(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
+    def provider_collection(manager)
       manager.with_provider_connection do |connection|
-        connection.api.job_templates.find(params.delete(:manager_ref)).update_attributes!(params)
+        connection.api.job_templates
       end
-
-      # Get the record in our database
-      # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.queue_refresh(manager)
-    end
-
-    def delete_in_provider(manager_id, params)
-      manager = ExtManagementSystem.find(manager_id)
-      manager.with_provider_connection do |connection|
-        connection.api.job_templates.find(params[:manager_ref]).destroy!
-      end
-
-      # Get the record in our database
-      # TODO: This needs to be targeted refresh so it doesn't take too long
-      EmsRefresh.queue_refresh(manager)
-    end
-
-    def delete_in_provider_queue(manager_id, params, auth_user = nil)
-      operate_in_provider_queue('delete', manager_id, params, auth_user)
-    end
-
-    def update_in_provider_queue(manager_id, params, auth_user = nil)
-      operate_in_provider_queue('update', manager_id, params, auth_user)
-    end
-
-    def create_in_provider_queue(manager_id, params, auth_user = nil)
-      operate_in_provider_queue('create', manager_id, params, auth_user)
-    end
-
-    private
-
-    def operate_in_provider_queue(action, manager_id, params, auth_user)
-      manager = ExtManagementSystem.find(manager_id)
-
-      task_opts = {
-        :action => "#{NAME_MAP[action]} Ansible Tower Job Template",
-        :userid => auth_user || "system"
-      }
-      queue_opts = {
-        :args        => [manager_id, params],
-        :class_name  => self.name,
-        :method_name => "#{action}_in_provider",
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => manager.my_zone
-      }
-
-      MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
   end
 
@@ -100,4 +26,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
   def provider_object(connection = nil)
     (connection || connection_source.connect).api.job_templates.find(manager_ref)
   end
+
+  FRIENDLY_NAME = 'Ansible Tower Job Template'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -16,6 +16,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
       end
     end
 
+    def notify_on_provider_interaction?
+      true
+    end
+
     def refresh_in_provider(project, id = nil)
       return unless project.can_update?
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -23,6 +23,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
         Vmdb::Settings.encrypt_passwords!(params)
       end
     end
+
+    def notify_on_provider_interaction?
+      true
+    end
   end
 
   def provider_object(connection = nil)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -2,4 +2,5 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScript
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 end

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -14,7 +14,9 @@ FactoryGirl.define do
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
           :parent => :configuration_script
-
+  factory :embedded_ansible_configuration_script,
+          :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript",
+          :parent => :configuration_script
   factory :embedded_playbook,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook",
           :parent => :configuration_script_payload

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -245,7 +245,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
     it 'does not update a job_template if the there is no playbook_id' do
       [:provision, :retirement, :reconfigure].each do |action|
-        catalog_item_options[:config_info][action].delete(:playbook_id) if catalog_item_options[:config_info][action]
+        catalog_item_options.delete_path(:config_info, action, :playbook_id)
       end
       service_template.send(:update_job_templates, 'blah', 'blah', catalog_item_options[:config_info], user)
       expect(job_template).to receive(:update_in_provider_queue).never

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -242,12 +242,15 @@ describe ServiceTemplateAnsiblePlaybook do
   end
 
   describe '#update_job_templates' do
-    let(:service_template) { prebuild_service_template(:job_template => false) }
+    let(:service_template) { prebuild_service_template(:job_template => true) }
 
     it 'does not update a job_template if the there is no playbook_id' do
+      [:provision, :retirement, :reconfigure].each do |action|
+        catalog_item_options[:config_info][action].delete(:playbook_id) if catalog_item_options[:config_info][action]
+      end
       expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
         .to receive(:update_in_provider_queue).never
-      service_template.send(:update_job_templates, 'blah', 'blah', catalog_item_options, user)
+      service_template.send(:update_job_templates, 'blah', 'blah', catalog_item_options[:config_info], user)
     end
 
     it 'does update a job_template if a playbook_id is included' do

--- a/spec/support/ansible_shared/automation_manager/configuration_script.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script.rb
@@ -84,10 +84,10 @@ shared_examples_for "ansible configuration_script" do
     end
   end
 
-  context "creates via the API" do
+  context "CUD via the API" do
     let(:atc)           { double("AnsibleTowerClient::Connection", :api => api) }
     let(:api)           { double("AnsibleTowerClient::Api", :job_templates => job_templates) }
-    let(:job_templates) { double("AnsibleTowerClient::Collection", :create! => job_template) }
+    let(:job_templates) { double("AnsibleTowerClient::Collection", :create! => job_template, :find => job_template) }
     let(:job_template)  { AnsibleTowerClient::JobTemplate.new(nil, job_template_json) }
     let(:manager)       { manager_with_authentication }
 
@@ -127,22 +127,13 @@ shared_examples_for "ansible configuration_script" do
         expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
         expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
         expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
-
         expect { described_class.create_in_provider(manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       context "provider raises on create" do
-        it "with a hash" do
-          expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-          expect(job_templates).to receive(:create!).and_raise(AnsibleTowerClient::Error, {"name"=>["Job template with this Name already exists."]}.to_json)
-
-          expect { described_class.create_in_provider(manager.id, params) }.to raise_error(AnsibleTowerClient::Error, "Job template with this Name already exists.")
-        end
-
         it "with a string" do
           expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
           expect(job_templates).to receive(:create!).and_raise(AnsibleTowerClient::Error, "Job template with this Name already exists.")
-
           expect { described_class.create_in_provider(manager.id, params) }.to raise_error(AnsibleTowerClient::Error, "Job template with this Name already exists.")
         end
       end
@@ -151,7 +142,7 @@ shared_examples_for "ansible configuration_script" do
     it ".create_in_provider_queue" do
       EvmSpecHelper.local_miq_server
       task_id = described_class.create_in_provider_queue(manager.id, params)
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating Ansible Tower Job Template")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
       expect(MiqQueue.first).to have_attributes(
         :args        => [manager.id, params],
         :class_name  => described_class.name,
@@ -162,19 +153,25 @@ shared_examples_for "ansible configuration_script" do
       )
     end
 
-    it ".update_in_provider_queue" do
-      EvmSpecHelper.local_miq_server
-      params[:manager_ref] = 10
-      task_id = described_class.update_in_provider_queue(manager.id, params)
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating Ansible Tower Job Template")
-      expect(MiqQueue.first).to have_attributes(
-        :args        => [manager.id, params],
-        :class_name  => described_class.name,
-        :method_name => "update_in_provider",
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "ems_operations",
-        :zone        => manager.zone.name
-      )
+    context "Update through API" do
+      let(:job_templates) { double("AnsibleTowerClient::Collection", :find => tower_project) }
+      let(:tower_project) { double("AnsibleTowerClient::Project", :update_attributes! => {}, :id => 1) }
+      let(:project)       { described_class.create!(:manager => manager, :manager_ref => tower_project.id) }
+
+      it "#update_in_provider_queue" do
+        task_id = project.update_in_provider_queue(params)
+        expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
+        expected_args = params.tap { |p| p[:task_id] = task_id }
+        expect(MiqQueue.first).to have_attributes(
+          :instance_id => project.id,
+          :args        => [expected_args],
+          :class_name  => described_class.name,
+          :method_name => "update_in_provider",
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => "ems_operations",
+          :zone        => manager.my_zone
+        )
+      end
     end
 
     def store_new_job_template(job_template, manager)


### PR DESCRIPTION
Tower `ConfigurationScriptSource` and `Credential` already using the [tower-api concern](https://github.com/jameswnl/manageiq/blob/153bb163bd6678f4d57af98134d513e7c5c7801e/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb)

This PR is to make `ConfigurationScript` follow and we can remove a bunch code.

@miq-bot add_labels wip, refactor, providers/ansible_tower

@bdunne @syncrou Please have a look. The original configuration_script's update/delete are `class_method`s. Now would be `instance_method`.  I searched and couldn't find usage of them. Please let me know if this change would be causing havoc.  

Need your early input and if this is ok, then I'll add some more specs.