### PR TITLE
[EUWE] Fix for 'Add Tag Information for Catalog Items'

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -76,7 +76,9 @@
               = h(@sb[entry_points_op[1]])
         .form-group
           .col-md-9
-            = render textual_group_render_options(:smart_management)
+            = render :partial => "shared/summary/textual_tags",
+              :locals => {:title => ("Smart Management"),
+                          :items => textual_group_smart_management}
       %hr
       %h3
         = _('Custom Image')


### PR DESCRIPTION
It's a fix for error 
```
Error caught: [ActionView::Template::Error] undefined method `textual_group_render_options'
```
after backported https://github.com/ManageIQ/manageiq-ui-classic/pull/1357 to the euwe

https://bugzilla.redhat.com/show_bug.cgi?id=1454442

