### PR TITLE
Add missing units on VMDB Utilization page for disk size

### DIFF
--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -148,6 +148,10 @@
     :v_snapshot_newest_total_size: :bytes
     :v_snapshot_oldest_total_size: :bytes
 
+    :disk_total_bytes: :bytes
+    :disk_free_bytes: :bytes
+    :disk_used_bytes: :bytes
+
     :capacity_profile_1_available_host_memory: :bytes
     :capacity_profile_2_available_host_memory: :bytes
     :capacity_profile_2_available_host_vcpu: :mhz


### PR DESCRIPTION
Add missing units on VMDB Utilization page for disk size.

Screenshots
----------------
Before:
![vmdb_utilization](https://cloud.githubusercontent.com/assets/9535558/25482461/3a8cfe2e-2b52-11e7-8189-a365cb61a931.png)

After:
![screenshot from 2017-04-27 14-04-13](https://cloud.githubusercontent.com/assets/9535558/25482503/703938c6-2b52-11e7-9251-b7fc87d5158b.png)

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1445465

Steps for Testing/QA [Optional]
-------------------------------
1.Navigate to Configure-> Diagnostics.
2.On the VMDB Utilization page, click the Utilization tab.
3.Zoom in on the Disk size graph.
