### PR TITLE
Switch to gemified ManageIQ::NetworkDiscovery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
+gem "manageiq-network_discovery",     "~>0.1.1",       :require => false
 gem "mime-types",                     "~>2.6.1",       :require => "mime/types/columnar"
 gem "more_core_extensions",           "~>3.2"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -944,11 +944,11 @@ class Host < ApplicationRecord
   end
 
   def rediscover(ipaddr, discover_types = [:esx])
-    require 'discovery/MiqDiscovery'
+    require 'manageiq-network_discovery'
     ost = OpenStruct.new(:usePing => true, :discover_types => discover_types, :ipaddr => ipaddr)
     _log.info "Rediscovering Host: #{ipaddr} with types: #{discover_types.inspect}"
     begin
-      MiqDiscovery.scanHost(ost)
+      ManageIQ::NetworkDiscovery.scanHost(ost)
       _log.info "Rediscovering Host: #{ipaddr} raw results: #{self.class.ost_inspect(ost)}"
 
       unless ost.hypervisor.empty?
@@ -964,11 +964,11 @@ class Host < ApplicationRecord
   end
 
   def self.discoverHost(options)
-    require 'discovery/MiqDiscovery'
+    require 'manageiq-network_discovery'
     ost = OpenStruct.new(Marshal.load(options))
     _log.info "Discovering Host: #{ost_inspect(ost)}"
     begin
-      MiqDiscovery.scanHost(ost)
+      ManageIQ::NetworkDiscovery.scanHost(ost)
 
       unless ost.hypervisor.empty?
         _log.info "Discovered: #{ost_inspect(ost)}"


### PR DESCRIPTION
Now that the discovery code has been [extracted](https://github.com/ManageIQ/manageiq-network_discovery) and [gemified](https://rubygems.org/gems/manageiq-network_discovery), we should switch to using it.