### PR TITLE
Remove reference to job.guid from VmOrTemplate

### DIFF
--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -14,6 +14,17 @@ describe "JobProxyDispatcherVmProxies4Job" do
         @vm = @vms.first
       end
 
+      context "with available active proxy" do
+        before(:each) do
+          allow(@vm).to receive_messages(:storage2proxies => [@server1])
+          allow(@vm).to receive_messages(:storage2active_proxies => [@server1])
+        end
+
+        it "should return with message informing that Smart State Analysis will be performed on this VM" do
+          expect(@vm.proxies4job[:message]).to eq("Perform SmartState Analysis on this VM")
+        end
+      end
+
       context "with no eligible active proxies, " do
         before(:each) do
           allow(@vm).to receive_messages(:storage2active_proxies => [])

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -10,7 +10,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before(:each) do
-        @hosts, @proxies, @storages, @vms = build_entities
+        _hosts, _proxies, _storages, @vms = build_entities
         @vm = @vms.first
       end
 
@@ -24,42 +24,18 @@ describe "JobProxyDispatcherVmProxies4Job" do
             allow(@vm).to receive_messages(:storage2proxies => [@server1])
           end
 
-          it "should return with message asking for VM's host's creds" do
+          it "should return with message asking for VM's host's credentials" do
             expect(@vm.proxies4job[:message]).to eq("Provide credentials for this VM's Host to perform SmartState Analysis")
           end
         end
 
-        context "with first host in list of all eligible proxies before filtering, " do
+        context "with empty list of all eligible proxies before filtering, " do
           before(:each) do
-            allow(@vm).to receive_messages(:storage2proxies => [@hosts.first])
+            allow(@vm).to receive_messages(:storage2proxies => [])
           end
 
           it "should return with message 'No active SmartProxies'" do
             expect(@vm.proxies4job[:message]).to eq("No active SmartProxies found to analyze this VM")
-          end
-        end
-      end
-
-      context "with a single host 'eligible' but not the active Vmware Vm's host" do
-        before(:each) do
-          @host, @vms_host = @hosts
-          allow(@vm).to receive_messages(:storage2active_proxies => [@host])
-          allow(@vm).to receive_messages(:storage2proxies => [@host])
-          @vm.host = @vms_host
-          @vm.raw_power_state = "poweredOn"
-          @vm.save
-        end
-
-        it "should return with message Smarstate Analysis is available through registered Host only" do
-          expect(@vm.proxies4job[:message]).to eq('SmartState Analysis is only available through the registered Host for running VM')
-        end
-
-        context "with a server in the all proxy list" do
-          before(:each) do
-            allow(@vm).to receive_messages(:storage2proxies => [@server1])
-          end
-          it "should return with message to start a smart proxy or provide Vm's hosts creds" do
-            expect(@vm.proxies4job[:message]).to eq("Start a SmartProxy or provide credentials for this VM's Host to perform SmartState Analysis")
           end
         end
       end
@@ -71,14 +47,9 @@ describe "JobProxyDispatcherVmProxies4Job" do
           allow(@vm).to receive_messages(:storage2activeproxies => [])
         end
 
-        it "should accept an instance of a job and call log proxies with a job" do
-          expect(@vm).to receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
+        it "should call 'log_all_proxies'" do
+          expect(@vm).to receive(:log_all_proxies).with([], instance_of(String))
           expect(@vm.proxies4job(@job)[:proxies]).to be_empty
-        end
-
-        it "should accept a job guid and call log proxies with a job" do
-          expect(@vm).to receive(:log_proxies).with([], [], (instance_of(String)), (instance_of(VmScan)))
-          expect(@vm.proxies4job(@job.guid)[:proxies]).to be_empty
         end
 
         context "with VmAmazon, " do


### PR DESCRIPTION
There is no need to include `job.guid` into error message when proxy for smart state analysis not available - proxy is instance of `MiqServer` and does not depend on job instance.

This PR:
- introduced new method `VmOrTemplate#log_all_proxies' which does not accept `job` 
- refactor `VmOrTemplate#proxies4job' to:
  - remove references to `job` 
  - remove logic related to registered `Host` been proxy for SmartState Analysis 

Follow-up PR will remove not used `VmOrTemplate#log_proxies` and replace call to it to `log_all_proxies` for `redhat` provider

@miq-bot add-label technical debt