### PR TITLE
Make TokenManager#token_ttl callable (evaluated at call time)

### DIFF
--- a/lib/services/api/user_token_service.rb
+++ b/lib/services/api/user_token_service.rb
@@ -15,7 +15,7 @@ module Api
       when 'api', 'ui' # The default API token and UI token share the same TokenStore
         @token_mgr['api'] ||= new_token_mgr(base_config[:module], base_config[:name], api_config)
       when 'ws'
-        @token_mgr['ws'] ||= TokenManager.new('ws', :token_ttl => ::Settings.session.timeout)
+        @token_mgr['ws'] ||= TokenManager.new('ws', :token_ttl => -> { ::Settings.session.timeout })
       end
     end
 
@@ -55,7 +55,7 @@ module Api
       token_ttl = api_config[:token_ttl]
 
       options                = {}
-      options[:token_ttl]    = token_ttl.to_i_with_method if token_ttl
+      options[:token_ttl]    = -> { token_ttl.to_i_with_method } if token_ttl
 
       log_init(mod, name, options) if @svc_options[:log_init]
       TokenManager.new(mod, options)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -14,12 +14,12 @@ class TokenManager
 
   def gen_token(token_options = {})
     token = SecureRandom.hex(16)
-    ttl = token_options.delete(:token_ttl_override) || @options[:token_ttl]
+    ttl = token_options.delete(:token_ttl_override) || token_ttl
     token_data = {:token_ttl => ttl, :expires_on => Time.now.utc + ttl}
 
     token_store.write(token,
                       token_data.merge!(prune_token_options(token_options)),
-                      :expires_in => @options[:token_ttl])
+                      :expires_in => token_ttl)
     token
   end
 
@@ -55,7 +55,7 @@ class TokenManager
   private
 
   def token_store
-    TokenStore.acquire(@namespace, @options[:token_ttl])
+    TokenStore.acquire(@namespace, token_ttl)
   end
 
   def prune_token_options(token_options = {})

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -9,7 +9,7 @@ class TokenManager
 
   def initialize(namespace = DEFAULT_NS, options = {})
     @namespace = namespace
-    @options = {:token_ttl => 10.minutes}.merge(options)
+    @options = {:token_ttl => -> { 10.minutes }}.merge(options)
   end
 
   def gen_token(token_options = {})
@@ -49,7 +49,7 @@ class TokenManager
   end
 
   def token_ttl
-    @options[:token_ttl]
+    @options[:token_ttl].call
   end
 
   private

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -14,8 +14,8 @@ class TokenManager
 
   def gen_token(token_options = {})
     token = SecureRandom.hex(16)
-    token_ttl = token_options.delete(:token_ttl_override) || @options[:token_ttl]
-    token_data = {:token_ttl => token_ttl, :expires_on => Time.now.utc + token_ttl}
+    ttl = token_options.delete(:token_ttl_override) || @options[:token_ttl]
+    token_data = {:token_ttl => ttl, :expires_on => Time.now.utc + ttl}
 
     token_store.write(token,
                       token_data.merge!(prune_token_options(token_options)),
@@ -27,11 +27,11 @@ class TokenManager
     token_data = token_store.read(token)
     return {} if token_data.nil?
 
-    token_ttl = token_data[:token_ttl]
-    token_data[:expires_on] = Time.now.utc + token_ttl
+    ttl = token_data[:token_ttl]
+    token_data[:expires_on] = Time.now.utc + ttl
     token_store.write(token,
                       token_data,
-                      :expires_in => token_ttl)
+                      :expires_in => ttl)
   end
 
   def token_get_info(token, what = nil)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -48,6 +48,10 @@ class TokenManager
     token_store.delete(token)
   end
 
+  def token_ttl
+    @options[:token_ttl]
+  end
+
   private
 
   def token_store

--- a/spec/lib/token_manager_spec.rb
+++ b/spec/lib/token_manager_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe TokenManager do
   describe "#token_ttl" do
     it "returns the ttl" do
-      token_manager = described_class.new(described_class::DEFAULT_NS, :token_ttl => 60)
+      token_manager = described_class.new(described_class::DEFAULT_NS, :token_ttl => -> { 60 })
 
       expect(token_manager.token_ttl).to eq(60)
     end
@@ -10,6 +10,15 @@ RSpec.describe TokenManager do
       token_manager = described_class.new
 
       expect(token_manager.token_ttl).to eq(600)
+    end
+
+    it "evaluates at call time" do
+      stub_settings(:session => {:timeout => 60})
+      token_manager = described_class.new(described_class::DEFAULT_NS, :token_ttl => -> { Settings.session.timeout })
+
+      stub_settings(:session => {:timeout => 120})
+
+      expect(token_manager.token_ttl).to eq(120)
     end
   end
 end

--- a/spec/lib/token_manager_spec.rb
+++ b/spec/lib/token_manager_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe TokenManager do
+  describe "#token_ttl" do
+    it "returns the ttl" do
+      token_manager = described_class.new(described_class::DEFAULT_NS, :token_ttl => 60)
+
+      expect(token_manager.token_ttl).to eq(60)
+    end
+
+    it "defaults to 10 minutes" do
+      token_manager = described_class.new
+
+      expect(token_manager.token_ttl).to eq(600)
+    end
+  end
+end


### PR DESCRIPTION
If we pass in a value that can change (i.e. settings), it's evaluated
once at construction time and will never change. Thus, if a user
changes the session time out setting, a restart of the server is
required.

By making this value callable we can delay evaluation until call time,
which honors updated settings values.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1451848

/cc @isimluk @jvlcek 

@miq-bot add-label bug, api
@miq-bot assign @abellotti 
