### PR TITLE
Return correct href when bulk assigning/unassigning tags

### DIFF
--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -9,6 +9,7 @@ module Api
         res[:result]  = options[:result] unless options[:result].nil?
         add_task_to_result(res, options[:task_id]) if options[:task_id].present?
         add_tasks_to_result(res, options[:task_ids]) if options[:task_ids].present?
+        add_parent_href_to_result(res, options[:parent_id]) if options[:parent_id].present?
         res
       end
 
@@ -17,8 +18,9 @@ module Api
         hash
       end
 
-      def add_parent_href_to_result(hash)
-        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{@req.c_id}"
+      def add_parent_href_to_result(hash, parent_id = nil)
+        return if hash[:href].present?
+        hash[:href] = "#{@req.api_prefix}/#{@req.collection}/#{parent_id ? parent_id : @req.c_id}"
         hash
       end
 

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -73,8 +73,7 @@ module Api
         else
           result = action_result(false, "Missing tag category or name")
         end
-
-        add_parent_href_to_result(result)
+        add_parent_href_to_result(result) unless tag_spec[:href]
         add_tag_to_result(result, tag_spec)
         log_result(result)
         result
@@ -125,7 +124,7 @@ module Api
           Classification.classify(ci, tag_spec[:category], tag_spec[:name])
           success = ci_is_tagged_with?(ci, tag_spec)
         end
-        action_result(success, desc)
+        action_result(success, desc, :parent_id => ci.id)
       rescue => err
         action_result(false, err.to_s)
       end
@@ -139,7 +138,7 @@ module Api
           desc = "Not tagged with #{tag_ident(tag_spec)}"
           success = true
         end
-        action_result(success, desc)
+        action_result(success, desc, :parent_id => ci.id)
       rescue => err
         action_result(false, err.to_s)
       end

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -543,9 +543,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(vms_url(vm1.id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(vms_url(vm2.id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -573,9 +575,11 @@ describe "Tag Collections API" do
         'results' => [
           a_hash_including('success' => false, 'message' => a_string_including("Couldn't find Vm")),
           a_hash_including('success'      => false,
+                           'href'         => a_string_including(vms_url(vm2.id)),
                            'tag_category' => bad_tag[:category],
                            'tag_name'     => bad_tag[:name]),
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(vms_url(vm2.id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name])
         ]
@@ -607,9 +611,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(vms_url(vm1.id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(vms_url(vm2.id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -818,9 +824,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(services_url(service1.id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(services_url(service2.id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]
@@ -844,9 +852,11 @@ describe "Tag Collections API" do
       expected = {
         'results' => [
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(services_url(service1.id)),
                            'tag_category' => tag1[:category],
                            'tag_name'     => tag1[:name]),
           a_hash_including('success'      => true,
+                           'href'         => a_string_including(services_url(service2.id)),
                            'tag_category' => tag2[:category],
                            'tag_name'     => tag2[:name])
         ]


### PR DESCRIPTION
Fixes #15076

The `add_parent_href_to_result`is using the request to form the `href` assigned to an action result, but with bulk tagging, there is no collection id which is causing the href to be returned incorrectly. 

This update appends a `:parent_id` to the `action_result` options so that the correct id is referenced and appended to the `href`

This occurs in Fine as well.

@miq-bot add_label bug, api, fine/yes
@miq-bot assign @abellotti 