### PR TITLE
LogManagement#delete_active use put_unless_exists

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -200,14 +200,13 @@ module MiqServer::LogManagement
   end
 
   def delete_active_log_collections_queue
-    MiqQueue.put_or_update(
+    MiqQueue.create_with(:priority => MiqQueue::HIGH_PRIORITY).put_unless_exists(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "delete_active_log_collections",
       :server_guid => guid
-    ) do |msg, item|
+    ) do |msg|
       _log.info("Previous cleanup is still running, skipping...") unless msg.nil?
-      item.merge(:priority => MiqQueue::HIGH_PRIORITY)
     end
   end
 


### PR DESCRIPTION
This is not updating the stored item, so getting away
from `put_or_update`.

Just wanted quick win that doesn't change any behavior and moves us towards
better queue etiquette and fewer queries.

Jason, if you want to go with a `put` just give the word and I can do that as well.

related: #14676