### PR TITLE
[EUWE] partial Add purge timer for archived entities

### DIFF
--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -43,6 +43,22 @@ module PurgingMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def purge_mode_and_value
+      [:date, purge_date]
+    end
+
+    def purge_timer
+      purge_queue(*purge_mode_and_value)
+    end
+
+    def purge_queue(mode, value)
+      MiqQueue.put(
+        :class_name  => name,
+        :method_name => "purge_by_#{mode}",
+        :args        => [value]
+      )
+    end
+
     def purge(older_than = nil, window = nil, &block)
       purge_by_date(older_than || purge_date, window || purge_window_size, &block)
     end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -10,6 +10,14 @@ describe PurgingMixin do
     end
   end
 
+  describe ".purge_mode_and_value" do
+    it "purge_mode_and_value should return proper options" do
+      stub_settings(:policy_events => {:history => {:keep_policy_events => 120}})
+      expect(example_class.purge_mode_and_value.first).to eq(:date)
+      expect(example_class.purge_mode_and_value.last).to be_within(1.second).of(120.seconds.ago.utc)
+    end
+  end
+
   describe ".purge" do
     let(:events) do
       (-2..2).collect do |date_modifier|


### PR DESCRIPTION
This is the first commit from #14676
It introduces common purging methods to `PurgingMixin`.

The models in #14322 use these methods.
For all other models, these methods are defined in the models themselves. So this should not change any behavior for them.

This is part of https://bugzilla.redhat.com/show_bug.cgi?id=1428595

This will fix the currently build fix /cc @zeari 