### PR TITLE
Check for timed out active tasks

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -172,6 +172,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "Service", :method_name => "queue_chargeback_reports", :zone => nil, :args => args)
   end
 
+  def check_for_timed_out_active_tasks
+    queue_work(:class_name => "MiqTask", :method_name => "update_status_for_timed_out_active_tasks", :zone => nil)
+  end
+
   private
 
   def queue_work(options)

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -234,9 +234,20 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       end
     end
 
-    # run run chargeback generation every day at specific time
+    # run chargeback generation every day at specific time
     schedule_chargeback_report_for_service_daily
+
+    schedule_check_for_task_timeout
+
     @schedules[:scheduler]
+  end
+
+  def schedule_check_for_task_timeout
+    every = worker_settings[:task_timeout_check_frequency]
+    scheduler = scheduler_for(:scheduler)
+    scheduler.schedule_every(every, :first_at => Time.current + 1.minute) do
+      enqueue :check_for_timed_out_active_tasks
+    end
   end
 
   def schedule_chargeback_report_for_service_daily

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1129,6 +1129,8 @@
   :max_parallel_scans_per_host: 1
   :max_qitems_per_scan_request: 0
   :watchdog_interval: 1.minute
+:task:
+  :active_task_timeout: 6.hours
 :ui:
   :mark_translated_strings: false
 :webservices:
@@ -1299,6 +1301,7 @@
       :session_timeout_interval: 30.seconds
       :storage_file_collection_interval: 1.days
       :storage_file_collection_time_utc: 21600
+      :task_timeout_check_frequency: 1.hour
       :vm_retired_interval: 10.minutes
       :yum_update_check: 12.hours
     :ui_worker:

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -49,4 +49,15 @@ describe MiqScheduleWorker::Jobs do
       )
     end
   end
+
+  describe "#check_for_timed_out_active_tasks" do
+    it "enqueues update_status_for_timed_out_active_tasks" do
+      allow(MiqServer).to receive(:my_zone)
+      described_class.new.check_for_timed_out_active_tasks
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => "MiqTask",
+        :method_name => "update_status_for_timed_out_active_tasks"
+      )
+    end
+  end
 end

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -412,7 +412,7 @@ describe MiqTask do
       end
 
       context "task is not active" do
-        it "does not updates status to 'Error' if task state is 'Finished'" do
+        it "does not update status to 'Error' if task state is 'Finished'" do
           miq_task.update_attributes(:state      => MiqTask::STATE_FINISHED,
                                      :updated_on => miq_task.updated_on - timeout.to_i_with_method)
           MiqTask.update_status_for_timed_out_active_tasks
@@ -420,7 +420,7 @@ describe MiqTask do
           expect(miq_task.status).not_to eq MiqTask::STATUS_ERROR
         end
 
-        it "does not updates status to 'Error' if task state is 'Queued'" do
+        it "does not update status to 'Error' if task state is 'Queued'" do
           miq_task.update_attributes(:state      => MiqTask::STATE_QUEUED,
                                      :updated_on => miq_task.updated_on - timeout.to_i_with_method)
           MiqTask.update_status_for_timed_out_active_tasks
@@ -436,7 +436,7 @@ describe MiqTask do
         job.miq_task
       end
 
-      it "does not updates status to 'Error'" do
+      it "does not update status to 'Error'" do
         miq_task.update_attributes(:state      => MiqTask::STATE_ACTIVE,
                                    :updated_on => miq_task.updated_on - timeout.to_i_with_method)
         MiqTask.update_status_for_timed_out_active_tasks


### PR DESCRIPTION
**Issue**:
 If reporting worker killed (`kill -9 <pid>`) when report is still running than task status stays `Running` forever. 

original BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1397600

This PR:
- adds `active_task_timeout` and `task_timeout_check_frequency` to `settings.yml`
- adds check for timed out tasks to `MiqScheduleWorker`

@miq-bot add-label bug, core

\cc @jrafanie @gtanzillo 