### PR TITLE
Support array of objects for custom button support

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -22,7 +22,7 @@ class ResourceAction < ApplicationRecord
     elsif target.kind_of?(Array) || target.kind_of?(ActiveRecord::Relation)
       klass = target.first.id.class
       object_ids = target.collect { |t| "#{klass}::#{t.id}" }.join(",")
-      override_attrs = {:target_object_type  => target.first.class.base_class.name,
+      override_attrs = {:target_object_type        => target.first.class.base_class.name,
                         'Array::target_object_ids' => object_ids}.merge(override_attrs || {})
       override_values = {}
     else

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -19,6 +19,12 @@ class ResourceAction < ApplicationRecord
       override_values = {}
     elsif target.kind_of?(Hash)
       override_values = target
+    elsif target.kind_of?(Array) || target.kind_of?(ActiveRecord::Relation)
+      klass = target.first.id.class
+      object_ids = target.collect { |t| "#{klass}::#{t.id}" }.join(",")
+      ae_attributes = {:array_object_type  => target.first.class.base_class.name,
+                       'Array::object_ids' => object_ids}.merge(self.ae_attributes || {})
+      override_values = {}
     else
       override_values = {:object_type => target.class.base_class.name, :object_id => target.id}
     end

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -22,8 +22,8 @@ class ResourceAction < ApplicationRecord
     elsif target.kind_of?(Array) || target.kind_of?(ActiveRecord::Relation)
       klass = target.first.id.class
       object_ids = target.collect { |t| "#{klass}::#{t.id}" }.join(",")
-      ae_attributes = {:array_object_type  => target.first.class.base_class.name,
-                       'Array::object_ids' => object_ids}.merge(self.ae_attributes || {})
+      override_attrs = {:array_object_type  => target.first.class.base_class.name,
+                        'Array::object_ids' => object_ids}.merge(override_attrs || {})
       override_values = {}
     else
       override_values = {:object_type => target.class.base_class.name, :object_id => target.id}

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -22,8 +22,8 @@ class ResourceAction < ApplicationRecord
     elsif target.kind_of?(Array) || target.kind_of?(ActiveRecord::Relation)
       klass = target.first.id.class
       object_ids = target.collect { |t| "#{klass}::#{t.id}" }.join(",")
-      override_attrs = {:array_object_type  => target.first.class.base_class.name,
-                        'Array::object_ids' => object_ids}.merge(override_attrs || {})
+      override_attrs = {:target_object_type  => target.first.class.base_class.name,
+                        'Array::target_object_ids' => object_ids}.merge(override_attrs || {})
       override_values = {}
     else
       override_values = {:object_type => target.class.base_class.name, :object_id => target.id}

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -61,7 +61,7 @@ describe ResourceAction do
         targets = [FactoryGirl.create(:vm_vmware), FactoryGirl.create(:vm_vmware)]
         ae_attributes[:array_object_type] = targets.first.class.base_class.name
         klass = targets.first.id.class
-        ae_attributes['Array::object_ids']  = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
+        ae_attributes['Array::object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
         expect(MiqQueue).to receive(:put).with(q_options).once
         ra.deliver_to_automate_from_dialog({}, targets, user)
       end

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -59,9 +59,9 @@ describe ResourceAction do
       let(:zone_name) { nil }
       it "validates queue entry" do
         targets = [FactoryGirl.create(:vm_vmware), FactoryGirl.create(:vm_vmware)]
-        ae_attributes[:array_object_type] = targets.first.class.base_class.name
+        ae_attributes[:target_object_type] = targets.first.class.base_class.name
         klass = targets.first.id.class
-        ae_attributes['Array::object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
+        ae_attributes['Array::target_object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
         expect(MiqQueue).to receive(:put).with(q_options).once
         ra.deliver_to_automate_from_dialog({}, targets, user)
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1613907/stories/140944305

These are changes in the Automate side to handle being passed in an array of objects.
The objects are not loaded by the Automate Engine, they are loaded by the Automate Method based on the passed in **target_object_type** and **target_object_ids**.


Links
-----

* https://www.pivotaltracker.com/n/projects/1613907/stories/140944305

* https://github.com/ManageIQ/manageiq/issues/14877

- Sample Automate Method that gets passed in array of objects -
```
$evm.log(:info, "Object Type: #{$evm.root['target_object_type']}")
$evm.log(:info, "Object IDS: #{$evm.root['target_object_ids']}")
klass = $evm.vmdb($evm.root['target_object_type'])
$evm.root['target_object_ids'].each do |id|
  obj = klass.find(id)
  $evm.log(:info, "Object name is #{obj.name}")
end
```