### PR TITLE
Return BadRequestError when invalid attributes are specified

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -54,16 +54,16 @@ module Api
         json    = Jbuilder.new
         json.ignore_nil!
 
-        physical_attrs, virtual_attrs = attr_validation(resource)
+        physical_attrs, virtual_attrs = validate_attr_selection(resource)
         normalize_options[:render_attributes] = physical_attrs if physical_attrs.present?
 
-        add_hash json, normalize_hash(reftype, resource, normalize_options), :render_resource_attr, resource
+        add_hash json, normalize_hash(reftype, resource, normalize_options)
 
         expand_virtual_attributes(json, type, resource, virtual_attrs) unless virtual_attrs.empty?
         expand_subcollections(json, type, resource) if resource.respond_to?(:attributes)
 
-        expand_actions(resource, json, type, opts) if opts[:expand_actions]
-        expand_resource_custom_actions(resource, json, type)
+        expand_actions(resource, json, type, opts, physical_attrs) if opts[:expand_actions]
+        expand_resource_custom_actions(resource, json, type, physical_attrs)
         json
       end
 
@@ -90,10 +90,10 @@ module Api
       #
       # Common proc for adding a hash directly to the Jbuilder
       #
-      def add_hash(json, hash, render_attr_proc = nil, resource = nil)
+      def add_hash(json, hash)
         return if hash.blank?
         hash.each do |attr, value|
-          json.set! attr, value if render_attr_proc.nil? || send(render_attr_proc, resource, attr)
+          json.set! attr, value
         end
       end
 
@@ -184,10 +184,10 @@ module Api
       # Let's expand virtual attributes and related objects if asked for
       # Supporting [<related_object>]*.<virtual_attribute>
       #
-      def expand_virtual_attributes(json, type, resource, attrs)
+      def expand_virtual_attributes(json, type, resource, virtual_attrs)
         result = {}
         object_hash = {}
-        attrs.each do |vattr|
+        virtual_attrs.each do |vattr|
           attr_name, attr_base = split_virtual_attribute(vattr)
           value, value_result = if attr_base.blank?
                                   fetch_direct_virtual_attribute(type, resource, attr_name)
@@ -234,16 +234,6 @@ module Api
         end
       end
 
-      #
-      # Let's get a list of virtual attributes applicable to the resource.
-      #
-      def virtual_attributes_list(resource)
-        return [] if attribute_selection == "all"
-        attribute_selection.collect do |requested_attr|
-          requested_attr if attr_virtual?(resource, requested_attr)
-        end.compact
-      end
-
       def split_virtual_attribute(attr)
         attr_parts = attr_split(attr)
         return [attr_parts.first, ""] if attr_parts.length == 1
@@ -279,8 +269,8 @@ module Api
       #
       # Let's expand actions
       #
-      def expand_actions(resource, json, type, opts)
-        return unless render_actions(resource)
+      def expand_actions(resource, json, type, opts, physical_attrs)
+        return unless render_actions(physical_attrs)
 
         href = json.attributes!["href"]
         cspec = collection_config[type]
@@ -296,8 +286,8 @@ module Api
         end
       end
 
-      def expand_resource_custom_actions(resource, json, type)
-        return unless render_actions(resource) && collection_config.custom_actions?(type)
+      def expand_resource_custom_actions(resource, json, type, physical_attrs)
+        return unless render_actions(physical_attrs) && collection_config.custom_actions?(type)
 
         href = json.attributes!["href"]
         json.actions do |js|
@@ -312,18 +302,7 @@ module Api
         Array(resource.custom_action_buttons).collect(&:name).collect(&:downcase)
       end
 
-      def render_resource_attr(resource, attr)
-        pas = physical_attribute_selection(resource)
-        pas.blank? || pas.include?(attr)
-      end
-
-      def physical_attribute_selection(resource)
-        return [] if resource.kind_of?(Hash)
-        physical_attributes = @req.attributes.select { |attr| attr_physical?(resource, attr) }
-        physical_attributes.present? ? ID_ATTRS | physical_attributes : []
-      end
-
-      def attr_validation(resource)
+      def validate_attr_selection(resource)
         physical_attrs, virtual_attrs = [], []
         attrs = attribute_selection
         return [physical_attrs, virtual_attrs] if resource.kind_of?(Hash) || attrs == 'all'
@@ -337,7 +316,8 @@ module Api
         end
 
         attrs = attrs - physical_attrs - virtual_attrs
-        raise BadRequestError, "#{attrs.join(',')} are not valid attributes" unless attrs.empty?
+        raise BadRequestError, "Invalid attributes specified: #{attrs.join(',')}" unless attrs.empty?
+
         [(physical_attrs - ID_ATTRS).empty? ? [] : physical_attrs, virtual_attrs]
       end
 
@@ -419,8 +399,8 @@ module Api
         Array(action_identifier).any? { |identifier| User.current_user.role_allows?(:identifier => identifier) }
       end
 
-      def render_actions(resource)
-        render_attr("actions") || physical_attribute_selection(resource).blank?
+      def render_actions(physical_attrs)
+        render_attr("actions") || physical_attrs.blank?
       end
 
       def action_validated?(resource, action_spec)

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -61,11 +61,18 @@ describe "Querying" do
       expect_result_resources_to_match_hash([{"name" => "ee"}])
     end
 
-    it 'raises a BadRequest Error for attributes that do not exist' do
+    it 'raises a BadRequestError for attributes that do not exist' do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
 
       run_get(vms_url(vm1.id), :attributes => 'not_an_attribute')
 
+      expected = {
+        'error' => a_hash_including(
+          'kind'    => 'bad_request',
+          'message' => "Invalid attributes specified: not_an_attribute"
+        )
+      }
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:bad_request)
     end
   end
@@ -598,7 +605,7 @@ describe "Querying" do
       run_get vms_url, :expand => "resources,software"
 
       expect_query_result(:vms, 1, 1)
-      expect_result_resources_to_include_keys("resources", %w(id href software))
+      expect_result_resources_to_include_keys("resources", %w(id href guid name vendor software))
     end
 
     it "supports suppressing resources" do
@@ -738,7 +745,7 @@ describe "Querying" do
       run_get vms_url(vm1.id), :attributes => "disconnected"
 
       expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(id href disconnected actions))
+      expect_result_to_have_keys(%w(id href name vendor disconnected actions))
     end
 
     it "does not return actions if asking for physical and virtual attributes" do

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -60,6 +60,14 @@ describe "Querying" do
       expect_query_result(:vms, 1, 5)
       expect_result_resources_to_match_hash([{"name" => "ee"}])
     end
+
+    it 'raises a BadRequest Error for attributes that do not exist' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      run_get(vms_url(vm1.id), :attributes => 'not_an_attribute')
+
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "Sorting vms by attribute" do
@@ -525,15 +533,6 @@ describe "Querying" do
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
-
-    it "skips requests of invalid attributes" do
-      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
-
-      run_get vms_url(vm1.id), :attributes => "bogus"
-
-      expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(id href name vendor))
-    end
   end
 
   describe "Querying vms by tag" do
@@ -599,7 +598,7 @@ describe "Querying" do
       run_get vms_url, :expand => "resources,software"
 
       expect_query_result(:vms, 1, 1)
-      expect_result_resources_to_include_keys("resources", %w(id href guid name vendor software))
+      expect_result_resources_to_include_keys("resources", %w(id href software))
     end
 
     it "supports suppressing resources" do
@@ -739,7 +738,7 @@ describe "Querying" do
       run_get vms_url(vm1.id), :attributes => "disconnected"
 
       expect(response).to have_http_status(:ok)
-      expect_result_to_have_keys(%w(id href name vendor disconnected actions))
+      expect_result_to_have_keys(%w(id href disconnected actions))
     end
 
     it "does not return actions if asking for physical and virtual attributes" do


### PR DESCRIPTION
This PR consolidates attribute selection into one method, `validate_attr_selection`, which is able to then validate the selected attributes, and adds some other minor/related refactoring.

By consolidating and returning the `physical_attrs` and `virtual_attrs`, it also removes the need to retrieve physical attributes via `physical_attribute_selection` more than once. 

One issue encountered is when @additional_attributes is set for a subcollection, and therefore it does not respond to `attr_virtual?` or `attr_physical?`, considering it as a `virtual_attribute` removes any issues.

`render_resource_attr` is unnecessary as `normalize_hash` already ensures only the selected attributes are chosen and that they are not nil. 

@miq-bot add_label wip, api, enhancement
@miq-bot assign @abellotti 
cc: @imtayadeway 
