### PR TITLE
Fix whitespace in api.yml

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1122,7 +1122,7 @@
       - :name: turn_on_loc_led
         :identifier: physical_server_turn_on_loc_led
       - :name: turn_off_loc_led
-        :identifier: physical_server_turn_off_loc_led        
+        :identifier: physical_server_turn_off_loc_led
   :pictures:
     :description: Pictures
     :options:


### PR DESCRIPTION
As always, not because I'm being picky, but because I *will* accidentally commit this in the wrong thing, leading to much :thinking: 

@miq-bot add-label api
@miq-bot assign @abellotti 
