### PR TITLE
Introduce: supports :capture

### DIFF
--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -1,5 +1,6 @@
 class ContainerService < ApplicationRecord
   include CustomAttributeMixin
+  include SupportsFeatureMixin
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :selector, :protocol, :port, :container_port, :portal_ip, :session_affinity
 

--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -19,6 +19,12 @@ module Metric::CiMixin
     Metric::LongTermAverages::AVG_METHODS_WITHOUT_OVERHEAD.each do |vcol|
       virtual_column vcol, :type => :float, :uses => :vim_performance_operating_ranges
     end
+
+    supports :capture do
+      unless self.class.parent::MetricsCapture.instance_methods.include?(:perf_collect_metrics)
+        unsupported_reason_add(:metrics, _('This provider does not support metrics collection'))
+      end
+    end
   end
 
   def has_perf_data?

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -16,6 +16,7 @@ class MiqEnterprise < ApplicationRecord
 
   acts_as_miq_taggable
 
+  include SupportsFeatureMixin
   include AggregationMixin
 
   include MiqPolicyMixin

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -26,6 +26,7 @@ class MiqRegion < ApplicationRecord
   include ConfigurationManagementMixin
 
   include MiqPolicyMixin
+  include SupportsFeatureMixin
   include Metric::CiMixin
 
   alias_method :all_storages,           :storages

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -89,6 +89,7 @@ module SupportsFeatureMixin
     :launch_cockpit             => 'Launch Cockpit UI',
     :live_migrate               => 'Live Migration',
     :migrate                    => 'Migration',
+    :capture                    => 'Capture of Capacity & Utilization Metrics',
     :provisioning               => 'Provisioning',
     :publish                    => 'Publishing',
     :quick_stats                => 'Quick Stats',

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -35,11 +35,11 @@ class Storage < ApplicationRecord
 
   include SerializedEmsRefObjMixin
   include FilterableMixin
+  include SupportsFeatureMixin
   include Metric::CiMixin
   include StorageMixin
   include AsyncDeleteMixin
   include AvailabilityMixin
-  include SupportsFeatureMixin
   include TenantIdentityMixin
 
   virtual_column :v_used_space,                   :type => :integer

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -28,6 +28,7 @@ class Zone < ApplicationRecord
 
   include AuthenticationMixin
 
+  include SupportsFeatureMixin
   include Metric::CiMixin
   include AggregationMixin
   include ConfigurationManagementMixin


### PR DESCRIPTION
### What
Not all providers support metrics :capture. 📊 

Currently we cannot tell, so we put perf_capture* into MiqQueue for whatever user has tagged. Putting everything on queue is unfortunate. It kills performance.

Note: This fixes first part of #15193.

### Why?
Currently we fail horribly when you tag your scvmm/hyper for C&U capture.

### Wait, why did the C&U fail for SCVMM?

It fails at https://github.com/ManageIQ/manageiq/blob/568ff204872e369305c47795a47199f4d9842886/app/models/metric/ci_mixin/capture.rb#L3 as self.class.parent::MetricsCapture resolves to Microsoft::Infra::MetricsCapture that does not have any methods for scvmm/hyperv (it's just the base Base::MetricCapture).
