### PR TITLE
Update miq-shortcuts

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -219,8 +219,8 @@
   :rbac_feature_name: container_service_show_list
   :startup: true
 - :name: container_containers
-  :description: Containers / Explorer
-  :url: /container/explorer
+  :description: Containers / Containers
+  :url: /container/show_list
   :rbac_feature_name: containers
   :startup: true
 - :name: control_explorer


### PR DESCRIPTION
**Description**

https://github.com/ManageIQ/manageiq-ui-classic/pull/1204 will change the url of the containers list view.

This PR update the new url in the `miq_shortcuts.yml` file.

This PR depend on https://github.com/ManageIQ/manageiq-ui-classic/pull/1204 

