### PR TITLE
identify openshift images through command variable

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -742,7 +742,7 @@ class MiqAction < ApplicationRecord
       return
     end
 
-    unless rec.digest.present?
+    unless !rec.ems_ref.blank?
       MiqPolicy.logger.error("#{error_prefix} ContainerImage is not linked with an OpenShift image")
       return
     end

--- a/db/migrate/20170605140212_add_ems_ref_to_container_image.rb
+++ b/db/migrate/20170605140212_add_ems_ref_to_container_image.rb
@@ -1,0 +1,5 @@
+class AddEmsRefToContainerImage < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_images, :ems_ref, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -748,6 +748,7 @@ container_images:
 - created_on
 - old_ems_id
 - deleted_on
+- ems_ref
 container_label_tag_mappings:
 - id
 - labeled_resource_type

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -216,6 +216,32 @@ describe MiqAction do
     end
   end
 
+  context "#action_container_image_annotate_deny_execution" do
+    let(:action) { FactoryGirl.create(:miq_action, :name => "container_image_annotate_deny_execution") }
+    let(:ems) { FactoryGirl.create(:ems_openshift) }
+    let(:event) { FactoryGirl.create(:miq_event_definition, :name => "whatever") }
+
+    it "annotates openshift images" do
+      image = FactoryGirl.create(:container_image, :ems_ref => "123", :ext_management_system => ems)
+      expect(image).to receive(:annotate_deny_execution)
+      action.action_container_image_annotate_deny_execution(action,
+                                                            image,
+                                                            :policy => FactoryGirl.create(:miq_policy),
+                                                            :event => event,
+                                                            :synchronous => true)
+    end
+
+    it "doesn't annotates non provider images" do
+      image = FactoryGirl.create(:container_image, :ext_management_system => ems)
+      expect(image).not_to receive(:annotate_deny_execution)
+      action.action_container_image_annotate_deny_execution(action,
+                                                            image,
+                                                            :policy => FactoryGirl.create(:miq_policy),
+                                                            :event => event,
+                                                            :synchronous => true)
+    end
+  end
+
   context '.create_default_actions' do
     context 'seeding default actions from a file with 3 csv rows and some comments' do
       before do


### PR DESCRIPTION
Factor out Openshift image identification and use the `command` attribute as we are also parsing digest for images originating only from pods.