### PR TITLE
Fix constant reference in ManagerRefresh::Inventory::AutomationManager

### DIFF
--- a/app/models/manager_refresh/inventory/automation_manager.rb
+++ b/app/models/manager_refresh/inventory/automation_manager.rb
@@ -1,6 +1,6 @@
 module ManagerRefresh::Inventory::AutomationManager
   extend ActiveSupport::Concern
-  include Core
+  include ::ManagerRefresh::Inventory::Core
 
   class_methods do
     def has_automation_manager_configuration_scripts(options = {})


### PR DESCRIPTION
Similar to the fix here:
https://github.com/ManageIQ/manageiq/blob/032fed6cf72af675cb5bed687a8cb821190aae4f/app/models/manager_refresh/inventory/middleware_manager.rb#L3
