### PR TITLE
Refactor Normalizer

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -206,7 +206,7 @@ module Api
         return unless attr_accessible?(resource, attr)
         virtattr_accessor = virtual_attribute_accessor(type, attr)
         value = virtattr_accessor.nil? ? resource.public_send(attr) : send(virtattr_accessor, resource)
-        result = {attr => normalize_virtual(nil, attr, value, :ignore_nil => true)}
+        result = {attr => normalize_attr(attr, value)}
         # set nil vtype above to "#{type}/#{resource.id}/#{attr}" to support id normalization
         [value, result]
       end
@@ -215,7 +215,7 @@ module Api
         query_related_objects(base, resource, object_hash)
         return unless attr_accessible?(object_hash[base], attr)
         value = object_hash[base].public_send(attr)
-        result = {attr => normalize_virtual(nil, attr, value, :ignore_nil => true)}
+        result = {attr => normalize_attr(attr, value)}
         # set nil vtype above to "#{type}/#{resource.id}/#{base.tr('.', '/')}/#{attr}" to support id normalization
         base.split(".").reverse_each { |level| result = {level => result} }
         [value, result]


### PR DESCRIPTION
This refactor:
 * removes the need for virtual normalizer functions by reusing the same function for normalizing all attributes
 * renames `normalize_attr_byname` to `normalize_attr` as it is a more accurately fits its purpose now
 * makes some methods private  as they are not needed publicly 

cc: @imtayadeway 

@miq-bot add_label api, refactoring 
@miq-bot assign @abellotti 