### PR TITLE
Add Pod to PersistentVolume relationship

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -24,6 +24,8 @@ class ContainerGroup < ApplicationRecord
   belongs_to :old_container_project, :foreign_key => "old_container_project_id", :class_name => 'ContainerProject'
   belongs_to :container_build_pod
   has_many :container_volumes, :as => :parent, :dependent => :destroy
+  has_many :persistent_volume_claim, :through => :container_volumes
+  has_many :persistent_volumes, -> { where(:type=>'PersistentVolume') }, :through => :persistent_volume_claim, :source => :container_volumes
 
   # Metrics destroy is handled by purger
   has_many :metrics, :as => :resource

--- a/spec/models/container_group.rb
+++ b/spec/models/container_group.rb
@@ -1,0 +1,51 @@
+describe ContainerGroup do
+  it "has container volumes and pods" do
+    pvc = FactoryGirl.create(
+      :persistent_volume_claim,
+      :name => "test_claim"
+    )
+
+    group = FactoryGirl.create(
+      :container_group,
+      :name => "group",
+    )
+
+    ems = FactoryGirl.create(
+      :ems_kubernetes,
+      :id   => group.id,
+      :name => "ems"
+    )
+
+    FactoryGirl.create(
+      :container_volume,
+      :name                    => "container_volume",
+      :type                    => 'ContainerVolume',
+      :parent                  => group,
+      :persistent_volume_claim => pvc
+    )
+
+    FactoryGirl.create(
+      :persistent_volume,
+      :name                    => "persistent_volume0",
+      :parent                  => ems,
+      :persistent_volume_claim => pvc
+    )
+
+    FactoryGirl.create(
+      :persistent_volume,
+      :name                    => "persistent_volume1",
+      :parent                  => ems,
+      :persistent_volume_claim => pvc
+    )
+
+    assert_pod_to_pv_relationships(group)
+  end
+
+  def assert_pod_to_pv_relationships(group)
+    expect(group.persistent_volume_claim.first.name).to eq("test_claim")
+    expect(group.persistent_volume_claim.count).to eq(1)
+    expect(group.persistent_volumes.first.name).to eq("persistent_volume0")
+    expect(group.persistent_volumes.second.name).to eq("persistent_volume1")
+    expect(group.persistent_volumes.count).to eq(2)
+  end
+end


### PR DESCRIPTION
Currently we do not show which PersisentVolumes a given Pod is using - 
In this PR we work towards supplying that information to the user.

cc: @zakiva @simon3z @kbrock 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1435235
