### PR TITLE
Do not delete report if task associated with this report deleted

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -11,10 +11,8 @@ class MiqReportResult < ApplicationRecord
   serialize :report
 
   virtual_delegate :description, :to => :miq_group, :prefix => true, :allow_nil => true
-  virtual_delegate :state_or_status, :to => "miq_task", :allow_nil => true
-  virtual_attribute :status, :string, :uses => :state_or_status
+  virtual_attribute :status, :string
   virtual_column :status_message,        :type => :string, :uses => :miq_task
-
   virtual_has_one :result_set,           :class_name => "Hash"
 
   before_save do
@@ -32,11 +30,15 @@ class MiqReportResult < ApplicationRecord
   end
 
   def status
-    MiqTask.human_status(state_or_status)
+    if miq_task
+      miq_task.human_status
+    else
+      report_results.blank? ? "Error" : "Complete"
+    end
   end
 
   def status_message
-    miq_task.nil? ? _("Report results are no longer available") : miq_task.message
+    miq_task.nil? ? _("The task associated with this report is no longer available") : miq_task.message
   end
 
   def report_results

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -19,7 +19,7 @@ class MiqTask < ApplicationRecord
 
   has_one :log_file, :dependent => :destroy
   has_one :binary_blob, :as => :resource, :dependent => :destroy
-  has_one :miq_report_result, :dependent => :destroy
+  has_one :miq_report_result
   has_one :job, :dependent => :destroy
 
   belongs_to :miq_server


### PR DESCRIPTION
**Issue**:  Deleting task (in task management screen) also deleting report linked to that task

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1450272


Fixes:
- remove `:dependent => :destroy` on association between `MiqTask` and `MiqReportResult`
- allow to access saved report after associated task deleted: `MiqReportResult#status` now returns `Completed` if associated task deleted

**AFTER**: on screenshot first report has task associated with it and for last 2 reports (one successful and one failed)  associated task was deleted
<img width="1060" alt="screen shot 2017-05-22 at 12 00 39 pm" src="https://cloud.githubusercontent.com/assets/6556758/26317804/b7b607f4-3ee6-11e7-80d0-0c52dc49742e.png">


@miq-bot add-label core, bug