### PR TITLE
[WIP] Add begin rescue callback to clean up job_templates

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/configuration_script.rb
@@ -43,7 +43,11 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Configurati
     def delete_in_provider(manager_id, params)
       manager = ExtManagementSystem.find(manager_id)
       manager.with_provider_connection do |connection|
-        connection.api.job_templates.find(params[:manager_ref]).destroy!
+        if params[:name]
+          connection.api.job_templates.all(:search => params[:name]).first.destroy!
+        else
+          connection.api.job_templates.find(params[:manager_ref]).destroy!
+        end
       end
 
       # Get the record in our database

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -73,6 +73,20 @@ describe ServiceTemplateAnsiblePlaybook do
     catalog_item_options.deep_merge(changed_items)
   end
 
+  let(:catalog_item_options_bad) do
+    {
+      :name                        => 'test_ansible_catalog_item',
+      :description                 => 'test ansible',
+      :service_template_catalog_id => service_template_catalog.id,
+      :display                     => true,
+      :config_info                 => {
+        :provision => {
+          :configuration_template => { :manager_id => rand }
+        },
+      }
+    }
+  end
+
   describe 'building_job_templates' do
     it '#create_job_templates' do
       expect(described_class).to receive(:create_job_template).exactly(2).times.and_return(job_template)
@@ -161,6 +175,11 @@ describe ServiceTemplateAnsiblePlaybook do
 
       saved_options = catalog_item_options_two[:config_info].deep_merge(:provision => {:dialog_id => service_template.dialogs.first.id})
       expect(service_template.options[:config_info]).to include(saved_options)
+    end
+
+    it 'rolls back the job_template on an exception' do
+      expect(described_class).to receive(:rollback_job_templates)
+      expect { described_class.create_catalog_item(catalog_item_options_bad, user) }.to raise_exception(NoMethodError)
     end
   end
 


### PR DESCRIPTION
If we have a problem during the transaction to create `service_template`, rollback the created
`job_templates` if there were any previous to the error.

https://bugzilla.redhat.com/show_bug.cgi?id=1449345

