### PR TITLE
[WIP] Tag visibility for Tenant model

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -443,6 +443,16 @@ module Rbac
       klass.tenant_joins_clause(scope).where(tenant_id_clause)
     end
 
+    def scope_for_user_role_group(scope, miq_group, user)
+      user_or_group = miq_group || user
+
+      if user_or_group.disallowed_roles
+        scope.with_allowed_roles_for(user_or_group)
+      else
+        scope
+      end
+    end
+
     ##
     # Main scoping method
     #
@@ -472,9 +482,8 @@ module Rbac
         scope_by_parent_ids(associated_class, scope, filtered_ids)
       elsif [User, MiqGroup].include?(klass) && (miq_group || user).try!(:self_service?)
         scope.where(:id => klass == User ? user.id : miq_group.id)
-      elsif [MiqUserRole, MiqGroup, User].include?(klass) && (user_or_group = miq_group || user) &&
-            user_or_group.disallowed_roles
-        scope.with_allowed_roles_for(user_or_group)
+      elsif [MiqUserRole, MiqGroup, User].include?(klass)
+        scope_for_user_role_group(scope, miq_group, user)
       else
         scope
       end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -443,15 +443,21 @@ module Rbac
       klass.tenant_joins_clause(scope).where(tenant_id_clause)
     end
 
-    def scope_for_user_role_group(klass, scope, miq_group, user)
+    def scope_for_user_role_group(klass, scope, miq_group, user, managed_filters)
       user_or_group = miq_group || user
 
       if user_or_group.try!(:self_service?) && MiqUserRole != klass
         scope.where(:id => klass == User ? user.id : miq_group.id)
-      elsif user_or_group.disallowed_roles
-        scope.with_allowed_roles_for(user_or_group)
       else
-        scope
+        if user_or_group.disallowed_roles
+          scope = scope.with_allowed_roles_for(user_or_group)
+        end
+
+        if MiqUserRole != klass
+          filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, managed_filters))
+        end
+
+        scope_by_ids(scope, filtered_ids)
       end
     end
 
@@ -483,7 +489,7 @@ module Rbac
         filtered_ids = calc_filtered_ids(associated_class, rbac_filters, user, miq_group, scope_tenant_filter)
         scope_by_parent_ids(associated_class, scope, filtered_ids)
       elsif [MiqUserRole, MiqGroup, User].include?(klass)
-        scope_for_user_role_group(klass, scope, miq_group, user)
+        scope_for_user_role_group(klass, scope, miq_group, user, rbac_filters['managed'])
       else
         scope
       end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -46,7 +46,7 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder)
+    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
 
     BELONGSTO_FILTER_CLASSES = %w(
       VmOrTemplate

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -470,12 +470,8 @@ module Rbac
 
         filtered_ids = calc_filtered_ids(associated_class, rbac_filters, user, miq_group, scope_tenant_filter)
         scope_by_parent_ids(associated_class, scope, filtered_ids)
-      elsif klass == User && user.try!(:self_service?)
-        # Self service users searching for users only see themselves
-        scope.where(:id => user.id)
-      elsif klass == MiqGroup && miq_group.try!(:self_service?)
-        # Self Service users searching for groups only see their group
-        scope.where(:id => miq_group.id)
+      elsif [User, MiqGroup].include?(klass) && (miq_group || user).try!(:self_service?)
+        scope.where(:id => klass == User ? user.id : miq_group.id)
       elsif [MiqUserRole, MiqGroup, User].include?(klass) && (user_or_group = miq_group || user) &&
             user_or_group.disallowed_roles
         scope.with_allowed_roles_for(user_or_group)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -43,6 +43,7 @@ module Rbac
       Service
       ServiceTemplate
       Storage
+      Tenant
       VmOrTemplate
     )
 

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -476,7 +476,8 @@ module Rbac
       end
 
       if apply_rbac_directly?(klass)
-        filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group, nil)
+        scope_with_current_tenant = scope.with_current_tenant if rbac_filters['managed'].present? && klass == Tenant
+        filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group, scope_with_current_tenant)
         scope_by_ids(scope, filtered_ids)
       elsif apply_rbac_through_association?(klass)
         # if subclasses of MetricRollup or Metric, use the associated

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -47,7 +47,7 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
+    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User Tenant)
 
     BELONGSTO_FILTER_CLASSES = %w(
       VmOrTemplate

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -366,6 +366,44 @@ describe Rbac::Filterer do
         expect(results).to match_array(expected_objects)
       end
 
+      context 'with tags' do
+        let!(:tagged_group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }
+        let!(:user)         { FactoryGirl.create(:user, :miq_groups => [tagged_group]) }
+        let!(:other_user)   { FactoryGirl.create(:user, :miq_groups => [group]) }
+
+        before do
+          tagged_group.entitlement = Entitlement.new
+          tagged_group.entitlement.set_belongsto_filters([])
+          tagged_group.entitlement.set_managed_filters([["/managed/environment/prod"]])
+          tagged_group.save!
+
+          tagged_group.tag_with('/managed/environment/prod', :ns => '*')
+          user.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'returns tagged users' do
+          expect(User.count).to eq(2)
+          get_rbac_results_for_and_expect_objects(User, [user])
+        end
+
+        it 'returns tagged groups' do
+          expect(MiqGroup.count).to eq(3)
+          get_rbac_results_for_and_expect_objects(MiqGroup, [tagged_group])
+        end
+
+        let(:tenant_administrator_user_role) do
+          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::DEFAULT_TENANT_ROLE_NAME)
+        end
+
+        it 'returns tagged groups when user\'s role has disallowed other roles' do
+          tagged_group.miq_user_role = tenant_administrator_user_role
+          tagged_group.save!
+
+          expect(MiqGroup.count).to eq(3)
+          get_rbac_results_for_and_expect_objects(MiqGroup, [tagged_group])
+        end
+      end
+
       it "returns all users" do
         get_rbac_results_for_and_expect_objects(User, [user, other_user])
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -358,7 +358,7 @@ describe Rbac::Filterer do
       }
     end
 
-    context "with User and Group" do
+    context "with User, Group and Tenant" do
       def get_rbac_results_for_and_expect_objects(klass, expected_objects)
         User.current_user = user
 
@@ -401,6 +401,19 @@ describe Rbac::Filterer do
 
           expect(MiqGroup.count).to eq(3)
           get_rbac_results_for_and_expect_objects(MiqGroup, [tagged_group])
+        end
+
+        context 'when searching Tenant' do
+          let!(:tenant_without_tag) { FactoryGirl.create(:tenant) }
+          let(:tenant_with_tag) { FactoryGirl.create(:tenant, :parent => default_tenant) }
+
+          before do
+            tenant_with_tag.tag_with('/managed/environment/prod', :ns => '*')
+          end
+
+          it 'returns tagged tenants and user\'s tenant' do
+            get_rbac_results_for_and_expect_objects(Tenant, [tenant_with_tag, default_tenant])
+          end
         end
       end
 


### PR DESCRIPTION
Enable RBAC filtering for Tenant model. In addition, logged user's tenant is always displayed.
This PR is starting with [Add model tenant to direct RBAC
](https://github.com/ManageIQ/manageiq/commit/0d8a838db035c2bb9bc69860c163e41f66de6a8b) and depends on https://github.com/ManageIQ/manageiq/pull/14903

@miq-bot assign @gtanzillo 
@miq-bot add_label wip, rbac, bug, blocker


 ## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1442972 (this part is second and last for th BZ)
