### PR TITLE
Use static redirect and balancer files for front-end workers

### DIFF
--- a/app/models/miq_cockpit_ws_worker.rb
+++ b/app/models/miq_cockpit_ws_worker.rb
@@ -2,7 +2,6 @@ class MiqCockpitWsWorker < MiqWorker
   require_nested :Runner
   require_nested :Authenticator
 
-  APACHE_CONF_FILE = '/etc/httpd/conf.d/manageiq-redirects-cockpit'.freeze
   self.required_roles = ['cockpit_ws']
   self.maximum_workers_count = 1
 
@@ -20,22 +19,8 @@ class MiqCockpitWsWorker < MiqWorker
   end
 
   def self.sync_workers
-    install_apache_proxy_config if MiqEnvironment::Command.supports_apache?
     @workers = should_start_worker? ? 1 : 0
     super
-  end
-
-  def self.install_apache_proxy_config
-    config_status = has_required_role?
-
-    # Only restart apache if status has changed
-    return if @config_status == config_status
-    @config_status = config_status
-    if config_status
-      MiqCockpit::ApacheConfig.new(MiqCockpitWsWorker.worker_settings).save(APACHE_CONF_FILE)
-    elsif File.exist?(APACHE_CONF_FILE)
-      File.truncate(APACHE_CONF_FILE, 0)
-    end
   end
 
   def kill

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -248,7 +248,7 @@ class MiqServer < ApplicationRecord
     EvmDatabase.seed_last
 
     start_memcached
-    prep_apache_proxying
+    MiqApache::Control.restart if MiqEnvironment::Command.supports_apache?
     server.start
     server.monitor_loop
   end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -81,25 +81,6 @@ module MiqServer::EnvironmentManagement
       MiqMemcached::Control.restart!(:port => port, :options => opts)
       _log.info("Status: #{MiqMemcached::Control.status[1]}")
     end
-
-    def prep_apache_proxying
-      return unless MiqEnvironment::Command.supports_apache?
-
-      MiqUiWorker.install_apache_proxy_config
-      MiqWebServiceWorker.install_apache_proxy_config
-      MiqWebsocketWorker.install_apache_proxy_config
-      MiqCockpitWsWorker.install_apache_proxy_config
-
-      # Because adding balancer members does a validation of the configuration
-      # files and these files try to load the redirect files among others,
-      # we need to add the balancers members after all configuration files have
-      # been written by install_apache_proxy_config.
-      MiqUiWorker.add_apache_balancer_members
-      MiqWebServiceWorker.add_apache_balancer_members
-      MiqWebsocketWorker.add_apache_balancer_members
-
-      MiqApache::Control.restart
-    end
   end
 
   #

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -13,12 +13,7 @@ class MiqUiWorker < MiqWorker
     end
   end
 
-  BALANCE_MEMBER_CONFIG_FILE = '/etc/httpd/conf.d/manageiq-balancer-ui.conf'
-  REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-ui'
-  STARTING_PORT              = 3000
-  PROTOCOL                   = 'http'
-  REDIRECTS                  = '/'
-  CLUSTER                    = 'evmcluster_ui'
+  STARTING_PORT = 3000
 
   def friendly_name
     @friendly_name ||= "User Interface Worker"

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -3,12 +3,7 @@ class MiqWebServiceWorker < MiqWorker
 
   self.required_roles = ['web_services']
 
-  BALANCE_MEMBER_CONFIG_FILE = '/etc/httpd/conf.d/manageiq-balancer-ws.conf'
-  REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-ws'
-  STARTING_PORT              = 4000
-  PROTOCOL                   = 'http'
-  REDIRECTS                  = ['/api']
-  CLUSTER                    = 'evmcluster_ws'
+  STARTING_PORT = 4000
 
   def friendly_name
     @friendly_name ||= "Web Services Worker"

--- a/app/models/miq_websocket_worker.rb
+++ b/app/models/miq_websocket_worker.rb
@@ -3,13 +3,8 @@ class MiqWebsocketWorker < MiqWorker
 
   self.required_roles = ['websocket']
 
-  RACK_APPLICATION           = WebsocketServer
-  BALANCE_MEMBER_CONFIG_FILE = '/etc/httpd/conf.d/manageiq-balancer-websocket.conf'
-  REDIRECTS_CONFIG_FILE      = '/etc/httpd/conf.d/manageiq-redirects-websocket'
-  STARTING_PORT              = 5000
-  PROTOCOL                   = 'ws'
-  REDIRECTS                  = '/ws'
-  CLUSTER                    = 'evmcluster_websocket'
+  RACK_APPLICATION = WebsocketServer
+  STARTING_PORT    = 5000
 
   def friendly_name
     @friendly_name ||= "Websocket Worker"

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -100,27 +100,8 @@ module MiqWebServerWorkerMixin
       Rails.root.join("tmp/pids/rails_server.#{port}.pid")
     end
 
-    def install_apache_proxy_config
-      options = {
-        :member_file    => self::BALANCE_MEMBER_CONFIG_FILE,
-        :redirects_file => self::REDIRECTS_CONFIG_FILE,
-        :redirects      => self::REDIRECTS,
-        :cluster        => self::CLUSTER,
-        :protocol       => self::PROTOCOL
-      }
-
-      _log.info("[#{options.inspect}")
-      MiqApache::Conf.install_default_config(options)
-    end
-
     def port_range
       self::STARTING_PORT...(self::STARTING_PORT + maximum_workers_count)
-    end
-
-    def add_apache_balancer_members
-      conf = MiqApache::Conf.new(self::BALANCE_MEMBER_CONFIG_FILE)
-      conf.add_ports(port_range.to_a, self::PROTOCOL)
-      conf.save
     end
 
     def reserve_port(ports)

--- a/lib/miq_cockpit.rb
+++ b/lib/miq_cockpit.rb
@@ -159,36 +159,5 @@ END_OF_CONFIG
     def self.url_root
       "/#{URL_ROOT}/"
     end
-
-    def initialize(opts = {})
-      @opts = opts || {}
-      update
-    end
-
-    def save(fname)
-      File.write(fname, @config)
-    end
-
-    def update
-      url = URI::HTTP.build(:host => "localhost",
-                            :port => @opts[:port] || WS::DEFAULT_PORT,
-                            :path => MiqCockpit::ApacheConfig.url_root)
-      http_url = url.to_s
-      url.scheme = "ws"
-      ws_url = url.to_s
-
-      @config = <<-END_OF_CONFIG
-    ProxyPreserveHost on
-    RequestHeader unset X-Forwarded-Proto
-    RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
-
-    <LocationMatch "^#{MiqCockpit::ApacheConfig.url_root}cockpi(t[^/]+|t)?/socket$">
-        ProxyPassMatch "#{ws_url}cockpi$1/socket"
-    </LocationMatch>
-
-    ProxyPass #{ApacheConfig.url_root} #{http_url}
-END_OF_CONFIG
-      @config
-    end
   end
 end

--- a/spec/lib/miq_cockpit_spec.rb
+++ b/spec/lib/miq_cockpit_spec.rb
@@ -147,31 +147,9 @@ describe MiqCockpit::WS do
 end
 
 describe MiqCockpit::ApacheConfig do
-  describe '#url_root' do
-    context "always" do
-      it "returns" do
-        expect(MiqCockpit::ApacheConfig.url_root).to eq("/cws/")
-      end
-    end
-  end
-
-  describe 'update' do
-    context "when using defaults" do
-      it "it uses http and ws" do
-        ins = MiqCockpit::ApacheConfig.new(nil)
-        config = ins.update
-        expect(config).to include("ProxyPass /cws/ http://localhost:9002/cws/")
-        expect(config).to include('ProxyPassMatch "ws://localhost:9002/cws/cockpi$1/socket"')
-      end
-    end
-
-    context "when using custom port" do
-      it "it uses custom port" do
-        ins = MiqCockpit::ApacheConfig.new(:port => 9001)
-        config = ins.update
-        expect(config).to include("ProxyPass /cws/ http://localhost:9001/cws/")
-        expect(config).to include('ProxyPassMatch "ws://localhost:9001/cws/cockpi$1/socket"')
-      end
+  describe '#url_root ' do
+    it "returns the correct URL path" do
+      expect(MiqCockpit::ApacheConfig.url_root).to eq("/cws/")
     end
   end
 end

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -27,10 +27,6 @@ describe MiqUiWorker do
     end
   end
 
-  it ".port_range" do
-    expect(described_class.port_range.to_a).to eq((3000..3009).to_a)
-  end
-
   describe ".reserve_port" do
     it "returns next free port" do
       ports = (3000..3001).to_a


### PR DESCRIPTION
These files have no dynamic content so we can just ship them in place instead of writing them on server start (which requires root).

Requires https://github.com/ManageIQ/manageiq-appliance/pull/124