### PR TITLE
Performance: Do not queue no-op destroy action

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -262,6 +262,7 @@ class MiqTask < ApplicationRecord
   end
 
   def self.delete_by_id(ids)
+    return if ids.empty?
     _log.info("Queuing deletion of tasks with the following ids: #{ids.inspect}")
     MiqQueue.put(
       :class_name  => name,

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1023,8 +1023,7 @@ describe Metric do
 
         it "should queue up enabled targets" do
           expected_targets = Metric::Targets.capture_targets
-          expected_queue_count = expected_targets.count * 9 # 1 realtime, 8 historical
-          expect(MiqQueue.count).to eq(expected_queue_count)
+          expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime' => expected_targets.count, 'perf_capture_historical' => expected_targets.count * 8)
           assert_metric_targets(expected_targets)
         end
       end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -62,7 +62,7 @@ describe Metric do
         end
 
         it "should queue up enabled targets" do
-          expect(MiqQueue.count).to eq(47)
+          expect(MiqQueue.count).to eq(46)
           assert_metric_targets
         end
 
@@ -1014,7 +1014,6 @@ describe Metric do
         it "should queue up enabled targets" do
           expected_targets = Metric::Targets.capture_targets
           expected_queue_count = expected_targets.count * 9 # 1 realtime, 8 historical
-          expected_queue_count += 1                         # cleanup task
           expect(MiqQueue.count).to eq(expected_queue_count)
           assert_metric_targets(expected_targets)
         end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -61,8 +61,18 @@ describe Metric do
           Metric::Capture.perf_capture_timer
         end
 
+        let(:expected_queue_items) do
+          {
+            %w(Host perf_capture_realtime)                                            => 3,
+            %w(Host perf_capture_historical)                                          => 24,
+            %w(Storage perf_capture_hourly)                                           => 1,
+            %w(ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_realtime)   => 2,
+            %w(ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_historical) => 16,
+          }
+        end
+
         it "should queue up enabled targets" do
-          expect(MiqQueue.count).to eq(46)
+          expect(MiqQueue.group(:class_name, :method_name).count).to eq(expected_queue_items)
           assert_metric_targets
         end
 


### PR DESCRIPTION
### What?

1) Avoid the queue overhead, i.e. worker_queue_lock, sql (insert, selects, updates, deletes) of this queue item

2) Avoid the log overhead (lock, sync, etc).

3) Profit


### Previously we did this:
```
SQL (0.3ms)  INSERT INTO "miq_queue" ("priority", "method_name", "state", "created_on", "updated_on", "queue_name", "class_name", "args", "zone", "msg_timeout", "lock_version") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING "id"  [["priority", 100], ["method_name", "destroy"], ["state", "ready"], ["created_on", 2017-05-12 12:48:26 UTC], ["updated_on", 2017-05-12 12:48:26 UTC], ["queue_name", "generic"], ["class_name", "MiqTask"], ["args", "---\n- []\n"], ["zone", "default"], ["msg_timeout", 600], ["lock_version", 0]]
```
Note this gets called quite often with empty ids. Just grep your logs ;-)
