### PR TITLE
Add MiqQueue#tracking_label

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -109,6 +109,7 @@ class MiqQueue < ApplicationRecord
     options[:queue_name]  ||= create_with_options[:queue_name] || "generic"
     options[:msg_timeout] ||= create_with_options[:msg_timeout] || TIMEOUT
     options[:task_id]      = $_miq_worker_current_msg.try(:task_id) unless options.key?(:task_id)
+    options[:tracking_label] = Thread.current[:tracking_label] || options[:task_id] unless options.key?(:tracking_label)
     options[:role]         = options[:role].to_s unless options[:role].nil?
 
     options[:args] = [options[:args]] if options[:args] && !options[:args].kind_of?(Array)

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -104,6 +104,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
 
     begin
       $_miq_worker_current_msg = msg
+      Thread.current[:tracking_label] = msg.tracking_label || msg.task_id
       status, message, result = msg.deliver
 
       if status == MiqQueue::STATUS_TIMEOUT
@@ -122,6 +123,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
       msg.unget
     ensure
       $_miq_worker_current_msg = nil # to avoid log messages inadvertantly prefixed by previous task_id
+      Thread.current[:tracking_label] = nil
       #
       # This tells the broker to release any memory being held on behalf of this process
       # and reset the global broker handle ($vim_broker_client).


### PR DESCRIPTION
Many times we pass a `task_id` into `MiqQueue.put` for logging only. Especially in automate.

This is not the best use of `task_id` as it prevents other workers from working concurrently on these jobs. Also, it is not a mechanism that works across other implementations of queues, so we are trying to phase it out.

This gives us a transition path away from using `task_id`, while still keeping the benefits of logging.
This also allows us to transition away from the global variable holding the current `MiqQueue` record.
related to https://github.com/ManageIQ/manageiq-gems-pending/pull/183
and https://github.com/ManageIQ/manageiq-schema/pull/17

/cc @mkanoor 