### PR TITLE
Drop calls to MiqUUID.new guid and .mac_address

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -159,7 +159,7 @@ class CustomButton < ApplicationRecord
   end
 
   def copy(options = {})
-    options[:guid] = MiqUUID.new_guid
+    options[:guid] = SecureRandom.uuid
     options.each_with_object(dup) { |(k, v), button| button.send("#{k}=", v) }.tap(&:save!)
   end
 end

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -30,7 +30,7 @@ class CustomButtonSet < ApplicationRecord
     raise ArgumentError, "options[:owner] is required" if options[:owner].blank?
 
     options.each_with_object(dup) { |(k, v), button_set| button_set.send("#{k}=", v) }.tap do |cbs|
-      cbs.guid = MiqUUID.new_guid
+      cbs.guid = SecureRandom.uuid
       cbs.name = "#{name}-#{cbs.guid}"
       cbs.save!
       custom_buttons.each { |cb| cbs.add_member(cb.copy(:applies_to => options[:owner])) }

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -532,7 +532,7 @@ class MiqServer < ApplicationRecord
   def self.my_guid
     @@my_guid_cache ||= begin
       guid_file = Rails.root.join("GUID")
-      File.write(guid_file, MiqUUID.new_guid) unless File.exist?(guid_file)
+      File.write(guid_file, SecureRandom.uuid) unless File.exist?(guid_file)
       File.read(guid_file).strip
     end
   end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -55,7 +55,7 @@ module MiqServer::EnvironmentManagement
           require 'MiqSockUtil'
           ipaddr      = MiqSockUtil.getIpAddr
           hostname    = MiqSockUtil.getFullyQualifiedDomainName
-          mac_address = MiqUUID.mac_address.dup
+          mac_address = UUIDTools::UUID.mac_address.dup
         end
       rescue
       end

--- a/db/migrate/20151021174140_assign_tenant_default_group.rb
+++ b/db/migrate/20151021174140_assign_tenant_default_group.rb
@@ -30,7 +30,7 @@ class AssignTenantDefaultGroup < ActiveRecord::Migration
         :description      => "Tenant #{tenant.name} #{tenant.id} access",
         :group_type       => TENANT_GROUP,
         :sequence         => 1,
-        :guid             => MiqUUID.new_guid,
+        :guid             => SecureRandom.uuid,
         :miq_user_role_id => role.try(:id)
       ).find_or_create_by!(:tenant_id => tenant.id)
     end

--- a/db/migrate/20151030201919_fix_miq_group_sequences.rb
+++ b/db/migrate/20151030201919_fix_miq_group_sequences.rb
@@ -8,7 +8,7 @@ class FixMiqGroupSequences < ActiveRecord::Migration
 
     say_with_time("Update MiqGroup missing guids") do
       MiqGroup.where(:guid => nil).each do |g|
-        g.update_attributes(:guid => MiqUUID.new_guid)
+        g.update_attributes(:guid => SecureRandom.uuid)
       end
     end
   end

--- a/db/migrate/20160226092911_separate_openstack_network_manager_from_openstack_cloud_manager.rb
+++ b/db/migrate/20160226092911_separate_openstack_network_manager_from_openstack_cloud_manager.rb
@@ -44,7 +44,7 @@ class SeparateOpenstackNetworkManagerFromOpenstackCloudManager < ActiveRecord::M
         :type          => 'ManageIQ::Providers::Openstack::NetworkManager',
         :name          => "#{cloud_manager.name} Network Manager",
         :parent_ems_id => cloud_manager.id,
-        :guid          => MiqUUID.new_guid)
+        :guid          => SecureRandom.uuid)
 
       affected_classes.each do |network_model_class|
         network_model_class

--- a/db/migrate/20160324085532_separate_amazon_network_manager_from_amazon_cloud_manager.rb
+++ b/db/migrate/20160324085532_separate_amazon_network_manager_from_amazon_cloud_manager.rb
@@ -41,7 +41,7 @@ class SeparateAmazonNetworkManagerFromAmazonCloudManager < ActiveRecord::Migrati
         :type          => 'ManageIQ::Providers::Amazon::NetworkManager',
         :name          => "#{cloud_manager.name} Network Manager",
         :parent_ems_id => cloud_manager.id,
-        :guid          => MiqUUID.new_guid)
+        :guid          => SecureRandom.uuid)
 
       affected_classes.each do |network_model_class|
         network_model_class

--- a/db/migrate/20160406072945_separate_azure_network_manager_from_azure_cloud_manager.rb
+++ b/db/migrate/20160406072945_separate_azure_network_manager_from_azure_cloud_manager.rb
@@ -41,7 +41,7 @@ class SeparateAzureNetworkManagerFromAzureCloudManager < ActiveRecord::Migration
         :type          => 'ManageIQ::Providers::Azure::NetworkManager',
         :name          => "#{cloud_manager.name} Network Manager",
         :parent_ems_id => cloud_manager.id,
-        :guid          => MiqUUID.new_guid)
+        :guid          => SecureRandom.uuid)
 
       affected_classes.each do |network_model_class|
         network_model_class

--- a/db/migrate/20160627074242_separate_google_network_manager_from_google_cloud_manager.rb
+++ b/db/migrate/20160627074242_separate_google_network_manager_from_google_cloud_manager.rb
@@ -41,7 +41,7 @@ class SeparateGoogleNetworkManagerFromGoogleCloudManager < ActiveRecord::Migrati
         :type          => 'ManageIQ::Providers::Google::NetworkManager',
         :name          => "#{cloud_manager.name} Network Manager",
         :parent_ems_id => cloud_manager.id,
-        :guid          => MiqUUID.new_guid)
+        :guid          => SecureRandom.uuid)
 
       affected_classes.each do |network_model_class|
         network_model_class

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -7,7 +7,7 @@ module UuidMixin
   private
 
   def set_guid
-    self.guid ||= MiqUUID.new_guid if self.respond_to?(:guid) && self.respond_to?(:guid=)
+    self.guid ||= SecureRandom.uuid if self.respond_to?(:guid) && self.respond_to?(:guid=)
   end
 
   def default_name_to_guid

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :chargeback_rate do
-    guid                   { MiqUUID.new_guid }
+    guid                   { SecureRandom.uuid }
     sequence(:description) { |n| "Chargeback Rate ##{n}" }
     rate_type 'Compute'
 

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:name)      { |n| "ems_#{seq_padded_for_sorting(n)}" }
     sequence(:hostname)  { |n| "ems-#{seq_padded_for_sorting(n)}" }
     sequence(:ipaddress) { |n| ip_from_seq(n) }
-    guid                 { MiqUUID.new_guid }
+    guid                 { SecureRandom.uuid }
     zone                 { Zone.first || FactoryGirl.create(:zone) }
     storage_profiles     { [] }
 

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :miq_server do
-    guid            { MiqUUID.new_guid }
+    guid            { SecureRandom.uuid }
     zone            { FactoryGirl.build(:zone) }
     sequence(:name) { |n| "miq_server_#{seq_padded_for_sorting(n)}" }
     last_heartbeat  { Time.now.utc }

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :provider do
     sequence(:name) { |n| "provider_#{seq_padded_for_sorting(n)}" }
-    guid            { MiqUUID.new_guid }
+    guid            { SecureRandom.uuid }
     zone            { Zone.first || FactoryGirl.create(:zone) }
   end
 

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :vm_or_template do
     sequence(:name) { |n| "vm_#{seq_padded_for_sorting(n)}" }
     location        "unknown"
-    uid_ems         { MiqUUID.new_guid }
+    uid_ems         { SecureRandom.uuid }
     vendor          "unknown"
     template        false
     raw_power_state "running"

--- a/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
+++ b/spec/migrations/20151030201919_fix_miq_group_sequences_spec.rb
@@ -15,7 +15,7 @@ describe FixMiqGroupSequences do
     end
 
     it "assigns guid" do
-      old_guid = MiqUUID.new_guid
+      old_guid = SecureRandom.uuid
       g1 = group_stub.create
       g2 = group_stub.create(:guid => old_guid)
 

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -5,7 +5,7 @@ describe EmbeddedAnsibleWorker::Runner do
       s.update(:hostname => "fancyserver")
       s
     }
-    let(:worker_guid) { MiqUUID.new_guid }
+    let(:worker_guid) { SecureRandom.uuid }
     let(:worker)      { FactoryGirl.create(:embedded_ansible_worker, :guid => worker_guid, :miq_server_id => miq_server.id) }
     let(:runner) {
       worker

--- a/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_spec.rb
@@ -54,7 +54,7 @@ describe EmsRefresh::SaveInventory do
 
     context "with dups in the database" do
       before(:each) do
-        @uid = MiqUUID.new_guid
+        @uid = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
       end
@@ -102,7 +102,7 @@ describe EmsRefresh::SaveInventory do
 
     context "with disconnected dups in the database" do
       before(:each) do
-        @uid = MiqUUID.new_guid
+        @uid = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => nil,  :uid_ems => @uid)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
       end
@@ -152,7 +152,7 @@ describe EmsRefresh::SaveInventory do
     context "with non-dup on a different EMS in the database" do
       before(:each) do
         @ems2 = FactoryGirl.create(:ems_vmware)
-        @uid  = MiqUUID.new_guid
+        @uid  = SecureRandom.uuid
         @vm1  = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems2, :uid_ems => @uid)
         @vm2  = FactoryGirl.build(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
       end
@@ -177,7 +177,7 @@ describe EmsRefresh::SaveInventory do
 
     context "with disconnected non-dup in the database" do
       before(:each) do
-        @uid  = MiqUUID.new_guid
+        @uid  = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => nil, :uid_ems => @uid)
         @vm2 = FactoryGirl.build(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
       end
@@ -272,7 +272,7 @@ describe EmsRefresh::SaveInventory do
 
   def raw_data_without_dups(*args)
     data = raw_data_process(*args)
-    data[1][:uid_ems] = MiqUUID.new_guid if data[0][:uid_ems] == data[1][:uid_ems]
+    data[1][:uid_ems] = SecureRandom.uuid if data[0][:uid_ems] == data[1][:uid_ems]
     data
   end
 

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -1,6 +1,6 @@
 describe "Message Timeout Handling" do
   before(:each) do
-    @guid = MiqUUID.new_guid
+    @guid = SecureRandom.uuid
     allow(MiqServer).to receive(:my_guid).and_return(@guid)
 
     @zone       = FactoryGirl.create(:zone)

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -4,7 +4,7 @@ describe MiqProvision do
     let(:ems)      { FactoryGirl.create(:ems_openstack_with_authentication) }
     let(:flavor)   { FactoryGirl.create(:flavor_openstack, :ems_ref => 24) }
     let(:options)  { {:src_vm_id => template.id, :vm_target_name => "test_vm_1"} }
-    let(:template) { FactoryGirl.create(:template_openstack, :ext_management_system => ems, :ems_ref => MiqUUID.new_guid) }
+    let(:template) { FactoryGirl.create(:template_openstack, :ext_management_system => ems, :ems_ref => SecureRandom.uuid) }
     let(:vm)       { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
 
     let(:task) do

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -4,9 +4,9 @@ describe MiqProvisionRequestTemplate do
     FactoryGirl.create(:template_vmware,
                        :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication))
   end
-  let(:parent_svc) { FactoryGirl.create(:service, :guid => MiqUUID.new_guid, :options => {:dialog => {}}) }
+  let(:parent_svc) { FactoryGirl.create(:service, :guid => SecureRandom.uuid, :options => {:dialog => {}}) }
   let(:bundle_parent_svc) do
-    FactoryGirl.create(:service, :guid => MiqUUID.new_guid, :options => {:dialog => {}})
+    FactoryGirl.create(:service, :guid => SecureRandom.uuid, :options => {:dialog => {}})
   end
   let(:service_resource) do
     FactoryGirl.create(:service_resource,

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -4,7 +4,7 @@ describe MiqScheduleWorker::Runner do
       @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
       @zone = @miq_server.zone
 
-      worker_guid = MiqUUID.new_guid
+      worker_guid = SecureRandom.uuid
       @worker = FactoryGirl.create(:miq_schedule_worker, :guid => worker_guid, :miq_server_id => @miq_server.id)
 
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:initialize_rufus)

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -797,7 +797,7 @@ describe "Server Monitor" do
           @miq_server1 = EvmSpecHelper.local_miq_server(:zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
 
-          @miq_server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone2, :name => "Server 2")
+          @miq_server2 = FactoryGirl.create(:miq_server, :guid => SecureRandom.uuid, :zone => @zone2, :name => "Server 2")
           @miq_server2.deactivate_all_roles
         end
 
@@ -832,7 +832,7 @@ describe "Server Monitor" do
           @roles1 = [['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 2], ['scheduler', 1], ['reporting', 1]]
           @roles1.each { |role, priority| @miq_server1.assign_role(role, priority) }
 
-          @miq_server2 = FactoryGirl.create(:miq_server, :guid => MiqUUID.new_guid, :zone => @zone2, :name => "Server 2")
+          @miq_server2 = FactoryGirl.create(:miq_server, :guid => SecureRandom.uuid, :zone => @zone2, :name => "Server 2")
           @miq_server2.deactivate_all_roles
           @roles2 = [['ems_operations', 1], ['event', 2], ['ems_metrics_coordinator', 1], ['scheduler', 2], ['reporting', 1]]
           @roles2.each { |role, priority| @miq_server2.assign_role(role, priority) }

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -33,7 +33,7 @@ describe MiqServer do
 
     it "should not generate a new GUID file if new_guid blows up" do # Test for case 10942
       MiqServer.my_guid_cache = nil
-      expect(MiqUUID).to receive(:new_guid).and_raise(StandardError)
+      expect(SecureRandom).to receive(:uuid).and_raise(StandardError)
       expect(File).to receive(:exist?).with(guid_file).and_return(false)
       expect(File).not_to receive(:write)
       expect { MiqServer.my_guid }.to raise_error(StandardError)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -24,11 +24,12 @@ describe MiqServer do
 
     it "should generate a new GUID and write it out when there is no GUID file" do
       MiqServer.my_guid_cache = nil
-      expect(MiqUUID).to receive(:new_guid).and_return("a-new-guid")
+      test_guid = SecureRandom.uuid
+      expect(SecureRandom).to receive(:uuid).and_return(test_guid)
       expect(File).to receive(:exist?).with(guid_file).and_return(false)
-      expect(File).to receive(:write).with(guid_file, "a-new-guid")
-      expect(File).to receive(:read).with(guid_file).and_return("a-new-guid")
-      expect(MiqServer.my_guid).to eq("a-new-guid")
+      expect(File).to receive(:write).with(guid_file, test_guid)
+      expect(File).to receive(:read).with(guid_file).and_return(test_guid)
+      expect(MiqServer.my_guid).to eq(test_guid)
     end
 
     it "should not generate a new GUID file if new_guid blows up" do # Test for case 10942

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -9,7 +9,7 @@ describe MiqVimBrokerWorker::Runner do
     other_ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
 
     # General stubbing for testing any worker (methods called during initialize)
-    @worker_guid = MiqUUID.new_guid
+    @worker_guid = SecureRandom.uuid
     @worker_record = FactoryGirl.create(:miq_vim_broker_worker, :guid => @worker_guid, :miq_server_id => server.id)
     @drb_uri = "drb://127.0.0.1:12345"
     allow(DRb).to receive(:uri).and_return(@drb_uri)

--- a/tools/create_evm_snapshot.rb
+++ b/tools/create_evm_snapshot.rb
@@ -20,7 +20,7 @@ when 'vm'
 
   descs = []
   vms.each do
-    descs << "Snapshot for scan job: #{MiqUUID.new_guid}, EVM Server build: #{Vmdb::Appliance.BUILD}  Server Time: #{Time.now.utc.iso8601}"
+    descs << "Snapshot for scan job: #{SecureRandom.uuid}, EVM Server build: #{Vmdb::Appliance.BUILD}  Server Time: #{Time.now.utc.iso8601}"
   end
 when 'job'
   jobs = Job.where(:id => ids)


### PR DESCRIPTION
SecureRandom is able to create guids for us allowing us to drop custom code.
MiqUUID was just forwarding `mac_address`, no need to do that.