### PR TITLE
Remove unneeded SmartState requires

### DIFF
--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -1,9 +1,3 @@
-# TODO: Nothing appears to be using xml_utils in this file???
-# Perhaps, it's being required here because lower level code requires xml_utils to be loaded
-# but wrongly doesn't require it itself.
-require 'xml/xml_utils'
-require 'blackbox/VmBlackBox'
-
 module VmOrTemplate::Scanning
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Nothing in `app/models/vm_or_template/scanning.rb` uses these requires.

These are probably a remnant and are also included in `app/models/mixins/scanning_mixin.rb` where they may actually be used.