### PR TITLE
Add missing word in a string for Cloud Subnet

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -57,7 +57,7 @@ class CloudSubnet < ApplicationRecord
   end
 
   def raw_delete_cloud_subnet
-    raise NotImplementedError, _("raw_delete_subnet must be implemented in a subclass")
+    raise NotImplementedError, _("raw_delete_cloud_subnet must be implemented in a subclass")
   end
 
   private


### PR DESCRIPTION
Fixed a string with adding `cloud` to `raw_delete_cloud_subnet`