### PR TITLE
Fixed bug: one call to Job#set_status from `VmScan#call_snapshot_delete' has one extra parameter

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -259,7 +259,7 @@ class VmScan < Job
         end
       else
         _log.error("Deleting snapshot: reference: [#{mor}], No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot")
-        set_status("No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot, skipping", "error", 1)
+        set_status("No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot, skipping", "error")
       end
     else
       set_status("Snapshot was not taken, delete not required") if options[:snapshot] == :skipped


### PR DESCRIPTION
One call to `Job#set_status` from `VmScan#call_snapshot_delete` had extra parameter.


@miq-bot add-label bug, smart state, fine/no