### PR TITLE
Allow to receive datastore by name or by id

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -412,6 +412,12 @@ class Storage < ApplicationRecord
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 
+  # searches for a storage by its ID or name, while the ID gets precedence over the name if both provided
+  def self.search_by_id_or_name(storage_id, storage_name)
+    return Storage.find_by(:id => storage_id) if storage_id
+    return Storage.find_by(:name => storage_name) if storage_name
+  end
+
   def count_of_vmdk_disk_files
     self.class.count_of_vmdk_disk_files[id]
   end

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -73,8 +73,8 @@ module VmOrTemplate::Operations::Configuration
 
   def raw_add_disk(disk_name, disk_size_mb, options = {})
     raise _("VM has no EMS, unable to add disk") unless ext_management_system
-    if options[:datastore]
-      datastore = Storage.find_by(:name => options[:datastore])
+    if options[:datastore] || options[:datastore_id]
+      datastore = Storage.search_by_id_or_name(options[:datastore_id], options[:datastore])
       raise _("Data Store does not exist, unable to add disk") unless datastore
     end
 

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -542,4 +542,63 @@ describe Storage do
       expect(storage.tenant_identity.current_tenant).to eq(Tenant.root_tenant)
     end
   end
+
+  context "#search_by_id_or_name" do
+    let(:storage_name) { "test_storage" }
+    let(:storage_id) { 123 }
+
+    context "when storage exists" do
+      let(:storage) { FactoryGirl.create(:storage, :name => storage_name, :id => storage_id) }
+
+      it "searches for a storage by specifying only the ID" do
+        allow(Storage).to receive(:find_by).with(:id => storage_id).and_return(storage)
+
+        expect(Storage).not_to receive(:find_by).with(:name => storage_name)
+        expect(Storage.search_by_id_or_name(storage_id, nil)).to eq(storage)
+      end
+
+      it "searches for a storage by specifying only the name" do
+        allow(Storage).to receive(:find_by).with(:name => storage_name).and_return(storage)
+
+        expect(Storage).not_to receive(:find_by).with(:id => storage_id)
+        expect(Storage.search_by_id_or_name(nil, storage_name)).to eq(storage)
+      end
+
+      it "searches for a storage both by its ID and name" do
+        allow(Storage).to receive(:find_by).with(:id => storage_id).and_return(storage)
+
+        expect(Storage).not_to receive(:find_by).with(:name => storage_name)
+        expect(Storage.search_by_id_or_name(storage_id, storage_name)).to eq(storage)
+      end
+    end
+
+    context "when storage does not exist" do
+      it "searches for a storage by specifying only the ID" do
+        allow(Storage).to receive(:find_by).with(:id => storage_id).and_return(nil)
+
+        expect(Storage).not_to receive(:find_by).with(:name => storage_name)
+        expect(Storage.search_by_id_or_name(storage_id, nil)).to eq(nil)
+      end
+
+      it "searches for a storage by specifying only the name" do
+        allow(Storage).to receive(:find_by).with(:name => storage_name).and_return(nil)
+
+        expect(Storage).not_to receive(:find_by).with(:id => storage_id)
+        expect(Storage.search_by_id_or_name(nil, storage_name)).to eq(nil)
+      end
+
+      it "searches for a storage both by its ID and name" do
+        allow(Storage).to receive(:find_by).with(:id => storage_id).and_return(nil)
+
+        expect(Storage).not_to receive(:find_by).with(:name => storage_name)
+        expect(Storage.search_by_id_or_name(storage_id, storage_name)).to eq(nil)
+      end
+
+      it "searches for a storage without specifying ID or name" do
+        expect(Storage).not_to receive(:find_by).with(:id => storage_id)
+        expect(Storage).not_to receive(:find_by).with(:name => storage_name)
+        expect(Storage.search_by_id_or_name(nil, nil)).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Datastores on the same setup may have the same name. In order to add a
disk on a specific datastore, it is better to use the datastore id.

https://bugzilla.redhat.com/show_bug.cgi?id=1450952
