### PR TITLE
Add update method for Cloud Subnet

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -52,6 +52,14 @@ class CloudSubnet < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudSubnet
   end
 
+  def update_cloud_subnet(options = {})
+    raw_update_cloud_subnet
+  end
+
+  def raw_update_cloud_subnet(_options = {})
+    raise NotImplementedError, _("raw_update_cloud_subnet must be implemented in a subclass")
+  end
+
   def delete_cloud_subnet
     raw_delete_cloud_subnet
   end


### PR DESCRIPTION
Add `update` and `raw_update` methods for Cloud Subnet model in order to expose update operation in Automate engine