### PR TITLE
Performance: Do not schedule Session.purge if this Session is not used

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -184,10 +184,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue :drift_state_purge_timer
     end
 
-    # Schedule - Check for session timeouts
-    scheduler.schedule_every(worker_settings[:session_timeout_interval]) do
-      # Session is global to the region, therefore, run it only once on the scheduler's server
-      enqueue :session_check_session_timeout
+    if Session.enabled?
+      # Schedule - Check for session timeouts
+      scheduler.schedule_every(worker_settings[:session_timeout_interval]) do
+        # Session is global to the region, therefore, run it only once on the scheduler's server
+        enqueue :session_check_session_timeout
+      end
     end
 
     # Schedule - Check for rogue EVM snapshots

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,6 +3,10 @@ class Session < ApplicationRecord
   @@interval = 30 # how often to purge in seconds
   @@job ||= nil
 
+  def self.enabled?
+    ::Settings.server.session_store == 'sql'
+  end
+
   def self.check_session_timeout
     $log.debug "Checking session data"
     purge(::Settings.session.timeout)


### PR DESCRIPTION
You can use memcache OR SQL session. When you use memcache this whole job does nothing. Just inserts into a queue, updates queue, selects empty from Session and then removes from queue.

This also frees up some memory and scheduler cycles. Yaix!

Note, we already require users (in documentation) to restart EVM server when they change session store (so we can do this).