### PR TITLE
Remove some more unused lets

### DIFF
--- a/spec/lib/acts_as_ar_model_spec.rb
+++ b/spec/lib/acts_as_ar_model_spec.rb
@@ -1,6 +1,5 @@
 describe ActsAsArModel do
   # id is a default column included regardless if it's in the set_columns_hash
-  let(:col_names_syms) { [:str, :id, :int, :flt, :dt] }
   let(:col_names_strs) { %w(str id int flt dt) }
 
   let(:base_class) do

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1350,15 +1350,9 @@ describe Rbac::Filterer do
   end
 
   describe ".filtered" do
-    let(:vm_location_filter) do
-      MiqExpression.new("=" => {"field" => "Vm-location", "value" => "good"})
-    end
-
     let(:matched_vms) { FactoryGirl.create_list(:vm_vmware, 2, :location => "good") }
     let(:other_vms)   { FactoryGirl.create_list(:vm_vmware, 1, :location => "other") }
     let(:all_vms)     { matched_vms + other_vms }
-    let(:partial_matched_vms) { [matched_vms.first] }
-    let(:partial_vms) { partial_matched_vms + other_vms }
 
     it "skips rbac on empty empty arrays" do
       all_vms

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -22,7 +22,6 @@ describe Authentication do
 
   context "with an authentication" do
     let(:pwd_plain) { "smartvm" }
-    let(:pwd_encrypt) { MiqPassword.encrypt(pwd_plain) }
     let(:auth) { FactoryGirl.create(:authentication, :password => pwd_plain) }
 
     it "should return decrypted password" do

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -192,7 +192,6 @@ describe AutomationRequest do
   end
 
   describe "#make_request" do
-    let(:alt_user) { FactoryGirl.create(:user_with_group) }
     it "creates and update a request" do
       expect(AuditEvent).not_to receive(:success)
       values = {}

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -3,7 +3,6 @@ describe ChargebackVm do
   let(:start_of_all_intervals) { Time.parse('2007-01-01 00:00:00Z').utc } # 0hours, Monday, 1st of month
   let(:consumed_hours) { 17 }
   let(:midle_of_the_first_day) { start_of_all_intervals + consumed_hours.hours } # it is a Monday
-  let(:ts) { midle_of_the_first_day.in_time_zone(Metric::Helper.get_time_zone(opt[:ext_options])) }
   let(:report_run_time) { midle_of_the_first_day }
 
   let(:opt) do

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -102,9 +102,6 @@ describe Compliance do
           )
         end
         let(:event_definition) { MiqEventDefinition.find_by(:name => "vm_compliance_check") }
-        let(:container_policy) do
-          FactoryGirl.create(:miq_policy, :mode => 'compliance', :towhat => 'Container Image', :active => true)
-        end
 
         before do
           policy.sync_events([FactoryGirl.create(:miq_event_definition, :name => "vm_compliance_check")])

--- a/spec/models/entitlement_spec.rb
+++ b/spec/models/entitlement_spec.rb
@@ -2,9 +2,6 @@ describe Entitlement do
   describe "::remove_tag_from_all_managed_filters" do
     let!(:entitlement1) { FactoryGirl.create(:entitlement) }
     let!(:entitlement2) { FactoryGirl.create(:entitlement) }
-    let(:filters) do
-      [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"], ["/managed/my_name/test"]]
-    end
 
     before do
       entitlement1.set_managed_filters([["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"],

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -23,7 +23,6 @@ describe Metric::Purging do
     context "with data" do
       let(:vm1) { FactoryGirl.create(:vm_vmware) }
       let(:vm2) { FactoryGirl.create(:vm_vmware) }
-      let(:host) { FactoryGirl.create(:host) }
       let(:settings) do
         {
           :performance => {

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -1,6 +1,5 @@
 describe MiqAlertStatus do
   let(:ems)                    { FactoryGirl.create(:ems_vmware, :name => 'ems') }
-  let(:alert_definition)       { FactoryGirl.create(:miq_alert) }
   let(:alert)                  { FactoryGirl.create(:miq_alert_status) }
   let(:user1)                  { FactoryGirl.create(:user, :name => 'user1') }
   let(:user2)                  { FactoryGirl.create(:user, :name => 'user2') }

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -167,7 +167,6 @@ describe InterRegionApiMethodRelay do
       let!(:server)           { EvmSpecHelper.local_miq_server(:has_active_webservices => true) }
       let!(:region)           { FactoryGirl.create(:miq_region, :region => region_number) }
       let(:region_number)     { ApplicationRecord.my_region_number }
-      let(:region_seq_start)  { ApplicationRecord.rails_sequence_start }
       let(:request_user)      { "test_user" }
       let(:api_connection)    { double("ManageIQ::API::Client connection") }
       let(:region_auth_token) { double("MiqRegion API auth token") }

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -1,6 +1,5 @@
 describe PurgingMixin do
   let(:example_class) { PolicyEvent }
-  let(:example_associated_class) { PolicyEventContent }
   let(:purge_date) { 2.weeks.ago }
 
   describe ".purge_date" do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -519,7 +519,6 @@ describe ServiceTemplate do
   let(:user) { FactoryGirl.create(:user_with_group) }
   let(:ra1) { FactoryGirl.create(:resource_action, :action => 'Provision') }
   let(:ra2) { FactoryGirl.create(:resource_action, :action => 'Retirement') }
-  let(:ra3) { FactoryGirl.create(:resource_action, :action => 'Reconfigure') }
   let(:ems) { FactoryGirl.create(:ems_amazon) }
   let(:vm) { FactoryGirl.create(:vm_amazon, :ext_management_system => ems) }
   let(:flavor) { FactoryGirl.create(:flavor_amazon) }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -261,8 +261,6 @@ describe Tenant do
 
   context "#admins" do
     let(:self_service_role) { FactoryGirl.create(:miq_user_role, :settings => {:restrictions => {:vms => :user}}) }
-
-    let(:brand_feature) { FactoryGirl.create(:miq_product_feature, :identifier => "edit-brand") }
     let(:admin_with_brand) { FactoryGirl.create(:miq_user_role, :name => "tenant_admin-brand-master") }
 
     let(:tenant1) { FactoryGirl.create(:tenant) }

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -3,9 +3,6 @@ RSpec.describe VimPerformanceAnalysis do
   let(:tag_good) { FactoryGirl.create(:tag, :name => "/managed/#{tag_text}") }
   let(:tag_bad)  { FactoryGirl.create(:tag, :name => "/managed/operations/bad") }
   let(:time_profile) { FactoryGirl.create(:time_profile_with_rollup, :profile => {:tz => "UTC"}) }
-
-  let(:user) { FactoryGirl.create(:user_admin) }
-
   let(:ems) { FactoryGirl.create(:ems_vmware) }
 
   let(:good_day) { DateTime.current - 2.day }

--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -10,7 +10,6 @@ shared_examples_for "ansible configuration_script_source" do
   context "create through API" do
     let(:projects) { double("AnsibleTowerClient::Collection", :create! => project) }
     let(:project)  { AnsibleTowerClient::Project.new(nil, project_json) }
-    let(:css)      { store_new_project(project, manager) }
 
     let(:project_json) do
       params.merge(

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -30,15 +30,6 @@ shared_examples_for "ansible credential" do
         :kind        => described_class::TOWER_KIND
       }
     end
-    let(:expected_notify_params) do
-      {
-        :description => "Description",
-        :name        => "My Credential",
-        :related     => {},
-        :username    => "john",
-        :kind        => described_class::TOWER_KIND
-      }
-    end
     let(:expected_notify) do
       {
         :type    => :tower_op_success,

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -8,7 +8,6 @@ describe FixAuth::AuthConfigModel do
   let(:v1_key)  { MiqPassword.generate_symmetric }
   let(:pass)    { "password" }
   let(:enc_v1)  { MiqPassword.new.encrypt(pass, "v1", v1_key) }
-  let(:bad_v2)  { "v2:{5555555555555555555555==}" }
 
   before do
     MiqPassword.add_legacy_key(v1_key, :v1)


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/15201, where I looked at the API specs. Here I cast the net to include the rest of the vmdb test suite.

@miq-bot add-label test, technical debt
@miq-bot assign @bdunne 