### PR TITLE
Exclude retired objects in retirement_check methods.

### DIFF
--- a/app/models/load_balancer/retirement_management.rb
+++ b/app/models/load_balancer/retirement_management.rb
@@ -8,7 +8,6 @@ class LoadBalancer
         ems_ids        = MiqServer.my_server.zone.ext_management_systems.pluck(:id)
         table          = LoadBalancer.arel_table
         load_balancers = LoadBalancer.where(table[:retires_on].not_eq(nil)
-                                              .or(table[:retired].eq(true))
                                               .and(table[:ems_id].in(ems_ids)))
         load_balancers.each(&:retirement_check)
       end

--- a/app/models/orchestration_stack/retirement_management.rb
+++ b/app/models/orchestration_stack/retirement_management.rb
@@ -8,7 +8,6 @@ class OrchestrationStack
         ems_ids = MiqServer.my_server.zone.ext_management_systems.pluck(:id)
         table   = OrchestrationStack.arel_table
         stacks  = OrchestrationStack.where(table[:retires_on].not_eq(nil)
-          .or(table[:retired].eq(true))
           .and(table[:ems_id].in(ems_ids)))
         stacks.each(&:retirement_check)
       end

--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -4,7 +4,7 @@ module Service::RetirementManagement
 
   module ClassMethods
     def retirement_check
-      services = Service.where("retires_on IS NOT NULL OR retired = ?", true)
+      services = Service.where("retires_on IS NOT NULL OR retired = ?", false)
       services.each(&:retirement_check)
     end
   end

--- a/app/models/vm_or_template/retirement_management.rb
+++ b/app/models/vm_or_template/retirement_management.rb
@@ -6,7 +6,7 @@ module VmOrTemplate::RetirementManagement
     def retirement_check
       zone    = MiqServer.my_server.zone
       ems_ids = zone.ext_management_system_ids
-      vms     = Vm.where("(retires_on IS NOT NULL OR retired = ?) AND ems_id IN (?)", true, ems_ids)
+      vms     = Vm.where("(retires_on IS NOT NULL OR retired = ?) AND ems_id IN (?)", false, ems_ids)
       vms.each(&:retirement_check)
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/145237979

Recently found that the check_retirement methods were including 'retired' objects which was leftover from the old retirement processing which first marked the object as retired, then optionally entered the retirement state machine. Current retirement process marks the objects 'retired' as the final state machine step, so 'retired' objects should be excluded from retirement_check.