### PR TITLE
[EUWE] New folder targeted refresh

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -95,7 +95,7 @@ module EmsRefresh
   def self.refresh_new_target(target_hash, ems_id)
     ems = ExtManagementSystem.find(ems_id)
 
-    target = save_new_target(target_hash)
+    target = save_new_target(ems, target_hash)
     if target.nil?
       _log.warn "Unknown target for event data: #{target_hash}."
       return

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -313,15 +313,14 @@ module EmsRefresh::SaveInventory
     save_inventory_multi(os.event_logs, hashes, :use_association, [:uid])
   end
 
-  def save_new_target(target_hash)
-    unless target_hash[:vm].nil?
+  def save_new_target(ems, target_hash)
+    if target_hash[:vm]
       vm_hash = target_hash[:vm]
       existing_vm = VmOrTemplate.find_by(:ems_ref => vm_hash[:ems_ref], :ems_id => target_hash[:ems_id])
       unless existing_vm.nil?
         return existing_vm
       end
 
-      ems = ExtManagementSystem.find_by_id(target_hash[:ems_id])
       old_cluster = get_cluster(ems, target_hash[:cluster], target_hash[:resource_pools], target_hash[:folders])
 
       vm_hash[:ems_cluster_id] = old_cluster[:id]
@@ -338,6 +337,8 @@ module EmsRefresh::SaveInventory
       resource_pool.save!
 
       new_vm
+    elsif target_hash[:folder]
+      ems.ems_folders.create!(target_hash[:folder])
     end
   end
 end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -39,7 +39,7 @@ module EmsRefresh::SaveInventoryInfra
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
-    if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank?)
+    if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank? && hashes[:folders].blank?)
       target.disconnect_inv
       return
     end

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -249,6 +249,34 @@ describe MiqVimBrokerWorker::Runner do
           expect(q.args).to eq([@ems.id, event])
         end
 
+        it "will handle create events properly" do
+          event = {
+            :server   => @ems.address,
+            :username => @ems.authentication_userid,
+            :objType  => "Folder",
+            :op       => "create",
+            :mor      => "group-v123"
+          }
+
+          expected_folder_hash = {
+            :folder => {
+              :type        => "EmsFolder",
+              :ems_ref     => "group-v123",
+              :ems_ref_obj => "group-v123",
+              :uid_ems     => "group-v123"
+            }
+          }
+
+          @vim_broker_worker.instance_variable_get(:@queue).enq(event.dup)
+
+          @vim_broker_worker.drain_event
+          expect(MiqQueue.count).to eq(1)
+          q = MiqQueue.first
+          expect(q.class_name).to eq("EmsRefresh")
+          expect(q.method_name).to eq("refresh_new_target")
+          expect(q.args).to eq([expected_folder_hash, @ems.id])
+        end
+
         it "will ignore updates to unknown properties" do
           vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
           @vim_broker_worker.instance_variable_get(:@queue).enq(:server       => @ems.address,


### PR DESCRIPTION
Euwe backport of https://github.com/ManageIQ/manageiq/pull/14460

I had to modify the `app/models/miq_vim_broker_worker/runner.rb` because https://github.com/ManageIQ/manageiq/pull/14228 changed how the `vc_updates` were handled.