### PR TITLE
Add hosts as child key to save physical server relationship with host

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -46,7 +46,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    child_keys = [:computer_system, :asset_details]
+    child_keys = [:computer_system, :asset_details, :host]
     save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end


### PR DESCRIPTION
The provider is passing a Host which matches using `service_tag`(from host side) and `serial_number`(from physical server side) and is added the `hosts` child key in the `save_physical_server_inventory` method. 