### PR TITLE
Bump to RSpec 3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ unless ENV["APPLIANCE"]
   group :development, :test do
     gem "good_migrations"
     gem "parallel_tests"
-    gem "rspec-rails",      "~>3.5.0"
+    gem "rspec-rails",      "~>3.6.0"
   end
 end
 


### PR DESCRIPTION
Upgrades RSpec to 3.6, which provides support for Rails 5.1.

This should be a harmless upgrade with minor output improvements, etc. Bumping this ahead of the 5.1 upgrade.

@jrafanie please review