### PR TITLE
Removed grouping from all Middleware* views

### DIFF
--- a/product/views/MiddlewareDatasource.yaml
+++ b/product/views/MiddlewareDatasource.yaml
@@ -63,8 +63,7 @@ sortby:
 - middleware_server.hostname
 
 # Group rows (y=yes,n=no,c=count)
-group: y
-
+group: n
 
 # Graph type
 #   Bar

--- a/product/views/MiddlewareDeployment.yaml
+++ b/product/views/MiddlewareDeployment.yaml
@@ -66,8 +66,7 @@ sortby:
 - middleware_server.hostname
 
 # Group rows (y=yes,n=no,c=count)
-group: y
-
+group: n
 
 # Graph type
 #   Bar

--- a/product/views/MiddlewareDomain.yaml
+++ b/product/views/MiddlewareDomain.yaml
@@ -62,8 +62,7 @@ sortby:
 - ext_management_system.name
 
 # Group rows (y=yes,n=no,c=count)
-group: y
-
+group: n
 
 # Graph type
 #   Bar

--- a/product/views/MiddlewareMessaging.yaml
+++ b/product/views/MiddlewareMessaging.yaml
@@ -61,8 +61,7 @@ sortby:
 - middleware_server.name
 
 # Group rows (y=yes,n=no,c=count)
-group: y
-
+group: n
 
 # Graph type
 #   Bar

--- a/product/views/MiddlewareServerGroup.yaml
+++ b/product/views/MiddlewareServerGroup.yaml
@@ -61,8 +61,7 @@ sortby:
 - feed
 
 # Group rows (y=yes,n=no,c=count)
-group: y
-
+group: n
 
 # Graph type
 #   Bar


### PR DESCRIPTION
Made it consistent with other view yamls where we do not set grouping in other list view yamls, this was causing an extra row for each name entry in the downloadable pdf file to show grouping by name.

https://bugzilla.redhat.com/show_bug.cgi?id=1442854

before:
![before](https://cloud.githubusercontent.com/assets/3450808/25867759/94e89084-34c8-11e7-95ad-6497f1ee5222.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/25867761/981eac84-34c8-11e7-82f3-202cb6cb4b5b.png)

@miq-bot add_label bug
@miq-bot add_label fine/yes
@dclarizio please review