### PR TITLE
Add :sort_by: :none to GCE Boot Disk Size dialog field.

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -282,6 +282,7 @@
           :required: true
           :display: :edit
           :data_type: string
+          :sort_by: :none
         :instance_type:
           :values_from:
             :method: :allowed_instance_types


### PR DESCRIPTION
Use :sort_by: :none to keep the field values in the order that they are inserted in the file.

UI [part #1248](https://github.com/ManageIQ/manageiq-ui-classic/pull/1248).
https://bugzilla.redhat.com/show_bug.cgi?id=1389010

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, provisioning, euwe/yes, fine/yes