### PR TITLE
Use ActiveRecord::Base for connection info

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -103,7 +103,7 @@ class EvmDatabase
   end
 
   # Determines the average time to the database in milliseconds
-  def self.ping(connection = ApplicationRecord.connection)
+  def self.ping(connection = ActiveRecord::Base.connection)
     query = "SELECT 1"
     Benchmark.realtime { 10.times { connection.select_value(query) } } / 10 * 1000
   end


### PR DESCRIPTION
Don't use `ApplicationRecord` for this purpose since it might not be defined, and `ActiveRecord::Base.connection` is what is used everywhere else in this class.

Another support PR for https://github.com/ManageIQ/manageiq/pull/14916

Links
-----
* https://github.com/ManageIQ/manageiq/pull/14916