### PR TITLE
Add Memory chart for Availability Zones

### DIFF
--- a/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
@@ -26,6 +26,25 @@
     :columns:
     - derived_vm_count_on
 
+- :title: Memory (MB)
+  :type: Line
+  :columns:
+  - derived_memory_used
+  - min_derived_memory_used
+  - max_derived_memory_used
+  - trend_max_derived_memory_used
+  - resource.derived_memory_used_high_over_time_period
+  - resource.derived_memory_used_low_over_time_period
+  :menu:
+  - Chart-Current-Hourly:Hourly for this day
+  - Chart-VMs-topday:Top Instances on this day
+  - Display-VMs-on:Instances that were running
+  :chart2:
+    :type: Line
+    :title: Instances
+    :columns:
+    - derived_vm_count_on
+
 - :title: Disk I/O (KBps)
   :type: Line
   :columns:


### PR DESCRIPTION
Add Memory chart for Availability Zones. I deleted this chart in #12609 but now i figure out hat it was wrong fix. For some providers, which don't support memory CU collection, chart will all values equal zero.



Screenshots
----------------
Before:
![screencapture-localhost-3000-availability_zone-show-10000000000006-1493711457392](https://cloud.githubusercontent.com/assets/9535558/25608973/617a5c7e-2f1d-11e7-922f-61d3a27e44ff.png)

After:
![screencapture-localhost-3000-availability_zone-show-10000000000006-1493711545432](https://cloud.githubusercontent.com/assets/9535558/25608969/5ff2a956-2f1d-11e7-8b8a-8e7a5dc962ad.png)


Links [Optional]
----------------
https://github.com/ManageIQ/manageiq/pull/12609

Steps for Testing/QA [Optional]
-------------------------------
