### PR TITLE
Add orchestration_stack_retired notification type.

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -159,3 +159,9 @@
   :expires_in: 24.hours
   :level: :warning
   :audience: global
+- :name: orchestration_stack_retired
+  :message: Orchestration Stack %{subject} has been retired.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
+


### PR DESCRIPTION
Notification types has service_retired and vm_retired, but was missing orchestration_stack_retired. 
https://bugzilla.redhat.com/show_bug.cgi?id=1446466

