### PR TITLE
Infer :name from :model_class in case its missing

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/shared/inventory/persister/automation_manager.rb
@@ -9,6 +9,6 @@ module ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::Automati
     has_automation_manager_configuration_script_payloads :model_class => ManageIQ::Providers::Inflector.provider_module(self)::AutomationManager::Playbook
     has_automation_manager_configured_systems
     has_automation_manager_inventory_root_groups
-    has_vms :name => :vms, :parent => nil, :arel => Vm, :strategy => :local_db_find_references
+    has_vms :parent => nil, :arel => Vm, :strategy => :local_db_find_references
   end
 end

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -285,7 +285,7 @@ module ManagerRefresh
     #        If there is only 1 unique index, this will be auto-discovered, otherwise we need to specify the correct
     #        one.
     # @param name [Symbol] A unique name of the InventoryCollection under a Persister. If not provided, the :association
-    #        attribute is used. Providing either :name or :association is mandatory.
+    #        attribute is used. If :association is nil as well, the :name will be inferred from the :model_class.
     # @param saver_strategy [Symbol] A strategy that will be used for InventoryCollection persisting into the DB.
     #        Allowed saver strategies are:
     #          - :default => Using Rails saving methods, this way is not safe to run in multiple workers concurrently,
@@ -355,7 +355,7 @@ module ManagerRefresh
       @update_only           = update_only.nil? ? false : update_only
       @builder_params        = builder_params
       @unique_index_columns  = unique_index_columns
-      @name                  = name || association
+      @name                  = name || association || model_class.to_s.demodulize.tableize
       @saver_strategy        = process_saver_strategy(saver_strategy)
 
       @manager_ref_allowed_nil = manager_ref_allowed_nil || []
@@ -366,8 +366,6 @@ module ManagerRefresh
       @skeletal_manager_uuids       = Set.new.merge(manager_uuids)
       @targeted_arel                = targeted_arel
       @targeted                     = !!targeted
-
-      raise "You have to pass either :name or :association argument to .new of #{self}" if @name.blank?
 
       @inventory_object_attributes = inventory_object_attributes
 

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -409,19 +409,16 @@ describe ManagerRefresh::SaveInventory do
         @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => ManageIQ::Providers::CloudManager::Vm,
           :arel        => @ems.vms.where(:ems_ref => vm_refs),
-          :name        => :vms
         )
         @data[:hardwares] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => Hardware,
           :arel        => @ems.hardwares.joins(:vm_or_template).where(:vms => {:ems_ref => vm_refs}),
           :manager_ref => [:vm_or_template],
-          :name        => :hardwares
         )
         @data[:disks] = ::ManagerRefresh::InventoryCollection.new(
           :model_class => Disk,
           :arel        => @ems.disks.joins(:hardware => :vm_or_template).where('hardware' => {'vms' => {'ems_ref' => vm_refs}}),
           :manager_ref => [:hardware, :device_name],
-          :name        => :disks,
         )
         @data[:image_hardwares] = ::ManagerRefresh::InventoryCollection.new(
           :model_class         => Hardware,


### PR DESCRIPTION
follow up for https://github.com/ManageIQ/manageiq/pull/15117

I think in 99% of the cases the :name derived from the Classname or the association name.

TBH, I'm not even sure _why_ the :name is needed in the InventoryCollection when its a concern of the Persister....

@miq-bot assign @Ladas 
@miq-bot add_labels refactoring