### PR TITLE
Allow for ansible tower service to be added to service

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -36,7 +36,7 @@ module ServiceMixin
         sr = service_resources.new(nh.merge(:resource => rsc))
         set_service_type if self.respond_to?(:set_service_type)
         # Create link between services
-        rsc.update_attributes(:parent => self) if self.class == Service && rsc.class == Service
+        rsc.update_attributes(:parent => self) if self.class == Service && rsc.kind_of?(Service)
       end
     end
     sr

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -254,6 +254,12 @@ describe Service do
       expect(@service.service_resources.size).to eq(1)
     end
 
+    it "should allow a service to connect to ansible tower service" do
+      s2 = FactoryGirl.create(:service_ansible_tower, :name => 'ansible')
+      @service.add_resource(s2)
+      expect(s2.parent).to eq(@service)
+    end
+
     it "should not allow service to connect to itself" do
       expect { @service << @service }.to raise_error(MiqException::MiqServiceCircularReferenceError)
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1446452

Previously we would only allow instances of the Service class
but not the sub classes of the service like ServiceAnsibleTower
to be connected to a service. This PR allows the Service class and
its sub classes to be connected.

Because of the parent linkage if the ServiceAnsibleTower is part of a Service bundle
it will not be displayed as a separate service.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1446452


Steps for Testing/QA 
---------------------
Described in BZ