### PR TITLE
Fix tag filtering for indirect RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -360,7 +360,8 @@ module Rbac
     end
     #
     # Algorithm: filter = u_filtered_ids UNION (b_filtered_ids INTERSECTION m_filtered_ids)
-    #            filter = (filter UNION d_filtered_ids if filter is not nil) UNION tenant_filter_ids
+    #            filter = (filter UNION d_filtered_ids if filter is not nil)
+    #            filter = filter INTERSECTION tenant_filter_ids if tenant_filter_ids is not nil
     # a nil as input for any field means it does not apply
     # a nil as output means there is not filter
     #
@@ -392,8 +393,8 @@ module Rbac
         filtered_ids.uniq!
       end
 
-      if filtered_ids.kind_of?(Array)
-        filtered_ids | tenant_filter_ids.to_a
+      if filtered_ids.kind_of?(Array) && tenant_filter_ids
+        filtered_ids & tenant_filter_ids.to_a
       elsif filtered_ids.nil? && tenant_filter_ids.kind_of?(Array) && tenant_filter_ids.present?
         tenant_filter_ids
       end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -397,6 +397,8 @@ module Rbac
         filtered_ids & tenant_filter_ids.to_a
       elsif filtered_ids.nil? && tenant_filter_ids.kind_of?(Array) && tenant_filter_ids.present?
         tenant_filter_ids
+      else
+        filtered_ids
       end
     end
 


### PR DESCRIPTION
in https://github.com/ManageIQ/manageiq/pull/14095 was added tenant scope filter 
for tenant restriction for associated models(indirect RBAC).

In method `combine_filtered_ids` was the issue that `ids` determined by tag filters, belongs filters and self-services users were joined to `ids` determined by tenant scope filter.
But both sets of `ids` express limitation so they have to be combined by intersection.

Example:

Tenant:
MyCompany->
     Tenant1 ->
       Tenant2

User is tight with group(with Tenant2) and role with
 filtering by tag 'my_tag'

Vm1 Belongs to Tenant2 and is not tagged with any tag
Vm2 Belongs to Tenant2 and is tagged with tag 'my_tag'

the user have to see only VMs from his tenant and
from these VMs he will only VMs which are tagged with tag 'my_tag'.

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1448994
https://github.com/ManageIQ/manageiq/pull/14095 


@miq-bot add_label fine/yes
@miq-bot add_label euwe/yes
@miq-bot assign @gtanzillo 

cc @kbrock 

@miq-bot add_label bug, rbac, blocker

