### PR TITLE
Fix the hosts key in method which save physical server

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -46,7 +46,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    child_keys = [:computer_system, :asset_details, :host]
+    child_keys = [:computer_system, :asset_details, :hosts]
     save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end


### PR DESCRIPTION
Fix the hosts key in the Physical server's save inventory method. 

Changing the key from `host` to `hosts`. This change fix a method name error in the refresh process in ManageIQ core. 