### PR TITLE
Alert Definitions API: add hash typed expression and symbolize options

### DIFF
--- a/app/controllers/api/alert_definitions_controller.rb
+++ b/app/controllers/api/alert_definitions_controller.rb
@@ -6,6 +6,7 @@ module Api
       assert_id_not_specified(data, type)
       assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       begin
+        data["options"].deep_symbolize_keys!
         data["expression"] = MiqExpression.new(data["expression"])
         data["enabled"] = true if data["enabled"].nil?
         super(type, id, data)

--- a/app/controllers/api/alert_definitions_controller.rb
+++ b/app/controllers/api/alert_definitions_controller.rb
@@ -6,8 +6,18 @@ module Api
       assert_id_not_specified(data, type)
       assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
       begin
+        if data["expression_type"].present?
+          if MiqAlert::ALLOWED_API_EXPRESSION_TYPES.include? data["expression_type"]
+            data["expression_type"] == "hash" ? data["expression"].deep_symbolize_keys! : data["expression"] = MiqExpression.new(data["expression"])
+            # Delete the following line once #15315 is merged
+            data.delete("expression_type")
+          else
+            raise "Invalid expression type specified: #{data["expression_type"]}"
+          end
+        else
+          data["expression"] = MiqExpression.new(data["expression"])
+        end
         data["options"].deep_symbolize_keys!
-        data["expression"] = MiqExpression.new(data["expression"])
         data["enabled"] = true if data["enabled"].nil?
         super(type, id, data)
       rescue => err

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -1,4 +1,5 @@
 class MiqAlert < ApplicationRecord
+  ALLOWED_API_EXPRESSION_TYPES = %w(miq_expression hash).freeze
   include UuidMixin
 
   serialize :expression


### PR DESCRIPTION
This PR contains 2 changes:

1. Create alert definition expression as hash (not as MiqExpression)
Currently, it is only possible to create an alert definition (MiqAlert) via API with expression as a MiqExpression.
It is essential for the Data Warehouse provider to generate a hash typed expression.
I added the flag "expression_type", with the options: "miq_expression" and "hash".

example:
```json
{
  "action": "create",
  "resource": {
   "description": "Test Alert 01",
   "expression_type": "hash",
   "options": { "notifications": {"delay_next_evaluation": 0, "evm_event": {} } },
   "db": "ContainerNode",
   "expression": {"eval_method": "dwh_generic", "mode": "internal", "options": {} },
   "enabled": true
  }
}
```

2. Deep symbolize options in Alert Definitions API creation request

depends on: https://github.com/ManageIQ/manageiq/pull/15315