### PR TITLE
Remove ontap and storage MiqShortcuts

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -164,35 +164,6 @@
   :url: provider_foreman/explorer
   :rbac_feature_name: provider_foreman_explorer
   :startup: true
-- :name: storage_systems
-  :description: Storage / Storage Systems
-  :url: /ontap_storage_system/show_list
-  :rbac_feature_name: ontap_storage_system_show_list
-  :startup: true
-- :name: file_shares
-  :description: Storage / File Shares
-  :url: /ontap_file_share/show_list
-  :rbac_feature_name: ontap_file_share_show_list
-  :startup: true
-- :name: logical_disks
-  :description: Storage / Logical Disks
-  :url: /ontap_logical_disk/show_list
-  :rbac_feature_name: ontap_logical_disk_show_list
-  :startup: true
-- :name: base_extents
-  :description: Storage / Base Extents
-  :url: /cim_base_storage_extent/show_list
-  :rbac_feature_name: cim_storage_extent_show_list
-  :startup: true
-- :name: storage_volumes
-  :description: Storage / Storage Volumes
-  :url: /ontap_storage_volume/show_list
-  :rbac_feature_name: ontap_storage_volume_show_list
-  :startup: true
-- :name: storage_managers
-  :description: Storage / Storage Managers
-  :url: /storage_manager/show_list
-  :rbac_feature_name: storage_manager_show_list
 - :name: ems_containers_overview
   :description: Containers / Overview
   :url: /container_dashboard/show


### PR DESCRIPTION
Storage pages are currently shown as start page options even if the role has no permissions.

![screen shot 2017-05-18 at 4 58 03 pm](https://cloud.githubusercontent.com/assets/39493/26228078/6013fde2-3beb-11e7-88a5-ea19bf4803bc.png)

This removes the seed entries for these shortcuts.

Related to
https://bugzilla.redhat.com/show_bug.cgi?id=1450012
