### PR TITLE
Request members should allow access to users with admin role

### DIFF
--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -58,7 +58,7 @@ module Api
 
     def find_requests(id)
       klass = collection_class(:requests)
-      return klass.find(id) if User.current_user.admin?
+      return klass.find(id) if User.current_user.admin_user?
       klass.find_by!(:requester => User.current_user, :id => id)
     end
 

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -33,7 +33,7 @@ module Api
 
     def find_service_requests(id)
       klass = collection_class(:service_requests)
-      return klass.find(id) if User.current_user.admin?
+      return klass.find(id) if User.current_user.admin_user?
       klass.find_by!(:requester => User.current_user, :id => id)
     end
 

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Requests API" do
     end
 
     it "an admin can see another user's request" do
-      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
       other_user = FactoryGirl.create(:user)
       service_request = FactoryGirl.create(:service_template_provision_request,
                                            :requester   => other_user,

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -261,7 +261,7 @@ describe "Service Requests API" do
     end
 
     it "an admin can see another user's request" do
-      allow_any_instance_of(User).to receive(:admin?).and_return(true)
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
       other_user = FactoryGirl.create(:user)
       service_request = FactoryGirl.create(:service_template_provision_request,
                                            :requester   => other_user,


### PR DESCRIPTION
This should have been done as part of
https://github.com/ManageIQ/manageiq/pull/15151, which fixed the
collection routes. This completes that work by fixing the member
routes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1421878

Oops! Don't know how I missed this

@miq-bot add-label api, bug
@miq-bot assign @abellotti 