### PR TITLE
Move VixDiskLib under VMwareWebService

### DIFF
--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -164,7 +164,7 @@ module MiqServer::ServerSmartProxy
     begin
       # This is only available on Linux
       if Sys::Platform::IMPL == :linux
-        require 'VixDiskLib/VixDiskLib'
+        require 'VMwareWebService/VixDiskLib/VixDiskLib'
         caps[:vixDisk] = true
       end
     rescue Exception => err


### PR DESCRIPTION
Needed after https://github.com/ManageIQ/manageiq-gems-pending/pull/176 moves `VixDiskLib` from `gems/pending` to `VMwareWebService`