### PR TITLE
Collect limit items for container definitions

### DIFF
--- a/db/migrate/20170528102055_add_limits_resources_to_container_definitions.rb
+++ b/db/migrate/20170528102055_add_limits_resources_to_container_definitions.rb
@@ -1,0 +1,8 @@
+class AddLimitsResourcesToContainerDefinitions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_definitions, :request_cpu,    :float  # cores
+    add_column :container_definitions, :request_memory, :bigint # bytes
+    add_column :container_definitions, :limit_cpu,      :float  # cores
+    add_column :container_definitions, :limit_memory,   :bigint # bytes
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -661,6 +661,10 @@ container_definitions:
 - deleted_on
 - ems_id
 - old_ems_id
+- request_cpu
+- request_memory
+- limit_cpu
+- limit_memory
 container_deployment_nodes:
 - id
 - address


### PR DESCRIPTION
pods may define limits for resources 'anonymously' on their container definitions without a limit range entity.

Please review @cben @moolitayer @dkorn 
cc @simon3z 


@miq-bot add_label providers/containers 

UI: https://github.com/ManageIQ/manageiq-ui-classic/pull/1401