### PR TITLE
container images are identified by image_ref only

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -219,10 +219,9 @@ module EmsRefresh::SaveInventoryContainer
       h[:type] ||= 'ContainerImage'
     end
 
-    save_inventory_multi(ems.container_images, hashes, :use_association, [:image_ref, :container_image_registry_id],
+    save_inventory_multi(ems.container_images, hashes, :use_association, [:image_ref],
                          [:labels, :docker_labels], :container_image_registry, true)
-    store_ids_for_new_records(ems.container_images, hashes,
-                              [:image_ref, :container_image_registry_id])
+    store_ids_for_new_records(ems.container_images, hashes, [:image_ref])
   end
 
   def save_container_image_registries_inventory(ems, hashes)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/9 will make sure that in all cases `image_ref` is set with a meaningful value that will include the image digest if available.

~This was missing from https://github.com/ManageIQ/manageiq/pull/14185 and causes images with `image_ref: ""` to be grouped together for association during the save.~