### PR TITLE
Performance: Use single query to fetch all relevant messages

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -80,12 +80,12 @@ module Metric::CiMixin::Capture
       :state       => ['ready', 'dequeue'],
     }
 
-    messages = MiqQueue.where(queue_item).index_by { |m| [m.method_name, m.args] }
+    messages = MiqQueue.where.not(:method_name => 'perf_capture_realtime').where(queue_item).index_by(&:args)
     items.each do |item_interval, *start_and_end_time|
       # Should both interval name and args (dates) be part of uniqueness query?
       queue_item_options = queue_item.merge(:method_name => "perf_capture_#{item_interval}")
       queue_item_options[:args] = start_and_end_time if start_and_end_time.present?
-      next if messages[queue_item_options.values_at(:method_name, :args)].try(:priority) == priority
+      next if item_interval != 'realtime' && messages[start_and_end_time].try(:priority) == priority
       MiqQueue.put_or_update(queue_item_options) do |msg, qi|
         if msg.nil?
           qi[:priority] = priority

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -85,7 +85,7 @@ module Metric::CiMixin::Capture
       # Should both interval name and args (dates) be part of uniqueness query?
       queue_item_options = queue_item.merge(:method_name => "perf_capture_#{item_interval}")
       queue_item_options[:args] = start_and_end_time if start_and_end_time.present?
-      next if messages[queue_item_options.values_at(:method_name, :args)]
+      next if messages[queue_item_options.values_at(:method_name, :args)].try(:priority) == priority
       MiqQueue.put_or_update(queue_item_options) do |msg, qi|
         if msg.nil?
           qi[:priority] = priority


### PR DESCRIPTION
This has TREMENDOUS 🎉  impact on whole appliance performance in cases, when

 - have perf collection gap and
 - have many resources (think of houndred of containers)

Although, all other C&U will benefit slightly as this code is run every 3 minutes and the cache will be hit even in cases when your collector is not days behind.

Measurements on my set-up
-------------------------
`5.times { Metric::Capture.perf_capture_timer }`

|           ms |        bytes |     objects |queries |  query (ms) |`comments`
|          ---:|          ---:|         ---:|    ---:|         ---:| ---
|  1,719,181.5 | 501,564,257* | 387,983,352 |156,670 | 1,426,929.2 |`before`
|     28,153.9 |  15,745,598* |  48,556,053 |  1,099 |     4,987.0 |`after`
|          99% |          96% |         87% |    99% |         99% |improvement 🌴 



So, what actually happens here?
-------------------------------

The perf_capture_timer is scheduled every 3 minutes and it queues up perf related work. Historical captures are scheduled per day. With a week window of missing C&U (gap) you get 7 queue items per resource. This can grow significantly, if you turn the capture on after it was turned off for a reason.

The problem is that after the C&U is turned on, we kill MiqQueue by put_or_update requests every three minutes. If you ever wondered why postgresql is taking 98% cpu time after you put C&U on, this is the
reason.

As a remedy, we fetch all related MiqQueue items to memory, and we run MiqQueue.put_or_update only when it makes sense.

