### PR TITLE
Hint us about nature of sporadic test failute

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -903,6 +903,7 @@ describe MiqReport do
                                                        :tag_names     => "")
         ChargebackRate.set_assignments(:compute, [{ :cb_rate => chargeback_rate, :label => [label, "container_image"] }])
         rpt = report.generate_table(:userid => "admin")
+        expect(rpt.keys).to contain_exactly(project_name, :_total_)
         row = rpt[project_name][:row]
         expect(row[label_report_column]).to eq(label_value)
       end


### PR DESCRIPTION
We saw failure with
```
    Failure/Error: row = rpt[project_name][:row]
    undefined method `[]' for nil:NilClass
```
This will fail earlier and on failure, it will tell us the content of rpt hash -> that might be helpful to understand what we are up to.

Found by @kbrock at https://travis-ci.org/ManageIQ/manageiq/jobs/226218098#L627