### PR TITLE
Move ResourceGroup relationship into VmOrTemplate model

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -3,7 +3,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   belongs_to :flavor
   belongs_to :orchestration_stack
   belongs_to :cloud_tenant
-  belongs_to :resource_group
 
   has_many :network_ports, :as => :device
   has_many :cloud_subnets, -> { distinct }, :through => :network_ports
@@ -127,7 +126,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   def resize(new_flavor_id)
     raise ArgumentError, _("new_flavor_id cannot be nil") if new_flavor_id.nil?
     new_flavor = Flavor.find(new_flavor_id)
-    raise ArgumentError, _("flavor cannot be found") if new_flavor.nil? 
+    raise ArgumentError, _("flavor cannot be found") if new_flavor.nil?
     raw_resize(new_flavor)
   end
 

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -1,3 +1,9 @@
 class ResourceGroup < ApplicationRecord
-  has_many :vms
+  alias_attribute :images, :templates
+
+  has_many :vm_or_templates
+
+  # Rely on default scopes to get expected information
+  has_many :vms, :class_name => 'Vm'
+  has_many :templates, :class_name => 'MiqTemplate'
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -79,6 +79,8 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
 
+  belongs_to                :resource_group
+
   # Accounts - Users and Groups
   has_many                  :accounts, :dependent => :destroy
   has_many                  :users, -> { where(:accttype => 'user') }, :class_name => "Account"

--- a/spec/models/resource_group_spec.rb
+++ b/spec/models/resource_group_spec.rb
@@ -23,8 +23,24 @@ describe ResourceGroup do
   end
 
   context "relationships" do
-    it "has many vms" do
-      expect(resource_group).to respond_to(:vms)
+    before do
+      @vm       = FactoryGirl.create(:vm_google, :template => false, :resource_group => resource_group)
+      @template = FactoryGirl.create(:template_google, :template => true, :resource_group => resource_group)
+    end
+
+    it "returns the expected results for vms" do
+      expect(resource_group.vms).to include(@vm)
+      expect(resource_group.vms).to_not include(@template)
+    end
+
+    it "returns the expected results for templates" do
+      expect(resource_group.templates).to include(@template)
+      expect(resource_group.templates).to_not include(@vm)
+    end
+
+    it "returns the expected results for vm_or_templates" do
+      expect(resource_group.vm_or_templates).to include(@template)
+      expect(resource_group.vm_or_templates).to include(@vm)
     end
   end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -335,6 +335,19 @@ describe VmOrTemplate do
     end
   end
 
+  context "#resource_group" do
+    before do
+      @resource_group = FactoryGirl.create(:resource_group)
+      @vm_with_rg     = FactoryGirl.create(:vm_amazon, :resource_group => @resource_group)
+      @vm_without_rg  = FactoryGirl.create(:vm_amazon)
+    end
+
+    it "has a has_one association with resource groups" do
+      expect(@vm_with_rg.resource_group).to eql(@resource_group)
+      expect(@vm_without_rg.resource_group).to be_nil
+    end
+  end
+
   context "#scan_profile_categories" do
     before do
       @vm = FactoryGirl.create(:vm_vmware)


### PR DESCRIPTION
This is a followup to https://github.com/ManageIQ/manageiq/pull/14000.

Originally I put the resource group relationship in the cloud_manager/vm.rb. Unfortunately, this left templates out. So, I've set the relationship in the VmOrTemplate model instead.

For backwards compatibility (and general handiness) I've created a `vms` method, as well as a `templates` method (and an :images alias). I've also updated the specs.