### PR TITLE
Use MiqRegion#role_active? method over private method on Provider

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -10,12 +10,7 @@ class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
           :autosave    => true
 
   def self.raw_connect(base_url, username, password, verify_ssl)
-    return super if role_enabled?
+    return super if MiqRegion.my_region.role_active?('embedded_ansible')
     raise StandardError, 'Embedded ansible is disabled'
   end
-
-  def self.role_enabled?
-    MiqServer.all.any? { |x| x.has_active_role?('embedded_ansible') }
-  end
-  private_class_method :role_enabled?
 end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -22,6 +22,7 @@ module EvmSpecHelper
   end
 
   def self.assign_embedded_ansible_role(miq_server = nil)
+    MiqRegion.seed
     miq_server ||= local_miq_server
     FactoryGirl.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
     miq_server.assign_role('embedded_ansible').update_attributes(:active => true)


### PR DESCRIPTION
🔥 ✂️ 🔥 ✂️ 🔥 ✂️ 🔥 ✂️ 🔥 ✂️ 

Sorry @syncrou, I didn't know about this method when you were writing this originally 😅 
(Original PR: https://github.com/ManageIQ/manageiq/pull/15045)