### PR TITLE
Allow Vmdb::Plugins to work through code reloads in development.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -115,10 +115,7 @@ module Vmdb
     # Because this is easy to mess up, keep your initializers in order.
     # register plugins even before loading settings, as plugins can bring their own settings
     initializer :register_vmdb_plugins, :before => :load_vmdb_settings do
-      Rails.application.railties.each do |railtie|
-        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
-        Vmdb::Plugins.instance.register_vmdb_plugin(railtie)
-      end
+      Vmdb::Plugins.instance.register_from_railties
     end
 
     initializer :load_vmdb_settings, :before => :load_config_initializers do

--- a/config/application.rb
+++ b/config/application.rb
@@ -115,7 +115,7 @@ module Vmdb
     # Because this is easy to mess up, keep your initializers in order.
     # register plugins even before loading settings, as plugins can bring their own settings
     initializer :register_vmdb_plugins, :before => :load_vmdb_settings do
-      Vmdb::Plugins.instance.register_from_railties
+      Vmdb::Plugins.instance.register_vmdb_plugins
     end
 
     initializer :load_vmdb_settings, :before => :load_config_initializers do

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -11,10 +11,10 @@ module Vmdb
     end
 
     def vmdb_plugins
-      @vmdb_plugins.empty? ? register_from_railties : @vmdb_plugins
+      @vmdb_plugins.empty? ? register_vmdb_plugins : @vmdb_plugins
     end
 
-    def register_from_railties
+    def register_vmdb_plugins
       Rails.application.railties.each do |railtie|
         next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
         register_vmdb_plugin(railtie)

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -2,7 +2,6 @@ module Vmdb
   class Plugins
     include Singleton
 
-    attr_reader :vmdb_plugins
     attr_reader :registered_automate_domains
 
     def initialize

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -11,6 +11,19 @@ module Vmdb
       @vmdb_plugins = []
     end
 
+    def vmdb_plugins
+      @vmdb_plugins.empty? ? register_from_railties : @vmdb_plugins
+    end
+
+    def register_from_railties
+      Rails.application.railties.each do |railtie|
+        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
+        register_vmdb_plugin(railtie)
+      end
+
+      @vmdb_plugins
+    end
+
     def register_vmdb_plugin(engine)
       @vmdb_plugins << engine
 


### PR DESCRIPTION
Currently plugins are registered with `Vmdb::Plugins` at boot. This is fine for production but in development a file change will cause a code reload which clears out plugin information.

This change still loads plugin info in an initializer, but reloads it if it has been cleared.