### PR TITLE
Escalate privilege

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -104,7 +104,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :ask_limit_on_launch      => true,
       :ask_inventory_on_launch  => true,
       :ask_credential_on_launch => true
-    }
+    }.merge(info.slice(:become_enabled))
     if info[:extra_vars]
       params[:extra_vars] = info[:extra_vars].transform_values do |val|
         val.kind_of?(String) ? val : val[:default] # TODO: support Hash only

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -100,11 +100,12 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :project                  => playbook.configuration_script_source.manager_ref,
       :playbook                 => playbook.name,
       :inventory                => tower.provider.default_inventory,
+      :become_enabled           => info[:become_enabled].present?,
       :ask_variables_on_launch  => true,
       :ask_limit_on_launch      => true,
       :ask_inventory_on_launch  => true,
       :ask_credential_on_launch => true
-    }.merge(info.slice(:become_enabled))
+    }
     if info[:extra_vars]
       params[:extra_vars] = info[:extra_vars].transform_values do |val|
         val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
@@ -144,8 +145,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
-    name = options[:name] || name
-    description = options[:description] || description
+    name = options[:name] || self.name
+    description = options[:description] || self.description
 
     update_job_templates(name, description, config_info, auth_user)
 

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -31,6 +31,7 @@ describe ServiceTemplateAnsiblePlaybook do
         :provision => {
           :new_dialog_name       => 'test_dialog',
           :hosts                 => 'many',
+          :become_enabled        => true,
           :credential_id         => auth_one.id,
           :network_credential_id => auth_two.id,
           :playbook_id           => playbook.id
@@ -62,6 +63,7 @@ describe ServiceTemplateAnsiblePlaybook do
                       :config_info => {
                         :provision => {
                           :new_dialog_name => 'test_dialog_updated',
+                          :become_enabled  => false,
                           :extra_vars      => {
                             'key1' => {:default => 'updated_val1'},
                             'key2' => {:default => 'updated_val2'}
@@ -127,6 +129,7 @@ describe ServiceTemplateAnsiblePlaybook do
       expect(params).to have_attributes(
         :name               => name,
         :description        => description,
+        :become_enabled     => true,
         :credential         => '6',
         :network_credential => '10'
       )
@@ -216,6 +219,7 @@ describe ServiceTemplateAnsiblePlaybook do
         'key1' => {:default => 'updated_val1'},
         'key2' => {:default => 'updated_val2'}
       )
+      expect(service_template.options.fetch_path(:config_info, :provision, :become_enabled)).to be false
       new_dialog_record = Dialog.where(:label => new_dialog_label).first
       expect(new_dialog_record).to be_truthy
       expect(service_template.resource_actions.first.dialog.id).to eq new_dialog_record.id


### PR DESCRIPTION
Tower API accepts option `:become_enabled` to escalate privilege at job template creation. The flag will enable the escalation at job launching.

Will need UI work to add a checkbox for user to decide whether to enable this flag.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1445377
