### PR TITLE
Only route PUT/PATCH/DELETE for collection member routes

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -64,7 +64,7 @@ module Api
         edit_resource(type, id, patched_attrs)
       end
 
-      def delete_subcollection_resource(type, id = nil)
+      def delete_subcollection_resource(type, id)
         raise BadRequestError,
               "Must specify an id for destroying a #{type} subcollection resource" if id.nil?
 

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -65,9 +65,6 @@ module Api
       end
 
       def delete_subcollection_resource(type, id)
-        raise BadRequestError,
-              "Must specify an id for destroying a #{type} subcollection resource" if id.nil?
-
         parent_resource = parent_resource_obj
         typed_target    = "delete_resource_#{type}"
         raise BadRequestError,

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -3,8 +3,6 @@ module Api
     module Manager
       def update_collection(type, id)
         if @req.method == :put || @req.method == :patch
-          raise BadRequestError,
-                "Must specify a resource id for the #{@req.method} HTTP method" if id.blank?
           return send("#{@req.method}_resource", type, id)
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,12 @@ Vmdb::Application.routes.draw do
             when :get
               root :action => :index
               get "/:c_id", :action => :show
+            when :put
+              put "/:c_id", :action => :update
+            when :patch
+              patch "/:c_id", :action => :update
+            when :delete
+              delete "/:c_id", :action => :destroy
             else
               match "(/:c_id)", :action => API_ACTIONS[verb], :via => verb
             end
@@ -59,6 +65,12 @@ Vmdb::Application.routes.draw do
             when :get
               get "/:c_id/#{subcollection_name}", :action => :index
               get "/:c_id/#{subcollection_name}/:s_id", :action => :show
+            when :put
+              put "/:c_id/#{subcollection_name}/:s_id", :action => :update
+            when :patch
+              patch "/:c_id/#{subcollection_name}/:s_id", :action => :update
+            when :delete
+              delete "/:c_id/#{subcollection_name}/:s_id", :action => :destroy
             else
               match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
             end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,8 +53,8 @@ Vmdb::Application.routes.draw do
               patch "/:c_id", :action => :update
             when :delete
               delete "/:c_id", :action => :destroy
-            else
-              match "(/:c_id)", :action => API_ACTIONS[verb], :via => verb
+            when :post
+              post "(/:c_id)", :action => :update
             end
           end
         end
@@ -71,8 +71,8 @@ Vmdb::Application.routes.draw do
               patch "/:c_id/#{subcollection_name}/:s_id", :action => :update
             when :delete
               delete "/:c_id/#{subcollection_name}/:s_id", :action => :destroy
-            else
-              match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
+            when :post
+              post "/:c_id/#{subcollection_name}(/:s_id)", :action => :update
             end
           end
         end


### PR DESCRIPTION
In the API controller code we raise errors in the case that a user tries to PUT/PATCH/DELETE without a collection member id in the URL. By not routing these requests instead we can simplify this code a little bit.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
