### PR TITLE
[WIP] Split inventory parser and persistor

### DIFF
--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -149,7 +149,11 @@ module EmsRefresh
       end
 
       def save_inventory(ems, target, hashes)
-        EmsRefresh.save_ems_inventory(ems, hashes, target)
+        if refresher_options.try(:queue_save_inventory)
+          EmsRefresh.queue_save_ems_inventory(ems, hashes, target)
+        else
+          EmsRefresh.save_ems_inventory(ems, hashes, target)
+        end
       end
 
       def post_refresh_ems_cleanup(_ems, _targets)

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -3,6 +3,9 @@ module EmsRefresh::SaveInventory
     ems    = get_target_objects(*ems).first    if ems.kind_of?(Array)
     target = get_target_objects(*target).first if target && target.kind_of?(Array)
 
+    log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
+    _log.info "#{log_header} Saving inventory..."
+
     if hashes.kind_of?(Array)
       ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
       return
@@ -22,6 +25,8 @@ module EmsRefresh::SaveInventory
 
     # Handle updates to the ext_management_system
     update_attributes!(ems, hashes[:ems], [:type]) unless hashes[:ems].nil?
+
+    _log.info "#{log_header} Saving inventory...Complete"
   end
 
   def save_ems_inventory_no_disconnect(ems, hashes, target = nil)

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -29,20 +29,25 @@ module EmsRefresh::SaveInventory
   end
 
   def queue_save_ems_inventory(ems, hashes, target = nil)
-    args = [[ems.class.name, ems.id], hashes]
+    args = [[ems.class.name, ems.id]]
     args << [target.class.name, target.id] unless target.nil?
 
     queue_opts = {
       :queue_name  => 'inventory',
       :class_name  => name,
-      :method_name => 'save_ems_inventory',
+      :method_name => 'save_ems_inventory_from_queue',
       :role        => 'ems_inventory',
       :zone        => ems.my_zone,
       :args        => args,
+      :data        => hashes,
       :msg_timeout => queue_timeout
     }
 
     MiqQueue.put(queue_opts)
+  end
+
+  def save_ems_inventory_from_queue(ems, target, hashes)
+    save_ems_inventory(ems, hashes, target)
   end
 
   #

--- a/app/models/miq_ems_inventory_persister.rb
+++ b/app/models/miq_ems_inventory_persister.rb
@@ -1,0 +1,6 @@
+class MiqEmsInventoryPersister < MiqQueueWorkerBase
+  require_nested :Runner
+
+  self.required_roles = ["ems_inventory"]
+  self.default_queue_name = "inventory"
+end

--- a/app/models/miq_ems_inventory_persister/runner.rb
+++ b/app/models/miq_ems_inventory_persister/runner.rb
@@ -1,0 +1,2 @@
+class MiqEmsInventoryPersister::Runner < MiqQueueWorkerBase::Runner
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1102,6 +1102,9 @@
         :memory_threshold: 600.megabytes
         :nice_delta: 7
         :poll_method: :escalate
+      :ems_inventory_persister:
+        :memory_threshold: 2.gigabytes
+        :count: 0
       :ems_refresh_worker:
         :defaults:
           :memory_threshold: 2.gigabytes

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -61,6 +61,7 @@ MIQ_WORKER_TYPES = {
   "MiqCockpitWsWorker"                                                        => [:cockpit],
   "MiqEmsMetricsProcessorWorker"                                              => [],
   "MiqEmsRefreshCoreWorker"                                                   => [],
+  "MiqEmsInventoryPersister"                                                  => [],
   "MiqEventHandler"                                                           => [],
   "MiqGenericWorker"                                                          => [],
   "MiqPriorityWorker"                                                         => [],
@@ -121,6 +122,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   MiqScheduleWorker
   MiqPriorityWorker
   MiqWebServiceWorker
+  MiqEmsInventoryPersister
   MiqEmsRefreshCoreWorker
   MiqVimBrokerWorker
   ManageIQ::Providers::Vmware::CloudManager::EventCatcher


### PR DESCRIPTION
Split out the refresh collector/parser from the save_inventory code and run save_inventory in a standalone worker that is shared between EMSs

TODO:
- [x] Serialize `InventoryCollection` and `InventoryObject`
- [ ] Move any saving done in the parsers (e.g.: [here](https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager/refresher.rb#L60) and [here](https://github.com/ManageIQ/manageiq-providers-ovirt/blob/master/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb#L29-L30)) into the hashes sent to the `InventoryPersistor`
- [x] Make save inventory queueing configurable

Longer term enhancements:
- [ ] Allow multiple `InventoryPersistor` processes
- [ ] Support EMS groups going to a defined `InventoryPersistor` process
- [ ] Allow multiple threads running in an `InventoryPersistor` process