### PR TITLE
Save resource group information

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -38,6 +38,7 @@ module EmsRefresh::SaveInventory
     child_keys = [:operating_system, :hardware, :custom_attributes, :snapshots, :advanced_settings, :labels, :tags]
     extra_infra_keys = [:host, :ems_cluster, :storage, :storages, :storage_profile, :raw_power_state, :parent_vm]
     extra_cloud_keys = [
+      :resource_group,
       :flavor,
       :availability_zone,
       :cloud_tenant,
@@ -79,6 +80,8 @@ module EmsRefresh::SaveInventory
         h[:cloud_tenant_id]        = key_backup.fetch_path(:cloud_tenant, :id)
         h[:cloud_tenant_ids]       = key_backup.fetch_path(:cloud_tenants).compact.map { |x| x[:id] } if key_backup.fetch_path(:cloud_tenants, 0, :id)
         h[:orchestration_stack_id] = key_backup.fetch_path(:orchestration_stack, :id)
+        h[:resource_group_id]      = key_backup.fetch_path(:resource_group, :id)
+
         begin
           raise MiqException::MiqIncompleteData if h[:invalid]
 

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -46,6 +46,7 @@ module EmsRefresh::SaveInventoryCloud
     end
 
     child_keys = [
+      :resource_groups,
       :cloud_tenants,
       :flavors,
       :availability_zones,
@@ -61,7 +62,6 @@ module EmsRefresh::SaveInventoryCloud
       :cloud_resource_quotas,
       :cloud_object_store_containers,
       :cloud_object_store_objects,
-      :resource_groups,
       :cloud_services,
     ]
 


### PR DESCRIPTION
We have a resource_group table within our schema, but it seems that resource group information cannot be saved by the providers yet. The first issue is that resource groups are being saved too late. The second issue is that they need to be explicitly added to the save_inventory call.

Depends on https://github.com/ManageIQ/manageiq/pull/14948 to work properly for images.