### PR TITLE
Compile and write stylesheets for PDF rendering

### DIFF
--- a/lib/asset_writer.rb
+++ b/lib/asset_writer.rb
@@ -1,0 +1,33 @@
+class AssetWriter
+  attr_reader :asset, :target_path
+
+  delegate :logical_path, :digest_path, :to => :asset
+
+  def initialize(asset_path, target_dir)
+    @asset = Rails.application.assets.find_asset(asset_path)
+
+    raise ArgumentError, "No asset found for that path" unless @asset
+
+    @target_dir = target_dir
+    @target_path = Rails.root.join(target_dir, @asset.digest_path)
+  end
+
+  def write
+    unless file_exists?
+      prep_target
+      File.write(target_path, asset.source)
+    end
+
+    target_path
+  end
+
+  def file_exists?
+    File.exist?(target_path)
+  end
+
+  private
+
+  def prep_target
+    FileUtils.mkdir_p(@target_dir)
+  end
+end

--- a/lib/pdf_generator.rb
+++ b/lib/pdf_generator.rb
@@ -42,17 +42,10 @@ class PdfGenerator
   end
   private_class_method :sanitize_html
 
-  # Search through plugins to find the first existing pdf stylesheet
-  #
-  # TODO: this could be refactored later to support multiple stylesheets
-  # from multiple plugins.
+  # Find stylesheet asset with short path and return filesystem path
   #
   def self.stylesheet_file_path(stylesheet)
-    paths = Vmdb::Plugins.instance.vmdb_plugins.map do |plugin|
-      plugin.root.join("app/assets/stylesheets", stylesheet)
-    end
-
-    paths.detect { |p| File.exist?(p) }
+    Rails.application.assets.find_asset(stylesheet).try(:pathname).try(:to_s)
   end
 
   private_class_method :stylesheet_file_path

--- a/lib/pdf_generator/prince_pdf_generator.rb
+++ b/lib/pdf_generator/prince_pdf_generator.rb
@@ -17,7 +17,7 @@ class PrincePdfGenerator < PdfGenerator
     options = {
       :params  => {
         :input  => "html",
-        :style  => stylesheet,
+        :style  => processed_stylesheet(stylesheet),
         :log    => Rails.root.join("log", "prince.log"),
         :output => "-", # Write to stdout
         "-"     => nil  # Read from stdin
@@ -31,5 +31,14 @@ class PrincePdfGenerator < PdfGenerator
       "Executing: #{command}"
     end
     AwesomeSpawn.run!(executable, options).output
+  end
+
+  private
+
+  # Writes the stylesheet Sprocket::Asset to a file and returns the path
+  # Relies on the digest_path to keep the file fresh
+  #
+  def processed_stylesheet(stylesheet_path)
+    AssetWriter.new(stylesheet_path, 'tmp/cache/pdf').write
   end
 end

--- a/spec/lib/pdf_generator_spec.rb
+++ b/spec/lib/pdf_generator_spec.rb
@@ -1,5 +1,9 @@
 describe PdfGenerator do
-  context ".new" do
+  let(:generator) do
+    double("PdfGenerator subclass", :available? => true, :pdf_from_string => "pdf-data")
+  end
+
+  describe ".new" do
     it "will return the detected subclass" do
       expect(PdfGenerator.new.class).to_not eq PdfGenerator
     end
@@ -9,27 +13,29 @@ describe PdfGenerator do
     end
   end
 
-  def stub_generator_instance
-    generator = double("PdfGenerator subclass", :available? => true, :pdf_from_string => "pdf-data")
-    allow(PdfGenerator).to receive_messages(:instance => generator)
-    generator
-  end
+  describe "availablity" do
+    subject { PdfGenerator }
 
-  context ".available?" do
-    it "when available" do
-      stub_generator_instance
-      expect(PdfGenerator).to be_available
+    before do
+      expect(PdfGenerator).to receive_messages(:instance => generator)
     end
 
-    it "when not available" do
-      generator = stub_generator_instance
-      allow(generator).to receive_messages(:available? => false)
-      expect(PdfGenerator).to_not be_available
+    context "when available" do
+      it { is_expected.to be_available }
+    end
+
+    context "when not available" do
+      before do
+        expect(PdfGenerator.instance).to receive(:available?).and_return(false)
+      end
+
+      it { is_expected.to_not be_available }
     end
   end
 
-  it ".pdf_from_string" do
-    stub_generator_instance
-    expect(PdfGenerator.pdf_from_string("html", "css")).to eq "pdf-data"
+  describe ".pdf_from_string" do
+    subject { generator.pdf_from_string("html", "pdf_report.css") }
+
+    it { is_expected.to eq "pdf-data" }
   end
 end

--- a/spec/lib/pdf_generator_spec.rb
+++ b/spec/lib/pdf_generator_spec.rb
@@ -1,0 +1,35 @@
+describe PdfGenerator do
+  context ".new" do
+    it "will return the detected subclass" do
+      expect(PdfGenerator.new.class).to_not eq PdfGenerator
+    end
+
+    it "can be called on a subclass" do
+      expect(NullPdfGenerator.new.class).to eq NullPdfGenerator
+    end
+  end
+
+  def stub_generator_instance
+    generator = double("PdfGenerator subclass", :available? => true, :pdf_from_string => "pdf-data")
+    allow(PdfGenerator).to receive_messages(:instance => generator)
+    generator
+  end
+
+  context ".available?" do
+    it "when available" do
+      stub_generator_instance
+      expect(PdfGenerator).to be_available
+    end
+
+    it "when not available" do
+      generator = stub_generator_instance
+      allow(generator).to receive_messages(:available? => false)
+      expect(PdfGenerator).to_not be_available
+    end
+  end
+
+  it ".pdf_from_string" do
+    stub_generator_instance
+    expect(PdfGenerator.pdf_from_string("html", "css")).to eq "pdf-data"
+  end
+end


### PR DESCRIPTION
Currently PDF rendering is broken because the asset paths sent to Prince are incorrect. This along with changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/1363 leans on the Asset Pipeline to base64 encode assets and write them to a temporary file.

Also, improves on #14793 with a more Rails-y way to look up assets provided by engines.

For some reason `pdf_generator_spec` was moved to ui-classic without `pdf_generator`. This moves the spec back.

**Addresses**
https://bugzilla.redhat.com/show_bug.cgi?id=1447940