### PR TITLE
Use human friendly names in task names and notifications for Tower CUD operations

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -49,4 +49,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
       self.class.refresh_in_provider(project, id)
     end
   end
+
+  FRIENDLY_NAME = 'Ansible Tower Project'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/credential.rb
@@ -30,4 +30,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   COMMON_ATTRIBUTES = {}.freeze
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  FRIENDLY_NAME = 'Ansible Tower Credential'.freeze
 end

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -19,7 +19,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
     def create_in_provider_queue(manager_id, params)
       manager = ExtManagementSystem.find(manager_id)
-      action = "Creating #{name} with name=#{params[:name]}"
+      action = "Creating #{self::FRIENDLY_NAME} (name=#{params[:name]})"
       queue(manager.my_zone, nil, "create_in_provider", [manager_id, params], action)
     end
 
@@ -76,7 +76,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   end
 
   def update_in_provider_queue(params)
-    action = "Updating #{self.class.name} with Tower internal reference=#{manager_ref}"
+    action = "Updating #{self.class::FRIENDLY_NAME} (Tower internal reference=#{manager_ref})"
     self.class.send('queue', manager.my_zone, id, "update_in_provider", [params], action)
   end
 
@@ -90,7 +90,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
   end
 
   def delete_in_provider_queue
-    action = "Deleting #{self.class.name} with Tower internal reference=#{manager_ref}"
+    action = "Deleting #{self.class::FRIENDLY_NAME} (Tower internal reference=#{manager_ref})"
     self.class.send('queue', manager.my_zone, id, "delete_in_provider", [], action)
   end
 end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -32,9 +32,9 @@ shared_examples_for "ansible configuration_script_source" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} create_in_provider",
-          :op_arg  => params.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} creation",
+          :op_arg  => "(name=My Project)",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end
@@ -70,7 +70,6 @@ shared_examples_for "ansible configuration_script_source" do
       expected_params = params.clone.merge(:credential => '1')
       expected_params.delete(:authentication_id)
       expect(projects).to receive(:create!).with(expected_params)
-      expected_notify[:options][:op_arg] = expected_params.to_s
       expect(Notification).to receive(:create).with(expected_notify)
       expect(described_class.create_in_provider(manager.id, params)).to be_a(described_class)
     end
@@ -106,9 +105,9 @@ shared_examples_for "ansible configuration_script_source" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} delete_in_provider",
-          :op_arg  => {:manager_ref => tower_project.id}.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} deletion",
+          :op_arg  => "(manager_ref=#{tower_project.id})",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end
@@ -151,9 +150,9 @@ shared_examples_for "ansible configuration_script_source" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} update_in_provider",
-          :op_arg  => {}.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} update",
+          :op_arg  => "()",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -78,7 +78,7 @@ shared_examples_for "ansible configuration_script_source" do
     it ".create_in_provider_queue" do
       EvmSpecHelper.local_miq_server
       task_id = described_class.create_in_provider_queue(manager.id, params)
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class.name} with name=#{params[:name]}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
       expect(MiqQueue.first).to have_attributes(
         :args        => [manager.id, params],
         :class_name  => described_class.name,
@@ -130,7 +130,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#delete_in_provider_queue" do
       task_id = project.delete_in_provider_queue
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with Tower internal reference=#{project.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => project.id,
         :args        => [],
@@ -175,7 +175,7 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider_queue" do
       task_id = project.update_in_provider_queue({})
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with Tower internal reference=#{project.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{project.manager_ref})")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => project.id,
         :args        => [{:task_id => task_id}],

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -43,9 +43,9 @@ shared_examples_for "ansible credential" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} create_in_provider",
-          :op_arg  => expected_params.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} creation",
+          :op_arg  => "(name=My Credential)",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end
@@ -102,9 +102,9 @@ shared_examples_for "ansible credential" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} delete_in_provider",
-          :op_arg  => {:manager_ref => credential.id}.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} deletion",
+          :op_arg  => "(manager_ref=#{credential.id})",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end
@@ -149,9 +149,9 @@ shared_examples_for "ansible credential" do
       {
         :type    => :tower_op_success,
         :options => {
-          :op_name => "#{described_class.name.demodulize} update_in_provider",
-          :op_arg  => expected_params.to_s,
-          :tower   => "Tower(manager_id: #{manager.id})"
+          :op_name => "#{described_class::FRIENDLY_NAME} update",
+          :op_arg  => "()",
+          :tower   => "Tower(manager_id=#{manager.id})"
         }
       }
     end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -74,7 +74,7 @@ shared_examples_for "ansible credential" do
 
     it ".create_in_provider_queue" do
       task_id = described_class.create_in_provider_queue(manager.id, params)
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class.name} with name=#{params[:name]}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})")
       expect(MiqQueue.first).to have_attributes(
         :args        => [manager.id, params],
         :class_name  => described_class.name,
@@ -126,7 +126,7 @@ shared_examples_for "ansible credential" do
 
     it "#delete_in_provider_queue" do
       task_id = ansible_cred.delete_in_provider_queue
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class.name} with Tower internal reference=#{ansible_cred.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Deleting #{described_class::FRIENDLY_NAME} (Tower internal reference=#{ansible_cred.manager_ref})")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => ansible_cred.id,
         :args        => [],
@@ -176,7 +176,7 @@ shared_examples_for "ansible credential" do
 
     it "#update_in_provider_queue" do
       task_id = ansible_cred.update_in_provider_queue({})
-      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class.name} with Tower internal reference=#{ansible_cred.manager_ref}")
+      expect(MiqTask.find(task_id)).to have_attributes(:name => "Updating #{described_class::FRIENDLY_NAME} (Tower internal reference=#{ansible_cred.manager_ref})")
       expect(MiqQueue.first).to have_attributes(
         :instance_id => ansible_cred.id,
         :args        => [{:task_id => task_id}],


### PR DESCRIPTION
A further improvement on top of https://github.com/ManageIQ/manageiq/pull/14656 for https://bugzilla.redhat.com/show_bug.cgi?id=1439203
and for https://bugzilla.redhat.com/show_bug.cgi?id=1448081 as well.

Use human friendly names instead of the class names in task names and keep the notification message brief and user friendly.

## Before:
e.g. 
* User would see in task:`Creating ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScriptSource name=My repo`
* User would see in notification: `The operation ConfigurationScriptSource update_in_provider {:name=>..... create_on.....} completed successully`

## Now:
e.g. 
* User would see: `Creating Ansible Tower Project (name=My repo)`
* User would see in notification: `The operation Ansible Tower Project update (name=My Repo, manager_ref=1) on Tower(manager_id=10000000) completed successfully.`
* The detail parameter hash (sans secrete) would be logged into logs

@miq-bot add_labels bug, providers/ansible_tower