### PR TITLE
Change retire_now to pass zone_name to raise_retirement_event.

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -175,7 +175,7 @@ module RetirementMixin
 
   def raise_retirement_event(event_name, requester = nil)
     $log.info("Raising Retirement Event for [#{name}]")
-    MiqEvent.raise_evm_event(self, event_name, setup_event_hash(requester))
+    MiqEvent.raise_evm_event(self, event_name, setup_event_hash(requester), retire_queue_options)
   end
 
   def raise_audit_event(event_name, message)
@@ -197,6 +197,14 @@ module RetirementMixin
   end
 
   private
+
+  def retire_queue_options
+    valid_zone? ? {:zone => my_zone} : {}
+  end
+
+  def valid_zone?
+    respond_to?(:my_zone) && my_zone.present?
+  end
 
   def setup_event_hash(requester)
     event_hash = {:retirement_initiator => "system"}

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -35,7 +35,7 @@ describe "Service Retirement Management" do
     event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
                   :retirement_initiator => "user", :userid => "freddy"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {}).once
 
     @stack.retire_now('freddy')
     @stack.reload
@@ -47,7 +47,7 @@ describe "Service Retirement Management" do
     event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
                   :retirement_initiator => "system"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {}).once
 
     @stack.retire_now
     @stack.reload
@@ -132,7 +132,8 @@ describe "Service Retirement Management" do
       :type                 => "OrchestrationStack",
       :retirement_initiator => "system"
     }
-    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash)
+
+    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {})
     @stack.raise_retirement_event(event_name)
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -35,7 +35,7 @@ describe "Service Retirement Management" do
     event_hash = {:service => @service, :type => "Service",
                   :retirement_initiator => "user", :userid => "freddy"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
 
     @service.retire_now('freddy')
     @service.reload
@@ -47,7 +47,7 @@ describe "Service Retirement Management" do
     event_hash = {:service => @service, :type => "Service",
                   :retirement_initiator => "system"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
 
     @service.retire_now
     @service.reload
@@ -165,7 +165,7 @@ describe "Service Retirement Management" do
   it "#raise_retirement_event" do
     event_name = 'foo'
     event_hash = {:service => @service, :type => "Service", :retirement_initiator => "system"}
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash)
+    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {})
     @service.raise_retirement_event(event_name)
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -1,7 +1,8 @@
 describe "VM Retirement Management" do
   before(:each) do
     miq_server = EvmSpecHelper.local_miq_server
-    @ems       = FactoryGirl.create(:ems_vmware, :zone => miq_server.zone)
+    @zone = miq_server.zone
+    @ems = FactoryGirl.create(:ems_vmware, :zone => @zone)
     @vm = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
   end
 
@@ -34,8 +35,9 @@ describe "VM Retirement Management" do
     event_name = 'request_vm_retire'
     event_hash = {:vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm",
                   :retirement_initiator => "user", :userid => 'freddy'}
+    options = {:zone => @zone.name}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash, options).once
 
     @vm.retire_now('freddy')
   end
@@ -44,8 +46,9 @@ describe "VM Retirement Management" do
     event_name = 'request_vm_retire'
     event_hash = {:vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm",
                   :retirement_initiator => "system"}
+    options = {:zone => @zone.name}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash, options).once
 
     @vm.retire_now
   end
@@ -142,8 +145,9 @@ describe "VM Retirement Management" do
     event_name = 'foo'
     event_hash = {:vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm",
                   :retirement_initiator => "system"}
+    options = {:zone => @vm.my_zone}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash, options).once
 
     @vm.raise_retirement_event(event_name)
   end


### PR DESCRIPTION
Pass zone as option to raise_evm_event.

Separate Automate engine miq_ae_event change required.

https://bugzilla.redhat.com/show_bug.cgi?id=1447625

Related PR https://github.com/ManageIQ/manageiq-automation_engine/pull/18