### PR TITLE
Performance: Do not schedule smartstate dispatch unless it is needed

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -188,6 +188,10 @@ class JobProxyDispatcher
     end
   end
 
+  def self.waiting?
+    Job.where(:state => 'waiting_to_start').exists?
+  end
+
   def pending_jobs(target_class = VmOrTemplate)
     class_name = target_class.base_class.name
     @zone = MiqServer.my_zone

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -69,7 +69,9 @@ class MiqScheduleWorker::Jobs
   end
 
   def job_proxy_dispatcher_dispatch
-    queue_work_on_each_zone(:class_name  => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate", :state => "ready")
+    if JobProxyDispatcher.waiting?
+      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate", :state => "ready")
+    end
   end
 
   def ems_refresh_timer(klass)


### PR DESCRIPTION
The smart-state job `dispatch` is not something that is needed every other moment. It is usually initiated manually or scheduled by some policy. Most of the time (for most appliances) JobProxyDispatcher#dispatch will result in no-op. We can tell (whether it is needed) by a single query that's really quick. The query uses index on jobs table and checks just existence (ends quickly on success).

Note that touching queue is expensive (observation of heavily loaded deployments) compared to touching jobs table.

Real time Savings depend on server load and number of zones.

People who enable smart-state, but use it only rarely will benefit greatly. The users who use smart-state heavily wouldn't be burdened that much as the smart-state itself consumes heck a lot of resources.