### PR TITLE
Reduce the default oVirt open timeout to 1 minute

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -101,8 +101,10 @@
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour
+      :open_timeout: 1.minute
     :service:
       :read_timeout: 1.hour
+      :open_timeout: 1.minute
   :ems_kubernetes:
     :miq_namespace: management-infra
     :image_inspector_registry: docker.io


### PR DESCRIPTION
Currently the timeout used when opening connections to oVirt isn't
explicitly set. That means that when trying to connect to an oVirt
system that doesn't exist, or that doesn't respond, it may take as long
as the TCP timeout till the error is detected. In a typical setup on top
of Linux this timeout is approx 2 minutes and 8 seconds. But in
production environments the web server that is in front of the ManageIQ
user interface has a request timeout explicitly set to 2 minutes. This
means that validation of credentials for oVirt systems that don't exist,
or don't respond are ignored by the ManageIQ user interface, because it
gives up before the error is detected by the ManageIQ server. To avoid
that issue this patch changes the default connection timeout used by the
oVirt provider to 1 minute.

https://bugzilla.redhat.com/1448065