### PR TITLE
use bundler.d relative to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,4 +165,4 @@ if File.exist?(dev_gemfile)
 end
 
 # Load other additional Gemfiles
-Dir.glob("bundler.d/*.rb").each { |f| eval_gemfile(File.expand_path(f, __dir__)) }
+Dir.glob(File.join(__dir__, 'bundler.d/*.rb')).each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
otherwise Dir.glob is relative to the current working directory
which is not always the same as the root of manageiq checkout

especially when working with plugins that link their spec/manageiq
to a local checkout

discovered by https://github.com/ManageIQ/manageiq/pull/14908

@miq-bot add_labels developer
@miq-bot assign bdunne