### PR TITLE
Service Playbook updates fqname and configuration_template

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -26,6 +26,7 @@ class ServiceTemplate < ApplicationRecord
 
   RESOURCE_ACTION_UPDATE_ATTRS = [:dialog,
                                   :dialog_id,
+                                  :fqname,
                                   :configuration_template,
                                   :configuration_template_id,
                                   :configuration_template_type].freeze

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -233,4 +233,15 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     opts = super
     self.class.send(:validate_config_info, opts)
   end
+
+  # override
+  def update_service_resources(_config_info, _auth_user = nil)
+    # do nothing since no service resources for this template
+  end
+
+  # override
+  def update_from_options(params)
+    options[:config_info] = Hash[params[:config_info].collect { |k, v| [k, v.except(:configuration_template)] }]
+    update_attributes!(params.except(:config_info))
+  end
 end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -47,18 +47,9 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
     transaction do
       create_from_options(options).tap do |service_template|
-        [:provision, :retirement, :reconfigure].each do |action|
-          action_info = enhanced_config[action]
-          next unless service_template.send(:new_dialog_required?, action_info)
-
-          dialog_name  = action_info[:new_dialog_name]
-          job_template = action_info[:configuration_template]
-          hosts        = action_info[:hosts]
-
-          new_dialog = service_template.send(:create_new_dialog, dialog_name, job_template, hosts)
-          action_info[:dialog] = new_dialog
-          service_template.options[:config_info][action][:dialog_id] = new_dialog.id
-        end
+        dialog_ids = service_template.send(:create_dialogs, enhanced_config)
+        enhanced_config.deep_merge!(dialog_ids)
+        service_template.options[:config_info].deep_merge!(dialog_ids)
         service_template.create_resource_actions(enhanced_config)
       end
     end
@@ -151,10 +142,15 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
     update_job_templates(name, description, config_info, auth_user)
 
-    updated_config = config_info.deep_merge(self.class.send(:create_job_templates, name, description, config_info, auth_user, self))
+    config_info.deep_merge!(self.class.send(:create_job_templates, name, description, config_info, auth_user, self))
 
-    create_dialogs(updated_config)
-    options[:config_info] = updated_config
+    [:provision, :retirement, :reconfigure].each do |action|
+      next unless config_info.key?(action)
+      config_info[action][:configuration_template] ||= job_template(action)
+    end
+    config_info.deep_merge!(create_dialogs(config_info))
+
+    options[:config_info] = config_info
 
     super
   end
@@ -186,11 +182,10 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   end
 
   def create_dialogs(config_info)
-    [:provision, :retirement, :reconfigure].each do |action|
+    [:provision, :retirement, :reconfigure].each_with_object({}) do |action, hash|
       info = config_info[action]
-      if new_dialog_required?(info)
-        info[:dialog_id] = create_new_dialog(info[:new_dialog_name], job_template(action), info[:hosts]).id
-      end
+      next unless new_dialog_required?(info)
+      hash[action] = {:dialog_id => create_new_dialog(info[:new_dialog_name], info[:configuration_template], info[:hosts]).id}
     end
   end
 

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -132,7 +132,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
 
   def job_template(action)
-    resource_actions.find_by(:action => action.to_s.capitalize).try(:configuration_template)
+    resource_actions.find_by(:action => action.capitalize).try(:configuration_template)
   end
 
   def update_catalog_item(options, auth_user = nil)
@@ -189,11 +189,12 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     end
   end
 
-  def delete_job_templates(job_templates)
+  def delete_job_templates(job_templates, action = nil)
     auth_user = User.current_userid || 'system'
     job_templates.each do |job_template|
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript
         .delete_in_provider_queue(job_template.manager.id, { :manager_ref => job_template.manager_ref }, auth_user)
+      resource_actions.find_by(:action => action.capitalize).update_attributes(:configuration_template => nil) if action
     end
   end
 
@@ -219,7 +220,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
         params[:manager_ref] = job_template(action).manager_ref
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.update_in_provider_queue(tower.id, params, auth_user)
       else
-        delete_job_templates([job_template])
+        delete_job_templates([job_template], action)
       end
     end
   end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -223,6 +223,7 @@ describe ServiceTemplateAnsiblePlaybook do
       new_dialog_record = Dialog.where(:label => new_dialog_label).first
       expect(new_dialog_record).to be_truthy
       expect(service_template.resource_actions.first.dialog.id).to eq new_dialog_record.id
+      expect(service_template.options[:config_info][:provision]).not_to have_key(:configuration_template)
     end
 
     it 'uses the existing dialog if :dialog_id is passed in' do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -586,11 +586,11 @@ describe ServiceTemplate do
           :instance_type           => [flavor.id, flavor.name],
           :src_ems_id              => [ems.id, ems.name],
           :provision               => {
-            :fqname    => ra1.fqname,
+            :fqname    => 'a1/b1/c1',
             :dialog_id => nil
           },
           :reconfigure             => {
-            :fqname    => ra3.fqname,
+            :fqname    => 'x1/y1/z1',
             :dialog_id => service_dialog.id
           }
         }
@@ -608,7 +608,9 @@ describe ServiceTemplate do
       # Removes Retirement / Adds Reconfigure
       expect(updated.resource_actions.pluck(:action)).to match_array(%w(Provision Reconfigure))
       expect(updated.resource_actions.first.dialog_id).to be_nil # Removes the dialog from Provision
+      expect(updated.resource_actions.first.fqname).to eq('/a1/b1/c1')
       expect(updated.resource_actions.last.dialog).to eq(service_dialog)
+      expect(updated.resource_actions.last.fqname).to eq('/x1/y1/z1')
       expect(updated.name).to eq('Updated Template Name')
       expect(updated.service_resources.first.resource.source_id).to eq(new_vm.id) # Validate request update
       expect(updated.config_info).to eq(updated_catalog_item_options[:config_info])


### PR DESCRIPTION
Multiple problems were discovered while debugging https://bugzilla.redhat.com/show_bug.cgi?id=1447701

1. Fix update process to include `:fqname` for `resource_actions`
2. Embedded job template, aka configuration_template, should not be recorded in `options[:config_info]`
3. Method `#create_dialogs` can be used both by `create_catalog_item` and `update_catalog_item`