### PR TITLE
Hint to UI that scm_credential private_key field should have multiple-line

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/automation_manager/scm_credential.rb
@@ -3,13 +3,13 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
 
   COMMON_ATTRIBUTES = {
     :userid => {
-      :label     => N_('Access Key'),
-      :help_text => N_('AWS Access Key for this credential')
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential')
     },
     :password => {
       :type      => :password,
-      :label     => N_('Secret Key'),
-      :help_text => N_('AWS Secret Key for this credential')
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential')
     }
   }.freeze
 
@@ -22,6 +22,7 @@ module ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredenti
     },
     :ssh_key_data => {
       :type       => :password,
+      :multiline  => true,
       :label      => N_('Private key'),
       :help_text  => N_('RSA or DSA private key to be used instead of password')
     }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1451326

Whiling reviewing https://github.com/ManageIQ/manageiq/pull/14707, it didn't come to my mind that other similar `private_key` fields need the same change.

Also corrected two field labels.
@miq-bot add_labels bug, blocker, providers/ansible_tower