### PR TITLE
Ensure order is qualified by table name for rss feeds

### DIFF
--- a/product/alerts/rss/all_alert_event.yml
+++ b/product/alerts/rss/all_alert_event.yml
@@ -34,7 +34,8 @@ search_method:
 search_conditions: "event_type = 'EVMAlertEvent'"
 limit_to_time: 
 limit_to_count: 
-orderby: "timestamp DESC"
+orderby:
+  :timestamp: :desc
 
 # tags_include: any or all
 tag_ns: 

--- a/product/alerts/rss/cluster_alert_event.yml
+++ b/product/alerts/rss/cluster_alert_event.yml
@@ -21,7 +21,8 @@ search_method:
 search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'EmsCluster'"
 limit_to_time:
 limit_to_count:
-orderby: "timestamp DESC"
+orderby:
+  :timestamp: :desc
 
 # tags_include: any or all
 tag_ns:

--- a/product/alerts/rss/dev_vms.yml
+++ b/product/alerts/rss/dev_vms.yml
@@ -29,7 +29,8 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/evmevents.yml
+++ b/product/alerts/rss/evmevents.yml
@@ -28,7 +28,8 @@ search_method:
 search_conditions: "event_type = 'GeneralUserEvent' and message like '%EVM%'"
 limit_to_time:
 limit_to_count: 
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # tags_include: any or all
 tag_ns: 

--- a/product/alerts/rss/host_alert_event.yml
+++ b/product/alerts/rss/host_alert_event.yml
@@ -21,7 +21,8 @@ search_method:
 search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'Host'"
 limit_to_time:
 limit_to_count:
-orderby: "timestamp DESC"
+orderby:
+  :timestamp: :desc
 
 # tags_include: any or all
 tag_ns:

--- a/product/alerts/rss/lifecycle_events.yml
+++ b/product/alerts/rss/lifecycle_events.yml
@@ -25,7 +25,8 @@ item_class: LifecycleEvent
 search_method: 
 limit_to_time: 
 limit_to_count: 
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/microsoft_vms.yml
+++ b/product/alerts/rss/microsoft_vms.yml
@@ -30,7 +30,8 @@ search_method:
 search_conditions: "vendor = 'microsoft'"
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/newest_hosts.yml
+++ b/product/alerts/rss/newest_hosts.yml
@@ -18,7 +18,8 @@ item_class: Host
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # tags_include: any or all
 tag_ns: "/managed/lifecycles"

--- a/product/alerts/rss/newest_vms.yml
+++ b/product/alerts/rss/newest_vms.yml
@@ -27,7 +27,8 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "vms.created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/polevents_vmconfiguration.yml
+++ b/product/alerts/rss/polevents_vmconfiguration.yml
@@ -29,7 +29,8 @@ search_method:
 search_conditions: "event_type = 'vm_create' OR event_type = 'vm_clone' OR event_type = 'vm_clone_start' OR event_type = 'vm_template' OR event_type = 'vm_reconfigure' OR event_type = 'request_vm_destroy'"
 limit_to_time:
 limit_to_count: 
-orderby: "timestamp DESC"
+orderby:
+  :timestamp: :desc
 
 # tags_include: any or all
 tag_ns: 

--- a/product/alerts/rss/prod_hosts.yml
+++ b/product/alerts/rss/prod_hosts.yml
@@ -18,7 +18,8 @@ item_class: Host
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # tags_include: any or all
 tag_ns: "/managed/environment"

--- a/product/alerts/rss/prod_vms.yml
+++ b/product/alerts/rss/prod_vms.yml
@@ -29,7 +29,8 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/test_vms.yml
+++ b/product/alerts/rss/test_vms.yml
@@ -29,7 +29,8 @@ item_class: Vm
 search_method:
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:

--- a/product/alerts/rss/vm_alert_event.yml
+++ b/product/alerts/rss/vm_alert_event.yml
@@ -21,7 +21,8 @@ search_method:
 search_conditions: "event_type = 'EVMAlertEvent' AND target_type = 'VmOrTemplate'"
 limit_to_time:
 limit_to_count:
-orderby: "timestamp DESC"
+orderby:
+  :timestamp: :desc
 
 # tags_include: any or all
 tag_ns:

--- a/product/alerts/rss/vmotionedvm.yml
+++ b/product/alerts/rss/vmotionedvm.yml
@@ -20,9 +20,11 @@ search_method:
 search_conditions: "event_type = 'RelocateVM_Task_Complete'"
 limit_to_time: 
 limit_to_count: 
-orderby: "created_on DESC"
 
 # tags_include: any or all
 tag_ns: 
 tags_include: 
 tags: 
+orderby:
+  :created_on: :desc
+

--- a/product/alerts/rss/vmpowerevent.yml
+++ b/product/alerts/rss/vmpowerevent.yml
@@ -28,7 +28,8 @@ search_method:
 search_conditions: "event_type = 'VmPoweredOffEvent' OR event_type = 'VmPoweredOnEvent'"
 limit_to_time: 
 limit_to_count: 
-orderby: "created_on DESC"
+orderby:
+  :created_on :desc
 
 # tags_include: any or all
 tag_ns: 

--- a/product/alerts/rss/vmpoweroff.yml
+++ b/product/alerts/rss/vmpoweroff.yml
@@ -20,7 +20,8 @@ search_method:
 search_conditions: "event_type = 'VmPoweredOffEvent'"
 limit_to_time: 
 limit_to_count: 
-orderby: "created_on DESC"
+orderby:
+  :created_on :desc
 
 # tags_include: any or all
 tag_ns: 

--- a/product/alerts/rss/vmreconfigevent.yml
+++ b/product/alerts/rss/vmreconfigevent.yml
@@ -20,9 +20,11 @@ search_method:
 search_conditions: "event_type = 'ReconfigVM_Task_Complete'"
 limit_to_time: 
 limit_to_count: 
-orderby: "created_on DESC"
 
 # tags_include: any or all
 tag_ns: 
 tags_include: 
 tags: 
+orderby:
+  :created_on: :desc
+

--- a/product/alerts/rss/vmware_vms.yml
+++ b/product/alerts/rss/vmware_vms.yml
@@ -28,7 +28,8 @@ search_method:
 search_conditions: "vendor = 'vmware'"
 limit_to_time:
 limit_to_count:
-orderby: "created_on DESC"
+orderby:
+  :created_on: :desc
 
 # Included tables and columns for query performance
 include:


### PR DESCRIPTION
BEFORE:

```
SELECT "vms"."id" [...] ORDER BY created_on DESC
```

This is problematic because if we later join another table to this
scope and execute the query, if that table has a `created_on` field
Postgres will complain and throw an error for the ambiguous statement.

AFTER:

```
SELECT "vms"."id" [...] ORDER BY "vms"."created_on" DESC
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1451180

Note: I tried to bisect but had great difficulty (because you need to check out all the git gems to be concurrent with the revision you're checking out in core), but since this seemed to be a good idea anyway (and works), I was satisfied.

@miq-bot add-label bug, core
@miq-bot assign @gtanzillo 
