### PR TITLE
Fix region_number filtering spec where region == 0

### DIFF
--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
 
-      run_get url, :filter => ["region_number=foo"]
+      run_get url, :filter => ["region_number=#{payload.region_number + 1}"]
 
       expected = {
         'subcount'  => 0,


### PR DESCRIPTION
This fails on some setups for the unexpected reason that non-integer
values given to the filterer for integer types are coerced as
0. Putting a non-my-region integer in the filter fixes this.

It might be nice if we could stub the region number instead of relying on a global setting. AFAICT there's no way to currently do that gracefully, so I'm OK with leaving this as it is for now.

@miq-bot add-label api, bug, test
@miq-bot assign @abellotti 