### PR TITLE
Use extra_vars to create a new dialog when editing Ansible playbook service template.

### DIFF
--- a/app/models/dialog/ansible_playbook_service_dialog.rb
+++ b/app/models/dialog/ansible_playbook_service_dialog.rb
@@ -1,17 +1,17 @@
 class Dialog
   class AnsiblePlaybookServiceDialog
-    def self.create_dialog(label, job_template, hosts = 'localhost')
-      new.create_dialog(label, job_template, hosts)
+    def self.create_dialog(label, extra_vars, hosts = 'localhost')
+      new.create_dialog(label, extra_vars, hosts)
     end
 
     # This dialog is to be used by a playbook service
     # The job_template contains the playbook
-    def create_dialog(label, job_template, hosts = 'localhost')
+    def create_dialog(label, extra_vars, hosts = 'localhost')
       Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
         tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
         add_options_group(tab, 0, hosts)
-        unless job_template.variables.blank?
-          add_variables_group(tab, 1, job_template)
+        unless extra_vars.blank?
+          add_variables_group(tab, 1, extra_vars)
         end
         dialog.save!
       end
@@ -65,13 +65,13 @@ class Dialog
       )
     end
 
-    def add_variables_group(tab, position, template)
+    def add_variables_group(tab, position, extra_vars)
       tab.dialog_groups.build(
         :display  => "edit",
         :label    => "Variables",
         :position => position
       ).tap do |dialog_group|
-        template.variables.each_with_index do |(key, value), index|
+        extra_vars.transform_values { |val| val[:default] }.each_with_index do |(key, value), index|
           value = value.to_json if [Hash, Array].include?(value.class)
           add_variable_field(key, value, dialog_group, index)
         end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -55,8 +55,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     end
   end
 
-  def create_new_dialog(dialog_name, job_template, hosts)
-    Dialog::AnsiblePlaybookServiceDialog.create_dialog(dialog_name, job_template, hosts)
+  def create_new_dialog(dialog_name, extra_vars, hosts)
+    Dialog::AnsiblePlaybookServiceDialog.create_dialog(dialog_name, extra_vars, hosts)
   end
   private :create_new_dialog
 
@@ -185,7 +185,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     [:provision, :retirement, :reconfigure].each_with_object({}) do |action, hash|
       info = config_info[action]
       next unless new_dialog_required?(info)
-      hash[action] = {:dialog_id => create_new_dialog(info[:new_dialog_name], info[:configuration_template], info[:hosts]).id}
+      hash[action] = {:dialog_id => create_new_dialog(info[:new_dialog_name], info[:extra_vars], info[:hosts]).id}
     end
   end
 

--- a/spec/models/dialog/ansible_playbook_service_dialog_spec.rb
+++ b/spec/models/dialog/ansible_playbook_service_dialog_spec.rb
@@ -1,13 +1,13 @@
 describe Dialog::AnsiblePlaybookServiceDialog do
-  let(:playbook) { FactoryGirl.create(:configuration_script, :variables => nil) }
-
   describe "#create_dialog" do
     it "creates a dialog for a playbook with variables" do
-      allow(playbook).to receive(:variables).and_return('some_extra_var'  => 'blah',
-                                                        'other_extra_var' => {'name' => 'some_value'},
-                                                        'array_extra_var' => [{'name' => 'some_value'}])
+      extra_vars = {
+        'some_extra_var'  => {:default => 'blah'},
+        'other_extra_var' => {:default => {'name' => 'some_value'}},
+        'array_extra_var' => {:default => [{'name' => 'some_value'}]}
+      }
 
-      dialog = subject.create_dialog("mydialog1", playbook)
+      dialog = subject.create_dialog("mydialog1", extra_vars)
       expect(dialog).to have_attributes(:label => 'mydialog1', :buttons => "submit,cancel")
 
       tabs = dialog.dialog_tabs
@@ -16,7 +16,7 @@ describe Dialog::AnsiblePlaybookServiceDialog do
     end
 
     it "creates a dialog for a playbook with no variables" do
-      dialog = described_class.create_dialog("mydialog2", playbook)
+      dialog = described_class.create_dialog("mydialog2", {})
       expect(dialog.dialog_tabs[0].dialog_groups.size).to eq(1)
     end
   end


### PR DESCRIPTION
Use the new values in extra_vars to create a new dialog, instead of waiting for the updated job template which may take some time.

https://bugzilla.redhat.com/show_bug.cgi?id=1450102

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes, providers/ansible_tower, services