### PR TITLE
Set maintenance column for SCVMM hosts.

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -21,7 +21,7 @@ $vms = Get-SCVirtualMachine -VMMServer localhost -All |
 
 $hosts = Get-SCVMHost -VMMServer localhost |
   Select -Property CommunicationStateString,CoresPerCPU,DiskVolumes,DVDDriveList,
-    HyperVStateString,ID,LogicalProcessorCount,Name,OperatingSystem,PhysicalCPUCount,
+    HyperVStateString,ID,LogicalProcessorCount,Name,OperatingSystem,OverallState,PhysicalCPUCount,
     ProcessorFamily,ProcessorManufacturer,ProcessorModel,ProcessorSpeed,TotalMemory,
     @{name='HyperVVersionString';expression={$_.HyperVVersion -As [string]}},
     @{name='OperatingSystemVersionString';expression={$_.OperatingSystemVersion -As [string]}},

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -136,6 +136,7 @@ module ManageIQ::Providers::Microsoft
         :vmm_version      => host['HyperVVersionString'],
         :vmm_product      => host_platform,
         :power_state      => lookup_power_state(host['HyperVStateString']),
+        :maintenance      => lookup_overall_state(host['OverallState']),
         :connection_state => lookup_connected_state(host['CommunicationStateString']),
         :operating_system => process_os(host),
         :hardware         => process_host_hardware(host),
@@ -571,6 +572,10 @@ module ManageIQ::Providers::Microsoft
       else
         adapter['IPAddresses'].split.first # Avoid IPv6 text if present
       end
+    end
+
+    def lookup_overall_state(overall_state)
+      overall_state.to_s.downcase != 'ok'
     end
 
     def lookup_power_state(power_state_input)


### PR DESCRIPTION
This PR sets the `maintenance` column for SCVMM hosts. It's set to `true` for any value other than `OK`. This addresses an issue for SCVMM provisioning.

The relevant BZ is: https://bugzilla.redhat.com/show_bug.cgi?id=1454880

The logic is handled here:

https://github.com/ManageIQ/manageiq-content/pull/84