### PR TITLE
Pack Tower credential's username into the hash of authentication.options

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -2,6 +2,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
+    :name     => {
+      :type      => :string,
+      :label     => N_('Name'),
+      :help_text => N_('Name of this credential'),
+      :required  => true
+    },
     :username => {
       :label     => N_('Access Key'),
       :help_text => N_('AWS Access Key for this credential'),

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/amazon_credential.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCrede
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
-    :userid => {
+    :username => {
       :label     => N_('Access Key'),
       :help_text => N_('AWS Access Key for this credential'),
       :required  => true

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -11,7 +11,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
     end
 
     def provider_params(params)
-      params[:username] = params.delete(:userid) if params.include?(:userid)
       params[:kind] = self::TOWER_KIND
       params
     end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -2,6 +2,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
+    :name     => {
+      :type      => :string,
+      :label     => N_('Name'),
+      :help_text => N_('Name of this credential'),
+      :required  => true
+    },
     :username => {
       :label     => N_('Username'),
       :help_text => N_('Username for this credential')

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/machine_credential.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCred
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
-    :userid => {
+    :username => {
       :label     => N_('Username'),
       :help_text => N_('Username for this credential')
     },

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -2,6 +2,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
+    :name     => {
+      :type      => :string,
+      :label     => N_('Name'),
+      :help_text => N_('Name of this credential'),
+      :required  => true
+    },
     :username => {
       :label     => N_('Access Key'),
       :help_text => N_('AWS Access Key for this credential')
@@ -20,10 +26,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
       :help_text  => N_('Passphrase to unlock SSH private key if encrypted'),
       :max_length => 1024
     },
-    :ssh_key_data => {
-      :type       => :password,
-      :label      => N_('Private key'),
-      :help_text  => N_('RSA or DSA private key to be used instead of password')
+    :ssh_key_data   => {
+      :type      => :password,
+      :label     => N_('Private key'),
+      :help_text => N_('RSA or DSA private key to be used instead of password')
     }
   }.freeze
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
-    :userid => {
+    :username => {
       :label     => N_('Access Key'),
       :help_text => N_('AWS Access Key for this credential')
     },

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
-    :userid => {
+    :username => {
       :label     => N_('Username'),
       :help_text => N_('Username for this credential'),
       :required  => true

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/vmware_credential.rb
@@ -2,6 +2,12 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCrede
   extend ActiveSupport::Concern
 
   COMMON_ATTRIBUTES = {
+    :name     => {
+      :type      => :string,
+      :label     => N_('Name'),
+      :help_text => N_('Name of this credential'),
+      :required  => true
+    },
     :username => {
       :label     => N_('Username'),
       :help_text => N_('Username for this credential'),

--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/parser/automation_manager.rb
@@ -76,7 +76,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
     collector.credentials.each do |credential|
       inventory_object = persister.credentials.find_or_build(credential.id.to_s)
       inventory_object.name = credential.name
-      inventory_object.userid = credential.username
       provider_module = ManageIQ::Providers::Inflector.provider_module(collector.manager.class).name
       inventory_object.type = case credential.kind
                                 when 'net' then "#{provider_module}::AutomationManager::NetworkCredential"
@@ -93,7 +92,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Parser::AutomationM
                                 when 'openstack' then "#{provider_module}::AutomationManager::OpenstackCredential"
                                 else "#{provider_module}::AutomationManager::Credential"
                                 end
-      inventory_object.options = inventory_object.type.constantize::EXTRA_ATTRIBUTES.keys.each_with_object({}) do |k, h|
+      inventory_object.options = inventory_object.type.constantize::API_ATTRIBUTES.keys.each_with_object({}) do |k, h|
         h[k] = credential.public_send(k)
       end
     end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -18,27 +18,11 @@ shared_examples_for "ansible credential" do
         :description => "Description",
         :name        => "My Credential",
         :related     => {},
-        :userid      => 'john'
+        :username    => 'john'
       }
     end
-    let(:expected_params) do
-      {
-        :description => "Description",
-        :name        => "My Credential",
-        :related     => {},
-        :username    => "john",
-        :kind        => described_class::TOWER_KIND
-      }
-    end
-    let(:expected_notify_params) do
-      {
-        :description => "Description",
-        :name        => "My Credential",
-        :related     => {},
-        :username    => "john",
-        :kind        => described_class::TOWER_KIND
-      }
-    end
+    let(:expected_params) { params.clone.tap { |h| h[:kind] = described_class::TOWER_KIND } }
+    let(:expected_notify_params) { expected_params }
     let(:expected_notify) do
       {
         :type    => :tower_op_success,
@@ -143,7 +127,7 @@ shared_examples_for "ansible credential" do
     let(:credentials)     { double("AnsibleTowerClient::Collection", :find => credential) }
     let(:credential)      { double("AnsibleTowerClient::Credential", :id => 1) }
     let(:ansible_cred)    { described_class.create!(:resource => manager, :manager_ref => credential.id) }
-    let(:params)          { {:userid => 'john'} }
+    let(:params)          { {:username => 'john'} }
     let(:expected_params) { {:username => 'john', :kind => described_class::TOWER_KIND} }
     let(:expected_notify) do
       {

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -101,9 +101,10 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :type => manager_class::MachineCredential
     )
     expect(machine_credential).to have_attributes(
-      :name   => "Demo Credential"
+      :name => "Demo Credential"
     )
     expect(machine_credential.options[:username]).to eq('admin')
+    expect(machine_credential.options[:name]).to eq('Demo Credential')
     expect(machine_credential.options.keys).to match_array(machine_credential.class::API_ATTRIBUTES.keys)
     expect(machine_credential.options[:become_method]).to eq('su')
     expect(machine_credential.options[:become_username]).to eq('root')
@@ -112,7 +113,7 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :type => manager_class::NetworkCredential
     )
     expect(network_credential).to have_attributes(
-      :name   => "Demo Creds 2"
+      :name => "Demo Creds 2"
     )
     expect(network_credential.options).to eq({})
     expect(network_credential.options.keys).to match_array(network_credential.class::API_ATTRIBUTES.keys)
@@ -121,16 +122,18 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :type => manager_class::VmwareCredential
     )
     expect(cloud_credential).to have_attributes(
-      :name   => "dev-vc60"
+      :name => "dev-vc60"
     )
     expect(cloud_credential.options[:username]).to eq('MiqAnsibleUser@vsphere.local')
+    expect(cloud_credential.options[:name]).to eq('dev-vc60')
     expect(cloud_credential.options.keys).to match_array(cloud_credential.class::API_ATTRIBUTES.keys)
 
     scm_credential = expected_configuration_script_source.authentication
     expect(scm_credential).to have_attributes(
-      :name   => "db-github"
+      :name => "db-github"
     )
     expect(scm_credential.options[:username]).to eq('syncrou')
+    expect(scm_credential.options[:name]).to eq('db-github')
     expect(scm_credential.options.keys).to match_array(scm_credential.class::API_ATTRIBUTES.keys)
   end
 

--- a/spec/support/ansible_shared/automation_manager/refresher.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher.rb
@@ -101,10 +101,10 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :type => manager_class::MachineCredential
     )
     expect(machine_credential).to have_attributes(
-      :name   => "Demo Credential",
-      :userid => "admin",
+      :name   => "Demo Credential"
     )
-    expect(machine_credential.options.keys).to match_array(machine_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(machine_credential.options[:username]).to eq('admin')
+    expect(machine_credential.options.keys).to match_array(machine_credential.class::API_ATTRIBUTES.keys)
     expect(machine_credential.options[:become_method]).to eq('su')
     expect(machine_credential.options[:become_username]).to eq('root')
 
@@ -112,26 +112,26 @@ shared_examples_for "ansible refresher" do |ansible_provider, manager_class, ems
       :type => manager_class::NetworkCredential
     )
     expect(network_credential).to have_attributes(
-      :name   => "Demo Creds 2",
-      :userid => "awdd",
+      :name   => "Demo Creds 2"
     )
-    expect(network_credential.options.keys).to match_array(network_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(network_credential.options).to eq({})
+    expect(network_credential.options.keys).to match_array(network_credential.class::API_ATTRIBUTES.keys)
 
     cloud_credential = expected_configuration_script.authentications.find_by(
       :type => manager_class::VmwareCredential
     )
     expect(cloud_credential).to have_attributes(
-      :name   => "dev-vc60",
-      :userid => "MiqAnsibleUser@vsphere.local",
+      :name   => "dev-vc60"
     )
-    expect(cloud_credential.options.keys).to match_array(cloud_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(cloud_credential.options[:username]).to eq('MiqAnsibleUser@vsphere.local')
+    expect(cloud_credential.options.keys).to match_array(cloud_credential.class::API_ATTRIBUTES.keys)
 
     scm_credential = expected_configuration_script_source.authentication
     expect(scm_credential).to have_attributes(
-      :name   => "db-github",
-      :userid => "syncrou"
+      :name   => "db-github"
     )
-    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(scm_credential.options[:username]).to eq('syncrou')
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::API_ATTRIBUTES.keys)
   end
 
   def assert_playbooks

--- a/spec/support/ansible_shared/automation_manager/refresher_v2.rb
+++ b/spec/support/ansible_shared/automation_manager/refresher_v2.rb
@@ -61,24 +61,27 @@ shared_examples_for "ansible refresher_v2" do |ansible_provider, manager_class, 
       :type => manager_class::MachineCredential
     )
     expect(machine_credential).to have_attributes(
-      :name   => "appliance",
-      :userid => "root",
+      :name => "appliance"
     )
+    expect(machine_credential.options[:username]).to eq('root')
+    expect(machine_credential.options[:name]).to eq('appliance')
 
     cloud_credential = expected_configuration_script.authentications.find_by(
       :type => manager_class::AmazonCredential
     )
     expect(cloud_credential).to have_attributes(
-      :name   => "AWS",
-      :userid => "065ZMGNV5WNKPMX4FF82",
+      :name => "AWS"
     )
+    expect(cloud_credential.options[:username]).to eq('065ZMGNV5WNKPMX4FF82')
+    expect(cloud_credential.options[:name]).to eq('AWS')
 
     scm_credential = expected_configuration_script_source.authentication
     expect(scm_credential).to have_attributes(
-      :name   => "db-github",
-      :userid => "syncrou"
+      :name => "db-github"
     )
-    expect(scm_credential.options.keys).to match_array(scm_credential.class::EXTRA_ATTRIBUTES.keys)
+    expect(scm_credential.options[:username]).to eq('syncrou')
+    expect(scm_credential.options[:name]).to eq('db-github')
+    expect(scm_credential.options.keys).to match_array(scm_credential.class::API_ATTRIBUTES.keys)
   end
 
   def assert_playbooks


### PR DESCRIPTION
This is the `#4` proposed solution in #14900 
What it does
1. rename `COMMON_ATTRIBUTES::userid` to `username` which is what Tower uses.  Now we can remove the translation between `userid` and `username`
2. refresh will inventory all values described in `API_ATTRIBUTES` (vs previously only the `EXTRA_ATTRIBUTES`) into the hash stored as `authentication.options`.  So now the meta data (`API_ATTRIBUTES`) will be consistent with the data store (the `options` hash).

@miq-bot add_labels wip, providers/ansible_tower, bug