### PR TITLE
Tower CUD to invoke targeted refresh

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -15,22 +15,15 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
         connection.api.projects
       end
     end
-  end
 
-  def provider_object(connection = nil)
-    (connection || connection_source.connect).api.projects.find(manager_ref)
-  end
-
-  REFRESH_ON_TOWER_SLEEP = 1.second
-  def refresh_in_provider
-    with_provider_object do |project|
+    def refresh_in_provider(project, id = nil)
       return unless project.can_update?
 
       project_update = project.update
 
       # this is really just a quick hack. We should do this properly once
       # https://github.com/ManageIQ/manageiq/pull/14405 is merged
-      log_header = "updating project #{project.id} (#{self.class.name} #{id})"
+      log_header = "updating project #{project.id} (#{name} #{id})"
       _log.info "#{log_header}..."
       Timeout.timeout(5.minutes) do
         loop do
@@ -43,6 +36,17 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
         end
       end
       _log.info "#{log_header}...Complete"
+    end
+  end
+
+  def provider_object(connection = nil)
+    (connection || connection_source.connect).api.projects.find(manager_ref)
+  end
+
+  REFRESH_ON_TOWER_SLEEP = 1.second
+  def refresh_in_provider
+    with_provider_object do |project|
+      self.class.refresh_in_provider(project, id)
     end
   end
 end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -54,7 +54,7 @@ shared_examples_for "ansible credential" do
       expected_params[:organization] = 1 if described_class.name.include?("::EmbeddedAnsible::")
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
       store_new_credential(credential, manager)
-      expect(EmsRefresh).to receive(:queue_refresh_task).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
       expect(ExtManagementSystem).to receive(:find).with(manager.id).and_return(manager)
       expect(credentials).to receive(:create!).with(expected_params)
       expect(Notification).to receive(:create).with(expected_notify)


### PR DESCRIPTION
For bug https://bugzilla.redhat.com/show_bug.cgi?id=1445995

After adding/editing a repo, user would like to see the playbooks asap. This PR is to trigger Tower's internal repo sync and we'll then inventory the updated repo and its playbooks.

@miq-bot add_label bug, providers/ansible_tower, wip