### PR TITLE
The last caller of queue_restart_apache has been removed

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -104,23 +104,6 @@ module MiqServer::EnvironmentManagement
   #
   # Apache
   #
-  def queue_restart_apache
-    MiqQueue.put_unless_exists(
-      :class_name  => 'MiqServer',
-      :instance_id => id,
-      :method_name => 'restart_apache',
-      :queue_name  => 'miq_server',
-      :zone        => zone.name,
-      :server_guid => guid
-    ) do |msg|
-      _log.info("Server: [#{id}] [#{name}], there is already a prior request to restart apache, skipping...") unless msg.nil?
-    end
-  end
-
-  def restart_apache
-    MiqApache::Control.restart(false)
-  end
-
   def start_apache
     MiqApache::Control.start
   end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -213,23 +213,6 @@ describe MiqServer do
       end
     end
 
-    context "enqueueing restart of apache" do
-      before(:each) do
-        @cond = {:method_name => 'restart_apache', :queue_name => "miq_server", :class_name => 'MiqServer', :instance_id => @miq_server.id, :server_guid => @miq_server.guid, :zone => @miq_server.zone.name}
-        @miq_server.queue_restart_apache
-      end
-
-      it "will queue only one restart_apache" do
-        @miq_server.queue_restart_apache
-        expect(MiqQueue.where(@cond).count).to eq(1)
-      end
-
-      it "delivering will restart apache" do
-        expect(MiqApache::Control).to receive(:restart).with(false)
-        @miq_server.process_miq_queue
-      end
-    end
-
     context "with a worker" do
       before(:each) do
         @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => Process.pid)


### PR DESCRIPTION
(which is the only caller of restart_apache)
https://github.com/ManageIQ/manageiq/pull/14007