### PR TITLE
Login Start Pages dropdown list - Clouds menus

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -369,49 +369,10 @@
   :url: /cloud_object_store_object/show_list
   :rbac_feature_name: cloud_object_store_object_show_list
   :startup: true
-- :name: storage_managers
-  :description: Storage / Storage Managers
-  :url: /storage_manager/show_list
-  :rbac_feature_name: storage_manager_show_list
-- :name: ems_containers_overview
-  :description: Containers / Overview
-  :url: /container_dashboard/show
-  :rbac_feature_name: ems_container_show_list
-  :startup: true
-- :name: ems_containers
-  :description: Containers / Providers
-  :url: /ems_container/show_list
-  :rbac_feature_name: ems_container_show_list
-  :startup: true
-- :name: container_nodes
-  :description: Containers / Nodes
-  :url: /container_node/show_list
-  :rbac_feature_name: container_node_show_list
-  :startup: true
-- :name: container_groups
-  :description: Containers / Pods
-  :url: /container_group/show_list
-  :rbac_feature_name: container_group_show_list
-  :startup: true
-- :name: container_services
-  :description: Containers / Services
-  :url: /container_service/show_list
-  :rbac_feature_name: container_service_show_list
-  :startup: true
-- :name: container_containers
-  :description: Containers / Containers
-  :url: /container/show_list
-  :rbac_feature_name: containers
-  :startup: true
 - :name: control_explorer
   :description: Control / Explorer
   :url: /miq_policy/explorer
   :rbac_feature_name: control_explorer
-  :startup: true
-- :name: automate_explorer
-  :description: Automate / Explorer
-  :url: /miq_ae_class/explorer
-  :rbac_feature_name: miq_ae_class_explorer
   :startup: true
 - :name: utilization
   :description: Optimize / Utilization
@@ -427,14 +388,4 @@
   :description: Optimize / Bottlenecks
   :url: /miq_capacity/bottlenecks
   :rbac_feature_name: bottlenecks
-  :startup: true
-- :name: miq_proxy_tasks
-  :description: Configure / Tasks
-  :url: /miq_task/index?jobs_tab=alltasks
-  :rbac_feature_name: tasks
-  :startup: true
-- :name: miq_automate_log
-  :description: Automate Log
-  :url: /miq_ae_tools/log
-  :rbac_feature_name: miq_ae_class_log
   :startup: true

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -55,124 +55,199 @@
   :rbac_feature_name: miq_request_show_list
   :startup: true
 - :name: ems_clouds
-  :description: Clouds / Providers
+  :description: Compute / Clouds / Providers
   :url: /ems_cloud/show_list
   :rbac_feature_name: ems_cloud_show_list
   :startup: true
 - :name: availability_zones
-  :description: Clouds / Availability Zones
+  :description: Compute / Clouds / Availability Zones
   :url: /availability_zone/show_list
   :rbac_feature_name: availability_zone_show_list
   :startup: true
 - :name: host_aggregates
-  :description: Clouds / Host Aggregates
+  :description: Compute / Clouds / Host Aggregates
   :url: /host_aggregate/show_list
   :rbac_feature_name: host_aggregate_show_list
   :startup: true
 - :name: cloud_tenants
-  :description: Clouds / Tenants
+  :description: Compute / Clouds / Tenants
   :url: /cloud_tenant/show_list
   :rbac_feature_name: cloud_tenant_show_list
   :startup: true
 - :name: flavors
-  :description: Clouds / Flavors
+  :description: Compute / Clouds / Flavors
   :url: /flavor/show_list
   :rbac_feature_name: flavor_show_list
   :startup: true
 - :name: vm_cloud_instances_accord
-  :description: Clouds / Instances / Instances By Providers
+  :description: Compute / Clouds / Instances / Instances By Providers
   :url: /vm_cloud/explorer?accordion=instances
   :rbac_feature_name: vm_cloud_explorer
   :startup: true
 - :name: vm_cloud_images_accord
-  :description: Clouds / Instances / Images By Providers
+  :description: Compute / Clouds / Instances / Images By Providers
   :url: /vm_cloud/explorer?accordion=images
   :rbac_feature_name: vm_cloud_explorer
   :startup: true
 - :name: vm_cloud_instances_filter_accord
-  :description: Clouds / Instances / Instances
+  :description: Compute / Clouds / Instances / Instances
   :url: /vm_cloud/explorer?accordion=instances_filter
   :rbac_feature_name: vm_cloud_explorer
   :startup: true
 - :name: vm_cloud_images_filter_accord
-  :description: Clouds / Instances / Images
+  :description: Compute / Clouds / Instances / Images
   :url: /vm_cloud/explorer?accordion=images_filter
   :rbac_feature_name: vm_cloud_explorer
   :startup: true
-- :name: vm_cloud_instances_accord
-  :description: Clouds / Instances / Instances By Providers
-  :url: /vm_cloud/explorer?accordion=instances
-  :rbac_feature_name: vm_cloud_explorer
-  :startup: true
-- :name: vm_cloud_images_accord
-  :description: Clouds / Instances / Images By Providers
-  :url: /vm_cloud/explorer?accordion=images
-  :rbac_feature_name: vm_cloud_explorer
-  :startup: true
-- :name: vm_cloud_instances_filter_accord
-  :description: Clouds / Instances / Instances
-  :url: /vm_cloud/explorer?accordion=instances_filter
-  :rbac_feature_name: vm_cloud_explorer
-  :startup: true
 - :name: cloud_orchestration_stack
-  :description: Clouds / Stacks
+  :description: Compute / Clouds / Stacks
   :url: orchestration_stack/show_list
-  :rbac_feature_name: orchestration_stack
+  :rbac_feature_name: orchestration_stack_show_list
   :startup: true
 - :name: auth_key_pair_clouds
-  :description: Clouds / Key Pairs
+  :description: Compute / Clouds / Key Pairs
   :url: /auth_key_pair_cloud/show_list
   :rbac_feature_name: auth_key_pair_cloud_show_list
   :startup: true
 - :name: cloud_topology
-  :description: Clouds / Topology
+  :description: Compute / Clouds / Topology
   :url: /cloud_topology
   :rbac_feature_name: cloud_topology_view
   :startup: true
-- :name: ems_networks
-  :description: Networks / Providers
-  :url: /ems_network/show_list
-  :rbac_feature_name: ems_network_show_list
-  :startup: true
 - :name: ems_infras
-  :description: Infrastructure / Providers
-  :url: /ems_infra/show_list
+  :description: Compute / Infrastructure / Providers
+  :url: /ems_infra
   :rbac_feature_name: ems_infra_show_list
   :startup: true
-- :name: clusters
-  :description: Infrastructure / Clusters
-  :url: /ems_cluster/show_list
+- :name: ems_clusters
+  :description: Compute / Infrastructure / Clusters
+  :url: /ems_cluster
   :rbac_feature_name: ems_cluster_show_list
   :startup: true
 - :name: hosts
-  :description: Infrastructure / Hosts
-  :url: /host/show_list
+  :description: Compute / Infrastructure / Hosts / Nodes
+  :url: /host
   :rbac_feature_name: host_show_list
   :startup: true
 - :name: vms_vandt
-  :description: Infrastructure / Virtual Machines / VMs & Templates
+  :description: Compute / Infrastructure / Virtual Machines / VMs & Templates
   :url: /vm_infra/explorer?accordion=vandt
   :rbac_feature_name: vandt_accord
   :startup: true
 - :name: vms
-  :description: Infrastructure / Virtual Machines / VMs
+  :description: Compute / Infrastructure / Virtual Machines / VMs
   :url: /vm_infra/explorer?accordion=vms_filter
   :rbac_feature_name: vms_filter_accord
   :startup: true
 - :name: templates
-  :description: Infrastructure / Virtual Machines / Templates
+  :description: Compute / Infrastructure / Virtual Machines / Templates
   :url: /vm_infra/explorer?accordion=templates_filter
   :rbac_feature_name: templates_filter_accord
   :startup: true
 - :name: resource_pools
-  :description: Infrastructure / Resource Pools
+  :description: Compute / Infrastructure / Resource Pools
   :url: /resource_pool/show_list
   :rbac_feature_name: resource_pool_show_list
   :startup: true
-- :name: datastores
-  :description: Infrastructure / Datastores
+- :name: storage
+  :description: Compute / Infrastructure / Datastores
   :url: /storage/show_list
   :rbac_feature_name: storage_show_list
+  :startup: true
+- :name: pxe
+  :description: Compute / Infrastructure / PXE
+  :url: /pxe/explorer
+  :rbac_feature_name: pxe
+  :startup: true
+- :name: infra_networking
+  :description: Compute / Infrastructure / Networking
+  :url: /infra_networking/explorer
+  :rbac_feature_name: infra_networking
+  :startup: true
+- :name: miq_request_hosts
+  :description: Compute / Infrastructure / Requests
+  :url: /miq_request/show_list
+  :rbac_feature_name: miq_request_show_list
+  :startup: true
+- :name: infra_topology
+  :description: Compute / Infrastructure / Topology
+  :url: /infra_topology
+  :rbac_feature_name: infra_topology_view
+  :startup: true
+- :name: container_dashboard
+  :description: Compute / Containers / Overview
+  :url: /container_dashboard
+  :rbac_feature_name: container_dashboard
+  :startup: true
+- :name: ems_containers
+  :description: Compute / Containers / Providers
+  :url: /ems_container/show_list
+  :rbac_feature_name: ems_container_show_list
+  :startup: true
+- :name: container_projects
+  :description: Compute / Containers / Projects
+  :url: /container_project/show_list
+  :rbac_feature_name: container_project_show_list
+  :startup: true
+- :name: container_routes
+  :description: Compute / Containers / Routes
+  :url: /container_route/show_list
+  :rbac_feature_name: container_route_show_list
+  :startup: true
+- :name: container_services
+  :description: Compute / Containers / Container Services
+  :url: /container_service/show_list
+  :rbac_feature_name: container_service_show_list
+  :startup: true
+- :name: container_replicators
+  :description: Compute / Containers / Replicators
+  :url: /container_replicator/show_list
+  :rbac_feature_name: container_replicator_show_list
+  :startup: true
+- :name: container_groups
+  :description: Compute / Containers / Pods
+  :url: /container_group/show_list
+  :rbac_feature_name: container_group_show_list
+  :startup: true
+- :name: containers
+  :description: Compute / Containers / Containers
+  :url: /container/explorer
+  :rbac_feature_name: containers
+  :startup: true
+- :name: container_nodes
+  :description: Compute / Containers / Container Nodes
+  :url: /container_node/show_list
+  :rbac_feature_name: container_node_show_list
+  :startup: true
+- :name: persistent_volumes
+  :description: Compute / Containers / Volumes
+  :url: /persistent_volume/show_list
+  :rbac_feature_name: persistent_volume_show_list
+  :startup: true
+- :name: container_builds
+  :description: Compute / Containers / Container Builds
+  :url: /container_build/show_list
+  :rbac_feature_name: container_build_show_list
+  :startup: true
+- :name: container_image_registries
+  :description: Compute / Containers / Image Registries
+  :url: /container_image_registry/show_list
+  :rbac_feature_name: container_image_registry_show_list
+  :startup: true
+- :name: container_images
+  :description: Compute / Containers / Container Images
+  :url: /container_image/show_list
+  :rbac_feature_name: container_image_show_list
+  :startup: true
+- :name: container_templates
+  :description: Compute / Containers / Container Templates
+  :url: /container_template/show_list
+  :rbac_feature_name: container_template_show_list
+  :startup: true
+- :name: container_topology
+  :description: Compute / Containers / Topology
+  :url: /container_topology
+  :rbac_feature_name: container_topology_view
   :startup: true
 - :name: configuration_management
   :description: Configuration / Management

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -372,7 +372,22 @@
 - :name: control_explorer
   :description: Control / Explorer
   :url: /miq_policy/explorer
-  :rbac_feature_name: control_explorer
+  :rbac_feature_name: control_explorer_view
+  :startup: true
+- :name: policy_simulation
+  :description: Control / Simulation
+  :url: /miq_policy/rsop
+  :rbac_feature_name: policy_simulation
+  :startup: true
+- :name: policy_import_export
+  :description: Control / Import / Export
+  :url: /miq_policy/export
+  :rbac_feature_name: policy_import_export
+  :startup: true
+- :name: policy_logs
+  :description: Control / Log
+  :url: /miq_policy/log
+  :rbac_feature_name: policy_log
   :startup: true
 - :name: utilization
   :description: Optimize / Utilization

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -4,24 +4,24 @@
   :url: /dashboard/show
   :rbac_feature_name: dashboard_view
   :startup: true
-- :name: chargeback
-  :description: Cloud Intelligence / Chargeback
-  :url: /chargeback/explorer
-  :rbac_feature_name: chargeback
-  :startup: true
-- :name: report_explorer
-  :description: Cloud Intelligence / Reports
+- :name: miq_report
+  :description: Cloud Intel / Reports
   :url: /report/explorer
   :rbac_feature_name: miq_report
   :startup: true
+- :name: chargeback
+  :description: Cloud Intel / Chargeback
+  :url: /chargeback/explorer
+  :rbac_feature_name: chargeback
+  :startup: true
 - :name: timelines
-  :description: Cloud Intelligence / Timelines
+  :description: Cloud Intel / Timelines
   :url: /dashboard/timeline
   :rbac_feature_name: timeline
   :startup: true
 - :name: rss
-  :description: Cloud Intelligence / RSS
-  :url: /alert
+  :description: Cloud Intel / RSS
+  :url: /alert/show_list
   :rbac_feature_name: rss
   :startup: true
 - :name: service_explorer
@@ -97,6 +97,21 @@
 - :name: vm_cloud_images_filter_accord
   :description: Clouds / Instances / Images
   :url: /vm_cloud/explorer?accordion=images_filter
+  :rbac_feature_name: vm_cloud_explorer
+  :startup: true
+- :name: vm_cloud_instances_accord
+  :description: Clouds / Instances / Instances By Providers
+  :url: /vm_cloud/explorer?accordion=instances
+  :rbac_feature_name: vm_cloud_explorer
+  :startup: true
+- :name: vm_cloud_images_accord
+  :description: Clouds / Instances / Images By Providers
+  :url: /vm_cloud/explorer?accordion=images
+  :rbac_feature_name: vm_cloud_explorer
+  :startup: true
+- :name: vm_cloud_instances_filter_accord
+  :description: Clouds / Instances / Instances
+  :url: /vm_cloud/explorer?accordion=instances_filter
   :rbac_feature_name: vm_cloud_explorer
   :startup: true
 - :name: cloud_orchestration_stack

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -299,6 +299,41 @@
   :url: /network_topology
   :rbac_feature_name: network_topology_view
   :startup: true
+- :name: ems_middleware
+  :description: Middleware / Providers
+  :url: /ems_middleware/show_list
+  :rbac_feature_name: ems_middleware_show_list
+  :startup: true
+- :name: middleware_domains
+  :description: Middleware / Domains
+  :url: /middleware_domain/show_list
+  :rbac_feature_name: middleware_domain_show_list
+  :startup: true
+- :name: middleware_servers
+  :description: Middleware / Servers
+  :url: /middleware_server/show_list
+  :rbac_feature_name: middleware_server_show_list
+  :startup: true
+- :name: middleware_deployments
+  :description: Middleware / Deployments
+  :url: /middleware_deployment/show_list
+  :rbac_feature_name: middleware_deployment_show_list
+  :startup: true
+- :name: middleware_datasources
+  :description: Middleware / Datasources
+  :url: /middleware_datasource/show_list
+  :rbac_feature_name: middleware_datasource_show_list
+  :startup: true
+- :name: middleware_messagings
+  :description: Middleware / Messagings
+  :url: /middleware_messaging/show_list
+  :rbac_feature_name: middleware_messaging_show_list
+  :startup: true
+- :name: middleware_topology
+  :description: Middleware / Topology
+  :url: /middleware_topology
+  :rbac_feature_name: middleware_topology_view
+  :startup: true
 - :name: storage_systems
   :description: Storage / Storage Systems
   :url: /ontap_storage_system/show_list

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -451,15 +451,15 @@
   :startup: true
 - :name: utilization
   :description: Optimize / Utilization
-  :url: /miq_capacity/utilization
+  :url: /miq_capacity
   :rbac_feature_name: utilization
   :startup: true
-- :name: capacity_planning
+- :name: planning
   :description: Optimize / Planning
   :url: /miq_capacity/planning
   :rbac_feature_name: planning
   :startup: true
-- :name: capacity_bottlenecks
+- :name: bottlenecks
   :description: Optimize / Bottlenecks
   :url: /miq_capacity/bottlenecks
   :rbac_feature_name: bottlenecks

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -24,6 +24,11 @@
   :url: /alert/show_list
   :rbac_feature_name: rss
   :startup: true
+- :name: consumption
+  :description: Consumption / Dashboard
+  :url: /consumption/show
+  :rbac_feature_name: consumption
+  :startup: true
 - :name: services
   :description: Services / My Services
   :url: /service/explorer
@@ -334,6 +339,11 @@
   :url: /middleware_topology
   :rbac_feature_name: middleware_topology_view
   :startup: true
+- :name: ems_datawarehouse
+  :description: Datawarehouse / Providers
+  :url: /ems_datawarehouse
+  :rbac_feature_name: ems_datawarehouse_show_list
+  :startup: true
 - :name: ems_block_storage
   :description: Storage / Block Storage / Managers
   :url: /ems_block_storage/show_list
@@ -463,4 +473,19 @@
   :description: Optimize / Bottlenecks
   :url: /miq_capacity/bottlenecks
   :rbac_feature_name: bottlenecks
+  :startup: true
+- :name: monitor_alerts_overview
+  :description: Monitor / Alerts / Overview
+  :url: /alerts_overview
+  :rbac_feature_name: monitor_alerts_overview
+  :startup: true
+- :name: monitor_alerts_list
+  :description: Monitor / Alerts / All Alerts
+  :url: /alerts_list
+  :rbac_feature_name: monitor_alerts_list
+  :startup: true
+- :name: monitor_alerts_most_recent
+  :description: Monitor / Alerts / Most Recent Alerts
+  :url: /alerts_most_recent
+  :rbac_feature_name: monitor_alerts_most_recent
   :startup: true

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -254,6 +254,51 @@
   :url: provider_foreman/explorer
   :rbac_feature_name: provider_foreman_explorer
   :startup: true
+- :name: ems_networks
+  :description: Networks / Providers
+  :url: /ems_network/show_list
+  :rbac_feature_name: ems_network_show_list
+  :startup: true
+- :name: cloud_networks
+  :description: Networks / Networks
+  :url: /cloud_network/show_list
+  :rbac_feature_name: cloud_network_show_list
+  :startup: true
+- :name: cloud_subnets
+  :description: Networks / Subnets
+  :url: /cloud_subnet/show_list
+  :rbac_feature_name: cloud_subnet_show_list
+  :startup: true
+- :name: network_routers
+  :description: Networks / Network Routers
+  :url: /network_router/show_list
+  :rbac_feature_name: network_router_show_list
+  :startup: true
+- :name: secutiry_groups
+  :description: Networks / Security Groups
+  :url: /security_group/show_list
+  :rbac_feature_name: security_group_show_list
+  :startup: true
+- :name: floating_ips
+  :description: Networks / Floating IPs
+  :url: /floating_ip/show_list
+  :rbac_feature_name: floating_ip_show_list
+  :startup: true
+- :name: network_ports
+  :description: Networks / Network Ports
+  :url: /network_port/show_list
+  :rbac_feature_name: network_port_show_list
+  :startup: true
+- :name: load_balancers
+  :description: Networks / Load Balancers
+  :url: /load_balancer/show_list
+  :rbac_feature_name: load_balancer_show_list
+  :startup: true
+- :name: network_topology
+  :description: Networks / Topology
+  :url: /network_topology
+  :rbac_feature_name: network_topology_view
+  :startup: true
 - :name: storage_systems
   :description: Storage / Storage Systems
   :url: /ontap_storage_system/show_list

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -24,20 +24,15 @@
   :url: /alert/show_list
   :rbac_feature_name: rss
   :startup: true
-- :name: service_explorer
+- :name: services
   :description: Services / My Services
   :url: /service/explorer
   :rbac_feature_name: service
   :startup: true
-- :name: catalog_explorer
+- :name: catalogs
   :description: Services / Catalogs
   :url: /catalog/explorer
   :rbac_feature_name: catalog
-  :startup: true
-- :name: requests
-  :description: Services / Requests
-  :url: /miq_request/show_list
-  :rbac_feature_name: miq_request_show_list
   :startup: true
 - :name: vms_myvms
   :description: Services / Workloads / VMs & Instances
@@ -54,6 +49,11 @@
   :url: /vm_or_template/explorer?button=vm_miq_request_new
   :rbac_feature_name: vm_miq_request_new
   :startup: false
+- :name: miq_requests
+  :description: Services / Requests
+  :url: /miq_request/show_list
+  :rbac_feature_name: miq_request_show_list
+  :startup: true
 - :name: ems_clouds
   :description: Clouds / Providers
   :url: /ems_cloud/show_list

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -334,30 +334,40 @@
   :url: /middleware_topology
   :rbac_feature_name: middleware_topology_view
   :startup: true
-- :name: storage_systems
-  :description: Storage / Storage Systems
-  :url: /ontap_storage_system/show_list
-  :rbac_feature_name: ontap_storage_system_show_list
+- :name: ems_block_storage
+  :description: Storage / Block Storage / Managers
+  :url: /ems_block_storage/show_list
+  :rbac_feature_name: ems_block_storage_show_list
   :startup: true
-- :name: file_shares
-  :description: Storage / File Shares
-  :url: /ontap_file_share/show_list
-  :rbac_feature_name: ontap_file_share_show_list
+- :name: cloud_volumes
+  :description: Storage / Block Storage / Volumes
+  :url: /cloud_volume/show_list
+  :rbac_feature_name: cloud_volume_show_list
   :startup: true
-- :name: logical_disks
-  :description: Storage / Logical Disks
-  :url: /ontap_logical_disk/show_list
-  :rbac_feature_name: ontap_logical_disk_show_list
+- :name: volume_snapshots
+  :description: Storage / Block Storage / Volume Snapshots
+  :url: /cloud_volume_snapshot/show_list
+  :rbac_feature_name: cloud_volume_snapshot_show_list
   :startup: true
-- :name: base_extents
-  :description: Storage / Base Extents
-  :url: /cim_base_storage_extent/show_list
-  :rbac_feature_name: cim_storage_extent_show_list
+- :name: volume_backups
+  :description: Storage / Block Storage / Volume Backups
+  :url: /cloud_volume_backup/show_list
+  :rbac_feature_name: cloud_volume_backup_show_list
   :startup: true
-- :name: storage_volumes
-  :description: Storage / Storage Volumes
-  :url: /ontap_storage_volume/show_list
-  :rbac_feature_name: ontap_storage_volume_show_list
+- :name: ems_object_storage
+  :description: Storage / Object Storage / Managers
+  :url: /ems_object_storage/show_list
+  :rbac_feature_name: ems_object_storage_show_list
+  :startup: true
+- :name: cloud_object_store_containers
+  :description: Storage / Object Storage / Object Store Containers
+  :url: /cloud_object_store_container/show_list
+  :rbac_feature_name: cloud_object_store_container_show_list
+  :startup: true
+- :name: cloud_object_store_objects
+  :description: Storage / Object Storage / Object Store Objects
+  :url: /cloud_object_store_object/show_list
+  :rbac_feature_name: cloud_object_store_object_show_list
   :startup: true
 - :name: storage_managers
   :description: Storage / Storage Managers

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -389,6 +389,66 @@
   :url: /miq_policy/log
   :rbac_feature_name: policy_log
   :startup: true
+- :name: embedded_configuration_script_payload
+  :description: Automation / Ansible / Playbooks
+  :url: /ansible_playbook
+  :rbac_feature_name: embedded_configuration_script_payload
+  :startup: true
+- :name: embedded_configuration_script_source
+  :description: Automation / Ansible / Repositories
+  :url: /ansible_repository
+  :rbac_feature_name: embedded_configuration_script_source
+  :startup: true
+- :name: embedded_automation_manager_credentials
+  :description: Automation / Ansible / Credentials
+  :url: /ansible_credential
+  :rbac_feature_name: embedded_automation_manager_credentials
+  :startup: true
+- :name: automation_manager
+  :description: Automation / Ansible Tower / Explorer
+  :url: /automation_manager/explorer
+  :rbac_feature_name: automation_manager
+  :startup: true
+- :name: configuration_job
+  :description: Automation / Ansible Tower / Jobs
+  :url: /configuration_job
+  :rbac_feature_name: configuration_job_show_list
+  :startup: true
+- :name: miq_ae_class_explorer
+  :description: Automation / Automate / Explorer
+  :url: /miq_ae_class/explorer
+  :rbac_feature_name: miq_ae_domain_view
+  :startup: true
+- :name: miq_ae_class_simulation
+  :description: Automation / Automate / Simulation
+  :url: /miq_ae_tools/resolve
+  :rbac_feature_name: miq_ae_class_simulation
+  :startup: true
+- :name: miq_ae_customization_explorer
+  :description: Automation / Automate / Customization
+  :url: /miq_ae_customization/explorer
+  :rbac_feature_name: miq_ae_customization_explorer
+  :startup: true
+- :name: miq_ae_class_import_export
+  :description: Automation / Automate / Import / Export
+  :url: /miq_ae_tools/import_export
+  :rbac_feature_name: miq_ae_class_import_export
+  :startup: true
+- :name: miq_ae_class_log
+  :description: Automation / Automate / Log
+  :url: /miq_ae_tools/log
+  :rbac_feature_name: miq_ae_class_log
+  :startup: true
+- :name: requests
+  :description: Automation / Automate / Requests
+  :url: /miq_request?typ=ae
+  :rbac_feature_name: miq_request_show_list
+  :startup: true
+- :name: utilization
+  :description: Optimize / Utilization
+  :url: /miq_capacity/utilization
+  :rbac_feature_name: utilization
+  :startup: true
 - :name: utilization
   :description: Optimize / Utilization
   :url: /miq_capacity/utilization


### PR DESCRIPTION
**NOTE: This PR requires MiqShortcut.seed to be run to re-populate database table.**

**NOTE: In order to check Datawarehouse and Monitor Alerts shortcuts and menu display settings need to change in Configuration => Server => Advanced tab, see screen shots below for actual settings change/addition if needed.**

https://bugzilla.redhat.com/show_bug.cgi?id=1331327

At Login Start Page drop down list in My Settings => Visual tab is not in sync with recent UI menu navigation changes/updates.

Code updates provided via multiple commits, each matching UI menu section.

**Screen shots of Start Page drop down list PRIOR to code fixes:**
![all start pages list prior to update 1](https://cloud.githubusercontent.com/assets/552686/25762618/4e6528c0-3194-11e7-8019-862186f882f2.png)


![all start pages list prior to update 2](https://cloud.githubusercontent.com/assets/552686/25762567/176a4030-3194-11e7-8e49-5fbf5ffff4a4.png)

![all start pages list prior to update 3](https://cloud.githubusercontent.com/assets/552686/25762574/1c432e78-3194-11e7-85d5-fbedd9256c18.png)

![all start pages list prior to update 4](https://cloud.githubusercontent.com/assets/552686/25762581/210ad0be-3194-11e7-81e7-a005e7732aa3.png)

![all start pages list prior to update 5](https://cloud.githubusercontent.com/assets/552686/25762583/24b914c8-3194-11e7-9c63-c50b457e71d2.png)



**Screen shots of Start Page drop down AFTER code fixes:**

![start page at login cloud intel short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176925/9f55e9dc-3b0c-11e7-8ef2-c8ad5d8b773e.png)

![start page at login services short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176932/a63e6116-3b0c-11e7-9ab6-bf11a4af9f63.png)

![start page at login compute clouds short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176946/b0ff0128-3b0c-11e7-94ac-8bc731d92f9d.png)

![start page at login compute infrastructure short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176952/b694da54-3b0c-11e7-9c3f-5d9847b9bbdd.png)

![start page at login compute containers short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176955/bb9cb3be-3b0c-11e7-8a3e-dd0986058f3b.png)

![start page at login configuration short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176963/c5ff998e-3b0c-11e7-9e9a-6df583c879ab.png)

![start page at login networks short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176969/cc153d60-3b0c-11e7-8733-885289c59390.png)

![start page at login middleware short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176974/d0dd0c6a-3b0c-11e7-8a49-ae92bfadd91a.png)

![start page at login storage short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176983/d9b036a0-3b0c-11e7-811e-58fbafc65f97.png)

![start page at login control short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26176992/e275e690-3b0c-11e7-9d98-a368dbd9de77.png)

![start page at login automation short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26177001/eadc2d76-3b0c-11e7-92ad-c48964ef7565.png)

![start page at login optimize short cuts post fix](https://cloud.githubusercontent.com/assets/552686/26177009/f2025562-3b0c-11e7-99e2-c9c448e76f08.png)


**NOTE: In order to see Datawarehouse and Monitor Alerts menus display in UI, change/add following settings in (top right corner) Configuration => Server => Advanced Tab:**

![datawarehouse and monitor alerts settings change in config server advanced tab](https://cloud.githubusercontent.com/assets/552686/25873765/92c89eba-34c4-11e7-9d9d-6435d597052b.png)

UI Datawarehouse menu displayed post settings set/save:

![datawarehouse and monitor alerts menus post settings change](https://cloud.githubusercontent.com/assets/552686/25873776/a19a8250-34c4-11e7-9259-234eedd12de4.png)
