### PR TITLE
Revert previous changes adding notification to finish retirement.

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -137,7 +137,6 @@ module RetirementMixin
     $log.info("Calling audit event for: #{message} ")
     raise_audit_event(retired_event_name, message)
     $log.info("Called audit event for: #{message} ")
-    Notification.create(:type => retired_event_name, :subject => self)
   end
 
   def start_retirement

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -72,7 +72,6 @@ describe "Service Retirement Management" do
   end
 
   it "#finish_retirement" do
-    expect(Notification).to receive(:create)
     expect(@stack.retirement_state).to be_nil
     @stack.finish_retirement
     @stack.reload

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -102,7 +102,6 @@ describe "Service Retirement Management" do
 
   it "#finish_retirement" do
     expect(@service.retirement_state).to be_nil
-    expect(Notification).to receive(:create)
     @service.finish_retirement
     @service.reload
     expect(@service.retired).to be_truthy

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -70,7 +70,6 @@ describe "VM Retirement Management" do
 
   it "#finish_retirement" do
     expect(@vm.retirement_state).to be_nil
-    expect(Notification).to receive(:create)
     @vm.finish_retirement
     @vm.reload
 


### PR DESCRIPTION
Since not all objects have user/tenant information, we're going
to create a content PR to add notifications to Automate methods where
that information is available.

https://bugzilla.redhat.com/show_bug.cgi?id=1446466

