### PR TITLE
[EUWE] kubernetes_connect, openshift_connect: add timeout settings

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -21,7 +21,11 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
         kubernetes_version,
         :ssl_options    => { :verify_ssl => verify_ssl_mode },
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
 

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -41,7 +41,11 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
         api_version,
         :ssl_options    => { :verify_ssl => verify_ssl_mode },
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,6 +104,8 @@
       :read_timeout: 1.hour
   :ems_kubernetes:
     :miq_namespace: management-infra
+    :open_timeout: 60.seconds
+    :read_timeout: 60.seconds
   :ems_amazon:
     :disabled_regions: []
   :ems_azure:

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -22,7 +22,7 @@ gem "hawkular-client",         "=2.7.0",            :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.3",           :require => false
 gem "iniparse",                                     :require => false
-gem "kubeclient",              "=2.3.0",            :require => false
+gem "kubeclient",              "~>2.4.0",           :require => false
 gem "linux_admin",             "~>0.19.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -69,7 +69,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
       require 'kubeclient'
       expect(Kubeclient::Client).to receive(:new).with(
         instance_of(URI::HTTPS), 'v1',
-        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri)
+        hash_including(:http_proxy_uri => VMDB::Util.http_proxy_uri,
+                       :timeouts       => match(:open => be > 0, :read => be > 0))
       )
       described_class.raw_connect(hostname, port, options)
     end


### PR DESCRIPTION
euwe backport of: https://github.com/ManageIQ/manageiq-gems-pending/pull/156, https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/10, https://github.com/ManageIQ/manageiq-providers-openshift/pull/8 (last one unnecessary on master but required in backports)

https://bugzilla.redhat.com/show_bug.cgi?id=1440950 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1454383 (euwe)

cc @simaishi @simon3z 

(cf. fine backport: #15090)