### PR TITLE
Drop support for changing load balancing method

### DIFF
--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -17,7 +17,6 @@ class MiqUiWorker < MiqWorker
   REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-ui'
   STARTING_PORT              = 3000
   PROTOCOL                   = 'http'
-  LB_METHOD                  = :busy
   REDIRECTS                  = '/'
   CLUSTER                    = 'evmcluster_ui'
 

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -7,7 +7,6 @@ class MiqWebServiceWorker < MiqWorker
   REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-ws'
   STARTING_PORT              = 4000
   PROTOCOL                   = 'http'
-  LB_METHOD                  = :busy
   REDIRECTS                  = ['/api']
   CLUSTER                    = 'evmcluster_ws'
 

--- a/app/models/miq_websocket_worker.rb
+++ b/app/models/miq_websocket_worker.rb
@@ -8,7 +8,6 @@ class MiqWebsocketWorker < MiqWorker
   REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-websocket'
   STARTING_PORT              = 5000
   PROTOCOL                   = 'ws'
-  LB_METHOD                  = :busy
   REDIRECTS                  = '/ws'
   CLUSTER                    = 'evmcluster_websocket'
 

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -104,7 +104,6 @@ module MiqWebServerWorkerMixin
       options = {
         :member_file    => self::BALANCE_MEMBER_CONFIG_FILE,
         :redirects_file => self::REDIRECTS_CONFIG_FILE,
-        :lbmethod       => self::LB_METHOD,
         :redirects      => self::REDIRECTS,
         :cluster        => self::CLUSTER,
         :protocol       => self::PROTOCOL


### PR DESCRIPTION
We always use the same load balancing method, so there's no need for it to be configurable

Depends on https://github.com/ManageIQ/manageiq-gems-pending/pull/147