### PR TITLE
Start Apache if roles were changed and it is needed by the current roles

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -121,6 +121,10 @@ module MiqServer::EnvironmentManagement
     MiqApache::Control.restart(false)
   end
 
+  def start_apache
+    MiqApache::Control.start
+  end
+
   def stop_apache
     MiqApache::Control.stop(false)
   end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -148,7 +148,9 @@ module MiqServer::WorkerManagement::Monitor
       log_role_changes           if roles_changed
       sync_active_roles          if roles_changed
       set_active_role_flags      if roles_changed
+
       stop_apache                if roles_changed && !apache_needed?
+      start_apache               if roles_changed &&  apache_needed?
 
       reset_queue_messages       if config_changed || roles_changed
     end


### PR DESCRIPTION
Fixes a bug that was introduced in da9523ee2168da89511c9260528c7bb243bfb777 when the Apache load balancer was made static.
That removed the code that started Apache up after the role or worker count changed.

https://bugzilla.redhat.com/show_bug.cgi?id=1449766

/cc @jrafanie 