### PR TITLE
Remove auth_user and auth_token ivars from API

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -16,7 +16,7 @@ module Api
     end
 
     def destroy
-      api_token_mgr.invalidate_token(@auth_token)
+      api_token_mgr.invalidate_token(request.headers[HttpHeaders::AUTH_TOKEN])
 
       render_normal_destroy
     end

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -5,7 +5,7 @@ module Api
     def show
       requester_type = fetch_and_validate_requester_type
       token_service = Environment.user_token_service
-      auth_token = token_service.generate_token(@auth_user, requester_type)
+      auth_token = token_service.generate_token(User.current_user.userid, requester_type)
       token_info = token_service.token_mgr(requester_type).token_get_info(auth_token)
       res = {
         :auth_token => auth_token,

--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -24,7 +24,7 @@ module Api
       raise "Must specify a reason for approving an automation request" unless data["reason"].present?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
-        request.approve(@auth_user, data["reason"])
+        request.approve(User.current_user.userid, data["reason"])
         action_result(true, "Automation request #{id} approved")
       end
     rescue => err
@@ -35,7 +35,7 @@ module Api
       raise "Must specify a reason for denying an automation request" unless data["reason"].present?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
-        request.deny(@auth_user, data["reason"])
+        request.deny(User.current_user.userid, data["reason"])
         action_result(true, "Automation request #{id} denied")
       end
     rescue => err

--- a/app/controllers/api/base_controller/action.rb
+++ b/app/controllers/api/base_controller/action.rb
@@ -16,7 +16,7 @@ module Api
       def queue_object_action(object, summary, options)
         task_options = {
           :action => summary,
-          :userid => @auth_user
+          :userid => User.current_user.userid
         }
 
         queue_options = {

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -6,7 +6,6 @@ module Api
       #
       def require_api_user_or_token
         log_request_initiated
-        @auth_token = nil
         if request.headers[HttpHeaders::MIQ_TOKEN]
           authenticate_with_system_token(request.headers[HttpHeaders::MIQ_TOKEN])
         elsif request.headers[HttpHeaders::AUTH_TOKEN]
@@ -64,14 +63,14 @@ module Api
       end
 
       def authenticate_with_user_token(x_auth_token)
-        @auth_token = x_auth_token
-        if !api_token_mgr.token_valid?(@auth_token)
-          raise AuthenticationError, "Invalid Authentication Token #{@auth_token} specified"
+        auth_token = x_auth_token
+        if !api_token_mgr.token_valid?(auth_token)
+          raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified"
         else
-          auth_user_obj = userid_to_userobj(api_token_mgr.token_get_info(@auth_token, :userid))
+          auth_user_obj = userid_to_userobj(api_token_mgr.token_get_info(auth_token, :userid))
 
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'
-            api_token_mgr.reset_token(@auth_token)
+            api_token_mgr.reset_token(auth_token)
           end
 
           authorize_user_group(auth_user_obj)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -6,7 +6,7 @@ module Api
       #
       def require_api_user_or_token
         log_request_initiated
-        @auth_token = @auth_user = nil
+        @auth_token = nil
         if request.headers[HttpHeaders::MIQ_TOKEN]
           authenticate_with_system_token(request.headers[HttpHeaders::MIQ_TOKEN])
         elsif request.headers[HttpHeaders::AUTH_TOKEN]
@@ -18,8 +18,7 @@ module Api
           }
 
           if (user = authenticate_with_http_basic { |u, p| User.authenticate(u, p, request, authenticate_options) })
-            @auth_user     = user.userid
-            auth_user_obj = userid_to_userobj(@auth_user)
+            auth_user_obj = userid_to_userobj(user.userid)
             authorize_user_group(auth_user_obj)
             validate_user_identity(auth_user_obj)
             User.current_user = auth_user_obj
@@ -69,8 +68,7 @@ module Api
         if !api_token_mgr.token_valid?(@auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{@auth_token} specified"
         else
-          @auth_user     = api_token_mgr.token_get_info(@auth_token, :userid)
-          auth_user_obj = userid_to_userobj(@auth_user)
+          auth_user_obj = userid_to_userobj(api_token_mgr.token_get_info(@auth_token, :userid))
 
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'
             api_token_mgr.reset_token(@auth_token)
@@ -90,8 +88,7 @@ module Api
 
         User.authorize_user(@miq_token_hash[:userid])
 
-        @auth_user     = @miq_token_hash[:userid]
-        auth_user_obj = userid_to_userobj(@auth_user)
+        auth_user_obj = userid_to_userobj(@miq_token_hash[:userid])
 
         authorize_user_group(auth_user_obj)
         validate_user_identity(auth_user_obj)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -62,8 +62,7 @@ module Api
         Environment.user_token_service.token_mgr('api')
       end
 
-      def authenticate_with_user_token(x_auth_token)
-        auth_token = x_auth_token
+      def authenticate_with_user_token(auth_token)
         if !api_token_mgr.token_valid?(auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{auth_token} specified"
         else

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -16,10 +16,10 @@ module Api
           auth_type = "system"
           log_request("System Auth", {:x_miq_token => request.headers[HttpHeaders::MIQ_TOKEN]}.merge(@miq_token_hash))
         else
-          auth_type = @auth_token.blank? ? "basic" : "token"
+          auth_type = request.headers[HttpHeaders::AUTH_TOKEN].blank? ? "basic" : "token"
         end
         log_request("Authentication", :type        => auth_type,
-                                      :token       => @auth_token,
+                                      :token       => request.headers[HttpHeaders::AUTH_TOKEN],
                                       :x_miq_group => request.headers[HttpHeaders::MIQ_GROUP],
                                       :user        => User.current_user.userid)
         if User.current_user

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -21,10 +21,10 @@ module Api
         log_request("Authentication", :type        => auth_type,
                                       :token       => @auth_token,
                                       :x_miq_group => request.headers[HttpHeaders::MIQ_GROUP],
-                                      :user        => @auth_user)
+                                      :user        => User.current_user.userid)
         if User.current_user
           group = User.current_user.current_group
-          log_request("Authorization", :user   => @auth_user,
+          log_request("Authorization", :user   => User.current_user.userid,
                                        :group  => group.description,
                                        :role   => group.miq_user_role_name,
                                        :tenant => group.tenant.name)

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -28,7 +28,7 @@ module Api
     def deny_resource(type, id, data)
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
-        provreq.deny(@auth_user, data['reason'])
+        provreq.deny(User.current_user.userid, data['reason'])
         action_result(true, "Provision request #{id} denied")
       end
     rescue => err
@@ -38,7 +38,7 @@ module Api
     def approve_resource(type, id, data)
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
-        provreq.approve(@auth_user, data['reason'])
+        provreq.approve(User.current_user.userid, data['reason'])
         action_result(true, "Provision request #{id} approved")
       end
     rescue => err

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -38,7 +38,7 @@ module Api
       raise "Must specify a reason for approving a request" if data["reason"].blank?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
-        request.approve(@auth_user, data["reason"])
+        request.approve(User.current_user.userid, data["reason"])
         action_result(true, "Request #{id} approved")
       end
     rescue => err
@@ -49,7 +49,7 @@ module Api
       raise "Must specify a reason for denying a request" if data["reason"].blank?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
-        request.deny(@auth_user, data["reason"])
+        request.deny(User.current_user.userid, data["reason"])
         action_result(true, "Request #{id} denied")
       end
     rescue => err

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -7,7 +7,7 @@ module Api
       raise "Must specify a reason for approving a service request" unless data["reason"].present?
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
-        provreq.approve(@auth_user, data['reason'])
+        provreq.approve(User.current_user.userid, data['reason'])
         action_result(true, "Service request #{id} approved")
       end
     rescue => err
@@ -18,7 +18,7 @@ module Api
       raise "Must specify a reason for denying a service request" unless data["reason"].present?
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
-        provreq.deny(@auth_user, data['reason'])
+        provreq.deny(User.current_user.userid, data['reason'])
         action_result(true, "Service request #{id} denied")
       end
     rescue => err

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -9,14 +9,14 @@ module Api
 
     def create_resource(_type, _id, data)
       catalog_item_type = ServiceTemplate.class_from_request_data(data)
-      catalog_item_type.create_catalog_item(data.deep_symbolize_keys, @auth_user)
+      catalog_item_type.create_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
       raise BadRequestError, "Could not create Service Template - #{err}"
     end
 
     def edit_resource(type, id, data)
       catalog_item = resource_search(id, type, collection_class(:service_templates))
-      catalog_item.update_catalog_item(data.deep_symbolize_keys, @auth_user)
+      catalog_item.update_catalog_item(data.deep_symbolize_keys, User.current_user.userid)
     rescue => err
       raise BadRequestError, "Could not update Service Template - #{err}"
     end

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -444,7 +444,7 @@ module Api
       task_id = queue_object_action(vm, desc,
                                     :method_name => "remote_console_acquire_ticket",
                                     :role        => "ems_operations",
-                                    :args        => [@auth_user, MiqServer.my_server.id, protocol])
+                                    :args        => [User.current_user.userid, MiqServer.my_server.id, protocol])
       # NOTE:
       # we are queuing the :remote_console_acquire_ticket and returning the task id and href.
       #


### PR DESCRIPTION
1. We can get the `@auth_user` value from `User.current_user.userid`, which is much clearer IMO
2. `@auth_token` is just set to the value of the corresponding header, so just use that instead

The result I think is a lot cleaner and intention revealing - and :scissors: a couple of lines along the way

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 