### PR TITLE
Add SQL store option to token store

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -27,6 +27,10 @@ class Session < ApplicationRecord
   def self.purge_one_batch(ttl, batch_size)
     sessions = where("updated_at <= ?", ttl.seconds.ago.utc).limit(batch_size)
     return 0 if sessions.size.zero?
+    sessions = sessions.reject do |s|
+      expires_on = Marshal.load(Base64.decode64(s.data.split("\n").join))[:expires_on] rescue nil
+      expires_on && expires_on >= Time.zone.now
+    end
 
     log_off_user_sessions(sessions)
     where(:id => sessions.collect(&:id)).destroy_all.size

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,26 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 25,
+      "fingerprint": "0051a4e9b0e19666f13befb5a9522f07d8de4d6f05ccc6f594f15bf1b9578dc6",
+      "check_name": "Deserialize",
+      "message": "Marshal.load called with model attribute",
+      "file": "lib/token_store/sql_store.rb",
+      "line": 16,
+      "link": "http://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Marshal.load(Base64.decode64(Session.find_by(:session_id => session_key(token)).data))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "TokenStore::SqlStore",
+        "method": "read"
+      },
+      "user_input": "Session.find_by(:session_id => session_key(token)).data",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "4e1918c2d5ff2beacc21db09f696af724d62f1a2a6a101e8e3cb564d0e8a94cd",
@@ -101,6 +121,6 @@
       "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
-  "updated": "2017-02-01 08:54:32 -0500",
-  "brakeman_version": "3.5.0"
+  "updated": "2017-05-30 13:45:37 -0700",
+  "brakeman_version": "3.6.2"
 }

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+:server:
+  :session_store: memory

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -3,13 +3,16 @@ class TokenStore
 
   def self.acquire(namespace, token_ttl)
     @token_caches[namespace] ||= begin
-      if test_environment?
+      case ::Settings.server.session_store
+      when "memory"
         require 'active_support/cache/memory_store'
         ActiveSupport::Cache::MemoryStore.new(cache_store_options(namespace, token_ttl))
-      else
+      when "cache"
         require 'active_support/cache/dalli_store'
         memcache_server = ::Settings.session.memcache_server
         ActiveSupport::Cache::DalliStore.new(memcache_server, cache_store_options(namespace, token_ttl))
+      else
+        raise "unsupported session store type: #{::Settings.server.session_store}"
       end
     end
   end
@@ -22,9 +25,4 @@ class TokenStore
     }
   end
   private_class_method :cache_store_options
-
-  def self.test_environment?
-    !Rails.env.development? && !Rails.env.production?
-  end
-  private_class_method :test_environment?
 end

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -4,6 +4,8 @@ class TokenStore
   def self.acquire(namespace, token_ttl)
     @token_caches[namespace] ||= begin
       case ::Settings.server.session_store
+      when "sql"
+        SqlStore.new(cache_store_options(namespace, token_ttl))
       when "memory"
         require 'active_support/cache/memory_store'
         ActiveSupport::Cache::MemoryStore.new(cache_store_options(namespace, token_ttl))

--- a/lib/token_store/sql_store.rb
+++ b/lib/token_store/sql_store.rb
@@ -1,0 +1,39 @@
+class TokenStore
+  class SqlStore
+    def initialize(options)
+      @namespace = options.fetch(:namespace)
+    end
+
+    def write(token, data, _options = nil)
+      record = Session.find_or_create_by(:session_id => session_key(token))
+      record.data = Base64.encode64(Marshal.dump(data))
+      record.save!
+    end
+
+    def read(token, _options = nil)
+      record = Session.find_by(:session_id => session_key(token))
+      return nil unless record
+      data = Marshal.load(Base64.decode64(record.data))
+      if data[:expires_on] > Time.zone.now
+        data
+      else
+        record.destroy
+        nil
+      end
+    end
+
+    def delete(token)
+      record = Session.find_by(:session_id => session_key(token))
+      return nil unless record
+      record.destroy!
+    end
+
+    private
+
+    attr_reader :namespace
+
+    def session_key(token)
+      "#{namespace}:#{token}"
+    end
+  end
+end

--- a/spec/lib/token_store/sql_store_spec.rb
+++ b/spec/lib/token_store/sql_store_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe TokenStore::SqlStore do
+  around { |example| Timecop.freeze { example.run } }
+
+  describe "#write" do
+    it "creates a session" do
+      store = build_sql_store
+      token = SecureRandom.hex
+      data = {
+        :expires_on => 1.hour.from_now,
+        :token_ttl  => 1.hour,
+        :userid     => "alice"
+      }
+
+      expect { store.write(token, data) }.to change(Session, :count).by(1)
+    end
+
+    it "updates a session if it exists" do
+      store = build_sql_store("TEST")
+      token = SecureRandom.hex
+      session = FactoryGirl.create(
+        :session,
+        :session_id => "TEST:#{token}",
+        :data       => serialize_data(:expires_on => 1.second.from_now)
+      )
+
+      store.write(token, :expires_on => 1.hour.from_now)
+
+      expect(deserialize_data(session.reload.data)[:expires_on]).to eq(1.hour.from_now)
+    end
+  end
+
+  describe "#read" do
+    it "reads a valid token" do
+      store = build_sql_store("TEST")
+      token = SecureRandom.hex
+      FactoryGirl.create(
+        :session,
+        :session_id => "TEST:#{token}",
+        :data       => serialize_data(:userid => "alice", :expires_on => 1.second.from_now)
+      )
+
+      data = store.read(token)
+
+      expect(data[:userid]).to eq("alice")
+    end
+
+    it "returns nil for an expired token" do
+      store = build_sql_store("TEST")
+      token = SecureRandom.hex
+      FactoryGirl.create(
+        :session,
+        :session_id => "TEST:#{token}",
+        :data       => serialize_data(:userid => "alice", :expires_on => 1.second.ago)
+      )
+
+      data = store.read(token)
+
+      expect(data).to be_nil
+    end
+
+    it "returns nil if no token can be found" do
+      store = build_sql_store("TEST")
+      token = SecureRandom.hex
+
+      data = store.read(token)
+
+      expect(data).to be_nil
+    end
+  end
+
+  describe "#delete" do
+    it "deletes a token" do
+      store = build_sql_store("TEST")
+      token = SecureRandom.hex
+      FactoryGirl.create(
+        :session,
+        :session_id => "TEST:#{token}",
+        :data       => serialize_data(:userid => "alice", :expires_on => 1.hour.from_now)
+      )
+
+      expect { store.delete(token) }.to change(Session, :count).by(-1)
+    end
+  end
+
+  def serialize_data(data)
+    Base64.encode64(Marshal.dump(data))
+  end
+
+  def deserialize_data(data)
+    Marshal.load(Base64.decode64(data))
+  end
+
+  def build_sql_store(namespace = "FOO")
+    described_class.new(:namespace => namespace)
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -44,5 +44,39 @@ describe Session do
 
       expect(described_class.count).to eq 0
     end
+
+    context "given some token store data" do
+      around { |example| Timecop.freeze { example.run } }
+
+      it "will purge an expired token" do
+        FactoryGirl.create(
+          :session,
+          :data => serialize_data(
+            :expires_on => 1.second.ago,
+          )
+        )
+
+        described_class.purge(0)
+
+        expect(described_class.count).to eq(0)
+      end
+
+      it "won't purge an unexpired token" do
+        FactoryGirl.create(
+          :session,
+          :data => serialize_data(
+            :expires_on => 1.second.from_now,
+          )
+        )
+
+        described_class.purge(0)
+
+        expect(described_class.count).to eq(1)
+      end
+
+      def serialize_data(data)
+        Base64.encode64(Marshal.dump(data))
+      end
+    end
   end
 end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -122,115 +122,121 @@ describe "Authentication API" do
   end
 
   context "Token Based Authentication" do
-    it "gets a token based identifier" do
-      api_basic_authorize
+    %w(sql memory).each do |session_store|
+      context "when using a #{session_store} session store" do
+        before { stub_settings_merge(:server => {:session_store => session_store}) }
 
-      run_get auth_url
+        it "gets a token based identifier" do
+          api_basic_authorize
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-    end
+          run_get auth_url
 
-    it "authentication using a bad token" do
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+        end
 
-      expect(response).to have_http_status(:unauthorized)
-    end
+        it "authentication using a bad token" do
+          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
 
-    it "authentication using a valid token" do
-      api_basic_authorize
+          expect(response).to have_http_status(:unauthorized)
+        end
 
-      run_get auth_url
+        it "authentication using a valid token" do
+          api_basic_authorize
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(auth_token))
+          run_get auth_url
 
-      auth_token = response.parsed_body["auth_token"]
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token))
 
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
+          auth_token = response.parsed_body["auth_token"]
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(ENTRYPOINT_KEYS)
-    end
+          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
-    it "authentication using a valid token updates the token's expiration time" do
-      api_basic_authorize
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(ENTRYPOINT_KEYS)
+        end
 
-      run_get auth_url
+        it "authentication using a valid token updates the token's expiration time" do
+          api_basic_authorize
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+          run_get auth_url
 
-      auth_token = response.parsed_body["auth_token"]
-      token_expires_on = response.parsed_body["expires_on"]
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
 
-      tm = TokenManager.new("api")
-      token_info = tm.token_get_info(auth_token)
-      expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
+          auth_token = response.parsed_body["auth_token"]
+          token_expires_on = response.parsed_body["expires_on"]
 
-      expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
-      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
+          tm = TokenManager.new("api")
+          token_info = tm.token_get_info(auth_token)
+          expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(ENTRYPOINT_KEYS)
-    end
+          expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
+          run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
-    it "gets a token based identifier with the default API based token_ttl" do
-      api_basic_authorize
-      run_get auth_url
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(ENTRYPOINT_KEYS)
+        end
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response.parsed_body["token_ttl"]).to eq(::Settings.api.token_ttl.to_i_with_method)
-    end
+        it "gets a token based identifier with the default API based token_ttl" do
+          api_basic_authorize
+          run_get auth_url
 
-    it "gets a token based identifier with an invalid requester_type" do
-      api_basic_authorize
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+          expect(response.parsed_body["token_ttl"]).to eq(::Settings.api.token_ttl.to_i_with_method)
+        end
 
-      run_get auth_url, :requester_type => "bogus_type"
+        it "gets a token based identifier with an invalid requester_type" do
+          api_basic_authorize
 
-      expect_bad_request(/invalid requester_type/i)
-    end
+          run_get auth_url, :requester_type => "bogus_type"
 
-    it "gets a token based identifier with a UI based token_ttl" do
-      api_basic_authorize
+          expect_bad_request(/invalid requester_type/i)
+        end
 
-      run_get auth_url, :requester_type => "ui"
+        it "gets a token based identifier with a UI based token_ttl" do
+          api_basic_authorize
 
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-      expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
-    end
+          run_get auth_url, :requester_type => "ui"
 
-    it "forgets the current token when asked to" do
-      api_basic_authorize
+          expect(response).to have_http_status(:ok)
+          expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+          expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
+        end
 
-      run_get auth_url
+        it "forgets the current token when asked to" do
+          api_basic_authorize
 
-      auth_token = response.parsed_body["auth_token"]
+          run_get auth_url
 
-      expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
-      run_delete auth_url, Api::HttpHeaders::AUTH_TOKEN => auth_token
-    end
+          auth_token = response.parsed_body["auth_token"]
 
-    context 'Tokens for Web Sockets' do
-      it 'gets a UI based token_ttl when requesting token for web sockets' do
-        api_basic_authorize
+          expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
+          run_delete auth_url, Api::HttpHeaders::AUTH_TOKEN => auth_token
+        end
 
-        run_get auth_url, :requester_type => 'ws'
-        expect(response).to have_http_status(:ok)
-        expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
-        expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
-      end
+        context 'Tokens for Web Sockets' do
+          it 'gets a UI based token_ttl when requesting token for web sockets' do
+            api_basic_authorize
 
-      it 'cannot authorize user to api based on token that is dedicated for web sockets' do
-        api_basic_authorize
-        run_get auth_url, :requester_type => 'ws'
-        ws_token = response.parsed_body["auth_token"]
+            run_get auth_url, :requester_type => 'ws'
+            expect(response).to have_http_status(:ok)
+            expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+            expect(response.parsed_body["token_ttl"]).to eq(::Settings.session.timeout.to_i_with_method)
+          end
 
-        run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
+          it 'cannot authorize user to api based on token that is dedicated for web sockets' do
+            api_basic_authorize
+            run_get auth_url, :requester_type => 'ws'
+            ws_token = response.parsed_body["auth_token"]
 
-        expect(response).to have_http_status(:unauthorized)
+            run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
+
+            expect(response).to have_http_status(:unauthorized)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This does a ~~couple of~~ few things:

1. Makes the token store honor the kind of session store that's been configured in the global settings
2. Adds support for a SQL session store, if that's been configured
3. Updates some existing tests to use both memory and sql to ensure good integration
4. Updates the purger to respect the ttl of the token, not the `updated_on` value

~~This is kind of a naive implementation that might have some issues. The most glaring is perhaps that we purge the `Session`s based on a global ttl, meaning that this won't respect the ttl that is configured in the API/elsewhere, and that may not be easy to change. Opening this as a WIP to aid discussion~~

@miq-bot add-label api, core, enhancement
@miq-bot assign @gtanzillo 

Fixes https://github.com/ManageIQ/manageiq/issues/14882
Fixes https://www.pivotaltracker.com/story/show/130490379

/cc @martinpovolny 
