### PR TITLE
Make request APIs consistent by restricting access to automation/provision requests to admin/requester

### DIFF
--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -41,5 +41,16 @@ module Api
     rescue => err
       action_result(false, err.to_s)
     end
+
+    def find_automation_requests(id)
+      klass = collection_class(:requests)
+      return klass.find(id) if User.current_user.admin_user?
+      klass.find_by!(:requester => User.current_user, :id => id)
+    end
+
+    def automation_requests_search_conditions
+      return {} if User.current_user.admin_user?
+      {:requester => User.current_user}
+    end
   end
 end

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -44,5 +44,16 @@ module Api
     rescue => err
       action_result(false, err.to_s)
     end
+
+    def find_provision_requests(id)
+      klass = collection_class(:requests)
+      return klass.find(id) if User.current_user.admin_user?
+      klass.find_by!(:requester => User.current_user, :id => id)
+    end
+
+    def provision_requests_search_conditions
+      return {} if User.current_user.admin_user?
+      {:requester => User.current_user}
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -262,6 +262,9 @@
     - :request_tasks
     - :tasks
     :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show_list
       :post:
       - :name: create
       - :name: approve
@@ -271,6 +274,9 @@
       - :name: edit
         :identifier: miq_request_edit
     :resource_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show
       :post:
       - :name: approve
         :identifier: miq_request_approval

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -50,7 +50,7 @@ describe "Rest API Collections" do
     end
 
     it "query Automation Requests" do
-      FactoryGirl.create(:automation_request)
+      FactoryGirl.create(:automation_request, :requester => @user)
       test_collection_query(:automation_requests, automation_requests_url, AutomationRequest)
     end
 

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -42,6 +42,72 @@ describe "Provision Requests API" do
       }
     end
 
+    it "filters the list of provision requests by requester" do
+      other_user = FactoryGirl.create(:user)
+      _provision_request1 = FactoryGirl.create(:miq_provision_request, :requester => other_user)
+      provision_request2 = FactoryGirl.create(:miq_provision_request, :requester => @user)
+      api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
+
+      run_get provision_requests_url
+
+      expected = {
+        "count"     => 2,
+        "subcount"  => 1,
+        "resources" => a_collection_containing_exactly(
+          "href" => a_string_matching(provision_requests_url(provision_request2.id)),
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "lists all the provision requests if you are admin" do
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
+      other_user = FactoryGirl.create(:user)
+      provision_request1 = FactoryGirl.create(:miq_provision_request, :requester => other_user)
+      provision_request2 = FactoryGirl.create(:miq_provision_request, :requester => @user)
+      api_basic_authorize collection_action_identifier(:provision_requests, :read, :get)
+
+      run_get provision_requests_url
+
+      expected = {
+        "count"     => 2,
+        "subcount"  => 2,
+        "resources" => a_collection_containing_exactly(
+          {"href" => a_string_matching(provision_requests_url(provision_request1.id))},
+          {"href" => a_string_matching(provision_requests_url(provision_request2.id))},
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it "restricts access to provision requests to requester" do
+      other_user = FactoryGirl.create(:user)
+      provision_request = FactoryGirl.create(:miq_provision_request, :requester => other_user)
+      api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
+
+      run_get provision_requests_url(provision_request.id)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "an admin can see another user's request" do
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
+      other_user = FactoryGirl.create(:user)
+      provision_request = FactoryGirl.create(:miq_provision_request, :requester => other_user)
+      api_basic_authorize action_identifier(:provision_requests, :read, :resource_actions, :get)
+
+      run_get provision_requests_url(provision_request.id)
+
+      expected = {
+        "id"   => provision_request.id,
+        "href" => a_string_matching(provision_requests_url(provision_request.id))
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "rejects requests without appropriate role" do
       api_basic_authorize
 
@@ -154,6 +220,10 @@ describe "Provision Requests API" do
     let(:provreq1_url)  { provision_requests_url(provreq1.id) }
     let(:provreq2_url)  { provision_requests_url(provreq2.id) }
     let(:provreqs_list) { [provreq1_url, provreq2_url] }
+
+    before do
+      @group.miq_user_role = @role = FactoryGirl.create(:miq_user_role, :role => "administrator")
+    end
 
     it "supports approving a request" do
       api_basic_authorize collection_action_identifier(:provision_requests, :approve)


### PR DESCRIPTION
Brings consistency to the automation/provision requests API so that it filters/restricts access to requests in the same way as the generic requests API

@miq-bot add-label bug, api
@miq-bot assign @abellotti 
