### PR TITLE
Fix for Error in re-configuring service 'undefined method `match` for Fixnum'

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -39,15 +39,13 @@ class DialogFieldTextBox < DialogField
     return if !required? && @value.blank? || !visible
 
     return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is required" if required? && @value.blank?
-    if data_type == "integer" && !@value.to_s.match(/^[0-9]+$/)
-      return "#{dialog_tab.label}/#{dialog_group.label}/#{label} must be an integer"
-    end
+    return "#{dialog_tab.label}/#{dialog_group.label}/#{label} must be an integer" if value_supposed_to_be_int?
 
     # currently only regex is supported
     rule = validator_rule if validator_type == 'regex'
 
     return unless rule
-    "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.to_s.match(/#{rule}/)
+    "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless @value.to_s =~ /#{rule}/
   end
 
   def script_error_values
@@ -80,5 +78,9 @@ class DialogFieldTextBox < DialogField
 
   def convert_value_to_type
     data_type == "integer" ? @value.to_i : @value
+  end
+
+  def value_supposed_to_be_int?
+    data_type == "integer" && @value.to_s !~ /^[0-9]+$/
   end
 end

--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -47,7 +47,7 @@ class DialogFieldTextBox < DialogField
     rule = validator_rule if validator_type == 'regex'
 
     return unless rule
-    "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.match(/#{rule}/)
+    "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.to_s.match(/#{rule}/)
   end
 
   def script_error_values

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -103,7 +103,7 @@ describe DialogFieldTextBox do
         end
 
         it "returns an error when the value doesn't match the regex rule" do
-          df.value = '123'
+          df.value = 123
           expect(df.validate_field_data(dt, dg)).to eq('tab/group/test field is invalid')
         end
 

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -111,6 +111,26 @@ describe DialogFieldTextBox do
           df.value = nil
           expect(df.validate_field_data(dt, dg)).to eq('tab/group/test field is required')
         end
+
+        context "when the validation rule is supposed to match a set of integers" do
+          before do
+            df.validator_rule = '916'
+          end
+
+          context "when the value is a string" do
+            it "returns nil" do
+              df.value = '916'
+              expect(df.validate_field_data(dt, dg)).to be_nil
+            end
+          end
+
+          context "when the value is an integer" do
+            it "returns nil" do
+              df.value = 916
+              expect(df.validate_field_data(dt, dg)).to be_nil
+            end
+          end
+        end
       end
 
       context "when validation rule is not present" do


### PR DESCRIPTION
Previous PR #14861 was forcing the use of a string when matching against a general "integer" regex, but where the value was being compared with the validation rule regex, it was not. This will force the use of a string when comparing to that regex.

https://bugzilla.redhat.com/show_bug.cgi?id=1442920

@miq-bot add_label bug, euwe/yes, fine/yes
@miq-bot assign @gmcculloug 