### PR TITLE
[api] Add support for Cloud Volume Delete action

### DIFF
--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class CloudVolumesController < BaseController
-    def delete_resource(type, id, _data)
+    def delete_resource(type, id, _data = {})
       cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
       task_id = cloud_volume.delete_volume_queue(User.current_user)
       action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)

--- a/app/controllers/api/cloud_volumes_controller.rb
+++ b/app/controllers/api/cloud_volumes_controller.rb
@@ -1,4 +1,11 @@
 module Api
   class CloudVolumesController < BaseController
+    def delete_resource(type, id, _data)
+      cloud_volume = resource_search(id, type, collection_class(:cloud_volumes))
+      task_id = cloud_volume.delete_volume_queue(User.current_user)
+      action_result(true, "Deleting Cloud Volume #{cloud_volume.name}", :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -479,9 +479,6 @@
         :identifier: cloud_volume_show_list
       - :name: delete
         :identifier: cloud_volume_delete
-      :delete:
-      - :name: delete
-        :identifier: cloud_volume_delete
     :resource_actions:
       :get:
       - :name: read

--- a/config/api.yml
+++ b/config/api.yml
@@ -484,8 +484,6 @@
       - :name: read
         :identifier: cloud_volume
       :post:
-      - :name: query
-        :identifier: cloud_volume_show_list
       - :name: delete
         :identifier: cloud_volume_delete
   :clusters:

--- a/config/api.yml
+++ b/config/api.yml
@@ -468,7 +468,7 @@
     :identifier: cloud_volume
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpppd
     :klass: CloudVolume
     :collection_actions:
       :get:
@@ -477,10 +477,17 @@
       :post:
       - :name: query
         :identifier: cloud_volume_show_list
+      - :name: delete
+        :identifier: cloud_volume_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: cloud_volume
+      :post:
+      - :name: query
+        :identifier: cloud_volume_show_list
+      - :name: delete
+        :identifier: cloud_volume_delete
   :clusters:
     :description: Clusters
     :identifier: ems_cluster

--- a/config/api.yml
+++ b/config/api.yml
@@ -468,7 +468,7 @@
     :identifier: cloud_volume
     :options:
     - :collection
-    :verbs: *gpppd
+    :verbs: *gpd
     :klass: CloudVolume
     :collection_actions:
       :get:
@@ -479,11 +479,17 @@
         :identifier: cloud_volume_show_list
       - :name: delete
         :identifier: cloud_volume_delete
+      :delete:
+      - :name: delete
+        :identifier: cloud_volume_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: cloud_volume
       :post:
+      - :name: delete
+        :identifier: cloud_volume_delete
+      :delete:
       - :name: delete
         :identifier: cloud_volume_delete
   :clusters:

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -69,6 +69,52 @@ describe "Cloud Volumes API" do
     expect(response).to have_http_status(:ok)
   end
 
+  it "can delete a cloud volume with DELETE as a resource action" do
+    zone = FactoryGirl.create(:zone, :name => "api_zone")
+    aws = FactoryGirl.create(:ems_amazon, :zone => zone)
+
+    cloud_volume1 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume1")
+
+    api_basic_authorize action_identifier(:cloud_volumes, :delete, :resource_actions, :delete)
+
+    run_delete cloud_volumes_url(cloud_volume1.id)
+
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it "can delete a cloud volume with DELETE as a collection action" do
+    zone = FactoryGirl.create(:zone, :name => "api_zone")
+    aws = FactoryGirl.create(:ems_amazon, :zone => zone)
+
+    cloud_volume1 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume1")
+
+    api_basic_authorize action_identifier(:cloud_volumes, :delete, :collection_actions, :delete)
+
+    run_delete(cloud_volumes_url, :resources => [{ 'id' => cloud_volume1.id }])
+
+    expect(response).to have_http_status(:no_content)
+  end
+
+  it "rejects delete request with DELETE as a resource action without appropriate role" do
+    cloud_volume = FactoryGirl.create(:cloud_volume)
+
+    api_basic_authorize
+
+    run_delete cloud_volumes_url(cloud_volume.id)
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "rejects delete request with DELETE as a collection action without appropriate role" do
+    cloud_volume = FactoryGirl.create(:cloud_volume)
+
+    api_basic_authorize
+
+    run_delete(cloud_volumes_url, :resources => [{ 'id' => cloud_volume.id }])
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
   it 'can delete cloud volumes through POST' do
     zone = FactoryGirl.create(:zone, :name => "api_zone")
     aws = FactoryGirl.create(:ems_amazon, :zone => zone)

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -49,6 +49,26 @@ describe "Cloud Volumes API" do
     expect(response).to have_http_status(:forbidden)
   end
 
+  it "can delete a single cloud volume" do
+    zone = FactoryGirl.create(:zone, :name => "api_zone")
+    aws = FactoryGirl.create(:ems_amazon, :zone => zone)
+
+    cloud_volume1 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume1")
+
+    api_basic_authorize action_identifier(:cloud_volumes, :delete, :resource_actions, :post)
+
+    run_post(cloud_volumes_url(cloud_volume1.id), :action => "delete")
+
+    expected = {
+      'message' => 'Deleting Cloud Volume CloudVolume1',
+      'success' => true,
+      'task_id' => a_kind_of(Numeric)
+    }
+
+    expect(response.parsed_body).to include(expected)
+    expect(response).to have_http_status(:ok)
+  end
+
   it 'can delete cloud volumes through POST' do
     zone = FactoryGirl.create(:zone, :name => "api_zone")
     aws = FactoryGirl.create(:ems_amazon, :zone => zone)

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -125,7 +125,7 @@ describe "Cloud Volumes API" do
     api_basic_authorize collection_action_identifier(:cloud_volumes, :delete, :post)
 
     expected = {
-      'results' => [
+      'results' => a_collection_containing_exactly(
         a_hash_including(
           'success' => true,
           'message' => a_string_including('Deleting Cloud Volume CloudVolume1'),
@@ -136,7 +136,7 @@ describe "Cloud Volumes API" do
           'message' => a_string_including('Deleting Cloud Volume CloudVolume2'),
           'task_id' => a_kind_of(Numeric)
         )
-      ]
+      )
     }
     run_post(cloud_volumes_url, :action => 'delete', :resources => [{ 'id' => cloud_volume1.id }, { 'id' => cloud_volume2.id }])
 

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -82,35 +82,12 @@ describe "Cloud Volumes API" do
     expect(response).to have_http_status(:no_content)
   end
 
-  it "can delete a cloud volume with DELETE as a collection action" do
-    zone = FactoryGirl.create(:zone, :name => "api_zone")
-    aws = FactoryGirl.create(:ems_amazon, :zone => zone)
-
-    cloud_volume1 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume1")
-
-    api_basic_authorize action_identifier(:cloud_volumes, :delete, :collection_actions, :delete)
-
-    run_delete(cloud_volumes_url, :resources => [{ 'id' => cloud_volume1.id }])
-
-    expect(response).to have_http_status(:no_content)
-  end
-
   it "rejects delete request with DELETE as a resource action without appropriate role" do
     cloud_volume = FactoryGirl.create(:cloud_volume)
 
     api_basic_authorize
 
     run_delete cloud_volumes_url(cloud_volume.id)
-
-    expect(response).to have_http_status(:forbidden)
-  end
-
-  it "rejects delete request with DELETE as a collection action without appropriate role" do
-    cloud_volume = FactoryGirl.create(:cloud_volume)
-
-    api_basic_authorize
-
-    run_delete(cloud_volumes_url, :resources => [{ 'id' => cloud_volume.id }])
 
     expect(response).to have_http_status(:forbidden)
   end

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -41,6 +41,14 @@ describe "Cloud Volumes API" do
     )
   end
 
+  it "rejects delete request without appropriate role" do
+    api_basic_authorize
+
+    run_post(cloud_volumes_url, :action => 'delete')
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
   it 'can delete cloud volumes through POST' do
     zone = FactoryGirl.create(:zone, :name => "api_zone")
     aws = FactoryGirl.create(:ems_amazon, :zone => zone)

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -40,4 +40,33 @@ describe "Cloud Volumes API" do
       "id"   => cloud_volume.id
     )
   end
+
+  it 'can delete cloud volumes through POST' do
+    zone = FactoryGirl.create(:zone, :name => "api_zone")
+    aws = FactoryGirl.create(:ems_amazon, :zone => zone)
+
+    cloud_volume1 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume1")
+    cloud_volume2 = FactoryGirl.create(:cloud_volume, :ext_management_system => aws, :name => "CloudVolume2")
+
+    api_basic_authorize collection_action_identifier(:cloud_volumes, :delete, :post)
+
+    expected = {
+      'results' => [
+        a_hash_including(
+          'success' => true,
+          'message' => a_string_including('Deleting Cloud Volume CloudVolume1'),
+          'task_id' => a_kind_of(Numeric)
+        ),
+        a_hash_including(
+          'success' => true,
+          'message' => a_string_including('Deleting Cloud Volume CloudVolume2'),
+          'task_id' => a_kind_of(Numeric)
+        )
+      ]
+    }
+    run_post(cloud_volumes_url, :action => 'delete', :resources => [{ 'id' => cloud_volume1.id }, { 'id' => cloud_volume2.id }])
+
+    expect(response.parsed_body).to include(expected)
+    expect(response).to have_http_status(:ok)
+  end
 end


### PR DESCRIPTION
Added support for deleting Cloud Volumes via POST.

```
POST /api/cloud_volumes

{
  "action" : "delete",
  "resources" : { 
    'id': 1,
    'id': 2
  }
}
```
/cc @abellotti 