### PR TITLE
ovirt-networking: using profiles

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -418,8 +418,8 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
-          :required: true
+          :description: Network
+          :required: false
           :display: :edit
           :data_type: :string
         :mac_address:


### PR DESCRIPTION
This patch fixes some issues in oVirt vm provision network tab.
1. Changing the 'vLan' label to 'Network'
2. Displaying the vnic profiles instead of the host/hosts networks (only
profiles configured in the cluster).
3. Using OvirtSDK4.

Changes relevant to version 4 only.