### PR TITLE
Do not queue miq_callback unless MiqTask exists

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -177,16 +177,18 @@ module EmsRefresh
                   task.id
                 end
 
-      item.merge(
-        :args         => [targets],
-        :task_id      => task_id,
-        :msg_timeout  => queue_timeout,
-        :miq_callback => {
+      unless task_id.nil?
+        item[:miq_callback] = {
           :class_name  => 'MiqTask',
           :method_name => :queue_callback,
           :instance_id => task_id,
           :args        => ['Finished']
         }
+      end
+      item.merge(
+        :args        => [targets],
+        :task_id     => task_id,
+        :msg_timeout => queue_timeout
       )
     end
 


### PR DESCRIPTION
Otherwise we re-occuring error messages like:

```
WARN -- : MIQ(MiqQueue#m_callback) Message id: [10000085451372], Instance: [MiqTask], does not respond to Method: [queue_callback], skipping
```

