### PR TITLE
Fix fetching non active ISO domains

### DIFF
--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -21,14 +21,7 @@ class IsoDatastore < ApplicationRecord
   def advertised_images
     return [] unless ext_management_system.kind_of?(ManageIQ::Providers::Redhat::InfraManager)
 
-    begin
-      ext_management_system.with_provider_connection do |rhevm|
-        rhevm.iso_images.collect { |image| image[:name] }
-      end
-    rescue Ovirt::Error => err
-      _log.error("Error Getting ISO Images on ISO Datastore on Management System <#{name}>: #{err.class.name}: #{err}")
-      raise
-    end
+    ext_management_system.ovirt_services(:use_highest_supported_version => true).advertised_images
   end
 
   def synchronize_advertised_images
@@ -49,6 +42,6 @@ class IsoDatastore < ApplicationRecord
     clear_association_cache
     update_attribute(:last_refresh_on, Time.now.utc)
     _log.info("Synchronizing images on #{log_for}...Complete")
-  rescue Ovirt::Error
+  rescue ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error
   end
 end

--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -1,0 +1,39 @@
+describe IsoDatastore do
+  let(:ems) { FactoryGirl.create(:ems_redhat) }
+  let(:iso_datastore) { FactoryGirl.create(:iso_datastore, :ext_management_system => ems) }
+
+  describe "#advertised_images" do
+    subject(:advertised_images) { iso_datastore.advertised_images }
+
+    context "ems is not rhv" do
+      let(:ems) { FactoryGirl.create(:ems_vmware) }
+      it "returns empty array" do
+        expect(advertised_images).to eq([])
+      end
+    end
+
+    context "ems is rhv" do
+      before do
+        allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
+      end
+
+      context "supports api4" do
+        let(:supported_api_versions) { %w(3 4) }
+        it "send the method to ovirt services v4" do
+          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4)
+            .to receive(:advertised_images)
+          advertised_images
+        end
+      end
+
+      context "does not support api4" do
+        let(:supported_api_versions) { ["3"] }
+        it "send the method to ovirt services v4" do
+          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V3)
+            .to receive(:advertised_images)
+          advertised_images
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We used to take the first available ISO domain even if it was not active.
As a result we would sometimes miss available ISO images.

https://bugzilla.redhat.com/show_bug.cgi?id=1447560

This whole module should become STI and its implementation should move to manageiq-providers-ovirt. (will be done in followup PR)
But for now this is a small change that does not require schema changes.

It depends on https://github.com/ManageIQ/manageiq-providers-ovirt/pull/34