### PR TITLE
[EUWE] Add sections for reporting of virtual custom attributes

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1456,7 +1456,7 @@ module ReportController::Reports::Editor
     rpt.col_order.each_with_index do |col, idx|
       if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
         field_key = rpt.db + "-" + col
-        field_value =_("Labels: %{name}") % { :name => col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "") }
+        field_value = CustomAttributeMixin.to_human(col)
       elsif !col.include?(".")  # Main table field
         field_key = rpt.db + "-" + col
         field_value = friendly_model_name(rpt.db) +

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,7 +27,10 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct
+      custom_attr_scope = CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct.pluck(:name, :section)
+      custom_attr_scope.map do |x|
+        "#{x[0]}#{x[1] ? SECTION_SEPARATOR + x[1] : ''}"
+      end
     end
 
     def self.load_custom_attributes_for(cols)

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -2,6 +2,8 @@ module CustomAttributeMixin
   extend ActiveSupport::Concern
 
   CUSTOM_ATTRIBUTES_PREFIX = "virtual_custom_attribute_".freeze
+  SECTION_SEPARATOR        = ":SECTION:".freeze
+  DEFAULT_SECTION_NAME     = 'Custom Attribute'.freeze
 
   included do
     has_many   :custom_attributes,     :as => :resource, :dependent => :destroy
@@ -43,6 +45,11 @@ module CustomAttributeMixin
         custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
       end
     end
+  end
+
+  def self.to_human(column)
+    col_name, section = column.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, '').split(SECTION_SEPARATOR)
+    _("%{section}: %{custom_key}") % { :custom_key => col_name, :section => section.try(:titleize) || DEFAULT_SECTION_NAME}
   end
 
   def self.select_virtual_custom_attributes(cols)

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -44,8 +44,14 @@ module CustomAttributeMixin
       virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
 
       define_method(custom_attribute.to_sym) do
-        custom_attribute_without_prefix = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
-        custom_attributes.detect { |x| custom_attribute_without_prefix == x.name }.try(:value)
+        custom_attribute_without_prefix           = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
+        custom_attribute_without_section, section = custom_attribute_without_prefix.split(SECTION_SEPARATOR)
+
+        where_args = {}
+        where_args[:name]    = custom_attribute_without_section
+        where_args[:section] = section if section
+
+        custom_attributes.find_by(where_args).try(:value)
       end
     end
   end

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,7 +27,7 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      CustomAttribute.where(:resource_type => base_class).distinct.pluck(:name).compact
+      CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct
     end
 
     def self.load_custom_attributes_for(cols)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -900,7 +900,7 @@ class MiqExpression
       dict_col = model.nil? ? col : [model, col].join(".")
       column_human = if col
                        if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
-                         col.gsub(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX, "")
+                         CustomAttributeMixin.to_human(col)
                        else
                          Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize)
                        end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1170,7 +1170,8 @@ class MiqExpression
 
     klass.custom_keys.each do |custom_key|
       custom_detail_column = [model, CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX + custom_key].join("-")
-      custom_detail_name = _("Labels: %{custom_key}") % { :custom_key => custom_key }
+      custom_detail_name = CustomAttributeMixin.to_human(custom_key)
+
       if options[:include_model]
         model_name = Dictionary.gettext(model, :type => :model, :notfound => :titleize)
         custom_detail_name = [model_name, custom_detail_name].join(" : ")

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -4,7 +4,7 @@ class MiqExpression::Field
 \.?(?<associations>[a-z_\.]+)*
 -
 (?:
-  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[_\-.\/[:alnum:]]*)|
+  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[:_\-.\/[:alnum:]]*)|
   (?<column>[a-z]+(_[[:alnum:]]+)*)
 )
 /x

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1466,6 +1466,27 @@ describe MiqExpression do
     it "ignores custom_attibutes with a nil name" do
       expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Custom Attribute: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
+
+    let(:conatiner_image) { FactoryGirl.create(:container_image) }
+
+    let!(:custom_attribute_with_section_1) do
+      FactoryGirl.create(:custom_attribute, :resource => conatiner_image, :name => 'CATTR_3', :value => "Value 3",
+                         :section => 'section_3')
+    end
+
+    let!(:custom_attribute_with_section_2) do
+      FactoryGirl.create(:custom_attribute, :resource => conatiner_image, :name => 'CATTR_3', :value => "Value 3",
+                         :section => 'docker_labels')
+    end
+
+    it "returns human names of custom attributes with sections" do
+      expected_result = [
+        ['Docker Labels: CATTR_3', 'ContainerImage-virtual_custom_attribute_CATTR_3:SECTION:docker_labels'],
+        ['Section 3: CATTR_3', 'ContainerImage-virtual_custom_attribute_CATTR_3:SECTION:section_3']
+      ]
+
+      expect(MiqExpression._custom_details_for("ContainerImage", {})).to match_array(expected_result)
+    end
   end
 
   context ".build_relats" do

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1458,15 +1458,12 @@ describe MiqExpression do
   end
 
   context "._custom_details_for" do
-    let(:klass)        { Vm }
-    let(:vm)           { FactoryGirl.create(:vm) }
-    let(:custom_attr1) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => "CATTR_1", :value => "Value 1") }
-    let(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
+    let(:klass)         { Vm }
+    let(:vm)            { FactoryGirl.create(:vm) }
+    let!(:custom_attr1) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => "CATTR_1", :value => "Value 1") }
+    let!(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
 
     it "ignores custom_attibutes with a nil name" do
-      custom_attr1
-      custom_attr2
-
       expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Labels: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
   end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1464,7 +1464,7 @@ describe MiqExpression do
     let!(:custom_attr2) { FactoryGirl.create(:custom_attribute, :resource => vm, :name => nil,       :value => "Value 2") }
 
     it "ignores custom_attibutes with a nil name" do
-      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Labels: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
+      expect(MiqExpression._custom_details_for("Vm", {})).to eq([["Custom Attribute: CATTR_1", "Vm-virtual_custom_attribute_CATTR_1"]])
     end
   end
 

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -28,6 +28,21 @@ describe CustomAttributeMixin do
     end
   end
 
+  describe '#custom_keys' do
+    let!(:custom_attribute) { FactoryGirl.create(:custom_attribute, :name => "attr_1", :value => 'value') }
+    let!(:custom_attribute_with_section) do
+      FactoryGirl.create(:custom_attribute, :name => "attr_2", :value => 'value', :section => 'labels')
+    end
+
+    let!(:vm) do
+      FactoryGirl.create(:vm_redhat, :custom_attributes => [custom_attribute, custom_attribute_with_section])
+    end
+
+    it 'returns human form of virtual custom attribute with sections' do
+      expect(vm.class.custom_keys).to match_array(["attr_1", "attr_2#{described_class::SECTION_SEPARATOR}labels"])
+    end
+  end
+
   it "defines #miq_custom_keys" do
     expect(test_class.new).to respond_to(:miq_custom_keys)
   end

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -8,6 +8,26 @@ describe CustomAttributeMixin do
     end
   end
 
+  describe '#to_human' do
+    let(:custom_attribute)                { 'virtual_custom_attribute_name' }
+    let(:custom_attribute_with_section_1) { "virtual_custom_attribute_name#{described_class::SECTION_SEPARATOR}labels" }
+    let(:custom_attribute_with_section_2) do
+      "virtual_custom_attribute_name#{described_class::SECTION_SEPARATOR}docker_labels"
+    end
+
+    it 'returns human form of virtual custom attribute with sections' do
+      expect(described_class.to_human(custom_attribute)).to eq('Custom Attribute: name')
+    end
+
+    it 'returns human form of virtual custom attribute' do
+      expect(described_class.to_human(custom_attribute_with_section_1)).to eq('Labels: name')
+    end
+
+    it 'returns human form of virtual custom attribute' do
+      expect(described_class.to_human(custom_attribute_with_section_2)).to eq('Docker Labels: name')
+    end
+  end
+
   it "defines #miq_custom_keys" do
     expect(test_class.new).to respond_to(:miq_custom_keys)
   end


### PR DESCRIPTION
Euwe version of 
https://github.com/ManageIQ/manageiq/pull/14835
https://github.com/ManageIQ/manageiq/pull/14837
https://github.com/ManageIQ/manageiq-ui-classic/pull/1099

Cherry-picks were clean, instead of https://github.com/ManageIQ/manageiq-ui-classic/pull/1099 which is in UI repo. For EUWE (in this PR) it is in the last commit.
Reporting tested also with/without expression engine.

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1434077

cc @gtanzillo @zeari 
@miq-bot assign @simaishi 
@miq-bot add_label enhacement, core, reporting
