### PR TITLE
Eliminate #any_instance_of in logging specs

### DIFF
--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -3,7 +3,13 @@
 #
 describe "Logging" do
   describe "Successful Requests logging" do
-    before { allow($api_log).to receive(:info) }
+    before do
+      @log = StringIO.new
+      $api_log.reopen(@log)
+      allow($api_log).to receive(:info)
+    end
+
+    after { $api_log.reopen(Rails.root.join("log", "api.log")) }
 
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -8,17 +8,12 @@ describe "Logging" do
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)
 
-      expect($api_log).to receive(:info).with(/API Request/)
-      expect($api_log).to receive(:info).with(/Authentication/)
-      expect($api_log).to receive(:info).with(/Authorization/)
       expect($api_log).to receive(:info).with(a_string_matching(/Request:/)
                                                .and(matching(%r{:path=>"/api/users"}))
                                                .and(matching(/:collection=>"users"/))
                                                .and(matching(/:c_id=>nil/))
                                                .and(matching(/:subcollection=>nil/))
                                                .and(matching(/:s_id=>nil/)))
-      expect($api_log).to receive(:info).with(/Parameters/)
-      expect($api_log).to receive(:info).with(/Response/)
 
       run_get users_url
     end
@@ -26,9 +21,6 @@ describe "Logging" do
     it "logs all hash entries about the request" do
       api_basic_authorize
 
-      expect($api_log).to receive(:info).with(/API Request/)
-      expect($api_log).to receive(:info).with(/Authentication/)
-      expect($api_log).to receive(:info).with(/Authorization/)
       expect($api_log).to receive(:info).with(
         a_string_matching(
           'Request:        {:method=>:get, :action=>"read", :fullpath=>"/api", :url=>"http://www.example.com/api", ' \
@@ -37,8 +29,6 @@ describe "Logging" do
           ':subcollection=>nil, :s_id=>nil}'
         )
       )
-      expect($api_log).to receive(:info).with(/Parameters/)
-      expect($api_log).to receive(:info).with(/Response/)
 
       run_get entrypoint_url
     end
@@ -46,10 +36,6 @@ describe "Logging" do
     it "filters password attributes in nested parameters" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
-      expect($api_log).to receive(:info).with(/API Request/)
-      expect($api_log).to receive(:info).with(/Authentication/)
-      expect($api_log).to receive(:info).with(/Authorization/)
-      expect($api_log).to receive(:info).with(/Request/)
       expect($api_log).to receive(:info).with(
         a_string_matching(
           'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \
@@ -57,7 +43,6 @@ describe "Logging" do
           '"options"=>{"password"=>"\[FILTERED\]"}}}}'
         )
       )
-      expect($api_log).to receive(:info).with(/Response/)
 
       run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
     end
@@ -70,7 +55,6 @@ describe "Logging" do
 
         miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
-        expect($api_log).to receive(:info).with(/API Request/)
         expect($api_log).to receive(:info).with(
           a_string_matching(
             "System Auth:    {:x_miq_token=>\"#{Regexp.escape(miq_token)}\", :server_guid=>\"#{server_guid}\", " \
@@ -82,10 +66,6 @@ describe "Logging" do
             'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"}'
           )
         )
-        expect($api_log).to receive(:info).with(/Authorization/)
-        expect($api_log).to receive(:info).with(/Request/)
-        expect($api_log).to receive(:info).with(/Parameters/)
-        expect($api_log).to receive(:info).with(/Response/)
 
         run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
       end

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -38,13 +38,10 @@ describe "Logging" do
 
       run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
 
-      @log.rewind
-      expect(@log.readlines).to include(
-        a_string_matching(
-          'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \
-          '"body"=>{"action"=>"create", "resource"=>{"name"=>"new_service_1", ' \
-          '"options"=>{"password"=>"\[FILTERED\]"}}}}'
-        )
+      expect(@log.string).to include(
+        'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \
+        '"body"=>{"action"=>"create", "resource"=>{"name"=>"new_service_1", ' \
+        '"options"=>{"password"=>"[FILTERED]"}}}}'
       )
     end
 
@@ -58,15 +55,10 @@ describe "Logging" do
 
         run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
-        @log.rewind
-        expect(@log.readlines).to include(
-          a_string_matching(
-            "System Auth:    {:x_miq_token=>\"#{Regexp.escape(miq_token)}\", :server_guid=>\"#{server_guid}\", " \
-            ":userid=>\"api_user_id\", :timestamp=>2017-01-01 00:00:00 UTC}"
-          ),
-          a_string_matching(
-            'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"}'
-          )
+        expect(@log.string).to include(
+          "System Auth:    {:x_miq_token=>\"#{miq_token}\", :server_guid=>\"#{server_guid}\", " \
+          ":userid=>\"api_user_id\", :timestamp=>2017-01-01 00:00:00 UTC}",
+          'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"}'
         )
       end
     end

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -30,11 +30,10 @@ describe "Logging" do
       run_get entrypoint_url
 
       @log.rewind
-      expect(@log.readlines).to include(
-        a_string_matching(
-          ":method.*:action.*:fullpath.*url.*:base.*:path.*:prefix.*:version.*:api_prefix.*:collection.*:c_suffix.*" \
-          ":c_id.*:subcollection.*:s_id"
-        )
+      request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
+      expect(request_log_line).to match(
+        ":method.*:action.*:fullpath.*url.*:base.*:path.*:prefix.*:version.*:api_prefix.*:collection.*:c_suffix.*" \
+        ":c_id.*:subcollection.*:s_id"
       )
     end
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -16,12 +16,9 @@ describe "Logging" do
       run_get users_url
 
       @log.rewind
-      expect(@log.readlines).to include(a_string_matching(/Request:/)
-                                         .and(matching(%r{:path=>"/api/users"}))
-                                         .and(matching(/:collection=>"users"/))
-                                         .and(matching(/:c_id=>nil/))
-                                         .and(matching(/:subcollection=>nil/))
-                                         .and(matching(/:s_id=>nil/)))
+      request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
+      expect(request_log_line).to include(':path=>"/api/users"', ':collection=>"users"', ":c_id=>nil",
+                                          ":subcollection=>nil", ":s_id=>nil")
     end
 
     it "logs all hash entries about the request" do

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -3,44 +3,20 @@
 #
 describe "Logging" do
   describe "Successful Requests logging" do
-    EXPECTED_LOGGED_PARAMETERS = {
-      "API Request"    => nil,
-      "Authentication" => nil,
-      "Authorization"  => nil,
-      "Request"        => nil,
-      "Parameters"     => nil,
-      "Response"       => nil
-    }.freeze
-
-    EXPECTED_SYSTEM_AUTH_LOGGED_PARAMETERS = {
-      "API Request"    => nil,
-      "System Auth"    => nil,
-      "Authentication" => nil,
-      "Authorization"  => nil,
-      "Request"        => nil,
-      "Parameters"     => nil,
-      "Response"       => nil
-    }.freeze
-
-    def expect_log_requests(expectations)
-      expectations.each do |category, expectation|
-        expect_any_instance_of(Api::BaseController).to receive(:log_request)
-          .with(category, expectation ? expectation : kind_of(Hash))
-      end
-    end
-
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)
 
-      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
-        "Request" => a_hash_including(:path          => "/api/users",
-                                      :collection    => "users",
-                                      :c_id          => nil,
-                                      :subcollection => nil,
-                                      :s_id          => nil)
-      )
-
-      expect_log_requests(log_request_expectations)
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("API Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("Authentication", a_kind_of(Hash))
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("Authorization", a_kind_of(Hash))
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("Request", a_hash_including(
+                                                                                  :path          => "/api/users",
+                                                                                  :collection    => "users",
+                                                                                  :c_id          => nil,
+                                                                                  :subcollection => nil,
+                                                                                  :s_id          => nil))
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("Parameters", a_kind_of(Hash))
+      expect_any_instance_of(Api::UsersController).to receive(:log_request).with("Response", a_kind_of(Hash))
 
       run_get users_url
     end
@@ -48,12 +24,26 @@ describe "Logging" do
     it "logs all hash entries about the request" do
       api_basic_authorize
 
-      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
-        "Request" => a_hash_including(:method, :action, :fullpath, :url, :base, :path, :prefix, :version, :api_prefix,
-                                      :collection, :c_suffix, :c_id, :subcollection, :s_id)
-      )
-
-      expect_log_requests(log_request_expectations)
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("API Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Authentication", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Authorization", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Request", a_hash_including(
+                                                                                 :method,
+                                                                                 :action,
+                                                                                 :fullpath,
+                                                                                 :url,
+                                                                                 :base,
+                                                                                 :path,
+                                                                                 :prefix,
+                                                                                 :version,
+                                                                                 :api_prefix,
+                                                                                 :collection,
+                                                                                 :c_suffix,
+                                                                                 :c_id,
+                                                                                 :subcollection,
+                                                                                 :s_id))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Parameters", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Response", a_kind_of(Hash))
 
       run_get entrypoint_url
     end
@@ -61,20 +51,18 @@ describe "Logging" do
     it "filters password attributes in nested parameters" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
-      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
-        "Parameters" => a_hash_including(
-          "action"     => "update",
-          "format"     => "json",
-          "controller" => "api/services",
-          "body"       => a_hash_including(
-            "resource" => a_hash_including(
-              "options" => a_hash_including("password" => "[FILTERED]")
-            )
-          )
-        )
-      )
-
-      expect_log_requests(log_request_expectations)
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("API Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("Authentication", a_kind_of(Hash))
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("Authorization", a_kind_of(Hash))
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("Parameters", a_hash_including(
+                                                                                      "action"     => "update",
+                                                                                      "format"     => "json",
+                                                                                      "controller" => "api/services",
+                                                                                      "body"       => a_hash_including(
+                                                                                        "resource" => a_hash_including(
+                                                                                          "options" => a_hash_including("password" => "[FILTERED]")))))
+      expect_any_instance_of(Api::ServicesController).to receive(:log_request).with("Response", a_kind_of(Hash))
 
       run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
     end
@@ -86,14 +74,19 @@ describe "Logging" do
 
       miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
-      log_request_expectations = EXPECTED_SYSTEM_AUTH_LOGGED_PARAMETERS.merge(
-        "System Auth"    => a_hash_including(
-          :x_miq_token => miq_token, :server_guid => server_guid, :userid => userid, :timestamp => timestamp
-        ),
-        "Authentication" => a_hash_including(:type => "system", :user => "api_user_id"),
-      )
-
-      expect_log_requests(log_request_expectations)
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("API Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("System Auth", a_hash_including(
+                                                                                   :x_miq_token => miq_token,
+                                                                                   :server_guid => server_guid,
+                                                                                   :userid => userid,
+                                                                                   :timestamp => timestamp))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Authentication", a_hash_including(
+                                                                                   :type => "system",
+                                                                                   :user => "api_user_id"))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Authorization", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Request", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Parameters", a_kind_of(Hash))
+      expect_any_instance_of(Api::ApiController).to receive(:log_request).with("Response", a_kind_of(Hash))
 
       run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
     end

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -23,10 +23,8 @@ describe "Logging" do
 
       expect($api_log).to receive(:info).with(
         a_string_matching(
-          'Request:        {:method=>:get, :action=>"read", :fullpath=>"/api", :url=>"http://www.example.com/api", ' \
-          ':base=>"http://www.example.com", :path=>"/api", :prefix=>"/api", :version=>"3.0.0-pre", ' \
-          ':api_prefix=>"http://www.example.com/api", :collection=>nil, :c_suffix=>"", :c_id=>nil, ' \
-          ':subcollection=>nil, :s_id=>nil}'
+          ":method.*:action.*:fullpath.*url.*:base.*:path.*:prefix.*:version.*:api_prefix.*:collection.*:c_suffix.*" \
+          ":c_id.*:subcollection.*:s_id"
         )
       )
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -3,10 +3,11 @@
 #
 describe "Logging" do
   describe "Successful Requests logging" do
+    before { allow($api_log).to receive(:info) }
+
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)
 
-      allow($api_log).to receive(:info)
       expect($api_log).to receive(:info).with(/API Request/)
       expect($api_log).to receive(:info).with(/Authentication/)
       expect($api_log).to receive(:info).with(/Authorization/)
@@ -25,7 +26,6 @@ describe "Logging" do
     it "logs all hash entries about the request" do
       api_basic_authorize
 
-      allow($api_log).to receive(:info)
       expect($api_log).to receive(:info).with(/API Request/)
       expect($api_log).to receive(:info).with(/Authentication/)
       expect($api_log).to receive(:info).with(/Authorization/)
@@ -46,7 +46,6 @@ describe "Logging" do
     it "filters password attributes in nested parameters" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
-      allow($api_log).to receive(:info)
       expect($api_log).to receive(:info).with(/API Request/)
       expect($api_log).to receive(:info).with(/Authentication/)
       expect($api_log).to receive(:info).with(/Authorization/)
@@ -71,7 +70,6 @@ describe "Logging" do
 
         miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
-        allow($api_log).to receive(:info)
         expect($api_log).to receive(:info).with(/API Request/)
         expect($api_log).to receive(:info).with(
           a_string_matching(

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -31,10 +31,9 @@ describe "Logging" do
 
       @log.rewind
       request_log_line = @log.readlines.detect { |l| l =~ /MIQ\(.*\) Request:/ }
-      expect(request_log_line).to match(
-        ":method.*:action.*:fullpath.*url.*:base.*:path.*:prefix.*:version.*:api_prefix.*:collection.*:c_suffix.*" \
-        ":c_id.*:subcollection.*:s_id"
-      )
+      expect(request_log_line).to include(":method", ":action", ":fullpath", ":url", ":base", ":path", ":prefix",
+                                          ":version", ":api_prefix", ":collection", ":c_suffix", ":c_id",
+                                          ":subcollection", ":s_id")
     end
 
     it "filters password attributes in nested parameters" do

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -6,7 +6,6 @@ describe "Logging" do
     before do
       @log = StringIO.new
       $api_log.reopen(@log)
-      allow($api_log).to receive(:info)
     end
 
     after { $api_log.reopen(Rails.root.join("log", "api.log")) }
@@ -14,41 +13,44 @@ describe "Logging" do
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)
 
-      expect($api_log).to receive(:info).with(a_string_matching(/Request:/)
-                                               .and(matching(%r{:path=>"/api/users"}))
-                                               .and(matching(/:collection=>"users"/))
-                                               .and(matching(/:c_id=>nil/))
-                                               .and(matching(/:subcollection=>nil/))
-                                               .and(matching(/:s_id=>nil/)))
-
       run_get users_url
+
+      @log.rewind
+      expect(@log.readlines).to include(a_string_matching(/Request:/)
+                                         .and(matching(%r{:path=>"/api/users"}))
+                                         .and(matching(/:collection=>"users"/))
+                                         .and(matching(/:c_id=>nil/))
+                                         .and(matching(/:subcollection=>nil/))
+                                         .and(matching(/:s_id=>nil/)))
     end
 
     it "logs all hash entries about the request" do
       api_basic_authorize
 
-      expect($api_log).to receive(:info).with(
+      run_get entrypoint_url
+
+      @log.rewind
+      expect(@log.readlines).to include(
         a_string_matching(
           ":method.*:action.*:fullpath.*url.*:base.*:path.*:prefix.*:version.*:api_prefix.*:collection.*:c_suffix.*" \
           ":c_id.*:subcollection.*:s_id"
         )
       )
-
-      run_get entrypoint_url
     end
 
     it "filters password attributes in nested parameters" do
       api_basic_authorize collection_action_identifier(:services, :create)
 
-      expect($api_log).to receive(:info).with(
+      run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
+
+      @log.rewind
+      expect(@log.readlines).to include(
         a_string_matching(
           'Parameters:     {"action"=>"update", "controller"=>"api/services", "format"=>"json", ' \
           '"body"=>{"action"=>"create", "resource"=>{"name"=>"new_service_1", ' \
           '"options"=>{"password"=>"\[FILTERED\]"}}}}'
         )
       )
-
-      run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
     end
 
     it "logs additional system authentication with miq_token" do
@@ -59,19 +61,18 @@ describe "Logging" do
 
         miq_token = MiqPassword.encrypt({:server_guid => server_guid, :userid => userid, :timestamp => timestamp}.to_yaml)
 
-        expect($api_log).to receive(:info).with(
+        run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
+
+        @log.rewind
+        expect(@log.readlines).to include(
           a_string_matching(
             "System Auth:    {:x_miq_token=>\"#{Regexp.escape(miq_token)}\", :server_guid=>\"#{server_guid}\", " \
             ":userid=>\"api_user_id\", :timestamp=>2017-01-01 00:00:00 UTC}"
-          )
-        )
-        expect($api_log).to receive(:info).with(
+          ),
           a_string_matching(
             'Authentication: {:type=>"system", :token=>nil, :x_miq_group=>nil, :user=>"api_user_id"}'
           )
         )
-
-        run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
       end
     end
   end


### PR DESCRIPTION
~~By mocking closer to the boundary (i.e. the `$api_log` itself)~~ By injecting a `StringIO` into the $api_log and making expectations on it, we can decouple these tests from some implementation details that required us to use `#any_instance_of`. The result I think is greater confidence in these tests, greater visibility in what's being logged from the test body, and looser coupling between the test and its implementation, freeing us to refactor some of the logging later if needed. ~~Also, by first stubbing the logger with `allow .... to receive(:info)`, we no longer have to specify every message it receives, giving the tests greater readability.~~ We also no longer required to specify every message that the logger receives (in the right order) - we can instead search through the log device to find only what is relevant to the example at hand. This also removes some constants from the example group which I know will make @kbrock happy :grin: 

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 
