### PR TITLE
High Voltage is only used by ui-classic and already depends on it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false
 gem "hamlit",                         "~>2.7.0"
 gem "hashie",                         "~>3.4.6",       :require => false
-gem "high_voltage",                   "~>3.0.0"
 gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,8 +1,0 @@
-HighVoltage.configure do |config|
-  config.layout = false
-
-  config.routes = false
-
-  # app/views/static
-  config.content_path = 'static/'
-end


### PR DESCRIPTION
DEPENDS ON: https://github.com/ManageIQ/manageiq-ui-classic/pull/1396

:fire: :scissors:

`/Users/joerafaniello/.gem/ruby/2.4.1/bundler/gems/manageiq-ui-classic-9f64aa7630d8/app/controllers/static_controller.rb:  include HighVoltage::StaticPage`

See: https://github.com/ManageIQ/manageiq-ui-classic/blob/e810f4592f543070aad2f7befa09bca1a8bebf94/manageiq-ui-classic.gemspec#L29
