### PR TITLE
Performance: evmserver start-up: Improve ChargeableField.seed

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -61,11 +61,12 @@ class ChargeableField < ApplicationRecord
   end
 
   def self.seed
+    measures = ChargebackRateDetailMeasure.all.index_by(&:name)
     seed_data.each do |f|
       rec = ChargeableField.find_by(:metric => f[:metric])
       measure = f.delete(:measure)
       if measure
-        f[:chargeback_rate_detail_measure_id] = ChargebackRateDetailMeasure.find_by!(:name => measure).id
+        f[:chargeback_rate_detail_measure_id] = measures[measure].id
       end
       if rec.nil?
         create(f)

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -62,12 +62,13 @@ class ChargeableField < ApplicationRecord
 
   def self.seed
     measures = ChargebackRateDetailMeasure.all.index_by(&:name)
+    existing = ChargeableField.all.index_by(&:metric)
     seed_data.each do |f|
-      rec = ChargeableField.find_by(:metric => f[:metric])
       measure = f.delete(:measure)
       if measure
         f[:chargeback_rate_detail_measure_id] = measures[measure].id
       end
+      rec = existing[f[:metric]]
       if rec.nil?
         create(f)
       else

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -72,7 +72,8 @@ class ChargeableField < ApplicationRecord
       if rec.nil?
         create(f)
       else
-        rec.update_attributes!(f)
+        rec.attributes = f
+        rec.save! if rec.changed?
       end
     end
   end


### PR DESCRIPTION
1000.times { ChargeableField.seed } 

|        ms |    bytes |  objects |queries | query (ms) |`comments`
|       ---:|      ---:|      ---:|  ---:|      ---:| ---
|  59,197.1 | 49,858,421* | 44,085,570 |59,000 | 19,059.5 | before
|  4,636.3 | 16,794,676* | 5,632,636 |2,000 |   763.2 | after
| 94% | 66% | 87% | 97% | 96% | improvement

🐸 