### PR TITLE
Show monitoring screen by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1037,7 +1037,6 @@
   :container_deployment_wizard: false
   :datawarehouse_manager: false
 :prototype:
-  :monitoring: false
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes


### PR DESCRIPTION
This suggest showing the new alerts screen by default.
Before this can go in:
- Approve this screen for non container providers[1] 
- hide "most recent alerts" link

[1]
Main differences in existing alerts: 
- alerts aren't being resolved and will remain in the screen (miq_alert_status.resolved vs miq_alert_status.result)
- Overview screen is per ems, need to handle alerts with no ems if any, probably create a default group of some kind.
- no severity, should default to error.
- message is fine, the `miq_alert_status.message` message will come from the `miq_alert.message`
- no url (cm-ops are using url to a document on the specific issue)

### Screenshots
![alerts_overview](https://user-images.githubusercontent.com/3010449/29820517-674b87aa-8ccd-11e7-9161-eaa0227058c2.png)

![alerts_list](https://user-images.githubusercontent.com/3010449/29820524-6a80262e-8ccd-11e7-87ee-6d49f4428b79.png)

![alerts_list_expanded](https://user-images.githubusercontent.com/3010449/29820527-6d695ee6-8ccd-11e7-82a0-acf97db41722.png)

![alerts_action](https://user-images.githubusercontent.com/3010449/29820545-7d580410-8ccd-11e7-8dbc-619a971b5e42.png)

![alerts_assignment](https://user-images.githubusercontent.com/3010449/29820568-97ed71ac-8ccd-11e7-986d-db56eed801b4.png)

### Playing with the screen
- Add a setting:
```
:prototype:
 :monitoring: true
```
- And some alert statuses:
https://github.com/moolitayer/scripts-public/blob/master/ruby/miq-create-alert-statuses.rb
(The script needs a container provider and a node)

