### PR TITLE
Cache node_types instead of calling on every request

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -328,9 +328,14 @@ class EmsCluster < ApplicationRecord
     end
   end
 
-  def self.node_types
-    return :non_openstack unless openstack_clusters_exists?
-    non_openstack_clusters_exists? ? :mixed_clusters : :openstack
+  cache_with_timeout(:node_types) do
+    if !openstack_clusters_exists?
+      :non_openstack
+    elsif non_openstack_clusters_exists?
+      :mixed_clusters
+    else
+      :openstack
+    end
   end
 
   def self.openstack_clusters_exists?

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1813,9 +1813,14 @@ class Host < ApplicationRecord
     !plist.blank?
   end
 
-  def self.node_types # TODO: This doesn't belong here
-    return :non_openstack unless openstack_hosts_exists?
-    non_openstack_hosts_exists? ? :mixed_hosts : :openstack
+  cache_with_timeout(:node_types) do # TODO: This doesn't belong here
+    if !openstack_hosts_exists?
+      :non_openstack
+    elsif non_openstack_hosts_exists?
+      :mixed_hosts
+    else
+      :openstack
+    end
   end
 
   def self.openstack_hosts_exists? # TODO: This doesn't belong here


### PR DESCRIPTION
For Hosts and Clusters, we display different text for customers who have open stack and those who do not.

We query the database 2-4 queries on every request for this label in the menu.
A typical lean screen has 17 queries.
So 2-4 queries is (11% - 25% by quantity). But these are fast, so % of time is small.

But to be honest, this is more of a frustration PR.

I'm working very hard to delete queries, and these are queries that are run on every page and seem like it should just be a `settings.yml` flag.

Options:

1. Run queries for every page <== master
2. Cache result of logic, only run once every 10 minutes. <=== this PR
3. put this haml partial into memcache (we avoid memcache for some reason)
4. Put into `settings.yaml`.
5. Delete this feature and let the customer override using their typical localization customization workflow.
