### PR TITLE
Remove not used features: job_my_smartproxy and job_all_smartproxy

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2570,20 +2570,12 @@
     :feature_type: view
     :identifier: tasks_view
     :children:
-    - :name: All VM and Container Analysis Tasks
-      :description: Display Lists of All VM and Container Analysis Tasks
-      :feature_type: view
-      :identifier: job_all_smartproxy
-    - :name: All Other Tasks
-      :description: Display Lists of All UI Tasks
+    - :name: All Tasks
+      :description: Display Lists of All Tasks
       :feature_type: view
       :identifier: miq_task_all_ui
-    - :name: VM and Container Analysis Tasks
-      :description: Display Lists of VM and Container Analysis Tasks
-      :feature_type: view
-      :identifier: job_my_smartproxy
-    - :name: Other UI Tasks
-      :description: Display Lists of UI Tasks
+    - :name: My Tasks
+      :description: Display Lists of My Tasks
       :feature_type: view
       :identifier: miq_task_my_ui
   - :name: Modify

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -62,8 +62,6 @@
   - infra_topology
   - host
   - infra_networking
-  - job_all_smartproxy
-  - job_my_smartproxy
   - miq_ae_class_explorer
   - miq_ae_customization_explorer
   - miq_ae_class_import_export
@@ -142,7 +140,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_new
   - storage_manager_edit
   - storage_manager_refresh_inventory
@@ -257,7 +254,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_new
   - storage_manager_edit
   - storage_manager_refresh_inventory
@@ -445,7 +441,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_new
   - storage_manager_edit
   - storage_manager_refresh_inventory
@@ -569,7 +564,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_show
   - storage_manager_show_list
   - my_settings_default_views
@@ -670,7 +664,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_show
   - storage_manager_show_list
   - miq_task_my_ui
@@ -768,7 +761,6 @@
   - host_perf
   - host_tag
   - host_timeline
-  - job_my_smartproxy
   - storage_manager_show
   - storage_manager_show_list
   - miq_task_my_ui
@@ -1029,8 +1021,6 @@
   - ems_infra
   - ems_physical_infra
   - host
-  - job_all_smartproxy
-  - job_my_smartproxy
   - load_balancer
   - miq_ae_class_explorer
   - miq_ae_customization_explorer
@@ -1099,8 +1089,6 @@
   - ems_infra
   - ems_physical_infra
   - host
-  - job_all_smartproxy
-  - job_my_smartproxy
   - miq_ae_class_explorer
   - miq_ae_customization_explorer
   - miq_ae_class_import_export


### PR DESCRIPTION
After merging `Job` and `MiqTask` screens there is mismatch between actual screens for Task managements and available list of Features.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1450185

In This PR:
- removed `All VM and Container Analysis Tasks` and `VM and Container Analysis Tasks`Features
- renamed `All Other Tasks` and `Other UI Tasks` to `All Tasks` and `My Tasks`

**BEFORE:**
<img width="809" alt="before-rolesavailable" src="https://cloud.githubusercontent.com/assets/6556758/25965672/aa571906-3656-11e7-94d7-68a646416441.png">

AFTER:
<img width="737" alt="after" src="https://cloud.githubusercontent.com/assets/6556758/25965795/013b9b2a-3657-11e7-9161-e05c03d77ac8.png">


@miq-bot add-label fine/no

\cc @gtanzillo 

