### PR TITLE
Localize SmartState requires to load only when actually needed.

### DIFF
--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -3,8 +3,6 @@
 # but wrongly doesn't require it itself.
 require 'xml/xml_utils'
 
-require 'blackbox/VmBlackBox'
-require 'metadata/MIQExtract/MIQExtract'
 require 'scanning_operations_mixin'
 
 module ScanningMixin
@@ -231,10 +229,12 @@ module ScanningMixin
     )
 
     begin
+      require 'metadata/MIQExtract/MIQExtract'
       _log.debug "instantiating MIQExtract"
       extractor = MIQExtract.new(miqVm, ost)
       _log.debug "instantiated MIQExtract"
 
+      require 'blackbox/VmBlackBox'
       _log.debug "instantiating BlackBox"
       bb = Manageiq::BlackBox.new(guid, ost) # TODO: target must have GUID
       _log.debug "instantiated BlackBox"
@@ -325,6 +325,7 @@ module ScanningMixin
         :dataDir            => data_dir,
         :forceFleeceDefault => false
       )
+      require 'blackbox/VmBlackBox'
       bb = Manageiq::BlackBox.new(guid, ost)
 
       update_job_message(ost, "Synchronization in progress")


### PR DESCRIPTION
Need to reduce unneeded loading of things.  VmOrTemplate loads ScanningMixin, so we are paying SmartState loading cost just to find a VM in SQL.