### PR TITLE
Tower CUD check and run refresh_in_provider followed by refreshing manager

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -67,7 +67,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
     with_provider_object do |provider_object|
       provider_object.update_attributes!(params)
     end
-    self.class.send('refresh', self)
+    if respond_to?(:refresh_in_provider)
+      refresh_in_provider
+    end
+    self.class.send('refresh', manager)
     reload
   rescue AnsibleTowerClient::ClientError => error
     raise

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -160,7 +160,8 @@ shared_examples_for "ansible configuration_script_source" do
 
     it "#update_in_provider to succeed and send notification" do
       expect(AnsibleTowerClient::Connection).to receive(:new).and_return(atc)
-      expect(EmsRefresh).to receive(:queue_refresh_task).with(project).and_return([finished_task])
+      expect(EmsRefresh).to receive(:queue_refresh_task).with(manager).and_return([finished_task])
+      expect(project).to receive(:refresh_in_provider)
       expect(Notification).to receive(:create).with(expected_notify)
       expect(project.update_in_provider({})).to be_a(described_class)
     end


### PR DESCRIPTION
The targeted refresh is only implemented on `confirguration_script_source` and so if it is in the context of updating a `credential`, the `refresh` on the `credential` will be dropped.

In prior [PR](https://github.com/ManageIQ/manageiq/pull/14954), was convinced by [this section](https://github.com/jameswnl/manageiq/blob/4e5e3bfccdddcd8faa773b562fd76088d6738fd4/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb#L123-L123) that it will fall back to ems refresh automatically.

Now realized, it will be dropped by [this queue attempt](https://github.com/jameswnl/manageiq/blob/82b1c046cf2f85f2367303fc8a2ccd3c2db1389d/app/models/ems_refresh.rb#L40-L40) way before.



@miq-bot add_labels fine/yess, providers/ansible_tower, blocker, bug