### PR TITLE
Use relation to get AZs to avoid N+1 in network topology

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -54,9 +54,10 @@ module ManageIQ::Providers
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
 
+    has_many :availability_zones, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+
     # Relationships delegated to parent manager
-    delegate :availability_zones,
-             :cloud_tenants,
+    delegate :cloud_tenants,
              :flavors,
              :cloud_resource_quotas,
              :cloud_volumes,

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -54,7 +54,7 @@ module ManageIQ::Providers
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
 
-    has_many :availability_zones, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :availability_zones, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
 
     # Relationships delegated to parent manager
     delegate :cloud_tenants,


### PR DESCRIPTION
Use relation to get AZs to avoid N+1 in network topology