### PR TITLE
Add require 'rest-client'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "rails",                          "~>5.0.2"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "responders",                     "~>2.0"
+gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",                              :require => false
 gem "ruby-dbus" # For external auth
 gem "ruby-progressbar",               "~>1.7.0",       :require => false

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -246,7 +246,7 @@ class AutomateHash
 
   def console
     print "\nPlace in a Rails console to run the POST API call\n" unless @quiet
-    print "\nRestClient.post '#{build_url}', '#{output.to_json}'\n\n"
+    print "\nrequire 'rest-client'; RestClient.post '#{build_url}', '#{output.to_json}'\n\n"
   end
 
   def hash_output


### PR DESCRIPTION
The `rebuild_provision_request tool` can fail to run if `rest-client` is not required
This change guarantees the gem is loaded before running the command