### PR TITLE
configuring job timeout adjustment for container image scanning

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -178,6 +178,11 @@ class Job < ApplicationRecord
   def timeout_adjustment
     timeout_adjustment = 1
     target = target_entity
+    ems_settings = target.try(:ext_management_system).try(:custom_attributes)
+    if ems_settings && ems_settings.find_by(:name => "job_timeout_adjustment")
+      return ems_settings.find_by(:name => "job_timeout_adjustment").value.to_i
+    end
+    return ::Settings.container_scanning.scanning_job_timeout_adjustment if target.kind_of?(ContainerImage)
     if target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
        target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
       timeout_adjustment = 4

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,6 +82,7 @@
   :use_vim_broker_ems: true
 :container_scanning:
   :concurrent_per_ems: 3
+  :scanning_job_timeout_adjustment: 3
 :database:
   :metrics_collection:
     :collection_schedule: "1 * * * *"

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -268,7 +268,16 @@ describe Job do
       context "#timeout_adjustment" do
         it "returns the correct adjusment" do
           expect(@job.timeout_adjustment).to eq(1)
-          expect(@image_scan_job.timeout_adjustment).to eq(1)
+        end
+
+        it "checks ems for job_timeout_adjustment custom_attribute" do
+          @ems_k8s.custom_attributes.create(:name => "job_timeout_adjustment", :value => "7")
+          expect(@image_scan_job.timeout_adjustment).to eq(7)
+        end
+
+        it "checks settings for container image timeout_adjustment" do
+          stub_settings_merge(:container_scanning => {:scanning_job_timeout_adjustment => 6})
+          expect(@image_scan_job.timeout_adjustment).to eq(6)
         end
       end
     end


### PR DESCRIPTION
Adding options to configure in config/settings.yml in container_scanning.scanning_job_timeout_adjustment or to have a custom attribute on the provider with the name "job_timeout_adjustment".

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1447672