### PR TITLE
bin/update - remove bower install if found

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -29,4 +29,5 @@ Dir.chdir ManageIQ::Environment::APP_ROOT do
   # Make sure bower is done before compiling assets
   ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
   ManageIQ::Environment.clear_logs_and_temp
+  ManageIQ::Environment.clear_obsolete
 end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -93,6 +93,14 @@ module ManageIQ
       run_rake_task("log:clear tmp:clear")
     end
 
+    def self.clear_obsolete
+      return unless Dir.exist? APP_ROOT.join('vendor', 'assets', 'bower_components')
+      puts "\n== Removing obsolete bower install =="
+      Dir.chdir APP_ROOT do
+        system("rm -rf vendor/assets/bower_components/")
+      end
+    end
+
     def self.write_region_file(region_number = 1)
       File.write(APP_ROOT.join("REGION"), region_number.to_s)
     end


### PR DESCRIPTION
We moved bower assets to ui-classic (https://github.com/ManageIQ/manageiq-ui-classic/pull/823), but if those assets exists in both repos, sometimes the old ones in `manageiq/` win, causing confusion and mayhem :).

Since people still encounter issues when switching back and forth, it makes sense for `bin/update` to clean those obsolete files.

@bdunne WDYT?

Cc @jzigmund, @vecerek - this should help :)