### PR TITLE
Add put_deprecated to MiqQueue

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -174,6 +174,12 @@ class MiqQueue < ApplicationRecord
     result
   end
 
+  # This are the queue calls related to worker management which
+  # might not be needed once we use kubernetes for worker/pod management
+  def self.put_deprecated(*args)
+    put(*args)
+  end
+
   def unget(options = {})
     update_attributes!(options.merge(:state => STATE_READY, :handler => nil))
     @delivered_on = nil

--- a/app/models/miq_server/worker_management/monitor/stop.rb
+++ b/app/models/miq_server/worker_management/monitor/stop.rb
@@ -11,7 +11,7 @@ module MiqServer::WorkerManagement::Monitor::Stop
   end
 
   def stop_worker_queue(worker, monitor_status = :waiting_for_stop, monitor_reason = nil)
-    MiqQueue.put(
+    MiqQueue.put_deprecated(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'stop_worker',

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -300,7 +300,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def send_message_to_worker_monitor(message, *args)
-    MiqQueue.put(
+    MiqQueue.put_deprecated(
       :class_name  => 'MiqServer',
       :instance_id => miq_server.id,
       :method_name => 'message_for_worker',

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -207,7 +207,7 @@ class Zone < ApplicationRecord
     _log.info("Zone: [#{name}], Queueing ntp_reload for [#{servers.length}] active_miq_servers, ids: #{servers.collect(&:id)}")
 
     servers.each do |s|
-      MiqQueue.put(
+      MiqQueue.put_deprecated(
         :class_name  => "MiqServer",
         :instance_id => s.id,
         :method_name => "ntp_reload",


### PR DESCRIPTION
This allows us to mark the use cases which might get removed
when we use kubernetes to do task/worker management