### PR TITLE
configuration_script_sources subcollection

### DIFF
--- a/app/controllers/api/configuration_script_sources_controller.rb
+++ b/app/controllers/api/configuration_script_sources_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ConfigurationScriptSourcesController < BaseController
+    include Subcollections::ConfigurationScriptPayloads
+
     def edit_resource(type, id, data)
       config_script_src = resource_search(id, type, collection_class(:configuration_script_sources))
       raise "Update not supported for #{config_script_src_ident(config_script_src)}" unless config_script_src.respond_to?(:update_in_provider_queue)

--- a/app/controllers/api/subcollections/configuration_script_payloads.rb
+++ b/app/controllers/api/subcollections/configuration_script_payloads.rb
@@ -1,0 +1,9 @@
+module Api
+  module Subcollections
+    module ConfigurationScriptPayloads
+      def configuration_script_payloads_query_resource(object)
+        object.configuration_script_payloads
+      end
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -564,6 +564,7 @@
     :description: Configuration Script Payloads
     :options:
     - :collection
+    - :subcollection
     :verbs: *g
     :klass: ConfigurationScriptPayload
     :subcollections:
@@ -573,6 +574,10 @@
       - :name: read
         :identifier: embedded_configuration_script_payload_view
     :resource_actions:
+      :get:
+      - :name: read
+        :identifier: embedded_configuration_script_payload_view
+    :subcollection_actions:
       :get:
       - :name: read
         :identifier: embedded_configuration_script_payload_view
@@ -589,6 +594,8 @@
     - :collection
     :verbs: *gpppd
     :klass: ConfigurationScriptSource
+    :subcollections:
+      - :configuration_script_payloads
     :collection_actions:
       :get:
       - :name: read


### PR DESCRIPTION
For this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1449696), it is necessary to filter on `region_number` of playbooks that belong to a repository.

While this can be achieved via
```
GET http://localhost:3000/api/configuration_script_payloads?expand=resources&filter[]=configuration_script_source_id=10000000000001&filter[]=region_number=10
```

adding it as a subcollection makes it possible to filter on the `configuration_script_sources` collection directly:
```
GET http://localhost:3000/api/configuration_script_sources/10000000000001/configuration_script_payloads?expand=resources&filter[]=region_number=10
```

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 

cc: @h-kataria @gmcculloug 