### PR TITLE
Add explicit 4.2 inheritance to all past migrations

### DIFF
--- a/db/migrate/20130923182042_collapsed_initial_migration.rb
+++ b/db/migrate/20130923182042_collapsed_initial_migration.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib/migration_helper')
 
-class CollapsedInitialMigration < ActiveRecord::Migration
+class CollapsedInitialMigration < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   def up

--- a/db/migrate/20131021190044_remove_miq_license_models_and_table.rb
+++ b/db/migrate/20131021190044_remove_miq_license_models_and_table.rb
@@ -1,4 +1,4 @@
-class RemoveMiqLicenseModelsAndTable < ActiveRecord::Migration
+class RemoveMiqLicenseModelsAndTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :miq_license_contents
   end

--- a/db/migrate/20131107000917_expand_dialog_field_default_value_size.rb
+++ b/db/migrate/20131107000917_expand_dialog_field_default_value_size.rb
@@ -1,4 +1,4 @@
-class ExpandDialogFieldDefaultValueSize < ActiveRecord::Migration
+class ExpandDialogFieldDefaultValueSize < ActiveRecord::Migration[4.2]
   class DialogField < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
 

--- a/db/migrate/20131118232818_encrypt_miq_database_registration_http_proxy_password_field.rb
+++ b/db/migrate/20131118232818_encrypt_miq_database_registration_http_proxy_password_field.rb
@@ -1,4 +1,4 @@
-class EncryptMiqDatabaseRegistrationHttpProxyPasswordField < ActiveRecord::Migration
+class EncryptMiqDatabaseRegistrationHttpProxyPasswordField < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20131121211455_change_options_in_miq_alert.rb
+++ b/db/migrate/20131121211455_change_options_in_miq_alert.rb
@@ -1,4 +1,4 @@
-class ChangeOptionsInMiqAlert < ActiveRecord::Migration
+class ChangeOptionsInMiqAlert < ActiveRecord::Migration[4.2]
   class MiqAlert < ActiveRecord::Base
     serialize :options
   end

--- a/db/migrate/20131125153220_import_provision_dialogs.rb
+++ b/db/migrate/20131125153220_import_provision_dialogs.rb
@@ -1,4 +1,4 @@
-class ImportProvisionDialogs < ActiveRecord::Migration
+class ImportProvisionDialogs < ActiveRecord::Migration[4.2]
   class MiqDialog < ActiveRecord::Base
     serialize :content
   end

--- a/db/migrate/20131210202928_update_log_collection_path_in_configurations_settings.rb
+++ b/db/migrate/20131210202928_update_log_collection_path_in_configurations_settings.rb
@@ -1,4 +1,4 @@
-class UpdateLogCollectionPathInConfigurationsSettings < ActiveRecord::Migration
+class UpdateLogCollectionPathInConfigurationsSettings < ActiveRecord::Migration[4.2]
   class Configuration < ActiveRecord::Base
     serialize :settings
   end

--- a/db/migrate/20131213173452_change_index_on_miq_queue_v2.rb
+++ b/db/migrate/20131213173452_change_index_on_miq_queue_v2.rb
@@ -1,4 +1,4 @@
-class ChangeIndexOnMiqQueueV2 < ActiveRecord::Migration
+class ChangeIndexOnMiqQueueV2 < ActiveRecord::Migration[4.2]
   def up
     remove_index :miq_queue, :name => "miq_queue_idx"
 

--- a/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
+++ b/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
@@ -1,4 +1,4 @@
-class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration
+class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   class Configuration < ActiveRecord::Base

--- a/db/migrate/20140106184152_remove_miq_queue_md5.rb
+++ b/db/migrate/20140106184152_remove_miq_queue_md5.rb
@@ -1,4 +1,4 @@
-class RemoveMiqQueueMd5 < ActiveRecord::Migration
+class RemoveMiqQueueMd5 < ActiveRecord::Migration[4.2]
   def up
     remove_column :miq_queue, :md5
   end

--- a/db/migrate/20140115160139_add_openstack_fields_to_cloud_networks.rb
+++ b/db/migrate/20140115160139_add_openstack_fields_to_cloud_networks.rb
@@ -1,4 +1,4 @@
-class AddOpenstackFieldsToCloudNetworks < ActiveRecord::Migration
+class AddOpenstackFieldsToCloudNetworks < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_networks, :status, :string
     add_column :cloud_networks, :enabled, :boolean

--- a/db/migrate/20140115160609_add_openstack_fields_to_cloud_subnets.rb
+++ b/db/migrate/20140115160609_add_openstack_fields_to_cloud_subnets.rb
@@ -1,4 +1,4 @@
-class AddOpenstackFieldsToCloudSubnets < ActiveRecord::Migration
+class AddOpenstackFieldsToCloudSubnets < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_subnets, :dhcp_enabled, :boolean
     add_column :cloud_subnets, :gateway, :string

--- a/db/migrate/20140121213913_split_widget_set_name_to_three_columns.rb
+++ b/db/migrate/20140121213913_split_widget_set_name_to_three_columns.rb
@@ -1,4 +1,4 @@
-class SplitWidgetSetNameToThreeColumns < ActiveRecord::Migration
+class SplitWidgetSetNameToThreeColumns < ActiveRecord::Migration[4.2]
   class MiqSet < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20140201040548_add_update_repo_name_to_miq_database.rb
+++ b/db/migrate/20140201040548_add_update_repo_name_to_miq_database.rb
@@ -1,4 +1,4 @@
-class AddUpdateRepoNameToMiqDatabase < ActiveRecord::Migration
+class AddUpdateRepoNameToMiqDatabase < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins

--- a/db/migrate/20140207203449_add_system_to_miq_ae_namespaces.rb
+++ b/db/migrate/20140207203449_add_system_to_miq_ae_namespaces.rb
@@ -1,4 +1,4 @@
-class AddSystemToMiqAeNamespaces < ActiveRecord::Migration
+class AddSystemToMiqAeNamespaces < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_ae_namespaces, :system, :boolean
   end

--- a/db/migrate/20140210175651_create_import_file_uploads.rb
+++ b/db/migrate/20140210175651_create_import_file_uploads.rb
@@ -1,4 +1,4 @@
-class CreateImportFileUploads < ActiveRecord::Migration
+class CreateImportFileUploads < ActiveRecord::Migration[4.2]
   def change
     create_table :import_file_uploads
   end

--- a/db/migrate/20140211141513_add_priority_to_miq_ae_namespaces.rb
+++ b/db/migrate/20140211141513_add_priority_to_miq_ae_namespaces.rb
@@ -1,4 +1,4 @@
-class AddPriorityToMiqAeNamespaces < ActiveRecord::Migration
+class AddPriorityToMiqAeNamespaces < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_ae_namespaces, :priority, :integer
   end

--- a/db/migrate/20140214191729_enhance_firewall_rules_for_neutron_networking.rb
+++ b/db/migrate/20140214191729_enhance_firewall_rules_for_neutron_networking.rb
@@ -1,4 +1,4 @@
-class EnhanceFirewallRulesForNeutronNetworking < ActiveRecord::Migration
+class EnhanceFirewallRulesForNeutronNetworking < ActiveRecord::Migration[4.2]
   class FirewallRule < ActiveRecord::Base
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins

--- a/db/migrate/20140218232357_add_group_and_user_columns_to_miq_widget_contents.rb
+++ b/db/migrate/20140218232357_add_group_and_user_columns_to_miq_widget_contents.rb
@@ -1,4 +1,4 @@
-class AddGroupAndUserColumnsToMiqWidgetContents < ActiveRecord::Migration
+class AddGroupAndUserColumnsToMiqWidgetContents < ActiveRecord::Migration[4.2]
   class MiqWidgetContent < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20140228153536_create_cloud_tenants.rb
+++ b/db/migrate/20140228153536_create_cloud_tenants.rb
@@ -1,4 +1,4 @@
-class CreateCloudTenants < ActiveRecord::Migration
+class CreateCloudTenants < ActiveRecord::Migration[4.2]
   def change
     create_table :cloud_tenants do |t|
       t.string  :name

--- a/db/migrate/20140301034340_leverage_authentications_for_registration_http_proxy_credentials.rb
+++ b/db/migrate/20140301034340_leverage_authentications_for_registration_http_proxy_credentials.rb
@@ -1,4 +1,4 @@
-class LeverageAuthenticationsForRegistrationHttpProxyCredentials < ActiveRecord::Migration
+class LeverageAuthenticationsForRegistrationHttpProxyCredentials < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   class Authentication < ActiveRecord::Base

--- a/db/migrate/20140306150006_add_cloud_tenant_ref_to_security_groups.rb
+++ b/db/migrate/20140306150006_add_cloud_tenant_ref_to_security_groups.rb
@@ -1,4 +1,4 @@
-class AddCloudTenantRefToSecurityGroups < ActiveRecord::Migration
+class AddCloudTenantRefToSecurityGroups < ActiveRecord::Migration[4.2]
   def self.up
     change_table :security_groups do |t|
       t.belongs_to  :cloud_tenant, :type => :bigint

--- a/db/migrate/20140306153718_add_cloud_tenant_ref_to_cloud_networks.rb
+++ b/db/migrate/20140306153718_add_cloud_tenant_ref_to_cloud_networks.rb
@@ -1,4 +1,4 @@
-class AddCloudTenantRefToCloudNetworks < ActiveRecord::Migration
+class AddCloudTenantRefToCloudNetworks < ActiveRecord::Migration[4.2]
   def self.up
     change_table :cloud_networks do |t|
       t.belongs_to  :cloud_tenant, :type => :bigint

--- a/db/migrate/20140306154541_add_cloud_tenant_ref_to_vms.rb
+++ b/db/migrate/20140306154541_add_cloud_tenant_ref_to_vms.rb
@@ -1,4 +1,4 @@
-class AddCloudTenantRefToVms < ActiveRecord::Migration
+class AddCloudTenantRefToVms < ActiveRecord::Migration[4.2]
   def self.up
     change_table :vms do |t|
       t.belongs_to  :cloud_tenant, :type => :bigint

--- a/db/migrate/20140306154747_add_cloud_tenant_ref_to_floating_ips.rb
+++ b/db/migrate/20140306154747_add_cloud_tenant_ref_to_floating_ips.rb
@@ -1,4 +1,4 @@
-class AddCloudTenantRefToFloatingIps < ActiveRecord::Migration
+class AddCloudTenantRefToFloatingIps < ActiveRecord::Migration[4.2]
   def self.up
     change_table :floating_ips do |t|
       t.belongs_to  :cloud_tenant, :type => :bigint

--- a/db/migrate/20140402134329_change_utc_time_profile_type_to_global.rb
+++ b/db/migrate/20140402134329_change_utc_time_profile_type_to_global.rb
@@ -1,4 +1,4 @@
-class ChangeUtcTimeProfileTypeToGlobal < ActiveRecord::Migration
+class ChangeUtcTimeProfileTypeToGlobal < ActiveRecord::Migration[4.2]
   class TimeProfile < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20140409134713_move_log_collection_depot_settings_to_file_depot.rb
+++ b/db/migrate/20140409134713_move_log_collection_depot_settings_to_file_depot.rb
@@ -1,4 +1,4 @@
-class MoveLogCollectionDepotSettingsToFileDepot < ActiveRecord::Migration
+class MoveLogCollectionDepotSettingsToFileDepot < ActiveRecord::Migration[4.2]
   class Authentication < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20140410132430_subclass_file_depot_by_protocol.rb
+++ b/db/migrate/20140410132430_subclass_file_depot_by_protocol.rb
@@ -1,4 +1,4 @@
-class SubclassFileDepotByProtocol < ActiveRecord::Migration
+class SubclassFileDepotByProtocol < ActiveRecord::Migration[4.2]
   class FileDepot < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20140415212812_add_hidden_column_to_product_features.rb
+++ b/db/migrate/20140415212812_add_hidden_column_to_product_features.rb
@@ -1,4 +1,4 @@
-class AddHiddenColumnToProductFeatures < ActiveRecord::Migration
+class AddHiddenColumnToProductFeatures < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_product_features, :hidden, :boolean
   end

--- a/db/migrate/20140421150958_create_miq_groups_users_join_table.rb
+++ b/db/migrate/20140421150958_create_miq_groups_users_join_table.rb
@@ -1,4 +1,4 @@
-class CreateMiqGroupsUsersJoinTable < ActiveRecord::Migration
+class CreateMiqGroupsUsersJoinTable < ActiveRecord::Migration[4.2]
   class MiqGroupsUsers < ActiveRecord::Base
     self.primary_key = nil
   end

--- a/db/migrate/20140421192753_add_enabled_to_miq_ae_namespaces.rb
+++ b/db/migrate/20140421192753_add_enabled_to_miq_ae_namespaces.rb
@@ -1,4 +1,4 @@
-class AddEnabledToMiqAeNamespaces < ActiveRecord::Migration
+class AddEnabledToMiqAeNamespaces < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_ae_namespaces, :enabled, :boolean
   end

--- a/db/migrate/20140424173120_migrate_automate_to_customer_domain.rb
+++ b/db/migrate/20140424173120_migrate_automate_to_customer_domain.rb
@@ -1,4 +1,4 @@
-class MigrateAutomateToCustomerDomain < ActiveRecord::Migration
+class MigrateAutomateToCustomerDomain < ActiveRecord::Migration[4.2]
   class MiqAeNamespace < ActiveRecord::Base
     def self.root_instances
       where(:parent_id => nil).where(arel_table[:name].not_eq("$"))

--- a/db/migrate/20140428145436_add_validator_to_service_dialog_field.rb
+++ b/db/migrate/20140428145436_add_validator_to_service_dialog_field.rb
@@ -1,4 +1,4 @@
-class AddValidatorToServiceDialogField < ActiveRecord::Migration
+class AddValidatorToServiceDialogField < ActiveRecord::Migration[4.2]
   def change
     add_column :dialog_fields, :validator_type, :string
     add_column :dialog_fields, :validator_rule, :string

--- a/db/migrate/20140428155842_add_reconfigurable_to_dialog_field.rb
+++ b/db/migrate/20140428155842_add_reconfigurable_to_dialog_field.rb
@@ -1,4 +1,4 @@
-class AddReconfigurableToDialogField < ActiveRecord::Migration
+class AddReconfigurableToDialogField < ActiveRecord::Migration[4.2]
   def change
     add_column :dialog_fields, :reconfigurable, :boolean
   end

--- a/db/migrate/20140428162159_rename_miq_group_id_column_in_users.rb
+++ b/db/migrate/20140428162159_rename_miq_group_id_column_in_users.rb
@@ -1,4 +1,4 @@
-class RenameMiqGroupIdColumnInUsers < ActiveRecord::Migration
+class RenameMiqGroupIdColumnInUsers < ActiveRecord::Migration[4.2]
   def up
     remove_index  :users, :miq_group_id
     rename_column :users, :miq_group_id, :current_group_id

--- a/db/migrate/20140519211930_add_user_current_group_to_miq_groups.rb
+++ b/db/migrate/20140519211930_add_user_current_group_to_miq_groups.rb
@@ -1,4 +1,4 @@
-class AddUserCurrentGroupToMiqGroups < ActiveRecord::Migration
+class AddUserCurrentGroupToMiqGroups < ActiveRecord::Migration[4.2]
   class User < ActiveRecord::Base
     belongs_to :current_group, :class_name => "AddUserCurrentGroupToMiqGroups::MiqGroup"
     has_and_belongs_to_many :miq_groups, :class_name => "AddUserCurrentGroupToMiqGroups::MiqGroup"

--- a/db/migrate/20140520202225_add_file_depot_id_to_log_file.rb
+++ b/db/migrate/20140520202225_add_file_depot_id_to_log_file.rb
@@ -1,4 +1,4 @@
-class AddFileDepotIdToLogFile < ActiveRecord::Migration
+class AddFileDepotIdToLogFile < ActiveRecord::Migration[4.2]
   def up
     add_column :log_files, :file_depot_id, :bigint
   end

--- a/db/migrate/20140522201901_add_local_file_to_log_file.rb
+++ b/db/migrate/20140522201901_add_local_file_to_log_file.rb
@@ -1,4 +1,4 @@
-class AddLocalFileToLogFile < ActiveRecord::Migration
+class AddLocalFileToLogFile < ActiveRecord::Migration[4.2]
   def up
     add_column :log_files, :local_file, :string
   end

--- a/db/migrate/20140611194007_change_options_in_miq_alert_for_email_to.rb
+++ b/db/migrate/20140611194007_change_options_in_miq_alert_for_email_to.rb
@@ -1,4 +1,4 @@
-class ChangeOptionsInMiqAlertForEmailTo < ActiveRecord::Migration
+class ChangeOptionsInMiqAlertForEmailTo < ActiveRecord::Migration[4.2]
   class MiqAlert < ActiveRecord::Base
     serialize :options
   end

--- a/db/migrate/20140612181021_update_cloud_volume_and_cloud_volume_snapshot.rb
+++ b/db/migrate/20140612181021_update_cloud_volume_and_cloud_volume_snapshot.rb
@@ -1,4 +1,4 @@
-class UpdateCloudVolumeAndCloudVolumeSnapshot < ActiveRecord::Migration
+class UpdateCloudVolumeAndCloudVolumeSnapshot < ActiveRecord::Migration[4.2]
   def up
     change_table :cloud_volumes do |t|
       t.remove     :vm_id

--- a/db/migrate/20140612212226_create_cloud_object_store_containers_and_cloud_object_store_objects.rb
+++ b/db/migrate/20140612212226_create_cloud_object_store_containers_and_cloud_object_store_objects.rb
@@ -1,4 +1,4 @@
-class CreateCloudObjectStoreContainersAndCloudObjectStoreObjects < ActiveRecord::Migration
+class CreateCloudObjectStoreContainersAndCloudObjectStoreObjects < ActiveRecord::Migration[4.2]
   def change
     create_table :cloud_object_store_containers do |t|
       t.string     :ems_ref

--- a/db/migrate/20140613041358_add_backing_id_to_disks.rb
+++ b/db/migrate/20140613041358_add_backing_id_to_disks.rb
@@ -1,4 +1,4 @@
-class AddBackingIdToDisks < ActiveRecord::Migration
+class AddBackingIdToDisks < ActiveRecord::Migration[4.2]
   def up
     change_table :disks do |t|
       t.integer :backing_id, :limit => 8

--- a/db/migrate/20140620201430_create_cloud_resource_quotas.rb
+++ b/db/migrate/20140620201430_create_cloud_resource_quotas.rb
@@ -1,4 +1,4 @@
-class CreateCloudResourceQuotas < ActiveRecord::Migration
+class CreateCloudResourceQuotas < ActiveRecord::Migration[4.2]
   def up
     create_table :cloud_resource_quotas do |t|
       t.string  :ems_ref

--- a/db/migrate/20140627175339_add_support_case_to_file_depot.rb
+++ b/db/migrate/20140627175339_add_support_case_to_file_depot.rb
@@ -1,4 +1,4 @@
-class AddSupportCaseToFileDepot < ActiveRecord::Migration
+class AddSupportCaseToFileDepot < ActiveRecord::Migration[4.2]
   def change
     add_column :file_depots, :support_case, :string
   end

--- a/db/migrate/20140715200621_set_default_for_pxe_server_customization_directory.rb
+++ b/db/migrate/20140715200621_set_default_for_pxe_server_customization_directory.rb
@@ -1,4 +1,4 @@
-class SetDefaultForPxeServerCustomizationDirectory < ActiveRecord::Migration
+class SetDefaultForPxeServerCustomizationDirectory < ActiveRecord::Migration[4.2]
   class PxeServer < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20140821203124_add_vm_raw_power_state.rb
+++ b/db/migrate/20140821203124_add_vm_raw_power_state.rb
@@ -1,4 +1,4 @@
-class AddVmRawPowerState < ActiveRecord::Migration
+class AddVmRawPowerState < ActiveRecord::Migration[4.2]
   def up
     add_column :vms, :raw_power_state, :string
   end

--- a/db/migrate/20140903194919_add_virtualization_type_to_hardware.rb
+++ b/db/migrate/20140903194919_add_virtualization_type_to_hardware.rb
@@ -1,4 +1,4 @@
-class AddVirtualizationTypeToHardware < ActiveRecord::Migration
+class AddVirtualizationTypeToHardware < ActiveRecord::Migration[4.2]
   def change
     add_column :hardwares, :virtualization_type, :string
   end

--- a/db/migrate/20140903195524_add_supports_hvm_to_flavor.rb
+++ b/db/migrate/20140903195524_add_supports_hvm_to_flavor.rb
@@ -1,4 +1,4 @@
-class AddSupportsHvmToFlavor < ActiveRecord::Migration
+class AddSupportsHvmToFlavor < ActiveRecord::Migration[4.2]
   def change
     add_column :flavors, :supports_hvm, :boolean
     add_column :flavors, :supports_paravirtual, :boolean

--- a/db/migrate/20140905020643_update_default_registration_channel_names.rb
+++ b/db/migrate/20140905020643_update_default_registration_channel_names.rb
@@ -1,4 +1,4 @@
-class UpdateDefaultRegistrationChannelNames < ActiveRecord::Migration
+class UpdateDefaultRegistrationChannelNames < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20140908201058_add_block_storage_only_to_flavor.rb
+++ b/db/migrate/20140908201058_add_block_storage_only_to_flavor.rb
@@ -1,4 +1,4 @@
-class AddBlockStorageOnlyToFlavor < ActiveRecord::Migration
+class AddBlockStorageOnlyToFlavor < ActiveRecord::Migration[4.2]
   def change
     add_column :flavors, :block_storage_based_only, :boolean
   end

--- a/db/migrate/20140908211826_add_root_device_type_to_hardware.rb
+++ b/db/migrate/20140908211826_add_root_device_type_to_hardware.rb
@@ -1,4 +1,4 @@
-class AddRootDeviceTypeToHardware < ActiveRecord::Migration
+class AddRootDeviceTypeToHardware < ActiveRecord::Migration[4.2]
   def change
     add_column :hardwares, :root_device_type, :string
   end

--- a/db/migrate/20140917145331_add_vm_publicly_available.rb
+++ b/db/migrate/20140917145331_add_vm_publicly_available.rb
@@ -1,4 +1,4 @@
-class AddVmPubliclyAvailable < ActiveRecord::Migration
+class AddVmPubliclyAvailable < ActiveRecord::Migration[4.2]
   def up
     add_column :vms, :publicly_available, :boolean
   end

--- a/db/migrate/20140918131740_add_template_multi_tenant_relationship.rb
+++ b/db/migrate/20140918131740_add_template_multi_tenant_relationship.rb
@@ -1,4 +1,4 @@
-class AddTemplateMultiTenantRelationship < ActiveRecord::Migration
+class AddTemplateMultiTenantRelationship < ActiveRecord::Migration[4.2]
   def up
     create_table :cloud_tenants_vms, :id => false do |t|
       t.column :cloud_tenant_id, :bigint

--- a/db/migrate/20140918140859_add_cloud_tenant_sti_column.rb
+++ b/db/migrate/20140918140859_add_cloud_tenant_sti_column.rb
@@ -1,4 +1,4 @@
-class AddCloudTenantStiColumn < ActiveRecord::Migration
+class AddCloudTenantStiColumn < ActiveRecord::Migration[4.2]
   class CloudTenant < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20140918154013_add_provider_region_to_ext_management_systems.rb
+++ b/db/migrate/20140918154013_add_provider_region_to_ext_management_systems.rb
@@ -1,4 +1,4 @@
-class AddProviderRegionToExtManagementSystems < ActiveRecord::Migration
+class AddProviderRegionToExtManagementSystems < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20140922163020_remove_vdi_models.rb
+++ b/db/migrate/20140922163020_remove_vdi_models.rb
@@ -1,4 +1,4 @@
-class RemoveVdiModels < ActiveRecord::Migration
+class RemoveVdiModels < ActiveRecord::Migration[4.2]
   def up
     change_table "ems_events" do |t|
       t.remove "vdi_endpoint_device_id"

--- a/db/migrate/20141002214356_add_refresh_status_to_ext_management_system.rb
+++ b/db/migrate/20141002214356_add_refresh_status_to_ext_management_system.rb
@@ -1,4 +1,4 @@
-class AddRefreshStatusToExtManagementSystem < ActiveRecord::Migration
+class AddRefreshStatusToExtManagementSystem < ActiveRecord::Migration[4.2]
   def change
     add_column :ext_management_systems, :last_refresh_error, :text
     add_column :ext_management_systems, :last_refresh_date,  :timestamp

--- a/db/migrate/20141015170920_remove_vdi_tab_from_miq_dialogs.rb
+++ b/db/migrate/20141015170920_remove_vdi_tab_from_miq_dialogs.rb
@@ -1,4 +1,4 @@
-class RemoveVdiTabFromMiqDialogs < ActiveRecord::Migration
+class RemoveVdiTabFromMiqDialogs < ActiveRecord::Migration[4.2]
   class MiqDialog < ActiveRecord::Base
     serialize :content, Hash
   end

--- a/db/migrate/20141020195642_create_orchestration_stacks.rb
+++ b/db/migrate/20141020195642_create_orchestration_stacks.rb
@@ -1,4 +1,4 @@
-class CreateOrchestrationStacks < ActiveRecord::Migration
+class CreateOrchestrationStacks < ActiveRecord::Migration[4.2]
   def change
     create_table :orchestration_templates do |t|
       t.string   :name

--- a/db/migrate/20141021103820_remove_miq_search_vdi_instances.rb
+++ b/db/migrate/20141021103820_remove_miq_search_vdi_instances.rb
@@ -1,4 +1,4 @@
-class RemoveMiqSearchVdiInstances < ActiveRecord::Migration
+class RemoveMiqSearchVdiInstances < ActiveRecord::Migration[4.2]
   class MiqSearch < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20141026111520_remove_black_box_from_vms.rb
+++ b/db/migrate/20141026111520_remove_black_box_from_vms.rb
@@ -1,4 +1,4 @@
-class RemoveBlackBoxFromVms < ActiveRecord::Migration
+class RemoveBlackBoxFromVms < ActiveRecord::Migration[4.2]
   def up
     change_table :vms do |t|
       t.remove :blackbox_exists

--- a/db/migrate/20141029000000_create_providers.rb
+++ b/db/migrate/20141029000000_create_providers.rb
@@ -1,4 +1,4 @@
-class CreateProviders < ActiveRecord::Migration
+class CreateProviders < ActiveRecord::Migration[4.2]
   def up
     create_table :providers do |t|
       t.string     :type

--- a/db/migrate/20141029005602_create_configuration_managers.rb
+++ b/db/migrate/20141029005602_create_configuration_managers.rb
@@ -1,4 +1,4 @@
-class CreateConfigurationManagers < ActiveRecord::Migration
+class CreateConfigurationManagers < ActiveRecord::Migration[4.2]
   def up
     create_table :configuration_managers do |t|
       t.string     :type

--- a/db/migrate/20141029005620_create_computer_systems.rb
+++ b/db/migrate/20141029005620_create_computer_systems.rb
@@ -1,4 +1,4 @@
-class CreateComputerSystems < ActiveRecord::Migration
+class CreateComputerSystems < ActiveRecord::Migration[4.2]
   def up
     create_table :computer_systems do |t|
       t.belongs_to :managed_entity, :type => :bigint, :polymorphic => true

--- a/db/migrate/20141029165319_create_provisioning_managers.rb
+++ b/db/migrate/20141029165319_create_provisioning_managers.rb
@@ -1,4 +1,4 @@
-class CreateProvisioningManagers < ActiveRecord::Migration
+class CreateProvisioningManagers < ActiveRecord::Migration[4.2]
   def up
     create_table :customization_scripts do |t|
       t.string     :name

--- a/db/migrate/20141117082419_add_dynamic_field_to_dialog_fields.rb
+++ b/db/migrate/20141117082419_add_dynamic_field_to_dialog_fields.rb
@@ -1,4 +1,4 @@
-class AddDynamicFieldToDialogFields < ActiveRecord::Migration
+class AddDynamicFieldToDialogFields < ActiveRecord::Migration[4.2]
   def up
     add_column :dialog_fields, :dynamic, :boolean
   end

--- a/db/migrate/20141121200053_create_endpoints.rb
+++ b/db/migrate/20141121200053_create_endpoints.rb
@@ -1,4 +1,4 @@
-class CreateEndpoints < ActiveRecord::Migration
+class CreateEndpoints < ActiveRecord::Migration[4.2]
   def change
     create_table :endpoints do |t|
       t.string     :role

--- a/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
+++ b/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb
@@ -1,4 +1,4 @@
-class MigrateEmsAttributesToEndpoints < ActiveRecord::Migration
+class MigrateEmsAttributesToEndpoints < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20141121200523_remove_endpoint_data_from_ems.rb
+++ b/db/migrate/20141121200523_remove_endpoint_data_from_ems.rb
@@ -1,4 +1,4 @@
-class RemoveEndpointDataFromEms < ActiveRecord::Migration
+class RemoveEndpointDataFromEms < ActiveRecord::Migration[4.2]
   def up
     remove_column :ext_management_systems, :port
     remove_column :ext_management_systems, :ipaddress

--- a/db/migrate/20141126161823_convert_show_refresh_button_and_load_values_on_init_to_real_columns_for_dialog_fields.rb
+++ b/db/migrate/20141126161823_convert_show_refresh_button_and_load_values_on_init_to_real_columns_for_dialog_fields.rb
@@ -1,4 +1,4 @@
-class ConvertShowRefreshButtonAndLoadValuesOnInitToRealColumnsForDialogFields < ActiveRecord::Migration
+class ConvertShowRefreshButtonAndLoadValuesOnInitToRealColumnsForDialogFields < ActiveRecord::Migration[4.2]
   class DialogField < ActiveRecord::Base
     serialize :options, Hash
     self.inheritance_column = :_type_disabled

--- a/db/migrate/20141202111010_add_ems_ref_to_cloudformation_stack.rb
+++ b/db/migrate/20141202111010_add_ems_ref_to_cloudformation_stack.rb
@@ -1,4 +1,4 @@
-class AddEmsRefToCloudformationStack < ActiveRecord::Migration
+class AddEmsRefToCloudformationStack < ActiveRecord::Migration[4.2]
   def up
     change_column :orchestration_stacks, :ems_ref, :text
     add_column :orchestration_stack_parameters, :ems_ref, :text

--- a/db/migrate/20141208194307_drop_miq_region_from_database_backups.rb
+++ b/db/migrate/20141208194307_drop_miq_region_from_database_backups.rb
@@ -1,4 +1,4 @@
-class DropMiqRegionFromDatabaseBackups < ActiveRecord::Migration
+class DropMiqRegionFromDatabaseBackups < ActiveRecord::Migration[4.2]
   def up
     remove_index  :database_backups, :miq_region_id
     remove_column :database_backups, :miq_region_id

--- a/db/migrate/20141219222843_remove_miq_worker_rows_without_model.rb
+++ b/db/migrate/20141219222843_remove_miq_worker_rows_without_model.rb
@@ -1,4 +1,4 @@
-class RemoveMiqWorkerRowsWithoutModel < ActiveRecord::Migration
+class RemoveMiqWorkerRowsWithoutModel < ActiveRecord::Migration[4.2]
   class MiqWorker < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end

--- a/db/migrate/20150109142457_namespace_ems_classes.rb
+++ b/db/migrate/20150109142457_namespace_ems_classes.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsClasses < ActiveRecord::Migration
+class NamespaceEmsClasses < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150111161446_create_nodes.rb
+++ b/db/migrate/20150111161446_create_nodes.rb
@@ -1,4 +1,4 @@
-class CreateNodes < ActiveRecord::Migration
+class CreateNodes < ActiveRecord::Migration[4.2]
   def up
     create_table :container_nodes do |t|
       t.string    :ems_ref

--- a/db/migrate/20150111161504_create_kubernetes_services.rb
+++ b/db/migrate/20150111161504_create_kubernetes_services.rb
@@ -1,4 +1,4 @@
-class CreateKubernetesServices < ActiveRecord::Migration
+class CreateKubernetesServices < ActiveRecord::Migration[4.2]
   def up
     create_table :container_services do |t|
       t.string     :ems_ref

--- a/db/migrate/20150128161824_create_container_groups.rb
+++ b/db/migrate/20150128161824_create_container_groups.rb
@@ -1,4 +1,4 @@
-class CreateContainerGroups < ActiveRecord::Migration
+class CreateContainerGroups < ActiveRecord::Migration[4.2]
   def up
     create_table :container_groups do |t|
       t.string     :ems_ref

--- a/db/migrate/20150128195918_add_manager_error_reporting.rb
+++ b/db/migrate/20150128195918_add_manager_error_reporting.rb
@@ -1,4 +1,4 @@
-class AddManagerErrorReporting < ActiveRecord::Migration
+class AddManagerErrorReporting < ActiveRecord::Migration[4.2]
   def change
     add_column :configuration_managers, :last_refresh_error, :text
     add_column :configuration_managers, :last_refresh_date,  :timestamp

--- a/db/migrate/20150131104420_remove_miq_proxy_models.rb
+++ b/db/migrate/20150131104420_remove_miq_proxy_models.rb
@@ -1,4 +1,4 @@
-class RemoveMiqProxyModels < ActiveRecord::Migration
+class RemoveMiqProxyModels < ActiveRecord::Migration[4.2]
   def up
     remove_index "miq_proxies", "guid"
     remove_index "miq_proxies", "host_id"

--- a/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
+++ b/db/migrate/20150202212058_fix_indexes_on_ems_events.rb
@@ -1,4 +1,4 @@
-class FixIndexesOnEmsEvents < ActiveRecord::Migration
+class FixIndexesOnEmsEvents < ActiveRecord::Migration[4.2]
   def up
     if find_index_by_name(:ems_events, "index_ems_events_on_vm_id")
       rename_index :ems_events, "index_ems_events_on_vm_id",      "index_ems_events_on_vm_or_template_id"

--- a/db/migrate/20150202215346_create_container_definitions.rb
+++ b/db/migrate/20150202215346_create_container_definitions.rb
@@ -1,4 +1,4 @@
-class CreateContainerDefinitions < ActiveRecord::Migration
+class CreateContainerDefinitions < ActiveRecord::Migration[4.2]
   def up
     create_table :container_definitions do |t|
       t.string     :ems_ref

--- a/db/migrate/20150202215414_create_containers.rb
+++ b/db/migrate/20150202215414_create_containers.rb
@@ -1,4 +1,4 @@
-class CreateContainers < ActiveRecord::Migration
+class CreateContainers < ActiveRecord::Migration[4.2]
   def up
     create_table :containers do |t|
       t.string     :ems_ref

--- a/db/migrate/20150202215435_create_container_port_configs.rb
+++ b/db/migrate/20150202215435_create_container_port_configs.rb
@@ -1,4 +1,4 @@
-class CreateContainerPortConfigs < ActiveRecord::Migration
+class CreateContainerPortConfigs < ActiveRecord::Migration[4.2]
   def up
     create_table :container_port_configs do |t|
       t.string     :ems_ref

--- a/db/migrate/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
+++ b/db/migrate/20150206150955_migrate_miq_database_registration_organization_display_name_out_of_reserves.rb
@@ -1,4 +1,4 @@
-class MigrateMiqDatabaseRegistrationOrganizationDisplayNameOutOfReserves < ActiveRecord::Migration
+class MigrateMiqDatabaseRegistrationOrganizationDisplayNameOutOfReserves < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base
     include ReservedMixin
     include MigrationStubHelper # NOTE: Must be included after other mixins

--- a/db/migrate/20150213135315_create_configured_system_last_checkin.rb
+++ b/db/migrate/20150213135315_create_configured_system_last_checkin.rb
@@ -1,4 +1,4 @@
-class CreateConfiguredSystemLastCheckin < ActiveRecord::Migration
+class CreateConfiguredSystemLastCheckin < ActiveRecord::Migration[4.2]
   def change
     add_column :configured_systems, :last_checkin, :timestamp
     add_column :configured_systems, :build_state, :string

--- a/db/migrate/20150224102026_create_host_hypervisor_hostname.rb
+++ b/db/migrate/20150224102026_create_host_hypervisor_hostname.rb
@@ -1,4 +1,4 @@
-class CreateHostHypervisorHostname < ActiveRecord::Migration
+class CreateHostHypervisorHostname < ActiveRecord::Migration[4.2]
   def change
     add_column :hosts, :hypervisor_hostname, :string
   end

--- a/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
+++ b/db/migrate/20150224164512_add_loopback_to_memcache_server_opts_in_configuration.rb
@@ -1,4 +1,4 @@
-class AddLoopbackToMemcacheServerOptsInConfiguration < ActiveRecord::Migration
+class AddLoopbackToMemcacheServerOptsInConfiguration < ActiveRecord::Migration[4.2]
   class Configuration < ActiveRecord::Base
     serialize :settings, Hash
   end

--- a/db/migrate/20150224192447_add_provider_id_to_ems.rb
+++ b/db/migrate/20150224192447_add_provider_id_to_ems.rb
@@ -1,4 +1,4 @@
-class AddProviderIdToEms < ActiveRecord::Migration
+class AddProviderIdToEms < ActiveRecord::Migration[4.2]
   def change
     add_column :ext_management_systems, :provider_id, :bigint
   end

--- a/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
+++ b/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
@@ -1,4 +1,4 @@
-class MigrateConfigurationManagerToEms < ActiveRecord::Migration
+class MigrateConfigurationManagerToEms < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     include UuidMixin
     self.inheritance_column = :_type_disabled

--- a/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
+++ b/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
@@ -1,4 +1,4 @@
-class MigrateProvisioningManagerToEms < ActiveRecord::Migration
+class MigrateProvisioningManagerToEms < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     include UuidMixin
     self.inheritance_column = :_type_disabled

--- a/db/migrate/20150224193752_drop_configration_manager_and_provisioning_manager.rb
+++ b/db/migrate/20150224193752_drop_configration_manager_and_provisioning_manager.rb
@@ -1,4 +1,4 @@
-class DropConfigrationManagerAndProvisioningManager < ActiveRecord::Migration
+class DropConfigrationManagerAndProvisioningManager < ActiveRecord::Migration[4.2]
   def up
     remove_index :configuration_managers, :provider_id
     drop_table   :configuration_managers

--- a/db/migrate/20150225160000_add_service_systemd_deps.rb
+++ b/db/migrate/20150225160000_add_service_systemd_deps.rb
@@ -1,4 +1,4 @@
-class AddServiceSystemdDeps < ActiveRecord::Migration
+class AddServiceSystemdDeps < ActiveRecord::Migration[4.2]
   def change
     add_column :system_services, :dependencies, :text
   end

--- a/db/migrate/20150227181349_add_configured_system_organization_location.rb
+++ b/db/migrate/20150227181349_add_configured_system_organization_location.rb
@@ -1,4 +1,4 @@
-class AddConfiguredSystemOrganizationLocation < ActiveRecord::Migration
+class AddConfiguredSystemOrganizationLocation < ActiveRecord::Migration[4.2]
   def change
     create_table :configuration_organizations do |t|
       t.string     :type

--- a/db/migrate/20150311181430_add_draft_to_orchestration_templates.rb
+++ b/db/migrate/20150311181430_add_draft_to_orchestration_templates.rb
@@ -1,4 +1,4 @@
-class AddDraftToOrchestrationTemplates < ActiveRecord::Migration
+class AddDraftToOrchestrationTemplates < ActiveRecord::Migration[4.2]
   class OrchestrationTemplate < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20150311182221_orchestration_template_rename_ems_ref_to_md5_and_drop_unique.rb
+++ b/db/migrate/20150311182221_orchestration_template_rename_ems_ref_to_md5_and_drop_unique.rb
@@ -1,4 +1,4 @@
-class OrchestrationTemplateRenameEmsRefToMd5AndDropUnique < ActiveRecord::Migration
+class OrchestrationTemplateRenameEmsRefToMd5AndDropUnique < ActiveRecord::Migration[4.2]
   def up
     remove_index  :orchestration_templates, :ems_ref
     rename_column :orchestration_templates, :ems_ref, :md5

--- a/db/migrate/20150312081342_add_read_only_to_dialog_fields.rb
+++ b/db/migrate/20150312081342_add_read_only_to_dialog_fields.rb
@@ -1,4 +1,4 @@
-class AddReadOnlyToDialogFields < ActiveRecord::Migration
+class AddReadOnlyToDialogFields < ActiveRecord::Migration[4.2]
   def change
     add_column :dialog_fields, :read_only, :boolean
   end

--- a/db/migrate/20150313110200_add_type_to_ems_clusters.rb
+++ b/db/migrate/20150313110200_add_type_to_ems_clusters.rb
@@ -1,4 +1,4 @@
-class AddTypeToEmsClusters < ActiveRecord::Migration
+class AddTypeToEmsClusters < ActiveRecord::Migration[4.2]
   def change
     add_column :ems_clusters, :type, :string
   end

--- a/db/migrate/20150316175916_update_miq_database_default_update_repo_name.rb
+++ b/db/migrate/20150316175916_update_miq_database_default_update_repo_name.rb
@@ -1,4 +1,4 @@
-class UpdateMiqDatabaseDefaultUpdateRepoName < ActiveRecord::Migration
+class UpdateMiqDatabaseDefaultUpdateRepoName < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   REPO_NAME_HASH = {

--- a/db/migrate/20150319115040_create_replication_controllers.rb
+++ b/db/migrate/20150319115040_create_replication_controllers.rb
@@ -1,4 +1,4 @@
-class CreateReplicationControllers < ActiveRecord::Migration
+class CreateReplicationControllers < ActiveRecord::Migration[4.2]
   def up
     create_table :container_replication_controllers do |t|
       t.string     :ems_ref

--- a/db/migrate/20150323003436_add_configured_system_attributes.rb
+++ b/db/migrate/20150323003436_add_configured_system_attributes.rb
@@ -1,4 +1,4 @@
-class AddConfiguredSystemAttributes < ActiveRecord::Migration
+class AddConfiguredSystemAttributes < ActiveRecord::Migration[4.2]
   def change
     add_column :configured_systems, :ipaddress, :string
     add_column :configured_systems, :mac_address, :string

--- a/db/migrate/20150323004436_add_locations_parent.rb
+++ b/db/migrate/20150323004436_add_locations_parent.rb
@@ -1,4 +1,4 @@
-class AddLocationsParent < ActiveRecord::Migration
+class AddLocationsParent < ActiveRecord::Migration[4.2]
   def change
     add_column :configuration_locations, :parent_id, :bigint
     add_column :configuration_locations, :parent_ref, :string

--- a/db/migrate/20150323172109_add_availability_zone_id_to_host.rb
+++ b/db/migrate/20150323172109_add_availability_zone_id_to_host.rb
@@ -1,4 +1,4 @@
-class AddAvailabilityZoneIdToHost < ActiveRecord::Migration
+class AddAvailabilityZoneIdToHost < ActiveRecord::Migration[4.2]
   def change
     add_column :hosts, :availability_zone_id, :bigint
     add_index  :hosts, :availability_zone_id

--- a/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
+++ b/db/migrate/20150324111111_add_retirement_requester_to_vms_and_services.rb
@@ -1,4 +1,4 @@
-class AddRetirementRequesterToVmsAndServices < ActiveRecord::Migration
+class AddRetirementRequesterToVmsAndServices < ActiveRecord::Migration[4.2]
   def change
     add_column :vms, :retirement_requester, :string
     add_column :services, :retirement_requester, :string

--- a/db/migrate/20150324143511_add_organization_title.rb
+++ b/db/migrate/20150324143511_add_organization_title.rb
@@ -1,4 +1,4 @@
-class AddOrganizationTitle < ActiveRecord::Migration
+class AddOrganizationTitle < ActiveRecord::Migration[4.2]
   def change
     add_column :configuration_organizations, :title, :string
     add_column :configuration_locations, :title, :string

--- a/db/migrate/20150324164033_create_configuration_tags.rb
+++ b/db/migrate/20150324164033_create_configuration_tags.rb
@@ -1,4 +1,4 @@
-class CreateConfigurationTags < ActiveRecord::Migration
+class CreateConfigurationTags < ActiveRecord::Migration[4.2]
   def change
     create_table :configuration_tags do |t|
       t.string :type

--- a/db/migrate/20150326015341_add_container_group_node_relationship.rb
+++ b/db/migrate/20150326015341_add_container_group_node_relationship.rb
@@ -1,4 +1,4 @@
-class AddContainerGroupNodeRelationship < ActiveRecord::Migration
+class AddContainerGroupNodeRelationship < ActiveRecord::Migration[4.2]
   def change
     add_column :container_groups, :container_node_id, :bigint
   end

--- a/db/migrate/20150326130147_create_container_groups_container_services.rb
+++ b/db/migrate/20150326130147_create_container_groups_container_services.rb
@@ -1,4 +1,4 @@
-class CreateContainerGroupsContainerServices < ActiveRecord::Migration
+class CreateContainerGroupsContainerServices < ActiveRecord::Migration[4.2]
   def change
     create_table :container_groups_container_services, :id => false do |t|
       t.bigint :container_service_id

--- a/db/migrate/20150326154800_add_application_install_time.rb
+++ b/db/migrate/20150326154800_add_application_install_time.rb
@@ -1,4 +1,4 @@
-class AddApplicationInstallTime < ActiveRecord::Migration
+class AddApplicationInstallTime < ActiveRecord::Migration[4.2]
   def change
     add_column :guest_applications, :install_time, :timestamp
   end

--- a/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
+++ b/db/migrate/20150330214408_add_file_depot_id_to_miq_schedule.rb
@@ -1,4 +1,4 @@
-class AddFileDepotIdToMiqSchedule < ActiveRecord::Migration
+class AddFileDepotIdToMiqSchedule < ActiveRecord::Migration[4.2]
   class MiqSchedule < ActiveRecord::Base
     def file_depot
       return @file_depot if defined?(@file_depot)

--- a/db/migrate/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag.rb
+++ b/db/migrate/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag.rb
@@ -1,4 +1,4 @@
-class ChangeDialogFieldDynamicListsToDialogFieldDropDownListWithDynamicFlag < ActiveRecord::Migration
+class ChangeDialogFieldDynamicListsToDialogFieldDropDownListWithDynamicFlag < ActiveRecord::Migration[4.2]
   class DialogField < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end

--- a/db/migrate/20150401090146_add_systemd_and_openstack_related_columns_to_system_services.rb
+++ b/db/migrate/20150401090146_add_systemd_and_openstack_related_columns_to_system_services.rb
@@ -1,4 +1,4 @@
-class AddSystemdAndOpenstackRelatedColumnsToSystemServices < ActiveRecord::Migration
+class AddSystemdAndOpenstackRelatedColumnsToSystemServices < ActiveRecord::Migration[4.2]
   def change
     add_column :system_services, :systemd_load, :string
     add_column :system_services, :systemd_active, :string

--- a/db/migrate/20150402115247_add_container_port_config_names.rb
+++ b/db/migrate/20150402115247_add_container_port_config_names.rb
@@ -1,4 +1,4 @@
-class AddContainerPortConfigNames < ActiveRecord::Migration
+class AddContainerPortConfigNames < ActiveRecord::Migration[4.2]
   def change
     add_column :container_port_configs, :name, :string
   end

--- a/db/migrate/20150402133252_add_container_node_cross_provider_association.rb
+++ b/db/migrate/20150402133252_add_container_node_cross_provider_association.rb
@@ -1,4 +1,4 @@
-class AddContainerNodeCrossProviderAssociation < ActiveRecord::Migration
+class AddContainerNodeCrossProviderAssociation < ActiveRecord::Migration[4.2]
   def up
     add_column :container_nodes, :lives_on_type, :string
     add_column :container_nodes, :lives_on_id,   :bigint

--- a/db/migrate/20150402182026_container_metrics.rb
+++ b/db/migrate/20150402182026_container_metrics.rb
@@ -1,4 +1,4 @@
-class ContainerMetrics < ActiveRecord::Migration
+class ContainerMetrics < ActiveRecord::Migration[4.2]
   def change
     add_column :container_nodes, :last_perf_capture_on, :datetime
     add_column :containers, :last_perf_capture_on, :datetime

--- a/db/migrate/20150405141637_remove_port_config_from_container_service.rb
+++ b/db/migrate/20150405141637_remove_port_config_from_container_service.rb
@@ -1,4 +1,4 @@
-class RemovePortConfigFromContainerService < ActiveRecord::Migration
+class RemovePortConfigFromContainerService < ActiveRecord::Migration[4.2]
   class ContainerService < ActiveRecord::Base
     has_many :container_service_port_configs,
              :class_name => "RemovePortConfigFromContainerService::ContainerServicePortConfig"

--- a/db/migrate/20150406141646_remove_service_id_from_ems_events.rb
+++ b/db/migrate/20150406141646_remove_service_id_from_ems_events.rb
@@ -1,4 +1,4 @@
-class RemoveServiceIdFromEmsEvents < ActiveRecord::Migration
+class RemoveServiceIdFromEmsEvents < ActiveRecord::Migration[4.2]
   def up
     remove_index  :ems_events, :service_id
     remove_column :ems_events, :service_id

--- a/db/migrate/20150407144345_add_kerberos_to_ext_management_system.rb
+++ b/db/migrate/20150407144345_add_kerberos_to_ext_management_system.rb
@@ -1,4 +1,4 @@
-class AddKerberosToExtManagementSystem < ActiveRecord::Migration
+class AddKerberosToExtManagementSystem < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
 

--- a/db/migrate/20150409145038_add_host_service_group_to_system_services.rb
+++ b/db/migrate/20150409145038_add_host_service_group_to_system_services.rb
@@ -1,4 +1,4 @@
-class AddHostServiceGroupToSystemServices < ActiveRecord::Migration
+class AddHostServiceGroupToSystemServices < ActiveRecord::Migration[4.2]
   def change
     add_column :system_services, :host_service_group_id, :bigint
     add_index :system_services, :host_service_group_id

--- a/db/migrate/20150409145147_add_host_service_group_to_filesystems.rb
+++ b/db/migrate/20150409145147_add_host_service_group_to_filesystems.rb
@@ -1,4 +1,4 @@
-class AddHostServiceGroupToFilesystems < ActiveRecord::Migration
+class AddHostServiceGroupToFilesystems < ActiveRecord::Migration[4.2]
   def change
     add_column :filesystems, :host_service_group_id, :bigint
     add_index :filesystems, :host_service_group_id

--- a/db/migrate/20150409145739_create_host_service_groups.rb
+++ b/db/migrate/20150409145739_create_host_service_groups.rb
@@ -1,4 +1,4 @@
-class CreateHostServiceGroups < ActiveRecord::Migration
+class CreateHostServiceGroups < ActiveRecord::Migration[4.2]
   def up
     create_table :host_service_groups do |t|
       t.string     :name

--- a/db/migrate/20150414094834_create_container_projects.rb
+++ b/db/migrate/20150414094834_create_container_projects.rb
@@ -1,4 +1,4 @@
-class CreateContainerProjects < ActiveRecord::Migration
+class CreateContainerProjects < ActiveRecord::Migration[4.2]
   def up
     create_table :container_projects do |t|
       t.string     :ems_ref

--- a/db/migrate/20150414183946_rename_container_id.rb
+++ b/db/migrate/20150414183946_rename_container_id.rb
@@ -1,4 +1,4 @@
-class RenameContainerId < ActiveRecord::Migration
+class RenameContainerId < ActiveRecord::Migration[4.2]
   def change
     rename_column :containers, :container_id, :backing_ref
   end

--- a/db/migrate/20150414201314_update_foreman_raw_attributes.rb
+++ b/db/migrate/20150414201314_update_foreman_raw_attributes.rb
@@ -1,4 +1,4 @@
-class UpdateForemanRawAttributes < ActiveRecord::Migration
+class UpdateForemanRawAttributes < ActiveRecord::Migration[4.2]
   def change
     rename_column :configured_systems, :operating_system_flavor_id,     :direct_operating_system_flavor_id
     rename_column :configured_systems, :customization_script_medium_id, :direct_customization_script_medium_id

--- a/db/migrate/20150414204018_create_container_node_identities.rb
+++ b/db/migrate/20150414204018_create_container_node_identities.rb
@@ -1,4 +1,4 @@
-class CreateContainerNodeIdentities < ActiveRecord::Migration
+class CreateContainerNodeIdentities < ActiveRecord::Migration[4.2]
   def change
     # identity_infra is the node id assigned by the infrastructure
     add_column :container_nodes, :identity_infra, :string

--- a/db/migrate/20150415131224_create_container_routes.rb
+++ b/db/migrate/20150415131224_create_container_routes.rb
@@ -1,4 +1,4 @@
-class CreateContainerRoutes < ActiveRecord::Migration
+class CreateContainerRoutes < ActiveRecord::Migration[4.2]
   def up
     create_table :container_routes do |t|
       t.string     :ems_ref

--- a/db/migrate/20150417125852_add_container_events.rb
+++ b/db/migrate/20150417125852_add_container_events.rb
@@ -1,4 +1,4 @@
-class AddContainerEvents < ActiveRecord::Migration
+class AddContainerEvents < ActiveRecord::Migration[4.2]
   def change
     add_column  :ems_events, :container_node_id, :bigint
     add_column  :ems_events, :container_node_name, :string

--- a/db/migrate/20150417162811_update_foreman_derived_values.rb
+++ b/db/migrate/20150417162811_update_foreman_derived_values.rb
@@ -1,4 +1,4 @@
-class UpdateForemanDerivedValues < ActiveRecord::Migration
+class UpdateForemanDerivedValues < ActiveRecord::Migration[4.2]
   def change
     add_column :configured_systems, :operating_system_flavor_id,     :bigint
     add_column :configured_systems, :customization_script_medium_id, :bigint

--- a/db/migrate/20150417210709_add_retirement_to_orchestration_stack.rb
+++ b/db/migrate/20150417210709_add_retirement_to_orchestration_stack.rb
@@ -1,4 +1,4 @@
-class AddRetirementToOrchestrationStack < ActiveRecord::Migration
+class AddRetirementToOrchestrationStack < ActiveRecord::Migration[4.2]
   def change
     add_column :orchestration_stacks, :retired,              :boolean
     add_column :orchestration_stacks, :retires_on,           :date

--- a/db/migrate/20150420201056_add_auto_refresh_fields_to_dialog_fields.rb
+++ b/db/migrate/20150420201056_add_auto_refresh_fields_to_dialog_fields.rb
@@ -1,4 +1,4 @@
-class AddAutoRefreshFieldsToDialogFields < ActiveRecord::Migration
+class AddAutoRefreshFieldsToDialogFields < ActiveRecord::Migration[4.2]
   def change
     add_column :dialog_fields, :auto_refresh, :boolean
     add_column :dialog_fields, :trigger_auto_refresh, :boolean

--- a/db/migrate/20150422162729_add_replicator_relationship.rb
+++ b/db/migrate/20150422162729_add_replicator_relationship.rb
@@ -1,4 +1,4 @@
-class AddReplicatorRelationship < ActiveRecord::Migration
+class AddReplicatorRelationship < ActiveRecord::Migration[4.2]
   def change
     add_column :container_groups, :container_replicator_id, :bigint
   end

--- a/db/migrate/20150426135513_add_image_id_to_containers.rb
+++ b/db/migrate/20150426135513_add_image_id_to_containers.rb
@@ -1,4 +1,4 @@
-class AddImageIdToContainers < ActiveRecord::Migration
+class AddImageIdToContainers < ActiveRecord::Migration[4.2]
   def up
     add_column    :containers, :image_ref, :string
   end

--- a/db/migrate/20150429214648_add_direct_configuration_tags.rb
+++ b/db/migrate/20150429214648_add_direct_configuration_tags.rb
@@ -1,4 +1,4 @@
-class AddDirectConfigurationTags < ActiveRecord::Migration
+class AddDirectConfigurationTags < ActiveRecord::Migration[4.2]
   def change
     create_table :direct_configuration_profiles_configuration_tags, :id => false do |t|
       t.belongs_to :configuration_profile, :type => :bigint

--- a/db/migrate/20150501193927_default_provider_verify_ssl.rb
+++ b/db/migrate/20150501193927_default_provider_verify_ssl.rb
@@ -1,4 +1,4 @@
-class DefaultProviderVerifySsl < ActiveRecord::Migration
+class DefaultProviderVerifySsl < ActiveRecord::Migration[4.2]
   class Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end

--- a/db/migrate/20150503094838_add_container_group_ip_to_container_groups.rb
+++ b/db/migrate/20150503094838_add_container_group_ip_to_container_groups.rb
@@ -1,4 +1,4 @@
-class AddContainerGroupIpToContainerGroups < ActiveRecord::Migration
+class AddContainerGroupIpToContainerGroups < ActiveRecord::Migration[4.2]
   def up
     add_column :container_groups, :ipaddress, :string
   end

--- a/db/migrate/20150504111111_add_cloud_subnet_required_to_flavor.rb
+++ b/db/migrate/20150504111111_add_cloud_subnet_required_to_flavor.rb
@@ -1,4 +1,4 @@
-class AddCloudSubnetRequiredToFlavor < ActiveRecord::Migration
+class AddCloudSubnetRequiredToFlavor < ActiveRecord::Migration[4.2]
   def change
     add_column :flavors, :cloud_subnet_required, :boolean
   end

--- a/db/migrate/20150505160516_add_status_reason_and_cloud_tenant_to_orchestration_stacks.rb
+++ b/db/migrate/20150505160516_add_status_reason_and_cloud_tenant_to_orchestration_stacks.rb
@@ -1,4 +1,4 @@
-class AddStatusReasonAndCloudTenantToOrchestrationStacks < ActiveRecord::Migration
+class AddStatusReasonAndCloudTenantToOrchestrationStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :orchestration_stacks, :status_reason,   :text
     add_column :orchestration_stacks, :cloud_tenant_id, :bigint

--- a/db/migrate/20150507102612_create_container_node_conditions.rb
+++ b/db/migrate/20150507102612_create_container_node_conditions.rb
@@ -1,4 +1,4 @@
-class CreateContainerNodeConditions < ActiveRecord::Migration
+class CreateContainerNodeConditions < ActiveRecord::Migration[4.2]
   def up
     create_table :container_node_conditions do |t|
       t.belongs_to :container_node, :type => :bigint

--- a/db/migrate/20150514124529_rename_replication_controllers_to_container_replicators.rb
+++ b/db/migrate/20150514124529_rename_replication_controllers_to_container_replicators.rb
@@ -1,4 +1,4 @@
-class RenameReplicationControllersToContainerReplicators < ActiveRecord::Migration
+class RenameReplicationControllersToContainerReplicators < ActiveRecord::Migration[4.2]
   def self.up
     rename_table :container_replication_controllers, :container_replicators
   end

--- a/db/migrate/20150519123317_create_container_env_vars.rb
+++ b/db/migrate/20150519123317_create_container_env_vars.rb
@@ -1,4 +1,4 @@
-class CreateContainerEnvVars < ActiveRecord::Migration
+class CreateContainerEnvVars < ActiveRecord::Migration[4.2]
   def up
     create_table :container_env_vars do |t|
       t.string     :name

--- a/db/migrate/20150521104843_create_container_images.rb
+++ b/db/migrate/20150521104843_create_container_images.rb
@@ -1,4 +1,4 @@
-class CreateContainerImages < ActiveRecord::Migration
+class CreateContainerImages < ActiveRecord::Migration[4.2]
   def up
     create_table :container_images do |t|
       t.string     :tag

--- a/db/migrate/20150521132514_create_container_image_registries.rb
+++ b/db/migrate/20150521132514_create_container_image_registries.rb
@@ -1,4 +1,4 @@
-class CreateContainerImageRegistries < ActiveRecord::Migration
+class CreateContainerImageRegistries < ActiveRecord::Migration[4.2]
   def up
     create_table :container_image_registries do |t|
       t.string     :name  # Never used but all entities are assumed to have a name.

--- a/db/migrate/20150521204814_add_container_relationship.rb
+++ b/db/migrate/20150521204814_add_container_relationship.rb
@@ -1,4 +1,4 @@
-class AddContainerRelationship < ActiveRecord::Migration
+class AddContainerRelationship < ActiveRecord::Migration[4.2]
   def change
     add_column :containers, :container_definition_id, :bigint
   end

--- a/db/migrate/20150522161336_add_container_entities_type.rb
+++ b/db/migrate/20150522161336_add_container_entities_type.rb
@@ -1,4 +1,4 @@
-class AddContainerEntitiesType < ActiveRecord::Migration
+class AddContainerEntitiesType < ActiveRecord::Migration[4.2]
   class ContainerNode < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20150526080322_add_container_node_versions_and_os_image.rb
+++ b/db/migrate/20150526080322_add_container_node_versions_and_os_image.rb
@@ -1,4 +1,4 @@
-class AddContainerNodeVersionsAndOsImage < ActiveRecord::Migration
+class AddContainerNodeVersionsAndOsImage < ActiveRecord::Migration[4.2]
   def change
     add_column    :operating_systems, :kernel_version, :string
     add_column    :container_nodes, :kubernetes_kubelet_version, :string

--- a/db/migrate/20150528113122_add_image_relation_to_container.rb
+++ b/db/migrate/20150528113122_add_image_relation_to_container.rb
@@ -1,4 +1,4 @@
-class AddImageRelationToContainer < ActiveRecord::Migration
+class AddImageRelationToContainer < ActiveRecord::Migration[4.2]
   def up
     add_column :containers, :container_image_id, :bigint
     remove_column :containers, :image

--- a/db/migrate/20150604154825_rename_container_node_conditions_to_container_conditions.rb
+++ b/db/migrate/20150604154825_rename_container_node_conditions_to_container_conditions.rb
@@ -1,4 +1,4 @@
-class RenameContainerNodeConditionsToContainerConditions < ActiveRecord::Migration
+class RenameContainerNodeConditionsToContainerConditions < ActiveRecord::Migration[4.2]
   class ContainerCondition < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20150610155632_add_image_to_guest_application.rb
+++ b/db/migrate/20150610155632_add_image_to_guest_application.rb
@@ -1,4 +1,4 @@
-class AddImageToGuestApplication < ActiveRecord::Migration
+class AddImageToGuestApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :guest_applications, :container_image_id, :bigint
   end

--- a/db/migrate/20150610172646_add_container_project_relationship.rb
+++ b/db/migrate/20150610172646_add_container_project_relationship.rb
@@ -1,4 +1,4 @@
-class AddContainerProjectRelationship < ActiveRecord::Migration
+class AddContainerProjectRelationship < ActiveRecord::Migration[4.2]
   def change
     add_column :container_groups, :container_project_id, :bigint
     add_column :container_routes, :container_project_id, :bigint

--- a/db/migrate/20150611083448_change_custom_attribute_value_type_to_text.rb
+++ b/db/migrate/20150611083448_change_custom_attribute_value_type_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeCustomAttributeValueTypeToText < ActiveRecord::Migration
+class ChangeCustomAttributeValueTypeToText < ActiveRecord::Migration[4.2]
   def up
     change_column :custom_attributes, :value, :text
   end

--- a/db/migrate/20150611094050_add_description_and_interpolated_value_to_custom_attribute.rb
+++ b/db/migrate/20150611094050_add_description_and_interpolated_value_to_custom_attribute.rb
@@ -1,4 +1,4 @@
-class AddDescriptionAndInterpolatedValueToCustomAttribute < ActiveRecord::Migration
+class AddDescriptionAndInterpolatedValueToCustomAttribute < ActiveRecord::Migration[4.2]
   def change
     add_column :custom_attributes, :description, :text
     add_column :custom_attributes, :value_interpolated, :text

--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -1,4 +1,4 @@
-class FixSerializedReportsForRailsFour < ActiveRecord::Migration
+class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
   module Serializer
     YAML_ATTRS = [:table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                   :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,

--- a/db/migrate/20150630025128_create_tenant.rb
+++ b/db/migrate/20150630025128_create_tenant.rb
@@ -1,4 +1,4 @@
-class CreateTenant < ActiveRecord::Migration
+class CreateTenant < ActiveRecord::Migration[4.2]
   def change
     create_table :tenants do |t|
       t.string :domain

--- a/db/migrate/20150630100251_namespace_ems_amazon.rb
+++ b/db/migrate/20150630100251_namespace_ems_amazon.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsAmazon < ActiveRecord::Migration
+class NamespaceEmsAmazon < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150701142710_associate_tenant_vm.rb
+++ b/db/migrate/20150701142710_associate_tenant_vm.rb
@@ -1,4 +1,4 @@
-class AssociateTenantVm < ActiveRecord::Migration
+class AssociateTenantVm < ActiveRecord::Migration[4.2]
   def change
     add_column :providers, :tenant_owner_id, :bigint
     add_column :vms, :tenant_owner_id, :bigint

--- a/db/migrate/20150701191241_add_shared_to_cloud_network.rb
+++ b/db/migrate/20150701191241_add_shared_to_cloud_network.rb
@@ -1,4 +1,4 @@
-class AddSharedToCloudNetwork < ActiveRecord::Migration
+class AddSharedToCloudNetwork < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_networks, :shared, :boolean
   end

--- a/db/migrate/20150708120923_create_tenant_resources.rb
+++ b/db/migrate/20150708120923_create_tenant_resources.rb
@@ -1,4 +1,4 @@
-class CreateTenantResources < ActiveRecord::Migration
+class CreateTenantResources < ActiveRecord::Migration[4.2]
   def change
     create_table :tenant_resources do |t|
       t.belongs_to :tenant, :type => :bigint

--- a/db/migrate/20150710081302_create_network_ports_and_routers.rb
+++ b/db/migrate/20150710081302_create_network_ports_and_routers.rb
@@ -1,4 +1,4 @@
-class CreateNetworkPortsAndRouters < ActiveRecord::Migration
+class CreateNetworkPortsAndRouters < ActiveRecord::Migration[4.2]
   def change
     create_table :network_ports do |t|
       t.string     :type

--- a/db/migrate/20150710110003_add_missing_fields_and_indexes_to_floating_ips.rb
+++ b/db/migrate/20150710110003_add_missing_fields_and_indexes_to_floating_ips.rb
@@ -1,4 +1,4 @@
-class AddMissingFieldsAndIndexesToFloatingIps < ActiveRecord::Migration
+class AddMissingFieldsAndIndexesToFloatingIps < ActiveRecord::Migration[4.2]
   def change
     add_column :floating_ips, :network_router_id, :bigint
     add_column :floating_ips, :network_port_id,   :bigint

--- a/db/migrate/20150710110243_add_missing_fields_and_indexes_to_cloud_networks.rb
+++ b/db/migrate/20150710110243_add_missing_fields_and_indexes_to_cloud_networks.rb
@@ -1,4 +1,4 @@
-class AddMissingFieldsAndIndexesToCloudNetworks < ActiveRecord::Migration
+class AddMissingFieldsAndIndexesToCloudNetworks < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_networks, :provider_physical_network, :string
     add_column :cloud_networks, :provider_network_type,     :string

--- a/db/migrate/20150710110244_add_sti_to_cloud_networks.rb
+++ b/db/migrate/20150710110244_add_sti_to_cloud_networks.rb
@@ -1,4 +1,4 @@
-class AddStiToCloudNetworks < ActiveRecord::Migration
+class AddStiToCloudNetworks < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_networks, :type, :string
   end

--- a/db/migrate/20150710110707_add_missing_fields_and_indexes_to_cloud_subnets.rb
+++ b/db/migrate/20150710110707_add_missing_fields_and_indexes_to_cloud_subnets.rb
@@ -1,4 +1,4 @@
-class AddMissingFieldsAndIndexesToCloudSubnets < ActiveRecord::Migration
+class AddMissingFieldsAndIndexesToCloudSubnets < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_subnets, :cloud_tenant_id,                :bigint
     add_column :cloud_subnets, :dns_nameservers,                :string

--- a/db/migrate/20150710110708_add_sti_to_cloud_subnets.rb
+++ b/db/migrate/20150710110708_add_sti_to_cloud_subnets.rb
@@ -1,4 +1,4 @@
-class AddStiToCloudSubnets < ActiveRecord::Migration
+class AddStiToCloudSubnets < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_subnets, :type, :string
   end

--- a/db/migrate/20150710120646_add_missing_fields_and_indexes_to_security_groups.rb
+++ b/db/migrate/20150710120646_add_missing_fields_and_indexes_to_security_groups.rb
@@ -1,4 +1,4 @@
-class AddMissingFieldsAndIndexesToSecurityGroups < ActiveRecord::Migration
+class AddMissingFieldsAndIndexesToSecurityGroups < ActiveRecord::Migration[4.2]
   def change
     add_index  :security_groups, :ems_id
     add_index  :security_groups, :cloud_tenant_id

--- a/db/migrate/20150714042229_add_routes_to_services.rb
+++ b/db/migrate/20150714042229_add_routes_to_services.rb
@@ -1,4 +1,4 @@
-class AddRoutesToServices < ActiveRecord::Migration
+class AddRoutesToServices < ActiveRecord::Migration[4.2]
   def change
     add_column :container_routes, :container_service_id, :bigint
     remove_column :container_routes, :service_name, :string

--- a/db/migrate/20150714053019_namespace_ems_redhat.rb
+++ b/db/migrate/20150714053019_namespace_ems_redhat.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsRedhat < ActiveRecord::Migration
+class NamespaceEmsRedhat < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150714143821_remove_ui_tasks_and_ui_task_sets.rb
+++ b/db/migrate/20150714143821_remove_ui_tasks_and_ui_task_sets.rb
@@ -1,4 +1,4 @@
-class RemoveUiTasksAndUiTaskSets < ActiveRecord::Migration
+class RemoveUiTasksAndUiTaskSets < ActiveRecord::Migration[4.2]
   class MiqSet < ActiveRecord::Base; end
 
   class Relationship < ActiveRecord::Base; end

--- a/db/migrate/20150716021334_fix_redhat_namespace.rb
+++ b/db/migrate/20150716021334_fix_redhat_namespace.rb
@@ -1,4 +1,4 @@
-class FixRedhatNamespace < ActiveRecord::Migration
+class FixRedhatNamespace < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150719123908_add_container_state.rb
+++ b/db/migrate/20150719123908_add_container_state.rb
@@ -1,4 +1,4 @@
-class AddContainerState < ActiveRecord::Migration
+class AddContainerState < ActiveRecord::Migration[4.2]
   def change
     add_column :containers, :reason, :string
     add_column :containers, :started_at, :datetime

--- a/db/migrate/20150724030353_namespace_ems_foreman.rb
+++ b/db/migrate/20150724030353_namespace_ems_foreman.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsForeman < ActiveRecord::Migration
+class NamespaceEmsForeman < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150726144643_remove_container_group_id_from_containers.rb
+++ b/db/migrate/20150726144643_remove_container_group_id_from_containers.rb
@@ -1,4 +1,4 @@
-class RemoveContainerGroupIdFromContainers < ActiveRecord::Migration
+class RemoveContainerGroupIdFromContainers < ActiveRecord::Migration[4.2]
   def change
     remove_column :containers, :container_group_id, :bigint
   end

--- a/db/migrate/20150730135121_add_container_group_phase.rb
+++ b/db/migrate/20150730135121_add_container_group_phase.rb
@@ -1,4 +1,4 @@
-class AddContainerGroupPhase < ActiveRecord::Migration
+class AddContainerGroupPhase < ActiveRecord::Migration[4.2]
   def change
     add_column :container_groups, :phase, :string
     add_column :container_groups, :message, :string

--- a/db/migrate/20150731025210_namespace_ems_openstack.rb
+++ b/db/migrate/20150731025210_namespace_ems_openstack.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsOpenstack < ActiveRecord::Migration
+class NamespaceEmsOpenstack < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150804194147_create_blacklisted_events.rb
+++ b/db/migrate/20150804194147_create_blacklisted_events.rb
@@ -1,4 +1,4 @@
-class CreateBlacklistedEvents < ActiveRecord::Migration
+class CreateBlacklistedEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :blacklisted_events do |t|
       t.string  :event_name

--- a/db/migrate/20150806190149_rename_miq_event_table_to_miq_event_definition.rb
+++ b/db/migrate/20150806190149_rename_miq_event_table_to_miq_event_definition.rb
@@ -1,4 +1,4 @@
-class RenameMiqEventTableToMiqEventDefinition < ActiveRecord::Migration
+class RenameMiqEventTableToMiqEventDefinition < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   class MiqSet < ActiveRecord::Base; end

--- a/db/migrate/20150806190349_rename_columns_starting_with_miq_event.rb
+++ b/db/migrate/20150806190349_rename_columns_starting_with_miq_event.rb
@@ -1,4 +1,4 @@
-class RenameColumnsStartingWithMiqEvent < ActiveRecord::Migration
+class RenameColumnsStartingWithMiqEvent < ActiveRecord::Migration[4.2]
   def change
     rename_column :miq_policy_contents, :miq_event_id, :miq_event_definition_id
     rename_column :policy_events, :miq_event_id, :miq_event_definition_id

--- a/db/migrate/20150806194147_migrate_filtered_events_to_blacklisted_events.rb
+++ b/db/migrate/20150806194147_migrate_filtered_events_to_blacklisted_events.rb
@@ -1,4 +1,4 @@
-class MigrateFilteredEventsToBlacklistedEvents < ActiveRecord::Migration
+class MigrateFilteredEventsToBlacklistedEvents < ActiveRecord::Migration[4.2]
   class Configuration < ActiveRecord::Base
     serialize :settings
   end

--- a/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
+++ b/db/migrate/20150806211453_rename_ems_event_table_to_event_stream.rb
@@ -1,4 +1,4 @@
-class RenameEmsEventTableToEventStream < ActiveRecord::Migration
+class RenameEmsEventTableToEventStream < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   include MigrationHelper
 

--- a/db/migrate/20150807165254_namespace_ems_container.rb
+++ b/db/migrate/20150807165254_namespace_ems_container.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsContainer < ActiveRecord::Migration
+class NamespaceEmsContainer < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150810015500_add_tenant_hierarchy.rb
+++ b/db/migrate/20150810015500_add_tenant_hierarchy.rb
@@ -1,4 +1,4 @@
-class AddTenantHierarchy < ActiveRecord::Migration
+class AddTenantHierarchy < ActiveRecord::Migration[4.2]
   def change
     add_column :tenants, :ancestry, :string
     add_index :tenants, :ancestry

--- a/db/migrate/20150813115025_create_container_resource_quota.rb
+++ b/db/migrate/20150813115025_create_container_resource_quota.rb
@@ -1,4 +1,4 @@
-class CreateContainerResourceQuota < ActiveRecord::Migration
+class CreateContainerResourceQuota < ActiveRecord::Migration[4.2]
   def change
     create_table :container_quotas do |t|
       t.string     :name

--- a/db/migrate/20150814210507_rename_tenant_company_name.rb
+++ b/db/migrate/20150814210507_rename_tenant_company_name.rb
@@ -1,4 +1,4 @@
-class RenameTenantCompanyName < ActiveRecord::Migration
+class RenameTenantCompanyName < ActiveRecord::Migration[4.2]
   def change
     rename_column :tenants, :company_name, :name
   end

--- a/db/migrate/20150815051916_namespace_ems_microsoft.rb
+++ b/db/migrate/20150815051916_namespace_ems_microsoft.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsMicrosoft < ActiveRecord::Migration
+class NamespaceEmsMicrosoft < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150815052719_fix_foreman_provider_type.rb
+++ b/db/migrate/20150815052719_fix_foreman_provider_type.rb
@@ -1,4 +1,4 @@
-class FixForemanProviderType < ActiveRecord::Migration
+class FixForemanProviderType < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150817213409_clear_tenant_seed.rb
+++ b/db/migrate/20150817213409_clear_tenant_seed.rb
@@ -1,4 +1,4 @@
-class ClearTenantSeed < ActiveRecord::Migration
+class ClearTenantSeed < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20150818181426_add_divisible_to_tenants.rb
+++ b/db/migrate/20150818181426_add_divisible_to_tenants.rb
@@ -1,4 +1,4 @@
-class AddDivisibleToTenants < ActiveRecord::Migration
+class AddDivisibleToTenants < ActiveRecord::Migration[4.2]
   def change
     add_column  :tenants, :divisible, :boolean
   end

--- a/db/migrate/20150818181427_update_tenant_divisible_on_existing_rows.rb
+++ b/db/migrate/20150818181427_update_tenant_divisible_on_existing_rows.rb
@@ -1,4 +1,4 @@
-class UpdateTenantDivisibleOnExistingRows < ActiveRecord::Migration
+class UpdateTenantDivisibleOnExistingRows < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20150818184658_create_tenant_quota.rb
+++ b/db/migrate/20150818184658_create_tenant_quota.rb
@@ -1,4 +1,4 @@
-class CreateTenantQuota < ActiveRecord::Migration
+class CreateTenantQuota < ActiveRecord::Migration[4.2]
   def change
     create_table :tenant_quotas do |t|
       t.belongs_to :tenant, :type => :bigint

--- a/db/migrate/20150819121823_drop_tenant_resources.rb
+++ b/db/migrate/20150819121823_drop_tenant_resources.rb
@@ -1,4 +1,4 @@
-class DropTenantResources < ActiveRecord::Migration
+class DropTenantResources < ActiveRecord::Migration[4.2]
   def up
     drop_table :tenant_resources
   end

--- a/db/migrate/20150819125202_add_tenant_description.rb
+++ b/db/migrate/20150819125202_add_tenant_description.rb
@@ -1,4 +1,4 @@
-class AddTenantDescription < ActiveRecord::Migration
+class AddTenantDescription < ActiveRecord::Migration[4.2]
   def change
     add_column :tenants, :description, :text
   end

--- a/db/migrate/20150819144149_add_container_entity_events.rb
+++ b/db/migrate/20150819144149_add_container_entity_events.rb
@@ -1,4 +1,4 @@
-class AddContainerEntityEvents < ActiveRecord::Migration
+class AddContainerEntityEvents < ActiveRecord::Migration[4.2]
   def change
     add_column  :event_streams, :container_id, :bigint
     add_column  :event_streams, :container_name, :string

--- a/db/migrate/20150819154348_drop_tenant_appliance_name.rb
+++ b/db/migrate/20150819154348_drop_tenant_appliance_name.rb
@@ -1,4 +1,4 @@
-class DropTenantApplianceName < ActiveRecord::Migration
+class DropTenantApplianceName < ActiveRecord::Migration[4.2]
   def up
     remove_column :tenants, :appliance_name
   end

--- a/db/migrate/20150820110215_create_container_limit_range.rb
+++ b/db/migrate/20150820110215_create_container_limit_range.rb
@@ -1,4 +1,4 @@
-class CreateContainerLimitRange < ActiveRecord::Migration
+class CreateContainerLimitRange < ActiveRecord::Migration[4.2]
   def change
     create_table :container_limits do |t|
       t.string     :name

--- a/db/migrate/20150822102141_fix_more_foreman_types.rb
+++ b/db/migrate/20150822102141_fix_more_foreman_types.rb
@@ -1,4 +1,4 @@
-class FixMoreForemanTypes < ActiveRecord::Migration
+class FixMoreForemanTypes < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150823120001_namespace_ems_openstack_availability_zones_null.rb
+++ b/db/migrate/20150823120001_namespace_ems_openstack_availability_zones_null.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsOpenstackAvailabilityZonesNull < ActiveRecord::Migration
+class NamespaceEmsOpenstackAvailabilityZonesNull < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150824120000_add_tenant_override_settings.rb
+++ b/db/migrate/20150824120000_add_tenant_override_settings.rb
@@ -1,4 +1,4 @@
-class AddTenantOverrideSettings < ActiveRecord::Migration
+class AddTenantOverrideSettings < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   def change

--- a/db/migrate/20150824130000_update_tenant_override_settings.rb
+++ b/db/migrate/20150824130000_update_tenant_override_settings.rb
@@ -1,4 +1,4 @@
-class UpdateTenantOverrideSettings < ActiveRecord::Migration
+class UpdateTenantOverrideSettings < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   class Tenant < ActiveRecord::Base; end

--- a/db/migrate/20150825120000_add_service_catalog_tenant.rb
+++ b/db/migrate/20150825120000_add_service_catalog_tenant.rb
@@ -1,4 +1,4 @@
-class AddServiceCatalogTenant < ActiveRecord::Migration
+class AddServiceCatalogTenant < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   def change

--- a/db/migrate/20150827120000_add_tenant_id_to_miq_ae_namespaces.rb
+++ b/db/migrate/20150827120000_add_tenant_id_to_miq_ae_namespaces.rb
@@ -1,4 +1,4 @@
-class AddTenantIdToMiqAeNamespaces < ActiveRecord::Migration
+class AddTenantIdToMiqAeNamespaces < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   def change

--- a/db/migrate/20150831123700_rename_tenant_owner_id.rb
+++ b/db/migrate/20150831123700_rename_tenant_owner_id.rb
@@ -1,4 +1,4 @@
-class RenameTenantOwnerId < ActiveRecord::Migration
+class RenameTenantOwnerId < ActiveRecord::Migration[4.2]
   def change
     rename_column :ext_management_systems, :tenant_owner_id, :tenant_id
     rename_column :miq_groups, :tenant_owner_id, :tenant_id

--- a/db/migrate/20150903073337_add_container_node_max_container_group.rb
+++ b/db/migrate/20150903073337_add_container_node_max_container_group.rb
@@ -1,4 +1,4 @@
-class AddContainerNodeMaxContainerGroup < ActiveRecord::Migration
+class AddContainerNodeMaxContainerGroup < ActiveRecord::Migration[4.2]
   def change
     add_column :container_nodes, :max_container_groups, :int
   end

--- a/db/migrate/20150903162623_assign_tenant.rb
+++ b/db/migrate/20150903162623_assign_tenant.rb
@@ -1,4 +1,4 @@
-class AssignTenant < ActiveRecord::Migration
+class AssignTenant < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base
     # seed and return the current root_tenant
     def self.root_tenant

--- a/db/migrate/20150904132351_add_scan_columns_to_container_images.rb
+++ b/db/migrate/20150904132351_add_scan_columns_to_container_images.rb
@@ -1,4 +1,4 @@
-class AddScanColumnsToContainerImages < ActiveRecord::Migration
+class AddScanColumnsToContainerImages < ActiveRecord::Migration[4.2]
   def change
     add_column :container_images, :last_sync_on, :datetime
     add_column :container_images, :last_scan_attempt_on, :datetime

--- a/db/migrate/20150904181202_miq_groups_add_ldap_role.rb
+++ b/db/migrate/20150904181202_miq_groups_add_ldap_role.rb
@@ -1,4 +1,4 @@
-class MiqGroupsAddLdapRole < ActiveRecord::Migration
+class MiqGroupsAddLdapRole < ActiveRecord::Migration[4.2]
   class MiqUserRole < ActiveRecord::Base; end
 
   class MiqGroup < ActiveRecord::Base; end

--- a/db/migrate/20150906123643_create_security_context.rb
+++ b/db/migrate/20150906123643_create_security_context.rb
@@ -1,4 +1,4 @@
-class CreateSecurityContext < ActiveRecord::Migration
+class CreateSecurityContext < ActiveRecord::Migration[4.2]
   def change
     create_table :security_contexts do |t|
       t.references :resource, :polymorphic => true, :type => :bigint

--- a/db/migrate/20150906123956_add_container_definition_security_contexts.rb
+++ b/db/migrate/20150906123956_add_container_definition_security_contexts.rb
@@ -1,4 +1,4 @@
-class AddContainerDefinitionSecurityContexts < ActiveRecord::Migration
+class AddContainerDefinitionSecurityContexts < ActiveRecord::Migration[4.2]
   def change
     add_column    :container_definitions, :privileged, :boolean
     add_column    :container_definitions, :run_as_user, :bigint

--- a/db/migrate/20150906234626_add_service_type.rb
+++ b/db/migrate/20150906234626_add_service_type.rb
@@ -1,4 +1,4 @@
-class AddServiceType < ActiveRecord::Migration
+class AddServiceType < ActiveRecord::Migration[4.2]
   def change
     add_column :container_services, :service_type, :string
   end

--- a/db/migrate/20150906234635_add_node_port.rb
+++ b/db/migrate/20150906234635_add_node_port.rb
@@ -1,4 +1,4 @@
-class AddNodePort < ActiveRecord::Migration
+class AddNodePort < ActiveRecord::Migration[4.2]
   def change
     add_column :container_service_port_configs, :node_port, :integer
   end

--- a/db/migrate/20150907095639_add_container_image_digest.rb
+++ b/db/migrate/20150907095639_add_container_image_digest.rb
@@ -1,4 +1,4 @@
-class AddContainerImageDigest < ActiveRecord::Migration
+class AddContainerImageDigest < ActiveRecord::Migration[4.2]
   # https://github.com/docker/distribution/blob/v2.1.1/digest/digester.go#L15-L17
   SUPPORTED_DIGESTS = 'sha256', 'sha384', 'sha512'
 

--- a/db/migrate/20150907120454_create_container_volumes.rb
+++ b/db/migrate/20150907120454_create_container_volumes.rb
@@ -1,4 +1,4 @@
-class CreateContainerVolumes < ActiveRecord::Migration
+class CreateContainerVolumes < ActiveRecord::Migration[4.2]
   def up
     create_table :container_volumes do |t|
       # prefixes are used to specify the volume source kind

--- a/db/migrate/20150907163347_confirm_all_class_renames.rb
+++ b/db/migrate/20150907163347_confirm_all_class_renames.rb
@@ -1,4 +1,4 @@
-class ConfirmAllClassRenames < ActiveRecord::Migration
+class ConfirmAllClassRenames < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150907234623_add_container_command.rb
+++ b/db/migrate/20150907234623_add_container_command.rb
@@ -1,4 +1,4 @@
-class AddContainerCommand < ActiveRecord::Migration
+class AddContainerCommand < ActiveRecord::Migration[4.2]
   def change
     add_column :container_definitions, :command, :text
   end

--- a/db/migrate/20150909023532_namespace_ems_azure.rb
+++ b/db/migrate/20150909023532_namespace_ems_azure.rb
@@ -1,4 +1,4 @@
-class NamespaceEmsAzure < ActiveRecord::Migration
+class NamespaceEmsAzure < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   NAME_MAP = Hash[*%w(

--- a/db/migrate/20150910153517_add_full_name_to_custom_attributes.rb
+++ b/db/migrate/20150910153517_add_full_name_to_custom_attributes.rb
@@ -1,4 +1,4 @@
-class AddFullNameToCustomAttributes < ActiveRecord::Migration
+class AddFullNameToCustomAttributes < ActiveRecord::Migration[4.2]
   def change
     add_column :custom_attributes, :unique_name, :text
   end

--- a/db/migrate/20150911152048_add_disk_info_to_flavors.rb
+++ b/db/migrate/20150911152048_add_disk_info_to_flavors.rb
@@ -1,4 +1,4 @@
-class AddDiskInfoToFlavors < ActiveRecord::Migration
+class AddDiskInfoToFlavors < ActiveRecord::Migration[4.2]
   def change
     add_column :flavors, :disk_size, :bigint
     add_column :flavors, :disk_count, :integer

--- a/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
+++ b/db/migrate/20150914202922_correct_user_created_role_feature_sets.rb
@@ -1,4 +1,4 @@
-class CorrectUserCreatedRoleFeatureSets < ActiveRecord::Migration
+class CorrectUserCreatedRoleFeatureSets < ActiveRecord::Migration[4.2]
   class MiqUserRole < ActiveRecord::Base
     has_and_belongs_to_many :miq_product_features, :join_table => :miq_roles_features, :class_name => "CorrectUserCreatedRoleFeatureSets::MiqProductFeature"
   end

--- a/db/migrate/20150914203523_add_warn_value_to.rb
+++ b/db/migrate/20150914203523_add_warn_value_to.rb
@@ -1,4 +1,4 @@
-class AddWarnValueTo < ActiveRecord::Migration
+class AddWarnValueTo < ActiveRecord::Migration[4.2]
   def change
     add_column :tenant_quotas, :warn_value, :float
   end

--- a/db/migrate/20150915000737_add_tenant_id_to_miq_request.rb
+++ b/db/migrate/20150915000737_add_tenant_id_to_miq_request.rb
@@ -1,4 +1,4 @@
-class AddTenantIdToMiqRequest < ActiveRecord::Migration
+class AddTenantIdToMiqRequest < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_requests, :tenant_id, :bigint
     add_column :miq_request_tasks, :tenant_id, :bigint

--- a/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
+++ b/db/migrate/20150915001329_assign_tenant_to_miq_request.rb
@@ -1,4 +1,4 @@
-class AssignTenantToMiqRequest < ActiveRecord::Migration
+class AssignTenantToMiqRequest < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base
     # seed and return the current root_tenant
     def self.root_tenant

--- a/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
+++ b/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
@@ -1,4 +1,4 @@
-class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration
+class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration[4.2]
   class HostsStorage < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20150924195523_enhance_flavors_for_cloud_disk_info.rb
+++ b/db/migrate/20150924195523_enhance_flavors_for_cloud_disk_info.rb
@@ -1,4 +1,4 @@
-class EnhanceFlavorsForCloudDiskInfo < ActiveRecord::Migration
+class EnhanceFlavorsForCloudDiskInfo < ActiveRecord::Migration[4.2]
   def change
     add_column :flavors, :root_disk_size, :bigint
     add_column :flavors, :swap_disk_size, :bigint

--- a/db/migrate/20150930083543_add_status_to_floating_ips.rb
+++ b/db/migrate/20150930083543_add_status_to_floating_ips.rb
@@ -1,4 +1,4 @@
-class AddStatusToFloatingIps < ActiveRecord::Migration
+class AddStatusToFloatingIps < ActiveRecord::Migration[4.2]
   def change
     add_column :floating_ips, :status, :string
   end

--- a/db/migrate/20150930201117_change_cloud_tenant_description_to_text.rb
+++ b/db/migrate/20150930201117_change_cloud_tenant_description_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeCloudTenantDescriptionToText < ActiveRecord::Migration
+class ChangeCloudTenantDescriptionToText < ActiveRecord::Migration[4.2]
   def up
     change_column :cloud_tenants, :description, :text
   end

--- a/db/migrate/20151001110220_add_resource_group_to_orchestration_stack.rb
+++ b/db/migrate/20151001110220_add_resource_group_to_orchestration_stack.rb
@@ -1,4 +1,4 @@
-class AddResourceGroupToOrchestrationStack < ActiveRecord::Migration
+class AddResourceGroupToOrchestrationStack < ActiveRecord::Migration[4.2]
   def change
     add_column :orchestration_stacks, :resource_group, :string
   end

--- a/db/migrate/20151001193521_rename_hardware_columns.rb
+++ b/db/migrate/20151001193521_rename_hardware_columns.rb
@@ -1,4 +1,4 @@
-class RenameHardwareColumns < ActiveRecord::Migration
+class RenameHardwareColumns < ActiveRecord::Migration[4.2]
   def change
     rename_column :hardwares, :cores_per_socket, :cpu_cores_per_socket
     rename_column :hardwares, :numvcpus, :cpu_sockets

--- a/db/migrate/20151005082821_change_device_id_to_bigint_in_network_ports.rb
+++ b/db/migrate/20151005082821_change_device_id_to_bigint_in_network_ports.rb
@@ -1,4 +1,4 @@
-class ChangeDeviceIdToBigintInNetworkPorts < ActiveRecord::Migration
+class ChangeDeviceIdToBigintInNetworkPorts < ActiveRecord::Migration[4.2]
   def up
     change_column :network_ports, :device_id, :bigint
   end

--- a/db/migrate/20151008114043_create_chargeback_rate_detail_measure.rb
+++ b/db/migrate/20151008114043_create_chargeback_rate_detail_measure.rb
@@ -1,4 +1,4 @@
-class CreateChargebackRateDetailMeasure < ActiveRecord::Migration
+class CreateChargebackRateDetailMeasure < ActiveRecord::Migration[4.2]
   def change
     create_table :chargeback_rate_detail_measures do |t|
       t.string :name

--- a/db/migrate/20151008114125_add_measure_ref_to_chargeback_rate_detail.rb
+++ b/db/migrate/20151008114125_add_measure_ref_to_chargeback_rate_detail.rb
@@ -1,4 +1,4 @@
-class AddMeasureRefToChargebackRateDetail < ActiveRecord::Migration
+class AddMeasureRefToChargebackRateDetail < ActiveRecord::Migration[4.2]
   def change
     add_column :chargeback_rate_details, :chargeback_rate_detail_measure_id, :bigint
   end

--- a/db/migrate/20151009174934_create_chargeback_rate_detail_currencies.rb
+++ b/db/migrate/20151009174934_create_chargeback_rate_detail_currencies.rb
@@ -1,4 +1,4 @@
-class CreateChargebackRateDetailCurrencies < ActiveRecord::Migration
+class CreateChargebackRateDetailCurrencies < ActiveRecord::Migration[4.2]
   def change
     create_table :chargeback_rate_detail_currencies do |t|
       t.string :code

--- a/db/migrate/20151012072007_create_container_component_statuses.rb
+++ b/db/migrate/20151012072007_create_container_component_statuses.rb
@@ -1,4 +1,4 @@
-class CreateContainerComponentStatuses < ActiveRecord::Migration
+class CreateContainerComponentStatuses < ActiveRecord::Migration[4.2]
   def up
     create_table :container_component_statuses do |t|
       t.belongs_to :ems, :type => :bigint

--- a/db/migrate/20151013104702_add_currencies_ref_to_chargeback_rate_detail.rb
+++ b/db/migrate/20151013104702_add_currencies_ref_to_chargeback_rate_detail.rb
@@ -1,4 +1,4 @@
-class AddCurrenciesRefToChargebackRateDetail < ActiveRecord::Migration
+class AddCurrenciesRefToChargebackRateDetail < ActiveRecord::Migration[4.2]
   def change
     add_column :chargeback_rate_details, :chargeback_rate_detail_currency_id, :bigint
   end

--- a/db/migrate/20151018090641_create_persistent_volume_claim.rb
+++ b/db/migrate/20151018090641_create_persistent_volume_claim.rb
@@ -1,4 +1,4 @@
-class CreatePersistentVolumeClaim < ActiveRecord::Migration
+class CreatePersistentVolumeClaim < ActiveRecord::Migration[4.2]
   def change
     create_table :persistent_volume_claims do |t|
       t.belongs_to :ems, :type => :bigint

--- a/db/migrate/20151019184531_create_resource_groups.rb
+++ b/db/migrate/20151019184531_create_resource_groups.rb
@@ -1,4 +1,4 @@
-class CreateResourceGroups < ActiveRecord::Migration
+class CreateResourceGroups < ActiveRecord::Migration[4.2]
   def up
     create_table :resource_groups do |t|
       t.string :name

--- a/db/migrate/20151019194111_tenant_cfg_not_nil.rb
+++ b/db/migrate/20151019194111_tenant_cfg_not_nil.rb
@@ -1,4 +1,4 @@
-class TenantCfgNotNil < ActiveRecord::Migration
+class TenantCfgNotNil < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20151020222634_add_watermark_reporting_fields_to_metric_and_metric_rollup.rb
+++ b/db/migrate/20151020222634_add_watermark_reporting_fields_to_metric_and_metric_rollup.rb
@@ -1,4 +1,4 @@
-class AddWatermarkReportingFieldsToMetricAndMetricRollup < ActiveRecord::Migration
+class AddWatermarkReportingFieldsToMetricAndMetricRollup < ActiveRecord::Migration[4.2]
   def change
     add_column :metrics,        :derived_host_sockets,     :integer
     add_column :metrics,        :derived_host_count_total, :integer

--- a/db/migrate/20151021093644_set_correct_sti_type_on_cloud_network.rb
+++ b/db/migrate/20151021093644_set_correct_sti_type_on_cloud_network.rb
@@ -1,4 +1,4 @@
-class SetCorrectStiTypeOnCloudNetwork < ActiveRecord::Migration
+class SetCorrectStiTypeOnCloudNetwork < ActiveRecord::Migration[4.2]
   CLOUD_TEMPLATE_CLASS = "ManageIQ::Providers::Openstack::CloudManager::Template".freeze
   CLOUD_PUBLIC_CLASS   = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public".freeze
   CLOUD_PRIVATE_CLASS  = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private".freeze

--- a/db/migrate/20151021095831_set_correct_sti_type_on_cloud_subnet.rb
+++ b/db/migrate/20151021095831_set_correct_sti_type_on_cloud_subnet.rb
@@ -1,4 +1,4 @@
-class SetCorrectStiTypeOnCloudSubnet < ActiveRecord::Migration
+class SetCorrectStiTypeOnCloudSubnet < ActiveRecord::Migration[4.2]
   CLOUD_SUBNET         = "ManageIQ::Providers::Openstack::CloudManager::CloudSubnet".freeze
   CLOUD_PUBLIC_CLASS   = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Public".freeze
   CLOUD_PRIVATE_CLASS  = "ManageIQ::Providers::Openstack::CloudManager::CloudNetwork::Private".freeze

--- a/db/migrate/20151021104529_add_persistent_volumes_to_container_volumes.rb
+++ b/db/migrate/20151021104529_add_persistent_volumes_to_container_volumes.rb
@@ -1,4 +1,4 @@
-class AddPersistentVolumesToContainerVolumes < ActiveRecord::Migration
+class AddPersistentVolumesToContainerVolumes < ActiveRecord::Migration[4.2]
   class ContainerVolume < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20151021143818_add_replicator_entity_events.rb
+++ b/db/migrate/20151021143818_add_replicator_entity_events.rb
@@ -1,4 +1,4 @@
-class AddReplicatorEntityEvents < ActiveRecord::Migration
+class AddReplicatorEntityEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :event_streams, :container_replicator_id, :bigint
     add_column :event_streams, :container_replicator_name, :string

--- a/db/migrate/20151021151216_add_resource_group_id_to_vms.rb
+++ b/db/migrate/20151021151216_add_resource_group_id_to_vms.rb
@@ -1,4 +1,4 @@
-class AddResourceGroupIdToVms < ActiveRecord::Migration
+class AddResourceGroupIdToVms < ActiveRecord::Migration[4.2]
   def up
     add_column :vms, :resource_group_id, :bigint
   end

--- a/db/migrate/20151021174044_add_tenant_default_group.rb
+++ b/db/migrate/20151021174044_add_tenant_default_group.rb
@@ -1,4 +1,4 @@
-class AddTenantDefaultGroup < ActiveRecord::Migration
+class AddTenantDefaultGroup < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base; end
 
   def change

--- a/db/migrate/20151021174140_assign_tenant_default_group.rb
+++ b/db/migrate/20151021174140_assign_tenant_default_group.rb
@@ -1,4 +1,4 @@
-class AssignTenantDefaultGroup < ActiveRecord::Migration
+class AssignTenantDefaultGroup < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base
     def add_default_miq_group
       tenant_group = ::AssignTenantDefaultGroup::MiqGroup.create_tenant_group(self)

--- a/db/migrate/20151022141745_remove_license_required_from_server_roles.rb
+++ b/db/migrate/20151022141745_remove_license_required_from_server_roles.rb
@@ -1,4 +1,4 @@
-class RemoveLicenseRequiredFromServerRoles < ActiveRecord::Migration
+class RemoveLicenseRequiredFromServerRoles < ActiveRecord::Migration[4.2]
   def up
     remove_column :server_roles, :license_required
   end

--- a/db/migrate/20151026170631_set_miq_groups_group_type.rb
+++ b/db/migrate/20151026170631_set_miq_groups_group_type.rb
@@ -1,4 +1,4 @@
-class SetMiqGroupsGroupType < ActiveRecord::Migration
+class SetMiqGroupsGroupType < ActiveRecord::Migration[4.2]
   class MiqGroup < ActiveRecord::Base
     USER_GROUP = "user"
   end

--- a/db/migrate/20151026220722_assign_vm_group.rb
+++ b/db/migrate/20151026220722_assign_vm_group.rb
@@ -1,4 +1,4 @@
-class AssignVmGroup < ActiveRecord::Migration
+class AssignVmGroup < ActiveRecord::Migration[4.2]
   class Tenant < ActiveRecord::Base
     def self.root_tenant
       where(:ancestry => nil).first

--- a/db/migrate/20151030201919_fix_miq_group_sequences.rb
+++ b/db/migrate/20151030201919_fix_miq_group_sequences.rb
@@ -1,4 +1,4 @@
-class FixMiqGroupSequences < ActiveRecord::Migration
+class FixMiqGroupSequences < ActiveRecord::Migration[4.2]
   class MiqGroup < ActiveRecord::Base; end
 
   def up

--- a/db/migrate/20151104115400_create_chargeback_tiers.rb
+++ b/db/migrate/20151104115400_create_chargeback_tiers.rb
@@ -1,4 +1,4 @@
-class CreateChargebackTiers < ActiveRecord::Migration
+class CreateChargebackTiers < ActiveRecord::Migration[4.2]
   def change
     create_table :chargeback_tiers do |t|
       t.bigint :chargeback_rate_detail_id

--- a/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
+++ b/db/migrate/20151104120951_transfer_rate_value_to_tiers.rb
@@ -1,4 +1,4 @@
-class TransferRateValueToTiers < ActiveRecord::Migration
+class TransferRateValueToTiers < ActiveRecord::Migration[4.2]
   class ChargebackRateDetail < ActiveRecord::Base
     has_many :chargeback_tiers
   end

--- a/db/migrate/20151106164333_add_project_to_ext_management_system.rb
+++ b/db/migrate/20151106164333_add_project_to_ext_management_system.rb
@@ -1,4 +1,4 @@
-class AddProjectToExtManagementSystem < ActiveRecord::Migration
+class AddProjectToExtManagementSystem < ActiveRecord::Migration[4.2]
   def change
     add_column :ext_management_systems, :project, :string
   end

--- a/db/migrate/20151109203749_add_service_account_to_authentication.rb
+++ b/db/migrate/20151109203749_add_service_account_to_authentication.rb
@@ -1,4 +1,4 @@
-class AddServiceAccountToAuthentication < ActiveRecord::Migration
+class AddServiceAccountToAuthentication < ActiveRecord::Migration[4.2]
   def change
     add_column :authentications, :service_account, :string
   end

--- a/db/migrate/20151111165020_rename_miq_search_db.rb
+++ b/db/migrate/20151111165020_rename_miq_search_db.rb
@@ -1,4 +1,4 @@
-class RenameMiqSearchDb < ActiveRecord::Migration
+class RenameMiqSearchDb < ActiveRecord::Migration[4.2]
   class MiqSearch < ActiveRecord::Base; end
 
   NAME_HASH = Hash[*%w(

--- a/db/migrate/20151119202643_update_default_update_repo_names.rb
+++ b/db/migrate/20151119202643_update_default_update_repo_names.rb
@@ -1,4 +1,4 @@
-class UpdateDefaultUpdateRepoNames < ActiveRecord::Migration
+class UpdateDefaultUpdateRepoNames < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   REPO_NAME_HASH = {

--- a/db/migrate/20151125081618_set_correct_sti_type_on_openstack_infra_miq_template.rb
+++ b/db/migrate/20151125081618_set_correct_sti_type_on_openstack_infra_miq_template.rb
@@ -1,4 +1,4 @@
-class SetCorrectStiTypeOnOpenstackInfraMiqTemplate < ActiveRecord::Migration
+class SetCorrectStiTypeOnOpenstackInfraMiqTemplate < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end

--- a/db/migrate/20151125155213_create_middleware_servers.rb
+++ b/db/migrate/20151125155213_create_middleware_servers.rb
@@ -1,4 +1,4 @@
-class CreateMiddlewareServers < ActiveRecord::Migration
+class CreateMiddlewareServers < ActiveRecord::Migration[4.2]
   def change
     create_table :middleware_servers do |t|
       t.string :name       # server name generated from id

--- a/db/migrate/20151204143045_set_correct_sti_type_on_openstack_cloud_volume.rb
+++ b/db/migrate/20151204143045_set_correct_sti_type_on_openstack_cloud_volume.rb
@@ -1,4 +1,4 @@
-class SetCorrectStiTypeOnOpenstackCloudVolume < ActiveRecord::Migration
+class SetCorrectStiTypeOnOpenstackCloudVolume < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
     self.inheritance_column = :_type_disabled
   end

--- a/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
+++ b/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
@@ -1,4 +1,4 @@
-class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration
+class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration[4.2]
   include MigrationHelper
 
   class MiqRegion < ActiveRecord::Base; end

--- a/db/migrate/20151209141840_create_middleware_deployments.rb
+++ b/db/migrate/20151209141840_create_middleware_deployments.rb
@@ -1,4 +1,4 @@
-class CreateMiddlewareDeployments < ActiveRecord::Migration
+class CreateMiddlewareDeployments < ActiveRecord::Migration[4.2]
   def change
     create_table :middleware_deployments do |t|
       t.string :name # name of the deployment

--- a/db/migrate/20151210154747_add_container_image_registry_to_container_service.rb
+++ b/db/migrate/20151210154747_add_container_image_registry_to_container_service.rb
@@ -1,4 +1,4 @@
-class AddContainerImageRegistryToContainerService < ActiveRecord::Migration
+class AddContainerImageRegistryToContainerService < ActiveRecord::Migration[4.2]
   def change
     add_column :container_services, :container_image_registry_id, :bigint
   end

--- a/db/migrate/20151216095054_create_container_builds.rb
+++ b/db/migrate/20151216095054_create_container_builds.rb
@@ -1,4 +1,4 @@
-class CreateContainerBuilds < ActiveRecord::Migration
+class CreateContainerBuilds < ActiveRecord::Migration[4.2]
   def change
     create_table :container_builds do |t|
       t.string     :ems_ref

--- a/db/migrate/20151221134925_remove_sat5_repo_config.rb
+++ b/db/migrate/20151221134925_remove_sat5_repo_config.rb
@@ -1,4 +1,4 @@
-class RemoveSat5RepoConfig < ActiveRecord::Migration
+class RemoveSat5RepoConfig < ActiveRecord::Migration[4.2]
   class MiqDatabase < ActiveRecord::Base; end
 
   class Authentication < ActiveRecord::Base

--- a/db/migrate/20151222103510_add_verify_ssl_to_endpoints.rb
+++ b/db/migrate/20151222103510_add_verify_ssl_to_endpoints.rb
@@ -1,4 +1,4 @@
-class AddVerifySslToEndpoints < ActiveRecord::Migration
+class AddVerifySslToEndpoints < ActiveRecord::Migration[4.2]
   def change
     add_column :endpoints, :verify_ssl, :integer
   end

--- a/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
+++ b/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb
@@ -1,4 +1,4 @@
-class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration
+class MigrateProviderAttributesToEndpoints < ActiveRecord::Migration[4.2]
   class Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20151222105242_remove_endpoint_data_from_provider.rb
+++ b/db/migrate/20151222105242_remove_endpoint_data_from_provider.rb
@@ -1,4 +1,4 @@
-class RemoveEndpointDataFromProvider < ActiveRecord::Migration
+class RemoveEndpointDataFromProvider < ActiveRecord::Migration[4.2]
   def up
     remove_column :providers, :verify_ssl
   end

--- a/db/migrate/20151222152212_remove_vm_discover_row_from_miq_event_definitions.rb
+++ b/db/migrate/20151222152212_remove_vm_discover_row_from_miq_event_definitions.rb
@@ -1,4 +1,4 @@
-class RemoveVmDiscoverRowFromMiqEventDefinitions < ActiveRecord::Migration
+class RemoveVmDiscoverRowFromMiqEventDefinitions < ActiveRecord::Migration[4.2]
   class Relationship < ActiveRecord::Base; end
 
   class MiqEventDefinition < ActiveRecord::Base; end

--- a/db/migrate/20160105170524_remove_miq_worker_command_line.rb
+++ b/db/migrate/20160105170524_remove_miq_worker_command_line.rb
@@ -1,4 +1,4 @@
-class RemoveMiqWorkerCommandLine < ActiveRecord::Migration
+class RemoveMiqWorkerCommandLine < ActiveRecord::Migration[4.2]
   def up
     remove_column :miq_workers, :command_line
   end

--- a/db/migrate/20160108214044_add_miq_workers_miq_servers_proportional_set_size.rb
+++ b/db/migrate/20160108214044_add_miq_workers_miq_servers_proportional_set_size.rb
@@ -1,4 +1,4 @@
-class AddMiqWorkersMiqServersProportionalSetSize < ActiveRecord::Migration
+class AddMiqWorkersMiqServersProportionalSetSize < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_servers, :proportional_set_size, :decimal, :precision => 20, :scale => 0
     add_column :miq_workers, :proportional_set_size, :decimal, :precision => 20, :scale => 0

--- a/db/migrate/20160110104053_add_claim_ref_to_container_volumes.rb
+++ b/db/migrate/20160110104053_add_claim_ref_to_container_volumes.rb
@@ -1,4 +1,4 @@
-class AddClaimRefToContainerVolumes < ActiveRecord::Migration
+class AddClaimRefToContainerVolumes < ActiveRecord::Migration[4.2]
   def change
     change_table :container_volumes do |t|
       t.belongs_to :persistent_volume_claim, :type => :bigint

--- a/db/migrate/20160114085140_add_network_router_id_to_cloud_subnet.rb
+++ b/db/migrate/20160114085140_add_network_router_id_to_cloud_subnet.rb
@@ -1,4 +1,4 @@
-class AddNetworkRouterIdToCloudSubnet < ActiveRecord::Migration
+class AddNetworkRouterIdToCloudSubnet < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_subnets, :network_router_id, :bigint
   end

--- a/db/migrate/20160114111114_delete_network_router_id_from_floating_ips.rb
+++ b/db/migrate/20160114111114_delete_network_router_id_from_floating_ips.rb
@@ -1,4 +1,4 @@
-class DeleteNetworkRouterIdFromFloatingIps < ActiveRecord::Migration
+class DeleteNetworkRouterIdFromFloatingIps < ActiveRecord::Migration[4.2]
   def up
     remove_index :floating_ips, :column => :network_router_id
     remove_column :floating_ips, :network_router_id, :bigint

--- a/db/migrate/20160114153948_delete_cloud_network_id_from_network_ports.rb
+++ b/db/migrate/20160114153948_delete_cloud_network_id_from_network_ports.rb
@@ -1,4 +1,4 @@
-class DeleteCloudNetworkIdFromNetworkPorts < ActiveRecord::Migration
+class DeleteCloudNetworkIdFromNetworkPorts < ActiveRecord::Migration[4.2]
   def up
     remove_index :network_ports, :column => :cloud_network_id
     remove_column :network_ports, :cloud_network_id, :bigint

--- a/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
+++ b/db/migrate/20160115111829_chargeback_rate_detail_currency_not_nil.rb
@@ -1,4 +1,4 @@
-class ChargebackRateDetailCurrencyNotNil < ActiveRecord::Migration
+class ChargebackRateDetailCurrencyNotNil < ActiveRecord::Migration[4.2]
   # Migration in order to put a currency by default in rates that were added by a user before the addition of currencies
   class ChargebackRateDetail < ActiveRecord::Base; end
 

--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -1,4 +1,4 @@
-class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
+class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration[4.2]
   class MiqEventDefinition < ActiveRecord::Base; end
 
   class ScanItem < ActiveRecord::Base; end

--- a/db/migrate/20160119125950_add_created_on_for_container_entities.rb
+++ b/db/migrate/20160119125950_add_created_on_for_container_entities.rb
@@ -1,4 +1,4 @@
-class AddCreatedOnForContainerEntities < ActiveRecord::Migration
+class AddCreatedOnForContainerEntities < ActiveRecord::Migration[4.2]
   class ContainerNode < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20160120151045_add_url_to_endpoints.rb
+++ b/db/migrate/20160120151045_add_url_to_endpoints.rb
@@ -1,4 +1,4 @@
-class AddUrlToEndpoints < ActiveRecord::Migration
+class AddUrlToEndpoints < ActiveRecord::Migration[4.2]
   def change
     add_column :endpoints, :url, :string
   end

--- a/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
+++ b/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
@@ -1,4 +1,4 @@
-class MigrateUrlFromProviderToEndpoints < ActiveRecord::Migration
+class MigrateUrlFromProviderToEndpoints < ActiveRecord::Migration[4.2]
   class Provider < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20160126151325_add_disk_and_memory_minimum_to_hardware.rb
+++ b/db/migrate/20160126151325_add_disk_and_memory_minimum_to_hardware.rb
@@ -1,4 +1,4 @@
-class AddDiskAndMemoryMinimumToHardware < ActiveRecord::Migration
+class AddDiskAndMemoryMinimumToHardware < ActiveRecord::Migration[4.2]
   def change
     add_column :hardwares, :disk_size_minimum, :integer, :limit => 8
     add_column :hardwares, :memory_mb_minimum, :integer, :limit => 8

--- a/db/migrate/20160127210622_migrate_old_configuration_settings.rb
+++ b/db/migrate/20160127210622_migrate_old_configuration_settings.rb
@@ -1,4 +1,4 @@
-class MigrateOldConfigurationSettings < ActiveRecord::Migration
+class MigrateOldConfigurationSettings < ActiveRecord::Migration[4.2]
   class Configuration < ActiveRecord::Base
     serialize :settings, Hash
   end

--- a/db/migrate/20160127210623_create_settings_changes_table.rb
+++ b/db/migrate/20160127210623_create_settings_changes_table.rb
@@ -1,4 +1,4 @@
-class CreateSettingsChangesTable < ActiveRecord::Migration
+class CreateSettingsChangesTable < ActiveRecord::Migration[4.2]
   def up
     create_table :settings_changes do |t|
       t.belongs_to :resource, :type => :bigint, :polymorphic => true

--- a/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
+++ b/db/migrate/20160127210624_convert_configurations_to_settings_changes.rb
@@ -1,4 +1,4 @@
-class ConvertConfigurationsToSettingsChanges < ActiveRecord::Migration
+class ConvertConfigurationsToSettingsChanges < ActiveRecord::Migration[4.2]
   class Configuration < ActiveRecord::Base
     serialize :settings
   end

--- a/db/migrate/20160127210625_remove_configurations.rb
+++ b/db/migrate/20160127210625_remove_configurations.rb
@@ -1,4 +1,4 @@
-class RemoveConfigurations < ActiveRecord::Migration
+class RemoveConfigurations < ActiveRecord::Migration[4.2]
   def up
     drop_table :configurations
   end

--- a/db/migrate/20160127210705_create_configuration_script.rb
+++ b/db/migrate/20160127210705_create_configuration_script.rb
@@ -1,4 +1,4 @@
-class CreateConfigurationScript < ActiveRecord::Migration
+class CreateConfigurationScript < ActiveRecord::Migration[4.2]
   def change
     create_table :configuration_scripts do |t|
       t.belongs_to :configuration_manager, :type => :bigint

--- a/db/migrate/20160202200713_create_generic_object.rb
+++ b/db/migrate/20160202200713_create_generic_object.rb
@@ -1,4 +1,4 @@
-class CreateGenericObject < ActiveRecord::Migration
+class CreateGenericObject < ActiveRecord::Migration[4.2]
   def change
     create_table :generic_object_definitions do |t|
       t.string     :name

--- a/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
+++ b/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
@@ -1,4 +1,4 @@
-class AddOrderableToOrchestrationTemplates < ActiveRecord::Migration
+class AddOrderableToOrchestrationTemplates < ActiveRecord::Migration[4.2]
   class OrchestrationTemplate < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20160203162135_add_deletion_time_for_container_archivables.rb
+++ b/db/migrate/20160203162135_add_deletion_time_for_container_archivables.rb
@@ -1,4 +1,4 @@
-class AddDeletionTimeForContainerArchivables < ActiveRecord::Migration
+class AddDeletionTimeForContainerArchivables < ActiveRecord::Migration[4.2]
   def change
     add_column :container_projects, :deleted_on, :datetime
     add_column :container_projects, :old_ems_id, :bigint

--- a/db/migrate/20160209124055_create_service_orders.rb
+++ b/db/migrate/20160209124055_create_service_orders.rb
@@ -1,4 +1,4 @@
-class CreateServiceOrders < ActiveRecord::Migration
+class CreateServiceOrders < ActiveRecord::Migration[4.2]
   def change
     create_table :service_orders do |t|
       t.string   :name

--- a/db/migrate/20160209130938_add_service_order_to_miq_request.rb
+++ b/db/migrate/20160209130938_add_service_order_to_miq_request.rb
@@ -1,4 +1,4 @@
-class AddServiceOrderToMiqRequest < ActiveRecord::Migration
+class AddServiceOrderToMiqRequest < ActiveRecord::Migration[4.2]
   def change
     add_column :miq_requests, :service_order_id, :bigint
   end

--- a/db/migrate/20160211113430_create_cloud_databases.rb
+++ b/db/migrate/20160211113430_create_cloud_databases.rb
@@ -1,4 +1,4 @@
-class CreateCloudDatabases < ActiveRecord::Migration
+class CreateCloudDatabases < ActiveRecord::Migration[4.2]
   def change
     create_table :cloud_database_flavors do |t|
       t.string  :name

--- a/db/migrate/20160214115800_inline_ems_id.rb
+++ b/db/migrate/20160214115800_inline_ems_id.rb
@@ -1,4 +1,4 @@
-class InlineEmsId < ActiveRecord::Migration
+class InlineEmsId < ActiveRecord::Migration[4.2]
   class ContainerDefinition < ActiveRecord::Base; end
 
   class ContainerGroup < ActiveRecord::Base

--- a/db/migrate/20160220123313_add_open_scap_result_entities.rb
+++ b/db/migrate/20160220123313_add_open_scap_result_entities.rb
@@ -1,4 +1,4 @@
-class AddOpenScapResultEntities < ActiveRecord::Migration
+class AddOpenScapResultEntities < ActiveRecord::Migration[4.2]
   def change
     create_table :openscap_results do |t|
       t.belongs_to :container_image, :type => :bigint

--- a/db/migrate/20160301111647_remove_rate_column_from_chargeback_rate_detail.rb
+++ b/db/migrate/20160301111647_remove_rate_column_from_chargeback_rate_detail.rb
@@ -1,4 +1,4 @@
-class RemoveRateColumnFromChargebackRateDetail < ActiveRecord::Migration
+class RemoveRateColumnFromChargebackRateDetail < ActiveRecord::Migration[4.2]
   def change
     remove_column :chargeback_rate_details, :rate, :string
   end

--- a/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
+++ b/db/migrate/20160307205816_fix_event_class_for_evm_alert_event.rb
@@ -1,4 +1,4 @@
-class FixEventClassForEvmAlertEvent < ActiveRecord::Migration
+class FixEventClassForEvmAlertEvent < ActiveRecord::Migration[4.2]
   class EventStream < ActiveRecord::Base
     self.inheritance_column = :_type_disabled # disable STI
   end

--- a/db/migrate/20160424124613_create_network_groups.rb
+++ b/db/migrate/20160424124613_create_network_groups.rb
@@ -1,4 +1,4 @@
-class CreateNetworkGroups < ActiveRecord::Migration
+class CreateNetworkGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :network_groups do |t|
       t.string     :ems_ref

--- a/db/migrate/20160424124654_add_network_group_id_to_security_groups.rb
+++ b/db/migrate/20160424124654_add_network_group_id_to_security_groups.rb
@@ -1,4 +1,4 @@
-class AddNetworkGroupIdToSecurityGroups < ActiveRecord::Migration
+class AddNetworkGroupIdToSecurityGroups < ActiveRecord::Migration[4.2]
   def change
     add_column :security_groups, :network_group_id, :bigint
 

--- a/db/migrate/20160424124710_add_network_group_id_to_cloud_subnets.rb
+++ b/db/migrate/20160424124710_add_network_group_id_to_cloud_subnets.rb
@@ -1,4 +1,4 @@
-class AddNetworkGroupIdToCloudSubnets < ActiveRecord::Migration
+class AddNetworkGroupIdToCloudSubnets < ActiveRecord::Migration[4.2]
   def change
     add_column :cloud_subnets, :network_group_id, :bigint
 

--- a/db/migrate/20160424124736_add_network_group_id_to_network_router.rb
+++ b/db/migrate/20160424124736_add_network_group_id_to_network_router.rb
@@ -1,4 +1,4 @@
-class AddNetworkGroupIdToNetworkRouter < ActiveRecord::Migration
+class AddNetworkGroupIdToNetworkRouter < ActiveRecord::Migration[4.2]
   def change
     add_column :network_routers, :network_group_id, :bigint
 

--- a/db/migrate/20160425161822_create_middleware_datasources.rb
+++ b/db/migrate/20160425161822_create_middleware_datasources.rb
@@ -1,4 +1,4 @@
-class CreateMiddlewareDatasources < ActiveRecord::Migration
+class CreateMiddlewareDatasources < ActiveRecord::Migration[4.2]
   def change
     create_table :middleware_datasources do |t|
       t.string :name # name of the datasource

--- a/db/migrate/20160628165030_create_middleware_messagings.rb
+++ b/db/migrate/20160628165030_create_middleware_messagings.rb
@@ -1,4 +1,4 @@
-class CreateMiddlewareMessagings < ActiveRecord::Migration
+class CreateMiddlewareMessagings < ActiveRecord::Migration[4.2]
   def change
     create_table :middleware_messagings do |t|
       t.string :name # name of the messaging


### PR DESCRIPTION
This is required for the Rails 5.1 upgrade.