### PR TITLE
Miq shortcut seeding

### DIFF
--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -3,8 +3,17 @@ class MiqShortcut < ApplicationRecord
   has_many :miq_widgets, :through => :miq_widget_shortcuts
 
   def self.seed
+    db_data = all.index_by(&:name)
+    seed_records = seed_data
+
+    seed_records_by_name = seed_records.group_by { |x| x[:name] }
+    if seed_records.size != seed_records_by_name.size
+      names = seed_records_by_name.select { |_n, v| v.size > 1 }.map(&:first)
+      _log.warn("Duplicate seeds for names: #{names.join(",")}")
+    end
+
     names = []
-    seed_data.each_with_index do |s, index|
+    seed_records.each_with_index do |s, index|
       names << s[:name]
       s[:sequence] = index
       rec = find_by(:name => s[:name])

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -12,11 +12,9 @@ class MiqShortcut < ApplicationRecord
       _log.warn("Duplicate seeds for names: #{names.join(",")}")
     end
 
-    names = []
     seed_records.each_with_index do |s, index|
-      names << s[:name]
       s[:sequence] = index
-      rec = find_by(:name => s[:name])
+      rec = db_data[s[:name]]
       if rec.nil?
         _log.info("Creating #{s.inspect}")
         rec = create!(s)
@@ -29,8 +27,8 @@ class MiqShortcut < ApplicationRecord
       end
     end
 
-    all.each do |rec|
-      next if names.include?(rec.name)
+    db_data.each do |name, rec|
+      next if seed_records_by_name[name]
       _log.info("Deleting #{rec.inspect}")
       rec.destroy
     end


### PR DESCRIPTION
- ~~fix `MiqShortcut` fixture (`miq_shortcut.csv`) to remove duplicate name.~~
- ~~Now populate both `cloud / snapshots` and `cloud / volumes` into the database~~
- Warn when there are problems with the fixture.
- remove N+1 from `MiqShortcut#seed`

**UPDATE:** #14914 took care of the duplicate shortcut fixture

### initial seed population

|     ms | bytes | objects |query | query ms |     rows |`comments`
|    ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|  282.0 | 8,270,837 | 83,793 |  217 | 147.2 |       54 |`before-3`
|  219.9 | 6,427,604 | 63,869 |  163 | 107.7 |          |`after-4`
| 22% | 22% | 24% | 25% | 27% | 100% | diff

### seed update

|     ms | bytes | objects |query | query ms |     rows |`comments`
|    ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|  102.3 | 2,752,629 | 29,810 |   55 |  50.6 |      108 |`before-update-3`
|   29.7 | 917,063 | 10,043 |    1 |   3.0 |       54 |`after-update-4`
| 71.0% | 67% | 66% | 98% | 94% | 50% | diff
