### PR TITLE
Refactor Api::Environment

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -31,13 +31,13 @@ module Api
           normalize_array(attr, value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
-        elsif Environment.normalized_attributes[:time].key?(attr.to_s)
+        elsif Environment.normalized_attributes[:time].include?(attr.to_s)
           normalize_time(value)
-        elsif Environment.normalized_attributes[:url].key?(attr.to_s)
+        elsif Environment.normalized_attributes[:url].include?(attr.to_s)
           normalize_url(value)
         elsif Api.encrypted_attribute?(attr)
           normalize_encrypted
-        elsif Environment.normalized_attributes[:resource].key?(attr.to_s)
+        elsif Environment.normalized_attributes[:resource].include?(attr.to_s)
           normalize_resource(value)
         else
           value

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -31,13 +31,13 @@ module Api
           normalize_array(attr, value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
-        elsif Environment.normalized_attributes[:time].include?(attr.to_s)
+        elsif Api.time_attribute?(attr)
           normalize_time(value)
-        elsif Environment.normalized_attributes[:url].include?(attr.to_s)
+        elsif Api.url_attribute?(attr)
           normalize_url(value)
         elsif Api.encrypted_attribute?(attr)
           normalize_encrypted
-        elsif Environment.normalized_attributes[:resource].include?(attr.to_s)
+        elsif Api.resource_attribute?(attr)
           normalize_resource(value)
         else
           value

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -7,7 +7,7 @@ module Api
   UnsupportedMediaTypeError = Class.new(ApiError)
 
   def self.encrypted_attribute?(attr)
-    Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
+    Environment.normalized_attributes[:encrypted].include?(attr.to_s) || attr.to_s.include?('password')
   end
 
   def self.init_env

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -7,19 +7,19 @@ module Api
   UnsupportedMediaTypeError = Class.new(ApiError)
 
   def self.encrypted_attribute?(attr)
-    Environment.normalized_attributes[:encrypted].include?(attr.to_s) || attr.to_s.include?('password')
+    Environment.encrypted_attributes.include?(attr.to_s) || attr.to_s.include?('password')
   end
 
   def self.time_attribute?(attr)
-    Environment.normalized_attributes[:time].include?(attr.to_s)
+    Environment.time_attributes.include?(attr.to_s)
   end
 
   def self.url_attribute?(attr)
-    Environment.normalized_attributes[:url].include?(attr.to_s)
+    Environment.url_attributes.include?(attr.to_s)
   end
 
   def self.resource_attribute?(attr)
-    Environment.normalized_attributes[:resource].include?(attr.to_s)
+    Environment.resource_attributes.include?(attr.to_s)
   end
 
   def self.init_env

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -10,6 +10,18 @@ module Api
     Environment.normalized_attributes[:encrypted].include?(attr.to_s) || attr.to_s.include?('password')
   end
 
+  def self.time_attribute?(attr)
+    Environment.normalized_attributes[:time].include?(attr.to_s)
+  end
+
+  def self.url_attribute?(attr)
+    Environment.normalized_attributes[:url].include?(attr.to_s)
+  end
+
+  def self.resource_attribute?(attr)
+    Environment.normalized_attributes[:resource].include?(attr.to_s)
+  end
+
   def self.init_env
     $api_log.info("Initializing Environment for #{ApiConfig.base[:name]}")
     $api_log.info("")

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -40,7 +40,7 @@ module Api
     def self.fetch_encrypted_attribute_names(klass)
       return [] unless klass.respond_to?(:encrypted_columns)
       encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-        normalized_attributes[:encrypted] << attr
+        encrypted_attributes << attr
       end
     end
 

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -1,14 +1,5 @@
 module Api
   class Environment
-    def self.normalized_attributes
-      @normalized_attributes ||= {
-        :time      => time_attributes,
-        :url       => url_attributes,
-        :resource  => resource_attributes,
-        :encrypted => encrypted_attributes
-      }
-    end
-
     def self.url_attributes
       @url_attributes ||= Set.new(%w(href))
     end

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -30,13 +30,13 @@ module Api
 
     def self.fetch_encrypted_attribute_names(klass)
       return [] unless klass.respond_to?(:encrypted_columns)
-      encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-        encrypted_attributes << attr
-      end
+      return if encrypted_objects_checked.include?(klass.name)
+      encrypted_attributes.merge(klass.encrypted_columns)
+      encrypted_objects_checked << klass.name
     end
 
     def self.encrypted_objects_checked
-      @encrypted_objects_checked ||= {}
+      @encrypted_objects_checked ||= Set.new
     end
   end
 end

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -16,15 +16,13 @@ module Api
     end
 
     def self.time_attributes
-      @time_attributes ||= begin
-                             ApiConfig.collections.each.with_object(Set.new(%w(expires_on))) do |(_, cspec), result|
-                               next if cspec[:klass].blank?
-                               klass = cspec[:klass].constantize
-                               klass.columns_hash.each do |name, typeobj|
-                                 result << name if %w(date datetime).include?(typeobj.type.to_s)
-                               end
-                             end
-                           end
+      @time_attributes ||= ApiConfig.collections.each.with_object(Set.new(%w(expires_on))) do |(_, cspec), result|
+        next if cspec[:klass].blank?
+        klass = cspec[:klass].constantize
+        klass.columns_hash.each do |name, typeobj|
+          result << name if %w(date datetime).include?(typeobj.type.to_s)
+        end
+      end
     end
 
     def self.user_token_service

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -2,15 +2,15 @@ module Api
   class Environment
     def self.normalized_attributes
       @normalized_attributes ||= {
-        :time      => time_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = true },
-        :url       => {"href" => true},
-        :resource  => {"image_href" => true},
-        :encrypted => encrypted_attributes.each_with_object({}) { |attr, hsh| hsh[attr] = true }
+        :time      => time_attributes,
+        :url       => Set.new(%w(href)),
+        :resource  => Set.new(%w(image_href)),
+        :encrypted => encrypted_attributes
       }
     end
 
     def self.encrypted_attributes
-      @encrypted_attributes ||= %w(password) |
+      @encrypted_attributes ||= Set.new(%w(password)) |
                                 ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
                                 ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
     end
@@ -32,7 +32,7 @@ module Api
     def self.fetch_encrypted_attribute_names(klass)
       return [] unless klass.respond_to?(:encrypted_columns)
       encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-        normalized_attributes[:encrypted][attr] = true
+        normalized_attributes[:encrypted] << attr
       end
     end
 

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -3,10 +3,18 @@ module Api
     def self.normalized_attributes
       @normalized_attributes ||= {
         :time      => time_attributes,
-        :url       => Set.new(%w(href)),
-        :resource  => Set.new(%w(image_href)),
+        :url       => url_attributes,
+        :resource  => resource_attributes,
         :encrypted => encrypted_attributes
       }
+    end
+
+    def self.url_attributes
+      @url_attributes ||= Set.new(%w(href))
+    end
+
+    def self.resource_attributes
+      @resource_attributes ||= Set.new(%w(image_href))
     end
 
     def self.encrypted_attributes


### PR DESCRIPTION
Took some suggestions out of https://github.com/ManageIQ/manageiq/pull/14624 and bundled them with some other refactorings. The result is a little longer, but I think it adds clarity and consistency.

Among the changes: 

1. Got rid of an unnecessary `begin` block
2. Implement the `normalized_attrs` data using sets instead of hashes (we don't use the values, we just assign all values to `true`
3. Remove the `normalized_attrs` hash altogether, which should lower the memory footprint of this module, since it duplicated some other data which never got GC'd
4. Provide a more consistent API for checking if an attribute needs to be normalized with some top-level `Api.<type>_attribute?` helper methods

@Fryguy thanks for some of these suggestions!
@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 