### PR TITLE
Let's not keep this dead code around

### DIFF
--- a/spec/requests/api/alerts_spec.rb
+++ b/spec/requests/api/alerts_spec.rb
@@ -1,6 +1,4 @@
 describe "Alerts API" do
-  let(:alert_definition) { FactoryGirl.create(:miq_alert, :severity => "info") }
-
   it "forbids access to alerts list without an appropriate role" do
     api_basic_authorize
     run_get(alerts_url)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -4,7 +4,6 @@
 describe "Rest API Collections" do
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
-  let(:ems) { FactoryGirl.create(:ext_management_system) }
   let(:template) do
     FactoryGirl.create(:miq_template, :name => "template 1", :vendor => "vmware", :location => "template1.vmtx")
   end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -153,7 +153,6 @@ describe "Provision Requests API" do
     let(:provreq2)      { FactoryGirl.create(:miq_provision_request, provreqbody) }
     let(:provreq1_url)  { provision_requests_url(provreq1.id) }
     let(:provreq2_url)  { provision_requests_url(provreq2.id) }
-    let(:provreqs_list) { [provreq1_url, provreq2_url] }
 
     it "supports approving a request" do
       api_basic_authorize collection_action_identifier(:provision_requests, :approve)

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -4,10 +4,6 @@
 # - Refresh dialog fields       /api/service_dialogs/:id "refresh_dialog_fields"
 #
 describe "Service Dialogs API" do
-  let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
-  let(:host)       { FactoryGirl.create(:host) }
-
   let(:dialog1)    { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
   let(:dialog2)    { FactoryGirl.create(:dialog, :label => "ServiceDialog2") }
 

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -95,7 +95,6 @@ describe "Service Requests API" do
     end
     let(:svcreq1_url)  { service_requests_url(svcreq1.id) }
     let(:svcreq2_url)  { service_requests_url(svcreq2.id) }
-    let(:svcreqs_list) { [svcreq1_url, svcreq2_url] }
 
     it "supports approving a request" do
       api_basic_authorize collection_action_identifier(:service_requests, :approve)

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -2,10 +2,6 @@
 # REST API Request Tests - /api/tags
 #
 describe "Tags API" do
-  let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
-  let(:ems)          { FactoryGirl.create(:ems_vmware, :zone => zone) }
-  let(:host)         { FactoryGirl.create(:host) }
-
   let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
   let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
   let(:invalid_tag_url) { tags_url(999_999) }


### PR DESCRIPTION
I noticed that some `let`s were going unused, so I did some static analysis to find more of them. This is what I found.

@miq-bot add-label api, test, technical debt
@miq-bot assign @abellotti 

:fire: :scissors: :toilet: 
