### PR TITLE
Add delete method for Cloud Subnet

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -52,6 +52,14 @@ class CloudSubnet < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudSubnet
   end
 
+  def delete_cloud_subnet
+    raw_delete_cloud_subnet
+  end
+
+  def raw_delete_cloud_subnet
+    raise NotImplementedError, _("raw_delete_subnet must be implemented in a subclass")
+  end
+
   private
 
   def extra_attributes_save(key, value)


### PR DESCRIPTION
Add `delete` and `raw_delete` methods for Cloud Subnet model in order to expose `delete` operations in Automate engine: https://github.com/ManageIQ/manageiq-automation_engine/pull/9