### PR TITLE
Disable worker heartbeating via ENV var

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -359,6 +359,10 @@ class MiqWorker::Runner
   end
 
   def heartbeat
+    # Disable heartbeat check.  Useful if a worker is running in isolation
+    # without the oversight of MiqServer::WorkerManagement
+    return if skip_heartbeat?
+
     now = Time.now.utc
     # Heartbeats can be expensive, so do them only when needed
     return if @last_hb.kind_of?(Time) && (@last_hb + worker_settings[:heartbeat_freq]) >= now
@@ -488,5 +492,11 @@ class MiqWorker::Runner
 
   def set_process_title
     Process.setproctitle(process_title)
+  end
+
+  private
+
+  def skip_heartbeat?
+    ENV["DISABLE_MIQ_WORKER_HEARTBEAT"]
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -335,6 +335,7 @@ class MiqWorker::Runner
   end
 
   def do_work_loop
+    warn_about_heartbeat_skipping if skip_heartbeat?
     loop do
       begin
         heartbeat
@@ -498,5 +499,14 @@ class MiqWorker::Runner
 
   def skip_heartbeat?
     ENV["DISABLE_MIQ_WORKER_HEARTBEAT"]
+  end
+
+  def warn_about_heartbeat_skipping
+    puts "**************************************************"
+    puts "WARNING:  SKIPPING HEARTBEATING WITH THIS WORKER!"
+    puts "**************************************************"
+    puts ""
+    puts "Remove the `DISABLE_MIQ_WORKER_HEARTBEAT` ENV variable"
+    puts "to reenable heartbeating normally."
   end
 end


### PR DESCRIPTION
Allows disabling worker heartbeats for workers that are running in isolation or where communicating via DRB is not possible.

The method of hearting will most likely be refactored in the future, but this allows for efforts to spin up workers without `rake evm:start` being done and activating a drb server to handle heartbeating.


TODO
----
* [x] Add warning for when this is enabled so users know when this has been triggered


Links
-----
* [Spike](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:RearchSpike-slim_openshift_worker) where this code would be useful (and eventually pulled into)