### PR TITLE
Return href on create

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -10,7 +10,7 @@ module Api
         attrs = normalize_select_attributes(obj, opts)
         result = {}
 
-        href = new_href(type, obj["id"], obj["href"], opts)
+        href = new_href(type, obj["id"], obj["href"])
         if href.present?
           result["href"] = href
           attrs -= ["href"]
@@ -113,8 +113,8 @@ module Api
         obj.collect { |item| normalize_attr(name, item) }
       end
 
-      def new_href(type, current_id, current_href, opts)
-        normalize_href(type, current_id) if opts[:add_href] && current_id.present? && current_href.blank?
+      def new_href(type, current_id, current_href)
+        normalize_href(type, current_id) if current_id.present? && current_href.blank?
       end
     end
   end

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -28,7 +28,7 @@ module Api
       def normalize_attr(attr, value)
         return if value.nil?
         if value.kind_of?(Array) || value.kind_of?(ActiveRecord::Relation)
-          normalize_array(attr, value)
+          normalize_array(value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
         elsif Api.time_attribute?(attr)
@@ -109,8 +109,8 @@ module Api
         end
       end
 
-      def normalize_array(name, obj)
-        obj.collect { |item| normalize_attr(name, item) }
+      def normalize_array(obj)
+        obj.collect { |item| normalize_attr(@req.subcollection || @req.collection, item) }
       end
 
       def new_href(type, current_id, current_href)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -49,11 +49,10 @@ module Api
       end
 
       def resource_to_jbuilder(type, reftype, resource, opts = {})
+        normalize_options = {}
         reftype = get_reftype(type, reftype, resource, opts)
         json    = Jbuilder.new
         json.ignore_nil!
-
-        normalize_options = {:add_href => true}
 
         pas = physical_attribute_selection(resource)
         normalize_options[:render_attributes] = pas if pas.present?
@@ -341,7 +340,7 @@ module Api
           json.set! sc.to_s do |js|
             subresources.each do |scr|
               if @req.expand?(sc) || scr["id"].nil?
-                add_child js, normalize_hash(sctype, scr, :add_href => true)
+                add_child js, normalize_hash(sctype, scr)
               else
                 js.child! { |jsc| jsc.href normalize_href(sctype, scr["id"]) }
               end

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("name" => "foo", "description" => "bar"),
-          a_hash_including("name" => "baz", "description" => "qux")
+          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including("/api/blueprints")),
+          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including("/api/blueprints"))
         )
       }
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including("/api/results")),
-          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including("/api/results"))
+          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including(blueprints_url)),
+          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including(blueprints_url))
         )
       }
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including("/api/blueprints")),
-          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including("/api/blueprints"))
+          a_hash_including("name" => "foo", "description" => "bar", "href" => a_string_including("/api/results")),
+          a_hash_including("name" => "baz", "description" => "qux", "href" => a_string_including("/api/results"))
         )
       }
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -36,7 +36,7 @@ describe "Tags API" do
         tag = Tag.find(result["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
-        expect(result["href"]).to include("/api/results/#{tag.id}")
+        expect(result["href"]).to include(tags_url(tag.id))
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -32,10 +32,11 @@ describe "Tags API" do
 
         expect { run_post tags_url, options }.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response.parsed_body["results"].first["id"])
+        result = response.parsed_body["results"].first
+        tag = Tag.find(result["id"])
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
-
+        expect(result["href"]).to include("/api/results/#{tag.id}")
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -45,7 +45,7 @@ describe "tenant quotas API" do
 
       expected = {
         'results' => [
-          a_hash_including('href' => a_string_including('api/results/'))
+          a_hash_including('href' => a_string_including("#{tenants_url(tenant.id)}/quotas/"))
         ]
       }
       expect do

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -43,10 +43,15 @@ describe "tenant quotas API" do
     it "can create a quota from a tenant" do
       api_basic_authorize action_identifier(:quotas, :create, :subcollection_actions, :post)
 
+      expected = {
+        'results' => [
+          a_hash_including('href' => a_string_including('api/results/'))
+        ]
+      }
       expect do
         run_post "/api/tenants/#{tenant.id}/quotas/", :name => :cpu_allocated, :value => 1
       end.to change(TenantQuota, :count).by(1)
-
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
 


### PR DESCRIPTION
The `{:add_href => true}` is not being sent to `normalize_hash` as it is looping through the `results` on create. As a result, the `href` was not being added to the resources. It does not appear that `:add_href` is actually serving any purpose.

Removing the condition on `:add_href` appropriately adds the `href` to the resources and maintains other functionality. 

@miq-bot add_label api, enhancement
@miq-bot assign @abellotti 

[Pivotal ticket](https://www.pivotaltracker.com/story/show/121850973)
