### PR TITLE
Add important asserts to the default save inventory

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -45,6 +45,18 @@ module ManagerRefresh::SaveCollection
         end
         true
       end
+
+      def assert_referential_integrity(hash, inventory_object)
+        inventory_object.inventory_collection.fixed_foreign_keys.each do |x|
+          if hash[x.to_s].blank?
+            _log.info("Ignoring #{inventory_object} because of missing foreign key #{x} for "\
+                      "#{inventory_object.inventory_collection.parent.class.name}:"\
+                      "#{inventory_object.inventory_collection.parent.id}")
+            return false
+          end
+        end
+        true
+      end
     end
   end
 end

--- a/app/models/manager_refresh/save_collection/saver/default.rb
+++ b/app/models/manager_refresh/save_collection/saver/default.rb
@@ -80,6 +80,8 @@ module ManagerRefresh::SaveCollection
       end
 
       def create_record!(inventory_collection, hash, inventory_object)
+        return unless assert_referential_integrity(hash, inventory_object)
+
         record = inventory_collection.model_class.create!(hash.except(:id))
 
         inventory_object.id = record.id


### PR DESCRIPTION
Add important asserts to the default save inventory. First we just extract the distinct assert to a base class. Then we are adding an assert for a referential_integrity.