### PR TITLE
[SCVMM] Remove -All from Get-SCVMTemplate call

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -31,7 +31,7 @@ $vnets = Get-SCVirtualNetwork -VMMServer localhost |
   Select -Property ID,Name,LogicalNetworks,VMHostNetworkAdapters,
     @{name='VMHostName';expression={$_.VMHost.Name -As [string]}}
 
-$images = Get-SCVMTemplate -VMMServer localhost -All |
+$images = Get-SCVMTemplate -VMMServer localhost |
   Select -Property CPUCount,Memory,Name,ID,VirtualHardDisks,VirtualDVDDrives,
     @{name="CPUTypeString";expression={$_.CPUType.Name}},
     @{name="OperatingSystemString";expression={$_.OperatingSystem.Name}},


### PR DESCRIPTION
Apparently the -All switch inadvertently included temporary templates, so I'm removing it.

Confirmed with @jteehan that this is correct.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1450527