### PR TITLE
Default the Cockpit console to IPV4

### DIFF
--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -18,14 +18,11 @@ module Vm::Operations
     miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
     MiqCockpit::WS.url(miq_server,
                        MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
-                       get_ipv4_address || ipaddresses.first)
+                       ipv4_address || ipaddresses.first)
   end
 
-  def return_ipv4_address
-    ipaddresses.each do |ip|
-      return ip if (IPAddr.new ip).ipv4?
-    end
-    ipaddresses.first
+  def ipv4_address
+    ipaddresses.find { |ip| (IPAddr.new ip).ipv4? }
   end
 
   def validate_collect_running_processes

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -18,7 +18,14 @@ module Vm::Operations
     miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
     MiqCockpit::WS.url(miq_server,
                        MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
-                       ipaddresses.first)
+                       get_ipv4_address || ipaddresses.first)
+  end
+
+  def return_ipv4_address
+    ipaddresses.each do |ip|
+      return ip if (IPAddr.new ip).ipv4?
+    end
+    ipaddresses.first
   end
 
   def validate_collect_running_processes

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -1,0 +1,30 @@
+describe 'VM::Operations' do
+  before(:each) do
+    miq_server = EvmSpecHelper.local_miq_server
+    @ems       = FactoryGirl.create(:ems_vmware, :zone => miq_server.zone)
+    @vm        = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
+    allow(@vm).to receive(:ipaddresses).and_return(@ipaddresses)
+  end
+
+  context '#cockpit_url' do
+    it '#returns a valid Cockpit url' do
+      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
+      expect(@vm).to receive(:cockpit_url).and_return('http://127.0.0.1:9090')
+      @vm.send(:cockpit_url)
+    end
+  end
+
+  context '#get_ipv4_address' do
+    after(:each) { @vm.send(:return_ipv4_address) }
+
+    it 'returns the existing ipv4 address' do
+      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
+      expect(@vm).to receive(:return_ipv4_address).and_return('127.0.0.1')
+    end
+
+    it 'returns the first ip address when no ipv4 addresses exist' do
+      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 fe80::dc0f:6b21:504b:2fb0)
+      expect(@vm).to receive(:return_ipv4_address).and_return('fe80::21a:4aff:fe22:dde5')
+    end
+  end
+end

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -14,17 +14,12 @@ describe 'VM::Operations' do
     end
   end
 
-  context '#get_ipv4_address' do
+  context '#ipv4_address' do
     after(:each) { @vm.send(:return_ipv4_address) }
 
     it 'returns the existing ipv4 address' do
       @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
       expect(@vm).to receive(:return_ipv4_address).and_return('127.0.0.1')
-    end
-
-    it 'returns the first ip address when no ipv4 addresses exist' do
-      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 fe80::dc0f:6b21:504b:2fb0)
-      expect(@vm).to receive(:return_ipv4_address).and_return('fe80::21a:4aff:fe22:dde5')
     end
   end
 end


### PR DESCRIPTION
Makes Cockpit consoles use an ipv4 ip address by default and falls back to the first ip address (current behavior) if an ipv4 address is not found.

https://bugzilla.redhat.com/show_bug.cgi?id=1443296