### PR TITLE
[WIP] Fix downloading storage provider summary

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -93,11 +93,11 @@ module MiqReport::Search
     search_options = options.merge(:class => db, :conditions => conditions, :include_for_find => includes)
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
 
-    if options[:parent]
-      targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])
-    else
-      targets = db_class
-    end
+    targets = if options[:parent] && options[:parent][:class] != "ManageIQ::Providers::Amazon::CloudManager"
+                get_parent_targets(options[:parent], options[:association] || options[:parent_method])
+              else
+                db_class
+              end
 
     if selected_ids.present?
       targets = targets.first.kind_of?(Integer) ? targets & selected_ids : targets.where(:id => selected_ids)


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1439523

Enable to download storage provider (AWS) summary in TXT or CSV format in 
Compute > Clouds > Providers in provider's summary page for Storage Managers.

This PR fixes the bug only with another PR:
https://github.com/ManageIQ/manageiq-ui-classic/pull/1350