### PR TITLE
Memoize root tenant

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -217,7 +217,7 @@ class Tenant < ApplicationRecord
   #
   # @return [Tenant] the root tenant
   def self.root_tenant
-    in_my_region.roots.first
+    @root_tenant ||= in_my_region.roots.first
   end
 
   # NOTE: returns the root tenant

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -217,7 +217,11 @@ class Tenant < ApplicationRecord
   #
   # @return [Tenant] the root tenant
   def self.root_tenant
-    @root_tenant ||= in_my_region.roots.first
+    @root_tenant ||= root_tenant_without_cache
+  end
+
+  def self.root_tenant_without_cache
+    in_my_region.roots.first
   end
 
   # NOTE: returns the root tenant
@@ -303,7 +307,7 @@ class Tenant < ApplicationRecord
   # validates that there is only one tree
   def validate_only_one_root
     unless parent_id || parent
-      root = self.class.root_tenant
+      root = self.class.root_tenant_without_cache
       errors.add(:parent, "required") if root && root != self
     end
   end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -40,6 +40,7 @@ module EvmSpecHelper
     clear_instance_variable(MiqProductFeature, :@feature_cache) if defined?(MiqProductFeature)
     clear_instance_variable(MiqProductFeature, :@obj_cache) if defined?(MiqProductFeature)
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
+    clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
     # Clear the thread local variable to prevent test contamination
     User.current_user = nil if defined?(User) && User.respond_to?(:current_user=)


### PR DESCRIPTION
First part for the BZ. (in other I will eliminate useless calls to `reporting_available_fields`)
From the BZ:

> _it takes 10-20 sec to add column to new report when report is based on big fields set like Virtual Machines_

it is (also) because there is method `reporting_available_fields` called and there is thru other methods(`MiqExpression.value2human`) called `Tenant.root_tenant` which is producing 1 query for each call and for getting the just name of root tenant and name is unchangeable.

**Numbers for `MiqExpression.reporting_available_fields('Vm', nil)`:**

before:
`:total_queries: 249 (:rows_by_class Tenant:242  )`

after:
`:total_queries: 8 (:rows_by_class Tenant:1 )` 

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1446542


@miq-bot assign @gtanzillo
@miq-bot add_label core, perfomance

