### PR TITLE
Allow :name parameter for an InventoryCollection

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
@@ -9,6 +9,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::Automati
     has_automation_manager_configuration_script_payloads :model_class => ManageIQ::Providers::Inflector.provider_module(self)::AutomationManager::Playbook
     has_automation_manager_configured_systems
     has_automation_manager_inventory_root_groups
-    has_vms :parent => nil, :arel => Vm, :strategy => :local_db_find_references
+    has_vms :name => :vms, :parent => nil, :arel => Vm, :strategy => :local_db_find_references
   end
 end

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -308,7 +308,7 @@ module ManagerRefresh
       @builder_params        = builder_params
       @name                  = name || association
 
-      raise "You have to pass either :name or :association argument to InventoryCollection.new" if @name.blank?
+      raise "You have to pass either :name or :association argument to .new of #{self}" if @name.blank?
 
       @inventory_object_attributes = inventory_object_attributes
 

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -6,7 +6,7 @@ module ManagerRefresh
                 :internal_attributes, :delete_method, :data, :data_index, :dependency_attributes, :manager_ref,
                 :association, :complete, :update_only, :transitive_dependency_attributes, :custom_manager_uuid,
                 :custom_db_finder, :check_changed, :arel, :builder_params, :loaded_references, :db_data_index,
-                :inventory_object_attributes
+                :inventory_object_attributes, :name
 
     delegate :each, :size, :to => :to_a
 
@@ -280,11 +280,13 @@ module ManagerRefresh
     #             inventory_object[:label] = inventory_object[:name]
     #           So by using inventory_object_attributes, we will be guarding the allowed attributes and will have an
     #           explicit list of allowed attributes, that can be used also for documentation purposes.
+    # @param name [Symbol] A unique name of the InventoryCollection under a Persister. If not provided, the :association
+    #        attribute is used. Providing either :name or :association is mandatory.
     def initialize(model_class: nil, manager_ref: nil, association: nil, parent: nil, strategy: nil, saved: nil,
                    custom_save_block: nil, delete_method: nil, data_index: nil, data: nil, dependency_attributes: nil,
                    attributes_blacklist: nil, attributes_whitelist: nil, complete: nil, update_only: nil,
                    check_changed: nil, custom_manager_uuid: nil, custom_db_finder: nil, arel: nil, builder_params: {},
-                   inventory_object_attributes: nil)
+                   inventory_object_attributes: nil, name: nil)
       @model_class           = model_class
       @manager_ref           = manager_ref || [:ems_ref]
       @custom_manager_uuid   = custom_manager_uuid
@@ -304,6 +306,10 @@ module ManagerRefresh
       @complete              = complete.nil? ? true : complete
       @update_only           = update_only.nil? ? false : update_only
       @builder_params        = builder_params
+      @name                  = name || association
+
+      raise "You have to pass either :name or :association argument to InventoryCollection.new" if @name.blank?
+
       @inventory_object_attributes = inventory_object_attributes
 
       @attributes_blacklist             = Set.new

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -408,24 +408,28 @@ describe ManagerRefresh::SaveInventory do
 
         @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => ManageIQ::Providers::CloudManager::Vm,
-          :arel        => @ems.vms.where(:ems_ref => vm_refs)
+          :arel        => @ems.vms.where(:ems_ref => vm_refs),
+          :name        => :vms
         )
         @data[:hardwares] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => Hardware,
           :arel        => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
-          :manager_ref => [:vm_or_template]
+          :manager_ref => [:vm_or_template],
+          :name        => :hardwares
         )
         @data[:disks] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => Disk,
           :arel        => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
-          :manager_ref => [:hardware, :device_name]
+          :manager_ref => [:hardware, :device_name],
+          :name        => :disks,
         )
         @data[:image_hardwares] = ::ManagerRefresh::InventoryCollection.new(
           :model_class         => Hardware,
           :arel                => @ems.hardwares,
           :manager_ref         => [:vm_or_template],
           :strategy            => :local_db_cache_all,
-          :custom_manager_uuid => ->(hardware) { [hardware.vm_or_template.try(:ems_ref)] }
+          :custom_manager_uuid => ->(hardware) { [hardware.vm_or_template.try(:ems_ref)] },
+          :name                => :image_hardwares,
         )
 
         @vm_data_3 = vm_data(3).merge(


### PR DESCRIPTION
Allow :name parameter for an InventoryCollection, name can be
used instead of :association, when we do not want to provide
the association. Name is used to uniquely identify the IC
under a specific Persister.

Adding a constraint requiring the name.