### PR TITLE
[EUWE] Update the azure-armrest dependency to 0.7.3

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -8,7 +8,7 @@ gem "activerecord",            "~> 5.0.0" # used by appliance_console
 gem "activesupport",           "~> 5.0.0"
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.4",            :require => false
-gem "azure-armrest",           "=0.7.0",            :require => false
+gem "azure-armrest",           "~> 0.7.3",          :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
@@ -30,7 +30,7 @@ gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>3.2",             :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
-gem "nokogiri",                "~>1.6.8",           :require => false
+gem "nokogiri",                "~>1.7.2",           :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "ovirt",                   "~>0.14.0",          :require => false
 gem "parallel",                "~>1.9",             :require => false # For OvirtInventory


### PR DESCRIPTION
This PR upgrades the azure-armrest gem to 0.7.3. The latest version includes some enhancements to the method that gathers private image data which prevents the refresh parser from failing due to sporadic ECONNREFUSED and TimeoutException's.

In conjunction with https://github.com/ManageIQ/manageiq-providers-azure/pull/74, it keeps the branches in sync, too.

Note that I also updated the nokogiri gem dependency. Not only does the azure-armrest gem depend on the newer version, we should update anyway because there was a CVE. See https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md for details.

https://bugzilla.redhat.com/show_bug.cgi?id=1456044