### PR TITLE
Stub settings merge as default

### DIFF
--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -214,7 +214,7 @@ describe EmsEvent do
     end
 
     it 'returns the provider event if configured' do
-      stub_settings_merge(
+      stub_settings(
         :ems => {
           :some_provider => {
             :event_handling => {

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -57,7 +57,7 @@ describe Metric do
 
       context "executing perf_capture_timer" do
         before(:each) do
-          stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
+          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
 

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -4,8 +4,7 @@ describe VmScan do
       @server = EvmSpecHelper.local_miq_server(:capabilities => {:vixDisk => true})
       assign_smartproxy_role_to_server(@server)
 
-      # TODO: stub only settings needed for test instead of all from settings.yml
-      stub_settings(::Settings.to_hash.merge(:coresident_miqproxy => {:scan_via_host => false}))
+      stub_settings(:coresident_miqproxy => {:scan_via_host => false, :use_vim_broker => false})
 
       @user      = FactoryGirl.create(:user_with_group, :userid => "tester")
       @ems       = FactoryGirl.create(:ems_vmware_with_authentication, :name   => "Test EMS", :zone => @server.zone,

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -87,7 +87,7 @@ describe "Settings API" do
     end
 
     before do
-      stub_settings_merge(sample_settings)
+      stub_settings(sample_settings)
     end
 
     it "supports multiple categories" do

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -1,11 +1,11 @@
-def stub_settings(hash)
+def stub_settings(hash, overwrite = false)
+  hash = Settings.to_hash.deep_merge(hash) unless overwrite
   settings = Config::Options.new.merge!(hash)
   stub_const("Settings", settings)
   allow(Vmdb::Settings).to receive(:for_resource) { settings }
 end
 
 def stub_settings_merge(hash)
-  hash = Settings.to_hash.deep_merge(hash)
   stub_settings(hash)
 end
 

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -6,6 +6,7 @@ def stub_settings(hash, overwrite = false)
 end
 
 def stub_settings_merge(hash)
+  warn("DEPRECATION WARNING: stub_settings_merge is deprecated as stub_settings defaults to merging")
   stub_settings(hash)
 end
 


### PR DESCRIPTION
as found in https://github.com/ManageIQ/manageiq/pull/14974 sometimes the code under test also touches other parts of the system which might need access to stettings which would be overwritten by `stub_settings`

this makes the merging the default behaviour and deprecates `stub_settings_merge`. Once the usage of this method is removed from providers we can remove it too