### PR TITLE
Fix for default dynamic text boxes should be blank

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -8,7 +8,7 @@ class DialogFieldTextBox < DialogField
   end
 
   def initial_values
-    "<None>"
+    ""
   end
 
   def protected=(passed_in_value)

--- a/spec/models/dialog_field_text_area_box_spec.rb
+++ b/spec/models/dialog_field_text_area_box_spec.rb
@@ -46,7 +46,7 @@ describe DialogFieldTextAreaBox do
       it_behaves_like "DialogFieldTextBox#normalize_automate_values"
 
       it "returns the initial values" do
-        expect(dialog_field.normalize_automate_values(automate_hash)).to eq("<None>")
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq("")
       end
     end
 

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -1,4 +1,12 @@
 describe DialogFieldTextBox do
+  describe "#initial_values" do
+    let(:dialog_field) { described_class.new }
+
+    it "returns a blank string" do
+      expect(dialog_field.initial_values).to eq("")
+    end
+  end
+
   context "dialog field text box without options hash" do
     before do
       @df = FactoryGirl.build(:dialog_field_text_box, :label => 'test field', :name => 'test field')
@@ -294,7 +302,7 @@ describe DialogFieldTextBox do
       it_behaves_like "DialogFieldTextBox#normalize_automate_values"
 
       it "returns the initial values" do
-        expect(dialog_field.normalize_automate_values(automate_hash)).to eq("<None>")
+        expect(dialog_field.normalize_automate_values(automate_hash)).to eq("")
       end
     end
 


### PR DESCRIPTION
This fix simply changes the initial value of dialog field text box to a blank string instead of `"<None>"`. I'm not exactly sure why it was `"<None>"` in the first place, but I don't think there's really any reason for it to have a value if what the user wants is for it to be blank.

https://bugzilla.redhat.com/show_bug.cgi?id=1438763

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes