### PR TITLE
provision_request returns a miq_request object instead of a hash of error and miq_request

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -376,7 +376,7 @@ class ServiceTemplate < ApplicationRecord
 
   def provision_request(user, options = nil, request_options = nil)
     result = provision_workflow(user, options, request_options).submit_request
-    raise result[:errors].join(",") if result[:errors].any?
+    raise result[:errors].join(", ") if result[:errors].any?
     result[:request]
   end
 

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -375,7 +375,9 @@ class ServiceTemplate < ApplicationRecord
   private_class_method :create_from_options
 
   def provision_request(user, options = nil, request_options = nil)
-    provision_workflow(user, options, request_options).submit_request
+    result = provision_workflow(user, options, request_options).submit_request
+    raise result[:errors].join(",") if result[:errors].any?
+    result[:request]
   end
 
   def provision_workflow(user, dialog_options = nil, request_options = nil)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -647,13 +647,12 @@ describe ServiceTemplate do
   context "#provision_request" do
     let(:user) { FactoryGirl.create(:user, :userid => "barney") }
     let(:resource_action) { FactoryGirl.create(:resource_action, :action => "Provision") }
-    let(:service_template) { FactoryGirl.create(:service_template,
-                                                :resource_actions => [resource_action]) }
-    let(:hash) {  {:target => service_template, :initiator => 'control'} }
-    let(:workflow)  { instance_double(ResourceActionWorkflow) }
+    let(:service_template) { FactoryGirl.create(:service_template, :resource_actions => [resource_action]) }
+    let(:hash) { {:target => service_template, :initiator => 'control'} }
+    let(:workflow) { instance_double(ResourceActionWorkflow) }
     let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
     let(:good_result) { { :errors => [], :request => miq_request } }
-    let(:bad_result) { { :errors => ["Error1","Error2"], :request => miq_request } }
+    let(:bad_result) { { :errors => %w(Error1 Error2), :request => miq_request } }
     let(:arg1) { {'ordered_by' => 'fred'} }
     let(:arg2) { {:initiator => 'control'} }
 
@@ -675,7 +674,6 @@ describe ServiceTemplate do
       expect(workflow).to receive(:request_options=).with(:initiator => 'control')
       expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
     end
-
   end
 end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -644,23 +644,38 @@ describe ServiceTemplate do
     end
   end
 
-  describe "#provision_request" do
-    it "provision's a service template " do
-      user = FactoryGirl.create(:user, :userid => "barney")
-      resource_action = FactoryGirl.create(:resource_action, :action => "Provision")
-      service_template = FactoryGirl.create(:service_template,
-                                            :resource_actions => [resource_action])
-      hash = {:target => service_template, :initiator => 'control'}
-      workflow = instance_double(ResourceActionWorkflow)
+  context "#provision_request" do
+    let(:user) { FactoryGirl.create(:user, :userid => "barney") }
+    let(:resource_action) { FactoryGirl.create(:resource_action, :action => "Provision") }
+    let(:service_template) { FactoryGirl.create(:service_template,
+                                                :resource_actions => [resource_action]) }
+    let(:hash) {  {:target => service_template, :initiator => 'control'} }
+    let(:workflow)  { instance_double(ResourceActionWorkflow) }
+    let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
+    let(:good_result) { { :errors => [], :request => miq_request } }
+    let(:bad_result) { { :errors => ["Error1","Error2"], :request => miq_request } }
+    let(:arg1) { {'ordered_by' => 'fred'} }
+    let(:arg2) { {:initiator => 'control'} }
+
+    it "provision's a service template without errors" do
       expect(ResourceActionWorkflow).to(receive(:new)
         .with({}, user, resource_action, hash).and_return(workflow))
-      expect(workflow).to receive(:submit_request)
+      expect(workflow).to receive(:submit_request).and_return(good_result)
       expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
       expect(workflow).to receive(:request_options=).with(:initiator => 'control')
 
-      service_template.provision_request(user, {'ordered_by' => 'fred'},
-                                         {:initiator => 'control'})
+      expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
     end
+
+    it "provision's a service template with errors" do
+      expect(ResourceActionWorkflow).to(receive(:new)
+        .with({}, user, resource_action, hash).and_return(workflow))
+      expect(workflow).to receive(:submit_request).and_return(bad_result)
+      expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
+      expect(workflow).to receive(:request_options=).with(:initiator => 'control')
+      expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+    end
+
   end
 end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447793

The provision request returns the miq_request object if there are no errors
else we raise an exception with the errors

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1447793

* https://github.com/ManageIQ/manageiq/pull/13972

Steps for Testing/QA
-------------------------------

Described in BZ