### PR TITLE
Prefer :dialog_id to :new_dialog_name in config_info

### DIFF
--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -225,19 +225,18 @@ describe ServiceTemplateAnsiblePlaybook do
       expect(service_template.resource_actions.first.dialog.id).to eq new_dialog_record.id
     end
 
-    it 'uses the existing dialog if :service_dialog_id is passed in' do
+    it 'uses the existing dialog if :dialog_id is passed in' do
       info = catalog_item_options_three.fetch_path(:config_info, :provision)
-      info.delete(:new_dialog_name)
-      info[:service_dialog_id] = service_template.dialogs.first.id
+      info[:dialog_id] = service_template.dialogs.first.id
 
-      expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
+      expect(service_template.dialogs.first.id).to eq info[:dialog_id]
       expect(described_class).to receive(:create_new_dialog).never
       expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:update_in_provider_queue).once
 
       service_template.update_catalog_item(catalog_item_options_three, user)
       service_template.reload
 
-      expect(service_template.dialogs.first.id).to eq info[:service_dialog_id]
+      expect(service_template.dialogs.first.id).to eq info[:dialog_id]
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447110

When the request config_info contains both new_dialog_name and dialog_id, the update process will fail with error dialog already exists.

The cause is we will try to create a new service dialog even if the dialog_id is already given. 

The fix is to use the given dialog_id and ignore the dialog name.

This problem was discovered while using rails console to test the update. OPS UI does not have the issue.

The fix is more preventive if the config_info comes from a REST API happens to contains both attributes.