### PR TITLE
Refuse not satisfactory patterns from Miq Expression :: Tag faster

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -12,6 +12,7 @@ class MiqExpression::Tag < MiqExpression::Target
   attr_reader :namespace
 
   def self.parse(field)
+    return unless field.include?('managed') || field.include?('user_tag')
     parsed_params = parse_params(field) || return
     managed = parsed_params[:namespace] == self::MANAGED_NAMESPACE
     new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column], managed)


### PR DESCRIPTION
I found during this https://github.com/ManageIQ/manageiq/pull/13692 

that for `MiqExpression::Tag::REGEX` is slow to refuse paterns like a

`ManageIQ::Providers::Vmware::InfraManager::Host.disks.allows`

@miq-bot assign @gtanzillo 
