### PR TITLE
Add power off/on events to automate control and the foreign key to events physical server

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -26,6 +26,7 @@ class EventStream < ApplicationRecord
   belongs_to :container_node
 
   belongs_to :middleware_server, :foreign_key => :middleware_server_id
+  belongs_to :physical_server
 
   after_commit :emit_notifications, :on => :create
 

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -1,6 +1,7 @@
 class PhysicalServer < ApplicationRecord
   include NewWithTypeStiMixin
   include MiqPolicyMixin
+  include TenantIdentityMixin
   include_concern 'Operations'
 
   acts_as_miq_taggable

--- a/db/fixtures/miq_event_definition_sets.csv
+++ b/db/fixtures/miq_event_definition_sets.csv
@@ -12,3 +12,4 @@ orchestration_process,Orchestration Lifecycle
 storage_operational,Datastore Operation
 auth_validation,Authentication Validation
 container_operations,Container Operation
+phs_operations,Physical Server Operation

--- a/db/fixtures/miq_event_definition_sets.csv
+++ b/db/fixtures/miq_event_definition_sets.csv
@@ -12,4 +12,4 @@ orchestration_process,Orchestration Lifecycle
 storage_operational,Datastore Operation
 auth_validation,Authentication Validation
 container_operations,Container Operation
-phs_operations,Physical Server Operation
+physical_server_operations,Physical Server Operation

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -212,7 +212,8 @@ containerreplicator_compliance_passed,Replicator Compliance Passed,Default,compl
 containerreplicator_compliance_failed,Replicator Compliance Failed,Default,compliance
 
 #
-# Physical Servers Operations
+# Physical Server Operations
 #
-phs_poweroff,PHS Power OFF,Default,phs_operations
-phs_poweron,PHS Power ON,Default,phs_operations
+physical_server_shutdown,Physical Server Shutdown,Default,physical_server_operations
+physical_server_start,Physical Server Start,Default,physical_server_operations
+physical_server_reset,Physical Server Reset,Default,physical_server_operations

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -210,3 +210,9 @@ containerreplicator_successfulcreate,Replicator Successfully Created Pod,Default
 containerreplicator_compliance_check,Replicator Compliance Check,Default,compliance
 containerreplicator_compliance_passed,Replicator Compliance Passed,Default,compliance
 containerreplicator_compliance_failed,Replicator Compliance Failed,Default,compliance
+
+#
+# Physical Servers Operations
+#
+phs_poweroff,PHS Power OFF,Default,phs_operations
+phs_poweron,PHS Power ON,Default,phs_operations


### PR DESCRIPTION
This PR make the following changes:
- Add power off/on events to automate control
- Add foreign key to physical server in miq_events