### PR TITLE
Move public/external network method into base class

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -16,6 +16,10 @@ class CloudNetwork < ApplicationRecord
   has_many :floating_ips,  :dependent => :destroy
   has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
+  has_many :public_network_vms, -> { distinct }, :through => :public_network_routers, :source => :vms
+  has_many :public_network_routers, :foreign_key => :cloud_network_id, :class_name => NetworkRouter
+  has_many :private_networks, -> { distinct }, :through => :public_network_routers, :source => :cloud_networks
+
   # TODO(lsmola) figure out what this means, like security groups used by VMs in the network? It's not being
   # refreshed, so we can probably delete this association
   has_many   :security_groups

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -16,7 +16,6 @@ module HasNetworkManagerMixin
              :network_routers,
              :public_networks,
              :private_networks,
-             :all_private_networks,
              :all_cloud_networks,
              :to        => :network_manager,
              :allow_nil => true


### PR DESCRIPTION
Move public/external network method into base class, since
external network can be attached directly to a Vm, under some
circumstances.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1431370