### PR TITLE
Allow running specs using rspec on the cli

### DIFF
--- a/lib/generators/provider/templates/.rspec
+++ b/lib/generators/provider/templates/.rspec
@@ -2,3 +2,4 @@
 --require spec_helper
 --color
 --order random
+--exclude-pattern "spec/manageiq/**/*_spec.rb"

--- a/lib/generators/provider/templates/.rspec_ci
+++ b/lib/generators/provider/templates/.rspec_ci
@@ -3,3 +3,4 @@
 --color
 --order random
 --profile 25
+--exclude-pattern "spec/manageiq/**/*_spec.rb"

--- a/lib/generators/provider/templates/lib/tasks_private/spec.rake
+++ b/lib/generators/provider/templates/lib/tasks_private/spec.rake
@@ -7,5 +7,4 @@ desc "Run all specs"
 RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
   spec_dir = File.expand_path("../../spec", __dir__)
   EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
-  t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
 end


### PR DESCRIPTION
Previously `bundle exec rake` worked, now `bundle exec rspec` can also be used to run all of the tests without including those in `spec/manageiq`.

See also:
https://github.com/ManageIQ/manageiq-automation_engine/pull/23
https://github.com/ManageIQ/manageiq-providers-hawkular/pull/19