### PR TITLE
Rails assets group was removed with rails 4.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ require 'sprockets/railtie'
 require 'action_cable/engine'
 
 if defined?(Bundler)
-  Bundler.require(*Rails.groups(:assets => %w(development test)), :ui_dependencies)
+  Bundler.require(*Rails.groups, :ui_dependencies)
 end
 
 module Vmdb


### PR DESCRIPTION
It was removed here:
https://github.com/rails/rails/pull/9955

The rails 5.1.0 template has just `Bundler.require(*Rails.groups)` here:
https://github.com/rails/rails/blob/v5.1.0/railties/lib/rails/generators/rails/app/templates/config/application.rb#L21