### PR TITLE
[EUWE] Vddk 6.5 Support

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -16,7 +16,7 @@ gem "bunny",                   "~>2.1.0",           :require => false
 gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
-gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
+gem "ffi-vix_disk_lib",        "~>1.0.3",           :require => false  # used by lib/VixDiskLib
 gem "fog-openstack",           "=0.1.20",           :require => false
 gem "hawkular-client",         "=2.7.0",            :require => false
 gem "httpclient",              "~>2.7.1",           :require => false


### PR DESCRIPTION
Add VDDK 6.5 Support to EUWE.

Add support for VDDK 6.5. This requires ffi-vix_disk_lib gem 1.0.3.

@roliveri @Fryguy @simaishi  This PR is dependent upon ManageIQ/ffi-vix_disk_lib#9 
https://bugzilla.redhat.com/show_bug.cgi?id=1432679 requests this change.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1432679 (original BZ)
* https://bugzilla.redhat.com/show_bug.cgi?id=1441726 (Zstream BZ)
* https://github.com/ManageIQ/manageiq-gems-pending/pull/113 (original PR)
