### PR TITLE
Remove unused code from old graph refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -4,11 +4,6 @@ module EmsRefresh::SaveInventory
       ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
       return
     end
-    if hashes && hashes[:_inventory_collection]
-      hashes.delete(:_inventory_collection)
-      ManagerRefresh::SaveInventory.save_inventory(ems, hashes.values)
-      return
-    end
 
     case ems
     when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target)


### PR DESCRIPTION
Amazon graph refresh used to use a key `:_inventory_collection` to differentiate it from classic refresh.  https://github.com/ManageIQ/manageiq-providers-amazon/pull/128 changed this over to a newer inventory parser so this is not needed any longer.