### PR TITLE
Split the code out for MiqQueue into modules

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -3,6 +3,7 @@ require 'digest'
 
 require 'miq_queue/constants'
 require 'miq_queue/format_methods'
+require 'miq_queue/put_methods'
 
 # Message Queue entry to run a method on any server
 #   zone
@@ -25,6 +26,7 @@ class MiqQueue < ApplicationRecord
   include MiqQueueConstants
 
   extend MiqQueueFormatMethods
+  extend MiqQueuePutMethods
 
   belongs_to :handler, :polymorphic => true
 
@@ -77,33 +79,6 @@ class MiqQueue < ApplicationRecord
 
   def data=(value)
     self.msg_data = Marshal.dump(value)
-  end
-
-  def self.put(options)
-    options = options.merge(
-      :zone         => Zone.determine_queue_zone(options),
-      :state        => STATE_READY,
-      :handler_type => nil,
-      :handler_id   => nil,
-    )
-
-    create_with_options = all.values[:create_with] || {}
-    options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
-    options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
-    options[:msg_timeout] ||= create_with_options[:msg_timeout] || TIMEOUT
-    options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
-    options[:role]         = options[:role].to_s unless options[:role].nil?
-
-    options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
-
-    if !Rails.env.production? && options[:args] &&
-       (arg = options[:args].detect { |a| a.kind_of?(ActiveRecord::Base) && !a.new_record? })
-      raise ArgumentError, "MiqQueue.put(:class_name => #{options[:class_name]}, :method => #{options[:method_name]}) does not support args with #{arg.class.name} objects"
-    end
-
-    msg = MiqQueue.create!(options)
-    _log.info(MiqQueue.format_full_log_msg(msg))
-    msg
   end
 
   MIQ_QUEUE_GET = <<-EOL
@@ -188,89 +163,6 @@ class MiqQueue < ApplicationRecord
     result = MiqQueue.where(cond).order(:priority, :id).limit(limit || 1)
     result = result.select(select) unless select.nil?
     result.to_a
-  end
-
-  # Find the MiqQueue item with the specified find options, and yields that
-  #   record to a block.  The block should return the options for updating
-  #   the record.  If the record was not found, the block's options will be
-  #   used to put a new item on the queue.
-  #
-  #   The find options may also contain an optional :args_selector proc that
-  #   will allow multiple records found by the find options to further be
-  #   searched against the args column, which is normally not easily searchable.
-  def self.put_or_update(find_options)
-    find_options  = default_get_options(find_options)
-    args_selector = find_options.delete(:args_selector)
-    conds = find_options.dup
-
-    # Since args are a serializable field, remove them and manually dump them
-    #   for proper comparison.  NOTE: hashes may not compare correctly due to
-    #   it's unordered nature.
-    where_scope = if conds.key?(:args)
-                    args = YAML.dump conds.delete(:args)
-                    MiqQueue.where(conds).where(['args = ?', args])
-                  else
-                    MiqQueue.where(conds)
-                  end
-
-    msg = nil
-    loop do
-      msg = if args_selector
-              where_scope.order("priority, id").detect { |m| args_selector.call(m.args) }
-            else
-              where_scope.order("priority, id").first
-            end
-
-      save_options = block_given? ? yield(msg, find_options) : nil
-      unless save_options.nil?
-        save_options = save_options.dup
-        save_options.delete(:args_selector)
-      end
-
-      # Add a new queue item based on the returned save options, or the find
-      #   options if no save options were given.
-      if msg.nil?
-        put_options = save_options || find_options
-        put_options.delete(:state)
-        msg = MiqQueue.put(put_options)
-        break
-      end
-
-      begin
-        # Update the queue item based on the returned save options.
-        unless save_options.nil?
-          if save_options.key?(:msg_timeout) && (msg.msg_timeout > save_options[:msg_timeout])
-            _log.warn("#{MiqQueue.format_short_log_msg(msg)} ignoring request to decrease timeout from <#{msg.msg_timeout}> to <#{save_options[:msg_timeout]}>")
-            save_options.delete(:msg_timeout)
-          end
-
-          msg.update_attributes!(save_options)
-          _log.info("#{MiqQueue.format_short_log_msg(msg)} updated with following: #{save_options.inspect}")
-          _log.info("#{MiqQueue.format_full_log_msg(msg)}, Requeued")
-        end
-        break
-      rescue ActiveRecord::StaleObjectError
-        _log.debug("#{MiqQueue.format_short_log_msg(msg)} stale, retrying...")
-      rescue => err
-        raise RuntimeError,
-              _("%{log_message} \"%{error}\" attempting merge next message") % {:log_message => _log.prefix,
-                                                                                :error       => err},
-              err.backtrace
-      end
-    end
-    msg
-  end
-
-  # Find the MiqQueue item with the specified find options, and if not found
-  #   puts a new item on the queue.  If the item was found, it will not be
-  #   changed, and will be yielded to an optional block, generally for logging
-  #   purposes.
-  def self.put_unless_exists(find_options)
-    put_or_update(find_options) do |msg, item_hash|
-      ret = yield(msg, item_hash) if block_given?
-      # create the record if the original message did not exist, don't change otherwise
-      ret if msg.nil?
-    end
   end
 
   def self.unqueue(options)

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -2,6 +2,7 @@ require 'timeout'
 require 'digest'
 
 require 'miq_queue/constants'
+require 'miq_queue/format_methods'
 
 # Message Queue entry to run a method on any server
 #   zone
@@ -22,6 +23,8 @@ require 'miq_queue/constants'
 class MiqQueue < ApplicationRecord
 
   include MiqQueueConstants
+
+  extend MiqQueueFormatMethods
 
   belongs_to :handler, :polymorphic => true
 
@@ -428,14 +431,6 @@ class MiqQueue < ApplicationRecord
       message.update_attributes(:state => STATE_ERROR) rescue nil
     end
     _log.info("Cleaning up queue messages... Complete")
-  end
-
-  def self.format_full_log_msg(msg)
-    "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{MiqPassword.sanitize_string(msg.args.inspect)}"
-  end
-
-  def self.format_short_log_msg(msg)
-    "Message id: [#{msg.id}]"
   end
 
   def get_worker

--- a/app/models/miq_queue/constants.rb
+++ b/app/models/miq_queue/constants.rb
@@ -1,0 +1,45 @@
+module MiqQueueConstants
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  MAX_PRIORITY    = 0
+  HIGH_PRIORITY   = 20
+  NORMAL_PRIORITY = 100
+  LOW_PRIORITY    = 150
+  MIN_PRIORITY    = 200
+
+  PRIORITY_WHICH  = [:max, :high, :normal, :low, :min]
+  PRIORITY_DIR    = [:higher, :lower]
+
+  STATE_READY     = 'ready'.freeze
+  STATE_DEQUEUE   = 'dequeue'.freeze
+  STATE_WARN      = 'warn'.freeze
+  STATE_ERROR     = 'error'.freeze
+  STATE_TIMEOUT   = 'timeout'.freeze
+  STATE_EXPIRED   = "expired".freeze
+
+  FINISHED_STATES = [STATE_WARN, STATE_ERROR, STATE_TIMEOUT, STATE_EXPIRED].freeze
+
+  STATUS_OK       = 'ok'.freeze
+  STATUS_RETRY    = 'retry'.freeze
+  STATUS_WARN     = STATE_WARN
+  STATUS_ERROR    = STATE_ERROR
+  STATUS_TIMEOUT  = STATE_TIMEOUT
+  STATUS_EXPIRED  = STATE_EXPIRED
+
+  TIMEOUT         = 10.minutes
+  DEFAULT_QUEUE   = "generic"
+
+  module ClassMethods
+    # default values for get operations
+    def default_get_options(options)
+      options.reverse_merge(
+        :queue_name => DEFAULT_QUEUE,
+        :state      => STATE_READY,
+        :zone       => Zone.determine_queue_zone(options)
+      )
+    end
+    private :default_get_options
+  end
+end

--- a/app/models/miq_queue/format_methods.rb
+++ b/app/models/miq_queue/format_methods.rb
@@ -1,0 +1,11 @@
+require 'miq-password'
+
+module MiqQueueFormatMethods
+  def format_full_log_msg(msg)
+    "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{MiqPassword.sanitize_string(msg.args.inspect)}"
+  end
+
+  def format_short_log_msg(msg)
+    "Message id: [#{msg.id}]"
+  end
+end

--- a/app/models/miq_queue/put_methods.rb
+++ b/app/models/miq_queue/put_methods.rb
@@ -1,0 +1,113 @@
+module MiqQueuePutMethods
+
+  def put(options)
+    options = options.merge(
+      :zone         => Zone.determine_queue_zone(options),
+      :state        => self::STATE_READY,
+      :handler_type => nil,
+      :handler_id   => nil,
+    )
+
+    create_with_options = all.values[:create_with] || {}
+    options[:priority]    ||= create_with_options[:priority] || self::NORMAL_PRIORITY
+    options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
+    options[:msg_timeout] ||= create_with_options[:msg_timeout] || self::TIMEOUT
+    options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
+    options[:role]         = options[:role].to_s unless options[:role].nil?
+
+    options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
+
+    if !Rails.env.production? && options[:args] &&
+       (arg = options[:args].detect { |a| a.kind_of?(ActiveRecord::Base) && !a.new_record? })
+      raise ArgumentError, "MiqQueue.put(:class_name => #{options[:class_name]}, :method => #{options[:method_name]}) does not support args with #{arg.class.name} objects"
+    end
+
+    msg = create!(options)
+    _log.info(format_full_log_msg(msg))
+    msg
+  end
+
+  # Find the MiqQueue item with the specified find options, and yields that
+  #   record to a block.  The block should return the options for updating
+  #   the record.  If the record was not found, the block's options will be
+  #   used to put a new item on the queue.
+  #
+  #   The find options may also contain an optional :args_selector proc that
+  #   will allow multiple records found by the find options to further be
+  #   searched against the args column, which is normally not easily searchable.
+  def put_or_update(find_options)
+    find_options  = default_get_options(find_options)
+    args_selector = find_options.delete(:args_selector)
+    conds = find_options.dup
+
+    # Since args are a serializable field, remove them and manually dump them
+    #   for proper comparison.  NOTE: hashes may not compare correctly due to
+    #   it's unordered nature.
+    where_scope = if conds.key?(:args)
+                    args = YAML.dump conds.delete(:args)
+                    where(conds).where(['args = ?', args])
+                  else
+                    where(conds)
+                  end
+
+    msg = nil
+    loop do
+      msg = if args_selector
+              where_scope.order("priority, id").detect { |m| args_selector.call(m.args) }
+            else
+              where_scope.order("priority, id").first
+            end
+
+      save_options = block_given? ? yield(msg, find_options) : nil
+      unless save_options.nil?
+        save_options = save_options.dup
+        save_options.delete(:args_selector)
+      end
+
+      # Add a new queue item based on the returned save options, or the find
+      #   options if no save options were given.
+      if msg.nil?
+        put_options = save_options || find_options
+        put_options.delete(:state)
+        msg = put(put_options)
+        break
+      end
+
+      begin
+        # Update the queue item based on the returned save options.
+        unless save_options.nil?
+          if save_options.key?(:msg_timeout) && (msg.msg_timeout > save_options[:msg_timeout])
+            _log.warn("#{format_short_log_msg(msg)} ignoring request to decrease timeout from <#{msg.msg_timeout}> to <#{save_options[:msg_timeout]}>")
+            save_options.delete(:msg_timeout)
+          end
+
+          msg.update_attributes!(save_options)
+          _log.info("#{format_short_log_msg(msg)} updated with following: #{save_options.inspect}")
+          _log.info("#{format_full_log_msg(msg)}, Requeued")
+        end
+        break
+      rescue ActiveRecord::StaleObjectError
+        _log.debug("#{format_short_log_msg(msg)} stale, retrying...")
+      rescue => err
+        raise RuntimeError,
+              _("%{log_message} \"%{error}\" attempting merge next message") % {:log_message => _log.prefix,
+                                                                                :error       => err},
+              err.backtrace
+      end
+    end
+    msg
+  end
+
+  # Find the MiqQueue item with the specified find options, and if not found
+  #   puts a new item on the queue.  If the item was found, it will not be
+  #   changed, and will be yielded to an optional block, generally for logging
+  #   purposes.
+  def put_unless_exists(find_options)
+    put_or_update(find_options) do |msg, item_hash|
+      ret = yield(msg, item_hash) if block_given?
+      # create the record if the original message did not exist, don't change otherwise
+      ret if msg.nil?
+    end
+  end
+
+end

--- a/app/models/miq_queue/put_methods.rb
+++ b/app/models/miq_queue/put_methods.rb
@@ -17,7 +17,7 @@ module MiqQueuePutMethods
 
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)
 
-    if !Rails.env.production? && options[:args] &&
+    if !vmdb_env.production? && options[:args] &&
        (arg = options[:args].detect { |a| a.kind_of?(ActiveRecord::Base) && !a.new_record? })
       raise ArgumentError, "MiqQueue.put(:class_name => #{options[:class_name]}, :method => #{options[:method_name]}) does not support args with #{arg.class.name} objects"
     end
@@ -109,5 +109,10 @@ module MiqQueuePutMethods
       ret if msg.nil?
     end
   end
+
+  def vmdb_env
+    @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+  end
+  private :vmdb_env
 
 end


### PR DESCRIPTION
Moves relevant sections of the code found in `MiqQueue`, and moves it into topical models to be digested by other things.  For use with https://github.com/ManageIQ/manageiq/pull/14916

Links
-----
* Extracted from https://github.com/ManageIQ/manageiq/pull/14916