### PR TITLE
Remove Invalid Hawkular Endpoints

### DIFF
--- a/db/migrate/20170427152006_remove_invalid_hawkular_endpoints.rb
+++ b/db/migrate/20170427152006_remove_invalid_hawkular_endpoints.rb
@@ -1,0 +1,83 @@
+class RemoveInvalidHawkularEndpoints < ActiveRecord::Migration[5.0]
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Endpoint < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class Authentication < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    ems_container_ids = ExtManagementSystem.where(
+      :type => %w(ManageIQ::Providers::Openshift::ContainerManager ManageIQ::Providers::Kubernetes::ContainerManager)
+    ).pluck(:id)
+    delete_ids = Endpoint.where(
+      :resource_type => 'ExtManagementSystem',
+      :resource_id   => ems_container_ids,
+      :role          => "hawkular",
+      :hostname      => ["", nil],
+    ).pluck(:resource_id)
+
+    unless delete_ids.empty?
+      say_with_time("Removing invalid endpoint and authentication for ems ids [#{delete_ids}]") do
+        Endpoint.where(
+          :resource_type => 'ExtManagementSystem',
+          :resource_id   => delete_ids,
+          :role          => "hawkular",
+        ).destroy_all
+        Authentication.where(
+          :authtype      => "hawkular",
+          :resource_type => 'ExtManagementSystem',
+          :resource_id   => delete_ids
+        ).destroy_all
+      end
+    end
+  end
+
+  def down
+    ems_containers_by_id = ExtManagementSystem.where(
+      :type => %w(ManageIQ::Providers::Openshift::ContainerManager ManageIQ::Providers::Kubernetes::ContainerManager)
+    ).map { |ems| [ems.id, ems] }.to_h
+
+    ems_container_ids = ems_containers_by_id.keys
+    ems_with_hawkular = Endpoint.where(
+      :resource_type => 'ExtManagementSystem',
+      :resource_id   => ems_container_ids,
+      :role          => "hawkular",
+    ).pluck(:resource_id)
+    create_ids = ems_container_ids - ems_with_hawkular
+
+    unless create_ids.empty?
+      create_ids.each do |ems_id|
+        say_with_time("Recreating invalid endpoint and authentication for [#{ems_id}]") do
+          Endpoint.create!(
+            :role              => "hawkular",
+            :hostname          => "",
+            :port              => 443,
+            :resource_type     => "ExtManagementSystem",
+            :resource_id       => ems_id,
+            :verify_ssl        => 1,
+            :security_protocol => "ssl-with-validation",
+          )
+          default_auth = Authentication.find_by(
+            :authtype      => 'bearer',
+            :resource_type => "ExtManagementSystem",
+            :resource_id   => ems_id
+          )
+          Authentication.create!(
+            :name          => "#{ems_containers_by_id[ems_id].type} #{ems_containers_by_id[ems_id].name}",
+            :authtype      => "hawkular",
+            :resource_type => "ExtManagementSystem",
+            :resource_id   => ems_id,
+            :type          => "AuthToken",
+            :auth_key      => default_auth.auth_key
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/migrations/20170427152006_remove_invalid_hawkular_endpoints_spec.rb
+++ b/spec/migrations/20170427152006_remove_invalid_hawkular_endpoints_spec.rb
@@ -1,0 +1,83 @@
+require_migration
+
+describe RemoveInvalidHawkularEndpoints do
+  let(:ext_management_system_stub) { migration_stub(:ExtManagementSystem) }
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+  let(:authentication_stub) { migration_stub(:Authentication) }
+
+  migration_context :up do
+    it 'Remove hawkular endpoints that are nil' do
+      ems = ext_management_system_stub.create!(
+        :name => 'container',
+        :type => 'ManageIQ::Providers::Openshift::ContainerManager'
+      )
+      endpoint_stub.create!(
+        :role          => "default",
+        :hostname      => "hostname",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+      endpoint_stub.create!(
+        :role          => "hawkular",
+        :hostname      => nil,
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+      authentication_stub.create!(
+        :name          => "#{ems.type} #{ems.name}",
+        :authtype      => "bearer",
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id,
+        :type          => "AuthToken"
+      )
+      authentication_stub.create!(
+        :name          => "#{ems.type} #{ems.name}",
+        :authtype      => "hawkular",
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id,
+        :type          => "AuthToken"
+      )
+      migrate
+      expect(endpoint_stub.pluck(:role)).to contain_exactly("default")
+      expect(authentication_stub.pluck(:authtype)).to contain_exactly("bearer")
+    end
+
+    it 'Does not remove hawkular endpoints that are not nil' do
+      ems = ext_management_system_stub.create!
+      endpoint_stub.create!(
+        :role          => "default",
+        :hostname      => "hostname",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+      endpoint_stub.create!(
+        :role          => "hawkular",
+        :hostname      => "somevalue",
+        :port          => 123,
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id
+      )
+      authentication_stub.create!(
+        :name          => "#{ems.type} #{ems.name}",
+        :authtype      => "bearer",
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id,
+        :type          => "AuthToken"
+      )
+      authentication_stub.create!(
+        :name          => "#{ems.type} #{ems.name}",
+        :authtype      => "hawkular",
+        :resource_type => "ExtManagementSystem",
+        :resource_id   => ems.id,
+        :type          => "AuthToken"
+      )
+      migrate
+      ems.reload
+      expect(endpoint_stub.count).to eq(2)
+      expect(authentication_stub.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/1205


Before this migration a disabled hawkular is expressed by an endpoint with a nil hostname.
After, a provider with a disabled hawkular will only have the default endpoint.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1437138