### PR TITLE
AWS SSA Core Changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 manageiq_plugin "manageiq-automation_engine"
 manageiq_plugin "manageiq-content"
 manageiq_plugin "manageiq-providers-amazon"
+manageiq_plugin "amazon_ssa_support" # Temporary dependency to be moved to manageiq-providers-amazon when officially released
 manageiq_plugin "manageiq-providers-azure"
 manageiq_plugin "manageiq-providers-hawkular"
 manageiq_plugin "manageiq-providers-kubernetes"

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -113,6 +113,7 @@ module MiqServer::ServerSmartProxy
     begin
       ost.args[1]  = YAML.load(ost.args[1]) # TODO: YAML.dump'd in call_scan - need it be?
       ost.scanData = ost.args[1].kind_of?(Hash) ? ost.args[1] : {}
+      ost.jobid    = job.id
       ost.config = OpenStruct.new(
         :vmdb               => true,
         :forceFleeceDefault => true,


### PR DESCRIPTION
The first iteration of changes for AWS SSA requires that the
amazon_ssa_support gem be included in the Gemfile.
In addition the job ID must be added to the OpenStruct by scan_metadata
before calling the provider-specific  perform_metadata_scan() so that
it can be used in queuing the request for the AWS Extractor Instance.

@roliveri @hsong-rh @yrudman please review.  PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/252 is a pre-requisite.  That PR upgrades the version of the aws-sdk to the version matching the amazon_ssa_support gem.