### PR TITLE
Fixed logging for proxy when storage not defined 

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -918,7 +918,14 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def log_proxies_vm_config
-    "[#{log_proxies_format_instance(self)}] on host [#{log_proxies_format_instance(host)}] #{ui_lookup(:table => "storages").downcase} [#{storage.name}-#{storage.store_type}]"
+    msg = "[#{log_proxies_format_instance(self)}] on host [#{log_proxies_format_instance(host)}] "\
+    "#{ui_lookup(:table => "storages").downcase} "
+    msg += if storage
+             "[#{storage.name}-#{storage.store_type}]"
+           else
+             "No storage"
+           end
+    msg
   end
 
   def log_proxies_format_instance(object)


### PR DESCRIPTION
Merging https://github.com/ManageIQ/manageiq/pull/15009 cause UI spec failing when attempting to log not existing storage.

Fix: check for nil before attempting to log storage info

@miq-bot add-label bug

\cc @jrafanie 


