### PR TITLE
recursive-open-struct is a dependency of kubeclient and openshift_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,6 @@ gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.0.2"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
-gem "recursive-open-struct",          "~>1.0.0"
 gem "responders",                     "~>2.0"
 gem "ripper_ruby_parser",                              :require => false
 gem "ruby-dbus" # For external auth


### PR DESCRIPTION
It was added in manageiq in b56f16a1285b0c0c21650a5b771bcc92eae32b89
but it's not used in manageiq proper.

We'll let gems manage their own dependencies.

cc @moolitayer @abonas @himdel  ( I don't understand why it was needed here but am hoping tests pass and it's ok to remove since we're not using it here)

Note, dependencies of manageiq were relying on manageiq to provide this dependency... they have been fixed in:

- [x] https://github.com/ManageIQ/manageiq-providers-hawkular/issues/23
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/16
- [x] https://github.com/ManageIQ/manageiq-providers-openshift/issues/13
- [x] https://github.com/ManageIQ/manageiq-ui-classic/issues/1359