### PR TITLE
Return partial states

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -199,7 +199,7 @@ class Service < ApplicationRecord
   end
 
   def all_states_match?(action, states = nil)
-    states = power_states if states.nil?
+    states ||= power_states
     return true if composite? && (states.uniq == map_power_states(action))
     return true if atomic? && (states[0] == POWER_STATE_MAP[action])
     false

--- a/lib/power_state.rb
+++ b/lib/power_state.rb
@@ -1,0 +1,52 @@
+class PowerState
+  attr_reader :service, :states, :action
+
+  ACTION_MAP = {
+    :starting   => :start,
+    :stopping   => :stop,
+    :suspending => :suspending
+  }.freeze
+
+  def self.current(options, service)
+    ps = new(options, service)
+    ps.current
+  end
+
+  def initialize(options, service)
+    @service = service
+    @states = service.power_states
+    @options = options
+  end
+
+  def current
+    determine_power_state
+  end
+
+  def partialize
+    "partial_#{partial_state_calculation}"
+  end
+
+  private
+
+  def determine_power_state
+    extract_action
+    if @action.nil?
+      Service::POWER_STATE_MAP.each do |action, value|
+        return value if service.power_states_match?(action, @states)
+      end
+    elsif service.power_states_match?(@action, @states)
+      return Service::POWER_STATE_MAP[@action]
+    end
+    partialize
+  end
+
+  def extract_action
+    @action = ACTION_MAP[@options[:power_status]]
+  end
+
+  def partial_state_calculation
+    summed_hash = @states.inject(Hash.new(0)) { |total, e| total[e] += 1; total }
+    greatest_value = summed_hash.values.sort.last
+    summed_hash.select { |x| summed_hash[x] == greatest_value }.keys.first
+  end
+end

--- a/lib/power_state.rb
+++ b/lib/power_state.rb
@@ -1,5 +1,5 @@
 class PowerState
-  attr_reader :service, :states, :action
+  attr_reader :service, :states
 
   ACTION_MAP = {
     :starting   => :start,
@@ -29,19 +29,10 @@ class PowerState
   private
 
   def determine_power_state
-    extract_action
-    if @action.nil?
-      Service::POWER_STATE_MAP.each do |action, value|
-        return value if @service.power_states_match?(action, @states)
-      end
-    elsif @service.power_states_match?(@action, @states)
-      return Service::POWER_STATE_MAP[@action]
+    Service::POWER_STATE_MAP.each do |action, value|
+      return value if @service.power_states_match?(action, @states)
     end
     partialize
-  end
-
-  def extract_action
-    @action = ACTION_MAP[@options[:power_status]]
   end
 
   def partial_state_calculation

--- a/lib/power_state.rb
+++ b/lib/power_state.rb
@@ -32,9 +32,9 @@ class PowerState
     extract_action
     if @action.nil?
       Service::POWER_STATE_MAP.each do |action, value|
-        return value if service.power_states_match?(action, @states)
+        return value if @service.power_states_match?(action, @states)
       end
-    elsif service.power_states_match?(@action, @states)
+    elsif @service.power_states_match?(@action, @states)
       return Service::POWER_STATE_MAP[@action]
     end
     partialize

--- a/lib/power_state.rb
+++ b/lib/power_state.rb
@@ -36,7 +36,9 @@ class PowerState
   end
 
   def partial_state_calculation
-    summed_hash = @states.inject(Hash.new(0)) { |total, e| total[e] += 1; total }
+    summed_hash = @states.each_with_object(Hash.new { |h, k| h[k] = 0 }) do |e, total|
+      total[e] += 1
+    end
     greatest_value = summed_hash.values.sort.last
     summed_hash.select { |x| summed_hash[x] == greatest_value }.keys.first
   end

--- a/spec/lib/power_state_spec.rb
+++ b/spec/lib/power_state_spec.rb
@@ -1,0 +1,38 @@
+describe PowerState do
+  let(:partial_power_states) { %w(on on off on) }
+  let(:common_power_states) { %w(on on on on) }
+  let(:service) { FactoryGirl.create(:service) }
+  let(:options) { { :power_status => "starting" } }
+
+  context "#{described_class}.current" do
+    it "returns the current power_state if all states match" do
+      expect(service).to receive(:power_states).and_return(common_power_states)
+
+      expect(PowerState.current(options, service)).to eq "on"
+    end
+
+    it "returns the partial power_state if some of the states match" do
+      allow(service).to receive(:power_states).and_return(partial_power_states)
+      expect(service).to receive(:composite?).and_return(true).exactly(4).times
+      expect(service).to receive(:atomic?).and_return(false).exactly(4).times
+
+      expect(PowerState.current(options, service)).to eq "partial_on"
+    end
+  end
+
+  context "#partialize" do
+    it "partializes the state with the most entries" do
+      allow(service).to receive(:power_states).and_return(partial_power_states)
+      power_state = PowerState.new(options, service)
+      expect(power_state.partialize).to eq "partial_on"
+    end
+
+    it "partializes any state that has the most entries" do
+      random_list = %w(blah blah test unknown)
+      allow(service).to receive(:power_states).and_return(random_list)
+      power_state = PowerState.new(options, service)
+
+      expect(power_state.partialize).to eq "partial_blah"
+    end
+  end
+end

--- a/spec/lib/power_state_spec.rb
+++ b/spec/lib/power_state_spec.rb
@@ -24,6 +24,7 @@ describe PowerState do
     it "partializes the state with the most entries" do
       allow(service).to receive(:power_states).and_return(partial_power_states)
       power_state = PowerState.new(options, service)
+
       expect(power_state.partialize).to eq "partial_on"
     end
 


### PR DESCRIPTION
1. Allow for the `service.power_state` method to retain original behavior
2. Add the ability to include a partial state when all power states for a service do not match

https://bugzilla.redhat.com/show_bug.cgi?id=1432254
