### PR TITLE
More migration spec cleanup

### DIFF
--- a/db/migrate/20160214115800_inline_ems_id.rb
+++ b/db/migrate/20160214115800_inline_ems_id.rb
@@ -28,7 +28,7 @@ class InlineEmsId < ActiveRecord::Migration[4.2]
 
   def update_columns
     say_with_time("Inline ems_id in containers") do
-      Container.includes(:container_definitions => :container_group).all.each do |container|
+      Container.includes(:container_definition => :container_group).all.each do |container|
         container.update_attribute(:ems_id, container.container_group.ems_id)
       end
     end

--- a/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
+++ b/db/migrate/20160406195810_add_id_primary_key_to_join_tables.rb
@@ -49,7 +49,7 @@ class AddIdPrimaryKeyToJoinTables < ActiveRecord::Migration[5.0]
 
   def delete_remote_region_rows(table)
     model = Class.new(ActiveRecord::Base) { self.table_name = table }
-    col = model.column_names_symbols.first
+    col = model.column_names.first
     ar_region_class = ArRegion.anonymous_class_with_ar_region
     model.where.not(col => ar_region_class.region_to_range(ar_region_class.my_region_number)).delete_all
   end

--- a/db/migrate/20160414094300_change_capacity_to_hash_from_persistent_volume.rb
+++ b/db/migrate/20160414094300_change_capacity_to_hash_from_persistent_volume.rb
@@ -20,7 +20,7 @@ class ChangeCapacityToHashFromPersistentVolume < ActiveRecord::Migration[5.0]
             begin
               result_hash[key.to_sym] = val.iec_60027_2_to_i
             rescue ArgumentError
-              _log.warn("Capacity attribute was in bad format - #{val}")
+              logger.warn("Capacity attribute was in bad format - #{val}")
             end
           end
         end

--- a/spec/migrations/20140715200621_set_default_for_pxe_server_customization_directory_spec.rb
+++ b/spec/migrations/20140715200621_set_default_for_pxe_server_customization_directory_spec.rb
@@ -7,7 +7,7 @@ describe SetDefaultForPxeServerCustomizationDirectory do
     it "Sets customization_directory to '' if nil" do
       pxe_server_stub.create!(:name => "pxe_server_a", :uri => "nfs://example.com/share")
 
-      expect(PxeServer.count).to eq(1)
+      expect(pxe_server_stub.count).to eq(1)
 
       migrate
 

--- a/spec/migrations/20140905020643_update_default_registration_channel_names_spec.rb
+++ b/spec/migrations/20140905020643_update_default_registration_channel_names_spec.rb
@@ -7,7 +7,7 @@ describe UpdateDefaultRegistrationChannelNames do
     it "Updates the default registration channel names for v5.3" do
       miq_database_stub.create!(:update_repo_name => "cf-me-5.2-for-rhel-6-rpms")
 
-      expect(MiqDatabase.count).to eq(1)
+      expect(miq_database_stub.count).to eq(1)
       expect(miq_database_stub.first.update_repo_name).to eq("cf-me-5.2-for-rhel-6-rpms")
 
       migrate
@@ -18,7 +18,7 @@ describe UpdateDefaultRegistrationChannelNames do
     it "Skips non-default channels" do
       miq_database_stub.create!(:update_repo_name => "not-default")
 
-      expect(MiqDatabase.count).to eq(1)
+      expect(miq_database_stub.count).to eq(1)
       expect(miq_database_stub.first.update_repo_name).to eq("not-default")
 
       migrate

--- a/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
+++ b/spec/migrations/20170120164058_create_task_for_each_job_and_transfer_attributes_spec.rb
@@ -12,8 +12,8 @@ describe CreateTaskForEachJobAndTransferAttributes do
       migrate
 
       expect(miq_tasks_stub.count).to eq 2
-      expect(MiqTask.find_by(:name => "Hello Test Job").status).to eq "Some test status"
-      expect(MiqTask.find_by(:name => "Hello Test Job2").state).to eq "Some state"
+      expect(miq_tasks_stub.find_by(:name => "Hello Test Job").status).to eq "Some test status"
+      expect(miq_tasks_stub.find_by(:name => "Hello Test Job2").state).to eq "Some state"
     end
   end
 

--- a/spec/replication/util/primary_key_spec.rb
+++ b/spec/replication/util/primary_key_spec.rb
@@ -1,13 +1,8 @@
 describe "all tables" do
   let(:connection) { ApplicationRecord.connection }
 
-  it "have a primary key called id" do
-    no_pk = []
-    connection.tables.each do |t|
-      next if %w(schema_migrations ar_internal_metadata).include?(t)
-      no_pk << t unless connection.primary_keys(t) == ["id"]
-    end
-    expect(no_pk.size).to eq(0), <<-EOS.gsub!(/^ +/, "")
+  def invalid_primary_key_message(no_pk)
+    <<-EOS.gsub!(/^ +/, "")
       Primary key "id" not found for the following table(s):
 
       #{no_pk.join("\n")}
@@ -17,5 +12,14 @@ describe "all tables" do
       We have chosen to use "id" rather than a composite key to avoid future migration
       problems should a table need to move away from a composite key in the future.
     EOS
+  end
+
+  it "have a primary key called id" do
+    no_pk = []
+    connection.tables.each do |t|
+      next if %w(schema_migrations ar_internal_metadata).include?(t)
+      no_pk << t unless connection.primary_keys(t) == ["id"]
+    end
+    expect(no_pk.size).to eq(0), invalid_primary_key_message(no_pk)
   end
 end

--- a/spec/replication/util/schema_structure_spec.rb
+++ b/spec/replication/util/schema_structure_spec.rb
@@ -1,11 +1,15 @@
 describe "database schema" do
-  it "is structured as expected" do
-    ret = EvmDatabase.check_schema
-
-    expect(ret).to be_nil, <<-EOS.gsub!(/^ +/, "")
+  def invalid_schema_message(message)
+    <<-EOS.gsub!(/^ +/, "")
       #{Rails.configuration.database_configuration[Rails.env]["database"]} is not structured as expected.
-      #{ret}
+      #{message}
       Refer to http://talk.manageiq.org/t/new-schema-specs-for-new-replication/1404 for detail
     EOS
+  end
+
+  it "is structured as expected" do
+    message = EvmDatabase.check_schema
+
+    expect(message).to be_nil, invalid_schema_message(message)
   end
 end


### PR DESCRIPTION
These are various places where we are accessing models incorrectly, or
using things which are not inherent to Rails, which makes having the
specs run against a dummy app impossible.

Additionally, the second commit prevents the "double rendering" of the long error messages, which
is visually confusing to the developer receiving the error.  The way
RSpec prints errors, it writes the line of code in error to the screen,
followed by the error message.  In these cases, the line of code also
contains the custom error message, so it is rendered twice; first,
uninterpolated as code, and again interpolated as the error.  Moving the
text to a method prevents this.

Follow on to #15015 

@chrisarcand Please review
cc @bdunne 