### PR TITLE
Add middleware models to direct RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -34,6 +34,12 @@ module Rbac
       Host
       LoadBalancer
       MiqCimInstance
+      MiddlewareDatasource
+      MiddlewareDeployment
+      MiddlewareDomain
+      MiddlewareMessaging
+      MiddlewareServer
+      MiddlewareServerGroup
       NetworkPort
       NetworkRouter
       OrchestrationTemplate

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -365,6 +365,37 @@ describe Rbac::Filterer do
       expect(results).to match_array(expected_objects)
     end
 
+    context 'with Middleware models' do
+      context 'with tags' do
+        before do
+          group.entitlement = Entitlement.new
+          group.entitlement.set_belongsto_filters([])
+          group.entitlement.set_managed_filters([["/managed/environment/prod"]])
+          group.save!
+        end
+
+        let(:count_of_created_instances) { 2 }
+
+        %w(
+          MiddlewareDatasource
+          MiddlewareDeployment
+          MiddlewareDomain
+          MiddlewareMessaging
+          MiddlewareServer
+          MiddlewareServerGroup
+        ).each do |middleware_model|
+          it "returns tagged instance of #{middleware_model}" do
+            middleware_instances = FactoryGirl.create_list(middleware_model.tableize.singularize.to_sym,
+                                                           count_of_created_instances)
+            middleware_instances[0].tag_with('/managed/environment/prod', :ns => '*')
+            middleware_model_class = middleware_model.constantize
+            expect(middleware_model_class.count).to eq(count_of_created_instances)
+            get_rbac_results_for_and_expect_objects(middleware_model_class, [middleware_instances[0]])
+          end
+        end
+      end
+    end
+
     context "with User and Group" do
       context 'with tags' do
         let!(:tagged_group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -358,14 +358,14 @@ describe Rbac::Filterer do
       }
     end
 
+    def get_rbac_results_for_and_expect_objects(klass, expected_objects)
+      User.current_user = user
+
+      results = described_class.search(:class => klass).first
+      expect(results).to match_array(expected_objects)
+    end
+
     context "with User and Group" do
-      def get_rbac_results_for_and_expect_objects(klass, expected_objects)
-        User.current_user = user
-
-        results = described_class.search(:class => klass).first
-        expect(results).to match_array(expected_objects)
-      end
-
       context 'with tags' do
         let!(:tagged_group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }
         let!(:user)         { FactoryGirl.create(:user, :miq_groups => [tagged_group]) }


### PR DESCRIPTION
these models can be tagged 
```
          MiddlewareDatasource
          MiddlewareDeployment
          MiddlewareDomain
          MiddlewareMessaging
          MiddlewareServer
          MiddlewareServerGroup
```
but RBAC search did not count with them.

So this PR is adding these models to direct RBAC to be able to use tags for RBAC filtering.

@karelhala - I guess that I took all related models to the middleware provider


## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1442964

## MiqBot
@miq-bot add_label rbac, bug
@miq-bot assign @gtanzillo 