### PR TITLE
Sync up dropdown list in My Settings => Visual Tab => Start Up

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -59,11 +59,6 @@
   :url: /ems_cloud/show_list
   :rbac_feature_name: ems_cloud_show_list
   :startup: true
-- :name: auth_key_pair_clouds
-  :description: Clouds / Key Pairs
-  :url: /auth_key_pair_cloud/show_list
-  :rbac_feature_name: auth_key_pair_cloud_show_list
-  :startup: true
 - :name: availability_zones
   :description: Clouds / Availability Zones
   :url: /availability_zone/show_list
@@ -74,25 +69,10 @@
   :url: /host_aggregate/show_list
   :rbac_feature_name: host_aggregate_show_list
   :startup: true
-- :name: cloud_object_store_containers
-  :description: Clouds / Object Store Containers
-  :url: /cloud_object_store_container/show_list
-  :rbac_feature_name: cloud_object_store_container_show_list
-  :startup: true
 - :name: cloud_tenants
   :description: Clouds / Tenants
   :url: /cloud_tenant/show_list
   :rbac_feature_name: cloud_tenant_show_list
-  :startup: true
-- :name: cloud_volumes
-  :description: Clouds / Volumes
-  :url: /cloud_volume/show_list
-  :rbac_feature_name: cloud_volume_show_list
-  :startup: true
-- :name: cloud_volumes
-  :description: Clouds / Snapshots
-  :url: /cloud_volume_snapshot/show_list
-  :rbac_feature_name: cloud_volume_snapshot_show_list
   :startup: true
 - :name: flavors
   :description: Clouds / Flavors
@@ -123,6 +103,16 @@
   :description: Clouds / Stacks
   :url: orchestration_stack/show_list
   :rbac_feature_name: orchestration_stack
+  :startup: true
+- :name: auth_key_pair_clouds
+  :description: Clouds / Key Pairs
+  :url: /auth_key_pair_cloud/show_list
+  :rbac_feature_name: auth_key_pair_cloud_show_list
+  :startup: true
+- :name: cloud_topology
+  :description: Clouds / Topology
+  :url: /cloud_topology
+  :rbac_feature_name: cloud_topology_view
   :startup: true
 - :name: ems_networks
   :description: Networks / Providers


### PR DESCRIPTION
**This fix requires MiqShortcut.seed to refresh startup settings and db table**

Syncs up drop down list entries for Start Up pages to match those in Compute / Clouds menus in recent UI upgrades. 

https://bugzilla.redhat.com/show_bug.cgi?id=1331399

Compute / Cloud menus screen shot:
![compute clouds ui menus](https://cloud.githubusercontent.com/assets/552686/25460190/081f399a-2a97-11e7-9fe6-8c2eefbe3196.png)


My Settings / Visual Tab / Start Up pages dropdown list prior to code fix:
![visual tab start page show at login part 1 before code fix](https://cloud.githubusercontent.com/assets/552686/25460200/12d03a92-2a97-11e7-9d34-8d42655348cf.png)
![visual tab start page show at login part 2 before code fix](https://cloud.githubusercontent.com/assets/552686/25460202/14dec736-2a97-11e7-8007-c478cb2485df.png)


My Settings / Visual Tab / Start Up pages dropdown list after code fix:
![visual tab start page show at login dropdown after code fix](https://cloud.githubusercontent.com/assets/552686/25460209/1d1a335e-2a97-11e7-9b93-fed5010413a6.png)

