### PR TITLE
MiqQueue: move affinity logic out of callers

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -51,12 +51,11 @@ class GenericMailer < ActionMailer::Base
     return unless MiqRegion.my_region.role_assigned?('notifier')
     _log.info("starting: method: #{method} args: #{options} ")
     options[:attachment] &&= attachment_to_blob(options[:attachment])
-    MiqQueue.put(
+    MiqQueue.submit_job(
+      :service     => "notifier",
       :class_name  => name,
       :method_name => 'deliver',
-      :role        => 'notifier',
       :args        => [method, options],
-      :zone        => nil
     )
   end
 

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -213,8 +213,7 @@ module Authenticator
       task = MiqTask.create(:name => "#{self.class.proper_name} User Authorization of '#{username}'", :userid => username)
       if authorize_queue?
         encrypt_ldap_password(config) if MiqLdap.using_ldap?
-        MiqQueue.put(
-          :queue_name   => "generic",
+        MiqQueue.submit_job(
           :class_name   => self.class.to_s,
           :method_name  => "authorize",
           :args         => [config, task.id, username, *args],

--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -4,7 +4,7 @@ class Compliance < ApplicationRecord
 
   def self.check_compliance_queue(targets, inputs = {})
     targets.to_miq_a.each do |target|
-      MiqQueue.put(
+      MiqQueue.submit_job(
         :class_name  => name,
         :method_name => 'check_compliance',
         :args        => [[target.class.name, target.id], inputs]

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -207,8 +207,13 @@ class EmsCluster < ApplicationRecord
   end
 
   def scan
-    zone = ext_management_system ? ext_management_system.my_zone : nil
-    MiqQueue.put(:class_name => self.class.to_s, :method_name => "save_drift_state", :instance_id => id, :zone => zone, :role => "smartstate")
+    MiqQueue.submit_job(
+      :service     => "smartstate",
+      :affinity    => ext_management_system,
+      :class_name  => self.class.to_s,
+      :method_name => "save_drift_state",
+      :instance_id => id,
+    )
   end
 
   def get_reserve(field)

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -59,13 +59,12 @@ class EmsEvent < EventStream
   end
 
   def self.add_queue(meth, ems_id, event)
-    MiqQueue.put(
+    MiqQueue.submit_job(
+      :service     => "event",
       :target_id   => ems_id,
       :class_name  => "EmsEvent",
       :method_name => meth,
       :args        => [event],
-      :queue_name  => "ems",
-      :role        => "event"
     )
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -214,12 +214,11 @@ class Job < ApplicationRecord
 
   def self.delete_by_id(ids)
     _log.info("Queuing deletion of jobs with the following ids: #{ids.inspect}")
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => name,
       :method_name => "destroy",
       :priority    => MiqQueue::HIGH_PRIORITY,
       :args        => [ids],
-      :zone        => MiqServer.my_zone
     )
   end
 

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -36,7 +36,7 @@ module Metric::Purging
   end
 
   def self.purge_timer(ts, interval)
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => name,
       :method_name => "purge_#{interval}",
       :args        => [ts],

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -754,14 +754,14 @@ class MiqAction < ApplicationRecord
     else
       MiqPolicy.logger.info("MIQ(#{__method__}): Queueing [#{action.description}] for event "\
                             "[#{inputs[:event].description}]")
-      MiqQueue.put(
+      MiqQueue.submit_job(
+        :service     => "ems_operations",
+        :affinity    => rec.ext_management_system,
         :class_name  => rec.class.name,
         :method_name => "annotate_deny_execution",
         :args        => inputs[:policy].name,
         :instance_id => rec.id,
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :zone        => rec.my_zone,
-        :role        => "ems_operations"
       )
     end
   end
@@ -782,15 +782,14 @@ class MiqAction < ApplicationRecord
       MiqPolicy.logger.info("MIQ(#{action_method}): Now executing [#{action.description}] of Host [#{rec.name}]")
       rec.scan
     else
-      role = "smartstate"
       MiqPolicy.logger.info("MIQ(#{action_method}): Queueing [#{action.description}] of Host [#{rec.name}]")
-      MiqQueue.put(
+      MiqQueue.submit_job(
+        :service     => "smartstate",
+        :affinity    => rec.ext_management_system,
         :class_name  => "Host",
         :method_name => "scan_from_queue",
         :instance_id => rec.id,
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :zone        => rec.my_zone,
-        :role        => role
       )
     end
   end

--- a/app/models/miq_automate.rb
+++ b/app/models/miq_automate.rb
@@ -5,13 +5,13 @@ class MiqAutomate
     if MiqServer.find_all_started_servers.detect { |s| s.has_active_role?("automate") }.nil?
       task.update_status("Finished", "Error", "No Server has Automate Role enabled")
     else
-      MiqQueue.put(
+      MiqQueue.submit_job(
+        :service     => "automate",
         :class_name  => to_s,
         :method_name => "_async_datastore_reset",
         :args        => [task.id],
         :priority    => MiqQueue::HIGH_PRIORITY,
         :msg_timeout => 3600,
-        :role        => "automate"
       )
       task.update_status("Queued", "Ok", "Task has been queued")
     end

--- a/app/models/miq_report/generator/async.rb
+++ b/app/models/miq_report/generator/async.rb
@@ -6,9 +6,8 @@ module MiqReport::Generator::Async
       sync = ::Settings.product.report_sync
 
       task = MiqTask.create(:name => "Generate Reports: #{options[:reports].collect(&:name).inspect}")
-      MiqQueue.put(
-        :queue_name  => "generic",
-        :role        => "reporting",
+      MiqQueue.submit_job(
+        :service     => "reporting",
         :class_name  => to_s,
         :method_name => "_async_generate_tables",
         :args        => [task.id, options],
@@ -54,9 +53,8 @@ module MiqReport::Generator::Async
     unless sync # Only queued if sync reporting disabled (default)
       cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
       unless self.new_record?
-        MiqQueue.put(
-          :queue_name   => "generic",
-          :role         => "reporting",
+        MiqQueue.submit_job(
+          :service      => "reporting",
           :class_name   => self.class.to_s,
           :instance_id  => id,
           :method_name  => "_async_generate_table",
@@ -66,8 +64,8 @@ module MiqReport::Generator::Async
           :msg_timeout  => queue_timeout
         )
       else
-        MiqQueue.put(
-          :queue_name   => "generic",
+        MiqQueue.submit_job(
+          :service      => "reporting",
           :role         => "reporting",
           :class_name   => self.class.to_s,
           :method_name  => "_async_generate_table",

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -187,9 +187,8 @@ class MiqReportResult < ApplicationRecord
 
     sync = ::Settings.product.report_sync
 
-    MiqQueue.put(
-      :queue_name  => "generic",
-      :role        => "reporting",
+    MiqQueue.submit_job(
+      :service     => "reporting",
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "_async_generate_result",
@@ -298,12 +297,11 @@ class MiqReportResult < ApplicationRecord
   def self.delete_by_userid(userids)
     userids = userids.to_miq_a
     _log.info("Queuing deletion of report results for the following user ids: #{userids.inspect}")
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => name,
       :method_name => "destroy_all",
       :priority    => MiqQueue::HIGH_PRIORITY,
       :args        => [["userid IN (?)", userids]],
-      :zone        => MiqServer.my_zone
     )
   end
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -73,7 +73,7 @@ class MiqSchedule < ApplicationRecord
       return
     end
 
-    msg = MiqQueue.put(
+    msg = MiqQueue.submit_job(
       :class_name  => name,
       :instance_id => sched.id,
       :method_name => "invoke_actions",

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -89,14 +89,13 @@ module MiqServer::ServerSmartProxy
       end
       $log.debug "#{log_prefix}: queuing call to #{self.class.name}##{ost.method_name}"
       # Queue call to scan_metadata or sync_metadata.
-      MiqQueue.put(
+      MiqQueue.submit_job(
+        :service     => "smartproxy",
         :class_name  => self.class.name,
         :instance_id => id,
         :method_name => ost.method_name,
         :args        => ost,
-        :server_guid => guid,
-        :role        => "smartproxy",
-        :queue_name  => "smartproxy",
+        :server_guid => guid, # this should be derived in service. fix this
         :msg_timeout => worker_setting[:queue_timeout] * timeout_adj
       )
     else

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -289,11 +289,10 @@ class MiqTask < ApplicationRecord
 
   def self.delete_older(ts, condition)
     _log.info("Queuing deletion of tasks older than #{ts} and with condition: #{condition}")
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => name,
       :method_name => "destroy_older_by_condition",
       :args        => [ts, condition],
-      :zone        => MiqServer.my_zone
     )
   end
 
@@ -305,11 +304,10 @@ class MiqTask < ApplicationRecord
   def self.delete_by_id(ids)
     return if ids.empty?
     _log.info("Queuing deletion of tasks with the following ids: #{ids.inspect}")
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => name,
       :method_name => "destroy",
       :args        => [ids],
-      :zone        => MiqServer.my_zone
     )
   end
 

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -17,7 +17,11 @@ module ProcessTasksMixin
     end
 
     def invoke_tasks_queue(options)
-      MiqQueue.put(:class_name => name, :method_name => "invoke_tasks", :args => [options])
+      MiqQueue.submit_job(
+        :class_name  => name,
+        :method_name => "invoke_tasks",
+        :args        => [options]
+      )
     end
 
     # Performs tasks received from the UI via the queue
@@ -70,7 +74,7 @@ module ProcessTasksMixin
 
           $log.error("An error occurred while invoking remote tasks...Requeueing for 1 minute from now.")
           $log.log_backtrace(err)
-          MiqQueue.put(
+          MiqQueue.submit_job(
             :class_name  => name,
             :method_name => 'invoke_tasks_remote',
             :args        => [remote_options],
@@ -134,7 +138,7 @@ module ProcessTasksMixin
         :args        => ["Finished"]
       } if task
 
-      MiqQueue.put(
+      MiqQueue.submit_job(
         :class_name   => name,
         :instance_id  => instance.id,
         :method_name  => options[:task],

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -52,7 +52,7 @@ module PurgingMixin
     end
 
     def purge_queue(mode, value)
-      MiqQueue.put(
+      MiqQueue.submit_job(
         :class_name  => name,
         :method_name => "purge_by_#{mode}",
         :args        => [value]

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -107,7 +107,7 @@ module ScanningMixin
   end
 
   def scan_queue(userid = "system", options = {})
-    MiqQueue.put(
+    MiqQueue.submit_job(
       :class_name  => self.class.base_class.name,
       :instance_id => id,
       :method_name => "scan",
@@ -378,14 +378,13 @@ module ScanningMixin
 
   def update_job_message(ost, message)
     ost.message = message
-    unless ost.taskid.blank?
-      MiqQueue.put(
+    if ost.taskid.present?
+      MiqQueue.submit_job(
+        :service     => "smartstate",
         :class_name  => "Job",
         :method_name => "update_message",
         :args        => [ost.taskid, message],
         :task_id     => "job_message_#{Time.now.to_i}",
-        :zone        => MiqServer.my_zone,
-        :role        => "smartstate"
       )
     end
   end

--- a/app/models/mixins/scanning_operations_mixin.rb
+++ b/app/models/mixins/scanning_operations_mixin.rb
@@ -9,14 +9,14 @@ module ScanningOperationsMixin
       Timeout.timeout(WS_TIMEOUT) do # TODO: do we need this timeout?
         _log.info "target [#{guid}],  job [#{jobid}] enter"
         _log.info "target [#{guid}] found target object id [#{id}], job [#{jobid}]"
-        MiqQueue.put(
+        MiqQueue.submit_job(
+          :service     => "smartstate",
+          :affinity    => ext_management_system,
           :target_id   => id,
           :class_name  => self.class.base_class.name,
           :method_name => "save_metadata",
           :data        => Marshal.dump([xmlFile, type]),
           :task_id     => jobid,
-          :zone        => my_zone,
-          :role        => "smartstate"
         )
         _log.info "target [#{guid}] data put on queue, job [#{jobid}]"
       end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -379,12 +379,11 @@ class Service < ApplicationRecord
   end
 
   def queue_chargeback_report_generation(options = {})
-    MiqQueue.put(
-      :role        => "reporting",
+    MiqQueue.submit_job(
+      :service     => "reporting",
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "generate_chargeback_report",
-      :priority    => MiqQueue::NORMAL_PRIORITY,
       :args        => options
     )
     _log.info "Added to queue: generate_chargeback_report for service #{name}"

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -182,15 +182,15 @@ class Storage < ApplicationRecord
     MiqEvent.raise_evm_job_event(self, :type => "scan", :prefix => "request")
     _log.info "Queueing SmartState Analysis for Storage ID: [#{id}], MiqTask ID: [#{miq_task_id}]"
     cb = {:class_name => self.class.name, :instance_id => id, :method_name => :scan_complete_callback, :args => [miq_task_id]}
-    MiqQueue.put(
+    MiqQueue.submit_job(
+      :service      => "ems_operations",
+      :affinity     => ext_management_system,
       :class_name   => self.class.name,
       :instance_id  => id,
       :method_name  => 'smartstate_analysis',
       :args         => [miq_task_id],
       :msg_timeout  => self.class.scan_collection_timeout,
       :miq_callback => cb,
-      :zone         => my_zone,
-      :role         => 'ems_operations'
     )
   end
 

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -29,7 +29,7 @@ module VmdbMetric::Purging
     end
 
     def purge_timer(value, interval)
-      MiqQueue.put(
+      MiqQueue.submit_job(
         :class_name  => name,
         :method_name => "purge_#{interval}",
         :args        => [value],


### PR DESCRIPTION
# Hypothesis

We are not always consistent with our partitioning of service responsibility.

For `MiqQueue.put`, we want to remove `:queue_name`, `:role`, and `:zone` from method calls.
We want to add `:service` and `:resource` instead.
We want to generate the same `miq_queue` records that we had before. So this is only cosmetic.

# Problems we want to solve:

### The `:service` field

- Sometimes we use the queue to call another service, sometimes queue callbacks, while other times we call directly. Declaring the service name makes violations more obvious.
- A lot of the service code lives on the models themselves. Having lines around the services will help us tease these large models apart.
- We are not consistent on how we target a services over `MiqQueue`. Sometimes we use `role` with `zone` and other times we use `queue_name`.

### The ~~`:resource`~~ `:affinity` field

Most service calls are asking for a resource affinity. Typically this is the ems.
For inventory, we will use this resource to determine the `queue_name`.
For ems operations, we will pass a `zone`.

# Conclusion

Using MiqQueue calls to declare the service introduces an easier way to draw lines between services. As we introduce events and background jobs, we will use this more consistent naming to ensure that our queue topics and gem extraction is properly partitioned.
