### PR TITLE
[FINE] kubernetes_connect, openshift_connect: add timeout settings

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -27,7 +27,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
         options[:version] || kubernetes_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
 

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -39,7 +39,11 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
         options[:version] || api_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,6 +112,8 @@
     :miq_namespace: management-infra
     :image_inspector_registry: docker.io
     :image_inspector_repository: openshift/image-inspector
+    :open_timeout: 60.seconds
+    :read_timeout: 60.seconds
 :event_streams:
   :history:
     :keep_events: 6.months

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -112,7 +112,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       require 'kubeclient'
       expect(Kubeclient::Client).to receive(:new).with(
         instance_of(URI::HTTPS), 'v1',
-        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri)
+        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri,
+                       :timeouts       => match(:open => be > 0, :read => be > 0))
       )
       described_class.raw_connect(hostname, port, options)
     end


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/10
plus https://github.com/ManageIQ/manageiq-providers-openshift/pull/8 (unnecessary on master but required in backports)

https://bugzilla.redhat.com/show_bug.cgi?id=1440950 (master)

1. I suppose bugzilla flags have to be confirmed & cloned first...
2. **https://github.com/ManageIQ/manageiq-gems-pending/pull/156 must be fine/backported before this** (this requires kubeclient 2.4.0)
3. Then this could pass tests and could land on fine.
4. Then I'll repeat for [EUWE](https://github.com/ManageIQ/manageiq/compare/euwe...cben:EUWE-kubeclient-timeout)...

cc @simon3z @simaishi.  