### PR TITLE
Modularize patches/database_configuration.rb

### DIFF
--- a/config/environments/patches/database_configuration.rb
+++ b/config/environments/patches/database_configuration.rb
@@ -3,33 +3,8 @@
 # password fields as strings without ERB.
 
 require 'rails/application/configuration'
+require 'patches/database_configuration_patch'
+
 Rails::Application::Configuration.module_eval do
-  prepend Module.new {
-    def database_configuration
-      path = paths["config/database"].existent.first
-      yaml = Pathname.new(path) if path
-
-      if yaml && yaml.exist?
-        require "yaml"
-        require "erb"
-
-        data = yaml.read
-        data = ERB.new(data).result if !Rails.env.production? || ENV['ERB_IN_CONFIG']
-
-        begin
-          data = YAML.load(data) || {}
-        rescue Psych::SyntaxError => e
-          raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
-                "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
-                "Error: #{e.message}"
-        rescue => e
-          raise e, "Cannot load `Rails.application.database_configuration`:\n#{e.message}", e.backtrace
-        end
-
-        Vmdb::Settings.decrypt_passwords!(data)
-      else
-        super
-      end
-    end
-  }
+  prepend DatabaseConfigurationPatch
 end

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,9 +1,8 @@
 module DatabaseConfigurationPatch
   def database_configuration
-    path = paths["config/database"].existent.first
-    yaml = Pathname.new(path) if path
+    yaml = Pathname.new(File.expand_path("../../config/database.yml", __dir__))
 
-    if yaml && yaml.exist?
+    if yaml.exist?
       require "yaml"
       require "erb"
 

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,3 +1,5 @@
+require "manageiq"
+
 module DatabaseConfigurationPatch
   def database_configuration
     yaml = Pathname.new(File.expand_path("../../config/database.yml", __dir__))
@@ -7,7 +9,7 @@ module DatabaseConfigurationPatch
       require "erb"
 
       data = yaml.read
-      data = ERB.new(data).result if !Rails.env.production? || ENV['ERB_IN_CONFIG']
+      data = ERB.new(data).result if !ManageIQ.env.production? || ENV['ERB_IN_CONFIG']
 
       begin
         data = YAML.load(data) || {}

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,0 +1,28 @@
+module DatabaseConfigurationPatch
+  def database_configuration
+    path = paths["config/database"].existent.first
+    yaml = Pathname.new(path) if path
+
+    if yaml && yaml.exist?
+      require "yaml"
+      require "erb"
+
+      data = yaml.read
+      data = ERB.new(data).result if !Rails.env.production? || ENV['ERB_IN_CONFIG']
+
+      begin
+        data = YAML.load(data) || {}
+      rescue Psych::SyntaxError => e
+        raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
+              "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
+              "Error: #{e.message}"
+      rescue => e
+        raise e, "Cannot load `Rails.application.database_configuration`:\n#{e.message}", e.backtrace
+      end
+
+      Vmdb::Settings.decrypt_passwords!(data)
+    else
+      super
+    end
+  end
+end

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -12,7 +12,13 @@ module DatabaseConfigurationPatch
       data = ERB.new(data).result if !ManageIQ.env.production? || ENV['ERB_IN_CONFIG']
 
       begin
+        # TODO: Allow this to work with miq-yaml:
+        #
+        # manageiq-gems-pending/gems/pending/util/extensions/miq-yaml
+        #
+        # rubocop:disable Security/YAMLLoad
         data = YAML.load(data) || {}
+        # rubocop:enable Security/YAMLLoad
       rescue Psych::SyntaxError => e
         raise "YAML syntax error occurred while parsing #{paths["config/database"].first}. " \
               "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \

--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -3,7 +3,7 @@ describe "DatabaseConfiguration patch" do
   let(:fake_db_config) { Pathname.new("does/not/exist") }
 
   before(:each) do
-    allow(Rails).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
+    allow(ManageIQ).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
 
     @app = Vmdb::Application.new
     @app.config.paths["config/database"] = fake_db_config.to_s # ignore real database.yml

--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -1,21 +1,20 @@
 describe "DatabaseConfiguration patch" do
+  let(:db_config_path) { File.expand_path "../../../config/database.yml", __dir__ }
+  let(:fake_db_config) { Pathname.new("does/not/exist") }
+
   before(:each) do
     allow(Rails).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
 
     @app = Vmdb::Application.new
-    @app.config.paths["config/database"] = "does/not/exist" # ignore real database.yml
+    @app.config.paths["config/database"] = fake_db_config.to_s # ignore real database.yml
   end
 
   context "ERB in the template" do
     before(:each) do
-      @tempfile = Tempfile.new('yml').tap do |f|
-        f.write database_config
-        f.close
-      end
-      @app.config.paths["config/database"].unshift @tempfile.path
+      database_config = StringIO.new "---\nvalue: <%= 1 %>\n"
+      allow(database_config).to receive(:exist?).and_return(true)
+      allow(Pathname).to receive(:new).and_return(database_config)
     end
-
-    let(:database_config) { "---\nvalue: <%= 1 %>\n" }
 
     it "doesn't execute" do
       expect(@app.config.database_configuration).to eq('value' => '<%= 1 %>')
@@ -35,12 +34,15 @@ describe "DatabaseConfiguration patch" do
     end
 
     it "ignores a missing file" do
+      expect(Pathname).to receive(:new).with(db_config_path).and_return(fake_db_config)
       expect(@app.config.database_configuration).to eq({})
     end
   end
 
   context "with no source of configuration" do
     it "explains the problem" do
+      expect(Pathname).to receive(:new).with(db_config_path).and_return(fake_db_config)
+
       begin
         old = ENV.delete('DATABASE_URL')
         expect { @app.config.database_configuration }.to raise_error(/Could not load database configuration/)


### PR DESCRIPTION
Takes the core code that is in an anonymous module in the database_configuration.rb file and move it into it's own file so it can be reused elsewhere.  Also converts some of the Rails specific code to more generic Ruby to allow it to be used when Rails is not present.

Risks
-----
Because this is meant for [slim worker effort](https://github.com/ManageIQ/manageiq/pull/15174), I have pulled out some of the "Rails-y" things from this, specifically two commits do this:

* `Use plain ruby to find config in db config patch`: https://github.com/ManageIQ/manageiq/commit/6d07fb870dc1032212a0fefc4d0afdbdd8969a3d
* `Skip relying on Rails.env in db config patch`: https://github.com/ManageIQ/manageiq/commit/e302f56a70602e7d39975a731b8c367e949200ec

The first should be relatively the same as what we were doing before, and is just a different mechanism for finding if a file exists (as far as I can tell).

The second might cause issues if what was done in https://github.com/ManageIQ/manageiq/pull/15020 does not function the same as `Rails.env` (it should, but you never know).  Other than that, the functionality should be exactly the same and cause no issues.

Links
-----
* Extracted from https://github.com/ManageIQ/manageiq/pull/14916 (probably won't be merged)
* Needed for slim worker effort:  https://github.com/ManageIQ/manageiq/pull/15174