### PR TITLE
[EUWE] Fix IE11 VMRC connectivity

### DIFF
--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -1,16 +1,10 @@
 = render :partial => 'layouts/doctype'
 %html{:lang => I18n.locale.to_s.sub('-', '_')}
   %head
-    - if %w(5.1 5.5 6.0).include?(api_version) && is_browser_ie?
-      - if browser_info(:version).to_i > 10
-        %meta{:content => "IE=EmulateIE8", "http-equiv" => "X-UA-Compatible"}
-      - elsif browser_info(:version).to_i > 9
-        %meta{:content => "IE=8", "http-equiv" => "X-UA-Compatible"}
     %meta{:content => "text/html; charset=ISO-8859-1", "http-equiv" => "Content-Type"}
     = favicon_link_tag
     = stylesheet_link_tag "vmrc"
-    -# need jQuery that works in IE8 mode and has $.browser, the plugin is broken in IE9 mode
-    = javascript_include_tag 'jquery-1.8/jquery'
+    = javascript_include_tag 'jquery'
     = javascript_include_tag 'jquery_overrides'
 
     :javascript
@@ -328,13 +322,14 @@
         }
         console.debug("VMRC: is ready to start.");
 
-        if ($.browser.msie) {
+        isIE = #{is_browser_ie?};
+        if (isIE) {
           vmrc.attachEvent("onScreenSizeChange", onSizeChanged);
           vmrc.attachEvent("onConnectionStateChange", onConnectionStateChanged);
           vmrc.attachEvent("onGrabStateChange", onGrabStateChanged);
           vmrc.attachEvent("onMessage", onMessage);
           vmrc.attachEvent("onWindowStateChange", onWindowStateChanged);
-        } else if ($.browser.mozilla || $.browser.chrome) {
+        } else {
           vmrc.onScreenSizeChange = onSizeChanged;
           vmrc.onConnectionStateChange = onConnectionStateChanged;
           vmrc.onGrabStateChange = onGrabStateChanged;


### PR DESCRIPTION
Verified VMRC connectivity in IE10, IE11, Edge, Chrome and Firefox during unit testing (Linux & Windows).

@miq-bot add_labels ui, bug, blocker

https://bugzilla.redhat.com/show_bug.cgi?id=1414869
