### PR TITLE
Fix for default value of dynamic dropdown list not being honored

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -83,7 +83,6 @@ class DialogFieldSortedItem < DialogField
     return data_to_sort if sort_by == :none
 
     value_position = sort_by == :value ? :first : :last
-    value_modifier = data_type == "integer" ? :to_i : :to_s
 
     data_to_sort = data_to_sort.sort_by { |d| d.send(value_position).send(value_modifier) }
     return data_to_sort.reverse! if sort_order == :descending
@@ -93,7 +92,7 @@ class DialogFieldSortedItem < DialogField
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
     use_first_value_as_default unless default_value_included_in_raw_values?
-    self.value ||= default_value
+    self.value ||= default_value.send(value_modifier)
 
     @raw_values
   end
@@ -103,7 +102,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def default_value_included_in_raw_values?
-    @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
+    @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value.send(value_modifier))
   end
 
   def static_raw_values
@@ -118,5 +117,9 @@ class DialogFieldSortedItem < DialogField
   def load_values_on_init?
     return true unless show_refresh_button
     load_values_on_init
+  end
+
+  def value_modifier
+    data_type == "integer" ? :to_i : :to_s
   end
 end


### PR DESCRIPTION
When using integers as keys for a dynamic sorted item (drop down or radio button), the default value would come in as a string regardless of how it was set in the automate method. This fix will coerce default_value for sorted items into the correct `data_type` before comparing and assigning it to the dialog field.

More details can be found here:
https://bugzilla.redhat.com/show_bug.cgi?id=1447442

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes

@gmcculloug I'm not sure if this should be euwe/yes or not? Please advise 😄 .