### PR TITLE
Avoid N+1 queries when looking-up assigned_roles to region

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -189,7 +189,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def assigned_roles
-    miq_servers.includes(:server_roles).collect(&:assigned_roles).flatten.uniq.compact
+    miq_servers.eager_load(:server_roles).collect(&:assigned_roles).flatten.uniq.compact
   end
 
   def role_active?(role_name)

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -189,7 +189,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def assigned_roles
-    miq_servers.collect(&:assigned_roles).flatten.uniq.compact
+    miq_servers.includes(:server_roles).collect(&:assigned_roles).flatten.uniq.compact
   end
 
   def role_active?(role_name)


### PR DESCRIPTION
So, running `1000.times { MiqRegion.my_region.assigned_roles }` gives

|        ms |    bytes |  objects |queries | query (ms) | `comments`
|       ---:|      ---:|      ---:|  ---:|      ---:| ---
|  32,578.4 | 21,442,630* | 47,452,449 |19,000 |  6,200.6 | without optimization
|  16,730.0 | 21,197,994* | 31,049,221 |3,000 |  1,571.9 | using `includes`
|  14,442.7 | 22,241,361* | 31,562,219 |1,000 |  1,417.4 | using `eager_load`

Thanks for @lpichler for suggesting `eager_load`.
