### PR TITLE
Migration to delete legacy "MiqReplicationWorker" rows from the miq_workers table

### DIFF
--- a/db/migrate/20170405192333_delete_miq_replication_worker.rb
+++ b/db/migrate/20170405192333_delete_miq_replication_worker.rb
@@ -1,0 +1,9 @@
+class DeleteMiqReplicationWorker < ActiveRecord::Migration[5.0]
+  class MiqWorker < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    MiqWorker.where(:type => "MiqReplicationWorker").destroy_all
+  end
+end

--- a/spec/migrations/20170405192333_delete_miq_replication_worker_spec.rb
+++ b/spec/migrations/20170405192333_delete_miq_replication_worker_spec.rb
@@ -1,0 +1,19 @@
+require_migration
+
+describe DeleteMiqReplicationWorker do
+  migration_context :up do
+    let(:miq_worker) { migration_stub(:MiqWorker) }
+
+    it "deletes replication worker instances" do
+      miq_worker.create(:type => "MiqWorker")
+      miq_worker.create(:type => "MiqReplicationWorker")
+
+      expect(miq_worker.count).to eq(2)
+
+      migrate
+
+      expect(miq_worker.count).to      eq(1)
+      expect(miq_worker.first.type).to eq("MiqWorker")
+    end
+  end
+end


### PR DESCRIPTION
Fixes "ActiveRecord::SubclassNotFound: The single-table inheritance mechanism failed to locate the subclass: 'MiqReplicationWorker'." error at server startup. The class was removed in the Euwe release and no longer exists

https://bugzilla.redhat.com/show_bug.cgi?id=1446398