### PR TITLE
Added jobs.target_class and jobs.target_id to returned dataset in MiqTask.yaml view

### DIFF
--- a/product/views/MiqTask.yaml
+++ b/product/views/MiqTask.yaml
@@ -31,7 +31,8 @@ cols:
 include:
   job:
     columns:
-    - guid
+    - target_class
+    - target_id
 
 # Order of columns (from all tables)
 col_order:


### PR DESCRIPTION
After merging `Jobs` and `MiqTask` management screens in https://github.com/ManageIQ/manageiq-ui-classic/pull/242  we lost some functionality: navigation to target object of SmartState Analysis for selected job.  To fix it, we need to have `jobs.target_class` and `jobs.target_id` in dataset returned by corresponding view (`MiqTask.yaml`)

In this PR:
- added `jobs.target_class` and `jobs.target_id` to include section in `MiqTask.yaml`
- removed `jobs.guid` from to include section in `MiqTask.yaml`.
**Reason for removing**: before merging `Job` and `MiqTask` screens, `jobs.guid` was used to filter out tasks which have linked Jobs, after merging that filtering logic was removed.

There are no any changes in UI.
**AFTER:**
<img width="1133" alt="before-after" src="https://cloud.githubusercontent.com/assets/6556758/25502189/aee7fbbe-2b63-11e7-9299-7c32059a9708.png">

@miq-bot add-label fine/no, tasks, bug








