### PR TITLE
override_gem - warn on stderr, not stdout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ def override_gem(name, *args)
 
     calling_file = caller_locations.detect { |loc| !loc.path.include?("lib/bundler") }.path
     gem(name, *args).tap do
-      Bundler::UI::Shell.new.warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" unless ENV["RAILS_ENV"] == "production"
+      warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" unless ENV["RAILS_ENV"] == "production"
     end
   end
 end


### PR DESCRIPTION
the warning about using `override_gem` goes to stdout right now, making it hard to parse rake task outputs

(There is support for stderr in bundler 2, not 1 - bundler/bundler#3353 and bundler/bundler#3354)

So.. changing to use `Kernel#warn`, which is not yellow, but does output to stderr.

Cc @jrafanie , @Fryguy 