### PR TITLE
Adds MiqHelper

### DIFF
--- a/lib/manageiq.rb
+++ b/lib/manageiq.rb
@@ -1,0 +1,26 @@
+require 'pathname'
+require 'active_support/core_ext/object/blank'
+require 'active_support/string_inquirer'
+
+module ManageIQ
+  # Defined in the same fasion
+  def self.env
+    @_env ||= begin
+      if defined?(Rails)
+        Rails.env
+      else
+        ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+      end
+    end
+  end
+
+  def self.root
+    @_root ||= begin
+      if defined?(Rails)
+        Rails.root
+      else
+        Pathname.new File.expand_path("../..", __FILE__)
+      end
+    end
+  end
+end

--- a/spec/lib/manageiq_spec.rb
+++ b/spec/lib/manageiq_spec.rb
@@ -1,0 +1,68 @@
+# This tests are done in a way that assume the Rails environment for ManageIQ are
+# loaded, and that Rails is present to do the comparisons.  Tests that confirm
+# that this works when rails is not present us a subprocess to run the
+# `lib/miq.rb` file in isolation.
+#
+# If tests are not passing, check to see if the spec/spec_helper.rb is being
+# loaded properly and initailizing the Vmdb::Application.
+
+require 'manageiq'
+
+describe ManageIQ do
+  def without_rails(rb_cmd)
+    miq_lib_file = Rails.root.join("lib", "manageiq.rb")
+    `#{Gem.ruby} -e 'require "#{miq_lib_file}"; print #{rb_cmd}'`
+  end
+
+  describe ".env" do
+    before(:each) do
+      ManageIQ.instance_variable_set(:@_env, nil)
+    end
+
+    it "equivalent to Rails.root when Rails is present" do
+      expect(ManageIQ.env.to_s).to eq(Rails.env.to_s)
+    end
+
+    it "equivalent to Rails.root even when Rails is not present" do
+      result = without_rails('ManageIQ.env.to_s')
+      expect(result).to eq(Rails.env.to_s)
+    end
+
+    it "responds to .test?" do
+      expect(ManageIQ.env.test?).to be true
+      expect(without_rails('ManageIQ.env.test?.inspect')).to eq("true")
+    end
+
+    it "responds to .development?" do
+      expect(ManageIQ.env.development?).to be false
+      expect(without_rails('ManageIQ.env.development?.inspect')).to eq("false")
+    end
+
+    it "responds to .production?" do
+      expect(ManageIQ.env.production?).to be false
+      expect(without_rails('ManageIQ.env.production?.inspect')).to eq("false")
+    end
+  end
+
+  describe ".root" do
+    before(:each) do
+      ManageIQ.instance_variable_set(:@_root, nil)
+    end
+
+    it "equivalent to Rails.root when Rails is present" do
+      expect(ManageIQ.root.to_s).to eq(Rails.root.to_s)
+    end
+
+    it "equivalent to Rails.root even when Rails is not present" do
+      result = without_rails('ManageIQ.root.to_s')
+      expect(result).to eq(Rails.root.to_s)
+    end
+
+    it "responds to .join" do
+      expected = Rails.root.join('config')
+      expect(ManageIQ.root.join('config')).to eq(expected)
+      # doing an .inspect here to confirm it is a Pathname
+      expect(without_rails('ManageIQ.root.join("config").inspect')).to eq(expected.inspect)
+    end
+  end
+end


### PR DESCRIPTION
Adds two methods to a global Miq module:

  * `Miq.env`:   Functions the same as `Rails.env`, but falls back to an equivalent implementation when `Rails` isn't present
  * `Miq.root`:  Functions the same as `Rails.root`, but falls back to an equivalent implementation when `Rails` isn't present

Tests are done in such a way that if `Rails` changes it's implementation that causes a difference in what we are seeing here, hopefully these tests will catch it.

Another support PR for https://github.com/ManageIQ/manageiq/pull/14916

Links
-----
* https://github.com/ManageIQ/manageiq/pull/14916