### PR TITLE
Requests should allow access to users with admin role

### DIFF
--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -63,7 +63,7 @@ module Api
     end
 
     def requests_search_conditions
-      return {} if User.current_user.admin?
+      return {} if User.current_user.admin_user?
       {:requester => User.current_user}
     end
 

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -38,7 +38,7 @@ module Api
     end
 
     def service_requests_search_conditions
-      return {} if User.current_user.admin?
+      return {} if User.current_user.admin_user?
       {:requester => User.current_user}
     end
 

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Requests API" do
     end
 
     it "lists all the service requests if you are admin" do
-      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
       other_user = FactoryGirl.create(:user)
       service_request_1 = FactoryGirl.create(:service_template_provision_request,
                                              :requester   => other_user,

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -234,7 +234,7 @@ describe "Service Requests API" do
     end
 
     it "lists all the service requests if you are admin" do
-      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
       other_user = FactoryGirl.create(:user)
       service_request_1 = FactoryGirl.create(:service_template_provision_request,
                                              :requester   => other_user,


### PR DESCRIPTION
Currently we check to see if the user is the "admin" user - we need to
check to see if the user has administrator priveleges regardless of
who they are.

Incidentally removes a couple of uses of `any_instance_of` :tada:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1421878

Side note: I'm not sure why they other request types do not allow admin access to all requests, it seems that we should fix that as a follow up to this once merged.

@miq-bot add-label api, bug
@miq-bot assign @abellotti 

Thanks @jvlcek for your help debugging this! 
