### PR TITLE
Add lenovo attributes to event streams table

### DIFF
--- a/db/migrate/20170517185419_add_physical_server_id_to_event_parser.rb
+++ b/db/migrate/20170517185419_add_physical_server_id_to_event_parser.rb
@@ -1,0 +1,5 @@
+class AddPhysicalServerIdToEventParser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_streams, :physical_server_id, :bigint
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1236,6 +1236,7 @@ event_streams:
 - middleware_deployment_id
 - middleware_deployment_name
 - generating_ems_id
+- physical_server_id
 ext_management_systems:
 - id
 - name


### PR DESCRIPTION
This PR make the fallowing changes:
- Add physical_server_id to event_streams table
- Add lxca_severity that represents the severity in the lxca
- Add lxca_cn like the unique id of the event