### PR TITLE
Allow deletion of groups with users belonging to other groups

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -230,8 +230,14 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  def own_users
+    own_users = []
+    users.each { |user| own_users << user if user.miq_groups.count == 1 }
+    own_users
+  end
+
   def ensure_can_be_destroyed
-    raise _("Still has users assigned.") unless users.empty?
+    raise _("Still has users assigned.") unless own_users.empty?
     raise _("A tenant default group can not be deleted") if tenant_group? && referenced_by_tenant?
     raise _("A read only group cannot be deleted.") if system_group?
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -217,18 +217,20 @@ describe MiqGroup do
     it "fails if referenced by user#current_group" do
       FactoryGirl.create(:user, :miq_groups => [group])
 
-      expect {
-        expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
-      }.to_not change { MiqGroup.count }
+      expect { expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/) }.to_not change { MiqGroup.count }
     end
 
-    it "fails if referenced by user#miq_groups" do
+    it "succeeds if referenced by multiple user#miq_groups" do
       group2 = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
+      expect { group.destroy }.not_to raise_error
+    end
 
-      expect {
-        expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
-      }.to_not change { MiqGroup.count }
+    it "fails if one user in the group does not belong to any other group" do
+      group2 = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
+      FactoryGirl.create(:user, :miq_groups => [group], :current_group => group)
+      expect { expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/) }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by a tenant#default_miq_group" do

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -217,7 +217,7 @@ describe MiqGroup do
     it "fails if referenced by user#current_group" do
       FactoryGirl.create(:user, :miq_groups => [group])
 
-      expect { expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/) }.to_not change { MiqGroup.count }
+      expect { expect { group.destroy }.to raise_error(RuntimeError, /The group has users assigned that do not belong to any other group/) }.to_not change { MiqGroup.count }
     end
 
     it "succeeds if referenced by multiple user#miq_groups" do
@@ -226,11 +226,18 @@ describe MiqGroup do
       expect { group.destroy }.not_to raise_error
     end
 
+    it "fails if trying to delete the current user's group" do
+      group2 = FactoryGirl.create(:miq_group)
+      user = FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group)
+      User.current_user = user
+      expect { expect { group.destroy }.to raise_error(RuntimeError, /The login group cannot be deleted/) }.to_not change { MiqGroup.count }
+    end
+
     it "fails if one user in the group does not belong to any other group" do
       group2 = FactoryGirl.create(:miq_group)
       FactoryGirl.create(:user, :miq_groups => [group, group2], :current_group => group2)
       FactoryGirl.create(:user, :miq_groups => [group], :current_group => group)
-      expect { expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/) }.to_not change { MiqGroup.count }
+      expect { expect { group.destroy }.to raise_error(RuntimeError, /The group has users assigned that do not belong to any other group/) }.to_not change { MiqGroup.count }
     end
 
     it "fails if referenced by a tenant#default_miq_group" do
@@ -458,6 +465,37 @@ describe MiqGroup do
       group = FactoryGirl.create(:miq_group)
       FactoryGirl.create_list(:user, 2, :miq_groups =>[group])
       expect(group.user_count).to eq(2)
+    end
+  end
+
+  describe "#single_group_users?" do
+    it "returns false if all users in the group belong to an additional group" do
+      testgroup1 = FactoryGirl.create(:miq_group)
+      testgroup2 = FactoryGirl.create(:miq_group)
+      testgroup3 = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup2])
+      FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup3])
+      expect(testgroup1.single_group_users?).to eq(false)
+    end
+
+    it "returns false if the group has no users" do
+      testgroup1 = FactoryGirl.create(:miq_group)
+      expect(testgroup1.single_group_users?).to eq(false)
+    end
+
+    it "returns true if all users in a group do not belong to any other group" do
+      testgroup1 = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:user, :miq_groups => [testgroup1])
+      FactoryGirl.create(:user, :miq_groups => [testgroup1])
+      expect(testgroup1.single_group_users?).to eq(true)
+    end
+
+    it "returns true if any user in a group does not belong to another group" do
+      testgroup1 = FactoryGirl.create(:miq_group)
+      testgroup2 = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:user, :miq_groups => [testgroup1])
+      FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup2])
+      expect(testgroup1.single_group_users?).to eq(true)
     end
   end
 end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -30,7 +30,7 @@ describe MiqWidgetSet do
     end
 
     it "the belong to group is being deleted" do
-      expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
+      expect { group.destroy }.to raise_error(RuntimeError, /The group has users assigned that do not belong to any other group/)
       expect(MiqWidgetSet.count).to eq(2)
     end
 


### PR DESCRIPTION
Allow deletion of groups when all users within the group also belong to other groups.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1264967
https://www.pivotaltracker.com/n/projects/1613907/stories/131568585