### PR TITLE
[WIP] Refactoring MiqQueue.put

### DIFF
--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -4,7 +4,7 @@ class Compliance < ApplicationRecord
 
   def self.check_compliance_queue(targets, inputs = {})
     targets.to_miq_a.each do |target|
-      MiqQueue.put(
+      MiqQueue.put_simple(
         :class_name  => name,
         :method_name => 'check_compliance',
         :args        => [[target.class.name, target.id], inputs]

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -36,7 +36,7 @@ module Metric::Purging
   end
 
   def self.purge_timer(ts, interval)
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => name,
       :method_name => "purge_#{interval}",
       :args        => [ts],

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -109,7 +109,7 @@ class MiqEvent < EventStream
   end
 
   def self.raise_evm_event_queue(target, raw_event, inputs = {})
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => name,
       :method_name => 'raise_evm_event',
       :args        => [[target.class.name, target.id], raw_event, inputs]

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -180,6 +180,13 @@ class MiqQueue < ApplicationRecord
     put(*args)
   end
 
+  # The work can be done without restrictions on role, zone, server
+  # Needs to be run right away, no delay and no expiry
+  # There are also no callbacks, fire and forget
+  def self.put_simple(*args)
+    put(*args)
+  end
+
   def unget(options = {})
     update_attributes!(options.merge(:state => STATE_READY, :handler => nil))
     @delivered_on = nil

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -73,7 +73,7 @@ class MiqSchedule < ApplicationRecord
       return
     end
 
-    msg = MiqQueue.put(
+    msg = MiqQueue.put_simple(
       :class_name  => name,
       :instance_id => sched.id,
       :method_name => "invoke_actions",

--- a/app/models/mixins/async_delete_mixin.rb
+++ b/app/models/mixins/async_delete_mixin.rb
@@ -3,7 +3,7 @@ module AsyncDeleteMixin
   included do
     def self._queue_task(task, ids)
       ids.each do |id|
-        MiqQueue.put(
+        MiqQueue.put_simple(
           :class_name  => name,
           :instance_id => id,
           :msg_timeout => 3600,

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -17,7 +17,7 @@ module ProcessTasksMixin
     end
 
     def invoke_tasks_queue(options)
-      MiqQueue.put(:class_name => name, :method_name => "invoke_tasks", :args => [options])
+      MiqQueue.put_simple(:class_name => name, :method_name => "invoke_tasks", :args => [options])
     end
 
     # Performs tasks received from the UI via the queue

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -52,7 +52,7 @@ module PurgingMixin
     end
 
     def purge_queue(mode, value)
-      MiqQueue.put(
+      MiqQueue.put_simple(
         :class_name  => name,
         :method_name => "purge_by_#{mode}",
         :args        => [value]

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -11,7 +11,7 @@ module RetirementMixin
         object = find_by(:id => id)
         object.retire(options) if object.respond_to?(:retire)
       end
-      MiqQueue.put(:class_name => base_model.name, :method_name => "retirement_check")
+      MiqQueue.put_simple(:class_name => base_model.name, :method_name => "retirement_check")
     end
   end
 

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -109,7 +109,7 @@ module ScanningMixin
   end
 
   def scan_queue(userid = "system", options = {})
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => self.class.base_class.name,
       :instance_id => id,
       :method_name => "scan",

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1129,7 +1129,7 @@ class VmOrTemplate < ApplicationRecord
   private_class_method :post_refresh_ems_folder_updates
 
   def self.assign_ems_created_on_queue(vm_ids)
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => name,
       :method_name => 'assign_ems_created_on',
       :args        => [vm_ids],
@@ -1168,7 +1168,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def post_create_actions_queue
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'post_create_actions'
@@ -1319,7 +1319,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def classify_with_parent_folder_path_queue(add = true)
-    MiqQueue.put(
+    MiqQueue.put_simple(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'classify_with_parent_folder_path',

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -29,7 +29,7 @@ module VmdbMetric::Purging
     end
 
     def purge_timer(value, interval)
-      MiqQueue.put(
+      MiqQueue.put_simple(
         :class_name  => name,
         :method_name => "purge_#{interval}",
         :args        => [value]


### PR DESCRIPTION
The put_simple is just an alias to put, but it records those use cases
where the work can be done on any worker since the caller dosesn't
restrict it by the zone, role, server_guid or task_id

Being done as part of the rearch project