### PR TITLE
Queue the VM scan command after vm_scan_start event is handled by automate.

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -52,18 +52,10 @@ class VmScan < Job
         }
       }
       inputs = {:vm => vm, :host => vm.host}
-      if !MiqEvent.raise_evm_job_event(vm, {:type => "scan", :suffix => "start"}, inputs, :miq_callback => cb)
-        msg = "Aborted policy resolution - scan event was not raised to automate."
-        _log.error(msg)
-        signal(:abort, msg, "error")
-      end
+      MiqEvent.raise_evm_job_event(vm, {:type => "scan", :suffix => "start"}, inputs, q_options)
     rescue => err
       _log.log_backtrace(err)
       signal(:abort, err.message, "error")
-    rescue Timeout::Error
-      msg = "Request to check policy timed out"
-      _log.error(msg)
-      signal(:abort, msg, "error")
     end
   end
 

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -128,7 +128,7 @@ describe VmScan do
             allow(@job).to receive(:signal).and_return(true)
             vm_scan = double("VmScan")
             allow(VmScan).to receive(:find).and_return(vm_scan)
-            expect(vm_scan).to receive(:check_policy_complete)
+            expect(vm_scan).to receive(:check_policy_complete).with(@server.my_zone, "ok", any_args)
             q = MiqQueue.where(:class_name => "MiqAeEngine", :method_name => "deliver").first
             q.delivered(*q.deliver)
           end
@@ -228,24 +228,6 @@ describe VmScan do
           an_instance_of(Hash)
         )
         job.call_check_policy
-      end
-    end
-
-    describe "#check_policy_complete" do
-      it "sends signal :abort with passed message if passed status is not 'ok' " do
-        message = "Hello, World!"
-        expect(@job).to receive(:signal).with(:abort, message, any_args)
-        @job.check_policy_complete('some status', message, nil)
-      end
-
-      it "does not send signal :abort if passed status is 'ok' " do
-        expect(@job).not_to receive(:signal).with(:abort)
-        @job.check_policy_complete('ok', nil, nil)
-      end
-
-      it "sends signal :start_snapshot if passed status is 'ok'" do
-        expect(@job).to receive(:signal).with(:start_snapshot)
-        @job.check_policy_complete('ok', nil, nil)
       end
     end
 
@@ -423,6 +405,111 @@ describe VmScan do
         expect(job).to receive(:create_snapshot).and_return(true)
         expect(job).to receive(:signal).with(:snapshot_complete)
         job.call_snapshot_create
+      end
+    end
+  end
+
+  # test cases for BZ #1454936
+  context "A VM Scan job in multiple zones" do
+    before do
+      # local zone
+      @server1 = EvmSpecHelper.local_miq_server(:capabilities => {:vixDisk => true})
+      @user      = FactoryGirl.create(:user_with_group, :userid => "tester")
+      @ems       = FactoryGirl.create(:ems_vmware_with_authentication, :name   => "Test EMS", :zone => @server1.zone,
+                                      :tenant                                  => FactoryGirl.create(:tenant))
+      @storage   = FactoryGirl.create(:storage, :name => "test_storage", :store_type => "VMFS")
+      @host      = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host",
+                                      :state       => 'on', :ext_management_system => @ems)
+      @vm        = FactoryGirl.create(:vm_vmware, :name => "test_vm", :location => "abc/abc.vmx",
+                                      :raw_power_state       => 'poweredOn',
+                                      :host                  => @host,
+                                      :ext_management_system => @ems,
+                                      :miq_group             => @user.current_group,
+                                      :evm_owner             => @user,
+                                      :storage               => @storage)
+
+      # remote zone
+      @server2 = EvmSpecHelper.remote_miq_server(:capabilities => {:vixDisk => true})
+      @user2     = FactoryGirl.create(:user_with_group, :userid => "tester2")
+      @storage2  = FactoryGirl.create(:storage, :name => "test_storage2", :store_type => "VMFS")
+      @host2     = FactoryGirl.create(:host, :name => "test_host2", :hostname => "test_host2",
+                                      :state       => 'on', :ext_management_system => @ems)
+      @vm2       = FactoryGirl.create(:vm_vmware, :name => "test_vm2", :location => "abc2/abc2.vmx",
+                                      :raw_power_state       => 'poweredOn',
+                                      :host                  => @host2,
+                                      :ext_management_system => @ems,
+                                      :miq_group             => @user2.current_group,
+                                      :evm_owner             => @user2,
+                                      :storage               => @storage2)
+
+      allow(MiqEventDefinition).to receive_messages(:find_by => true)
+      allow(@server1).to receive(:has_active_role?).with('automate').and_return(true) # set automate role in local zone
+    end
+
+    describe "#check_policy_complete" do
+      context "in local zone" do
+        before do
+          @vm.scan
+          job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+          job_item.delivered(*job_item.deliver)
+
+          @job = Job.first
+        end
+
+        it "signals :abort if passed status is not 'ok' to local zone" do
+          message = "Hello, World!"
+          expect(@job).to receive(:signal).with(:abort, message, "error")
+          @job.check_policy_complete(@server1.my_zone, 'some status', message, nil)
+        end
+
+        it "does not send signal :abort if passed status is 'ok' " do
+          expect(@job).not_to receive(:signal).with(:abort, nil, "error")
+          @job.check_policy_complete(@server1.my_zone, 'ok', nil, nil)
+        end
+
+        it "sends signal :start_snapshot if status is 'ok' to local zone" do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => @job.class.to_s,
+            :instance_id => @job.id,
+            :method_name => "signal",
+            :args        => [:start_snapshot],
+            :zone        => @server1.my_zone,
+            :role        => "smartstate"
+          )
+          @job.check_policy_complete(@server1.my_zone, 'ok', nil, nil)
+        end
+      end
+
+      context "in remote zone" do
+        before do
+          @vm2.scan
+          job_item = MiqQueue.find_by(:class_name => "MiqAeEngine", :method_name => "deliver")
+          job_item.delivered(*job_item.deliver)
+
+          @job = Job.first
+        end
+        it "signals :abort if status is not 'ok' to remote zone" do
+          message = "Hello, World!"
+          expect(@job).to receive(:signal).with(:abort, message, "error")
+          @job.check_policy_complete(@server2.my_zone, 'some status', message, nil)
+        end
+
+        it "does not send signal :abort if passed status is 'ok' " do
+          expect(@job).not_to receive(:signal).with(:abort, nil, "error")
+          @job.check_policy_complete(@server2.my_zone, 'ok', nil, nil)
+        end
+
+        it "signals :start_snapshot if status is 'ok' to remote zone" do
+          expect(MiqQueue).to receive(:put).with(
+            :class_name  => @job.class.to_s,
+            :instance_id => @job.id,
+            :method_name => "signal",
+            :args        => [:start_snapshot],
+            :zone        => @server2.my_zone,
+            :role        => "smartstate"
+          )
+          @job.check_policy_complete(@server2.my_zone, 'ok', nil, nil)
+        end
       end
     end
   end


### PR DESCRIPTION
All events are handled by automate role server. And VM scan is handled only by SmartState role server.
Queueing the VM scan signal for next step allows the separation of these two server roles.

https://bugzilla.redhat.com/show_bug.cgi?id=1454936

@miq-bot assign @gmcculloug 
@miq-bot add_label bugs, euwe/yes, fine/yes, smart state