### PR TITLE
Fetch new gem refs on bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -29,7 +29,7 @@ Dir.chdir ManageIQ::Environment::APP_ROOT do
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler
-  ManageIQ::Environment.bundle_install
+  ManageIQ::Environment.bundle_update
 
   ManageIQ::Environment.while_updating_bower do
     if options[:do_db]


### PR DESCRIPTION
Fixes #15044 

This change forces git based gems to fetch new refs every time bin/setup
is run so people don't get confused and wonder why those gems didn't get
the latest version. `update` works Fine without a lockfile, etc.

@bdunne Thoughts? Please review.