### PR TITLE
merge settings instead of overwriting

### DIFF
--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -57,7 +57,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
+          stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 


### PR DESCRIPTION
otherwise other Settings will return nil

fixes the root cause in https://github.com/ManageIQ/manageiq-providers-amazon/pull/243

reproducer by @imtayadeway 
```
rspec ./spec/models/metric_spec.rb[1:1:1:2:1] ./spec/models/service_orchestration_spec.rb[1:1:1,1:1:2,1:2:1,1:2:2:1,1:2:2:2,1:2:2:3,1:2:3,1:2:4,1:2:5:1,1:2:5:2,1:2:5:3,1:2:5:4,1:2:5:5,1:2:5:6,1:3:1,1:3:2,1:4:1,1:4:2,1:5:1,1:5:2,1:5:3,1:6:1,1:6:2,1:7:1,1:7:2,1:7:3] --format progress --seed=61471
```

@jrafanie @Fryguy I wonder if all `stub_settings` calls shall be converted to `stub_settings_merge` or change `stub_settings` implementation to merge instead of overwrite

@miq-bot add_label bug, test
