### PR TITLE
Allow Tower Project to reset credential

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script_source.rb
@@ -5,8 +5,10 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
 
   module ClassMethods
     def provider_params(params)
-      authentication_id = params.delete(:authentication_id)
-      params[:credential] = Authentication.find(authentication_id).manager_ref if authentication_id
+      if params.keys.include?(:authentication_id)
+        authentication_id = params.delete(:authentication_id)
+        params[:credential] = authentication_id ? Authentication.find(authentication_id).manager_ref : nil
+      end
       params
     end
 

--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/tower_api.rb
@@ -24,6 +24,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
     end
 
     private
+
     def notify(op, manager_id, params, success)
       params = hide_secrets(params) if respond_to?(:hide_secrets)
       _log.info "#{name} in_provider #{op} with parameters: #{params} #{success ? 'succeeded' : 'failed'}"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1448483

This is to allow a Tower project to be disassociated with a `scm_credential`.

@miq-bot add_labels bug, blocker, providers/ansible_tower, fine/yes