### PR TITLE
Fallback to ActiveRecord config for DB host lookup

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -95,7 +95,11 @@ class EvmDatabase
   end
 
   def self.host
-    Rails.configuration.database_configuration[Rails.env]['host']
+    if defined?(Rails)
+      Rails.configuration.database_configuration[Rails.env]['host']
+    else
+      ActiveRecord::Base.configurations[ENV['RAILS_ENV']]['host']
+    end
   end
 
   def self.local?


### PR DESCRIPTION
In the case where a Rails application has not been initialized, check to see if the ActiveRecord::Base.configurations is available to provide that information.

Another support PR for https://github.com/ManageIQ/manageiq/pull/14916

Links
-----
* https://github.com/ManageIQ/manageiq/pull/14916