### PR TITLE
Only run the setup playbook the first time we start embedded ansible

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -32,9 +32,6 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def setup_ansible
     raise_role_notification(:role_activate_start)
 
-    _log.info("calling EmbeddedAnsible.configure")
-    EmbeddedAnsible.configure unless EmbeddedAnsible.configured?
-
     _log.info("calling EmbeddedAnsible.start")
     EmbeddedAnsible.start
     _log.info("calling EmbeddedAnsible.start finished")

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -4,14 +4,13 @@ require "linux_admin"
 require "ansible_tower_client"
 
 class EmbeddedAnsible
-  ANSIBLE_ROLE                = "embedded_ansible".freeze
-  SETUP_SCRIPT                = "ansible-tower-setup".freeze
-  SECRET_KEY_FILE             = "/etc/tower/SECRET_KEY".freeze
-  CONFIGURE_EXCLUDE_TAGS      = "packages,migrations,firewall,supervisor".freeze
-  START_EXCLUDE_TAGS          = "packages,migrations,firewall".freeze
-  HTTP_PORT                   = 54_321
-  HTTPS_PORT                  = 54_322
-  WAIT_FOR_ANSIBLE_SLEEP      = 1.second
+  ANSIBLE_ROLE           = "embedded_ansible".freeze
+  SETUP_SCRIPT           = "ansible-tower-setup".freeze
+  SECRET_KEY_FILE        = "/etc/tower/SECRET_KEY".freeze
+  EXCLUDE_TAGS           = "packages,migrations,firewall".freeze
+  HTTP_PORT              = 54_321
+  HTTPS_PORT             = 54_322
+  WAIT_FOR_ANSIBLE_SLEEP = 1.second
 
   def self.available?
     return false unless MiqEnvironment::Command.is_appliance?
@@ -43,15 +42,13 @@ class EmbeddedAnsible
     true
   end
 
-  def self.configure
-    configure_secret_key
-    run_setup_script(CONFIGURE_EXCLUDE_TAGS)
-    stop
-  end
-
   def self.start
-    configure_secret_key
-    run_setup_script(START_EXCLUDE_TAGS)
+    if configured?
+      services.each { |service| LinuxAdmin::Service.new(service).start.enable }
+    else
+      configure_secret_key
+      run_setup_script(EXCLUDE_TAGS)
+    end
 
     5.times do
       return if alive?

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -74,26 +74,7 @@ describe EmbeddedAnsibleWorker::Runner do
         NotificationType.seed
       end
 
-      it "configures EmbeddedAnsible if it is not configured" do
-        expect(EmbeddedAnsible).to receive(:start)
-
-        expect(EmbeddedAnsible).to receive(:configured?).and_return(false)
-        expect(EmbeddedAnsible).to receive(:configure)
-
-        runner.setup_ansible
-      end
-
-      it "doesn't call configure if EmbeddedAnsible is already configured" do
-        expect(EmbeddedAnsible).to receive(:start)
-
-        expect(EmbeddedAnsible).to receive(:configured?).and_return(true)
-        expect(EmbeddedAnsible).not_to receive(:configure)
-
-        runner.setup_ansible
-      end
-
       it "creates a notification to inform the user that the service has started" do
-        expect(EmbeddedAnsible).to receive(:configured?).and_return(true)
         expect(EmbeddedAnsible).to receive(:start)
 
         runner.setup_ansible
@@ -104,7 +85,6 @@ describe EmbeddedAnsibleWorker::Runner do
       end
 
       it "creates a notification to inform the user that the role has been assigned" do
-        expect(EmbeddedAnsible).to receive(:configured?).and_return(true)
         expect(EmbeddedAnsible).to receive(:start)
 
         runner.setup_ansible


### PR DESCRIPTION
It needs to run once to put files in place and such, but it restarts services in a way that could cause us to operate on a running stack only to have it restart from under us.

This change makes us only run the setup playbook once so the chance of hitting this kind of issue should be much smaller.

This effectively combines the `.configure` and `.start` methods so that we detect when we are in the first configuration state vs just starting up the services.

https://bugzilla.redhat.com/show_bug.cgi?id=1455063

/cc @ghjm @matburt