### PR TITLE
Added a check that URL is a type of HTTPS uri.

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -49,6 +49,10 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
   end
 
   def verify_credentials(auth_type = nil, options = {})
+    uri = URI.parse(url) unless url.blank?
+    unless uri.kind_of?(URI::HTTPS)
+      raise "URL has to be HTTPS"
+    end
     with_provider_connection(options.merge(:auth_type => auth_type), &:verify?)
   rescue SocketError,
          Errno::ECONNREFUSED,

--- a/spec/models/manageiq/providers/foreman/provider_spec.rb
+++ b/spec/models/manageiq/providers/foreman/provider_spec.rb
@@ -2,7 +2,7 @@ require "foreman_api_client"
 
 describe ManageIQ::Providers::Foreman::Provider do
   let(:provider) { FactoryGirl.build(:provider_foreman) }
-  let(:attrs)    do
+  let(:attrs) do
     {:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
   end
 
@@ -18,6 +18,12 @@ describe ManageIQ::Providers::Foreman::Provider do
 
       expect(ForemanApiClient::Connection).to receive(:new).with(attrs)
       provider.connect
+    end
+
+    it "without https uri" do
+      provider.url = "example.com"
+      attrs[:base_url] = "example.com"
+      expect { provider.verify_credentials }.to raise_error(RuntimeError, "URL has to be HTTPS")
     end
   end
 


### PR DESCRIPTION
Relates to BZ [1405369](https://bugzilla.redhat.com/show_bug.cgi?id=1405369)

Forman UI allows non https uri, but then later fails with api and reprovisioning.