### PR TITLE
Concurent safe batch saver

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -75,12 +75,11 @@ module ManagerRefresh::SaveCollection
 
       def assert_referential_integrity(hash, inventory_object)
         inventory_object.inventory_collection.fixed_foreign_keys.each do |x|
-          if hash[x].blank?
-            _log.info("Ignoring #{inventory_object} because of missing foreign key #{x} for "\
-                      "#{inventory_object.inventory_collection.parent.class.name}:"\
-                      "#{inventory_object.inventory_collection.parent.id}")
-            return false
-          end
+          next unless hash[x].blank?
+          _log.info("Ignoring #{inventory_object} because of missing foreign key #{x} for "\
+                    "#{inventory_object.inventory_collection.parent.class.name}:"\
+                    "#{inventory_object.inventory_collection.parent.id}")
+          return false
         end
         true
       end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -32,6 +32,10 @@ module ManagerRefresh::SaveCollection
 
       attr_reader :unique_index_keys, :unique_db_primary_keys
 
+      def batch_size
+        1000
+      end
+
       def delete_complement(inventory_collection)
         return unless inventory_collection.delete_allowed?
 

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -60,6 +60,12 @@ module ManagerRefresh::SaveCollection
                   "#{all_manager_uuids_size}, deleted=#{deleted_counter} *************")
       end
 
+      def delete_record!(inventory_collection, record)
+        return false unless inventory_collection.delete_allowed?
+        record.public_send(inventory_collection.delete_method)
+        true
+      end
+
       def assert_distinct_relation(record)
         if unique_db_primary_keys.include?(record.id) # Include on Set is O(1)
           # Change the InventoryCollection's :association or :arel parameter to return distinct results. The :through

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -2,6 +2,7 @@ module ManagerRefresh::SaveCollection
   module Saver
     class Base
       include Vmdb::Logging
+      include ManagerRefresh::SaveCollection::Saver::SqlHelper
 
       attr_reader :inventory_collection
 

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -3,8 +3,137 @@ module ManagerRefresh::SaveCollection
     class ConcurrentSafeBatch < ManagerRefresh::SaveCollection::Saver::Base
       private
 
-      def save!(_inventory_collection, _association)
-        raise "saver_strategy :concurent_safe_batch is not implemented"
+      def save!(inventory_collection, association)
+        attributes_index        = {}
+        inventory_objects_index = {}
+        all_attribute_keys      = Set.new
+
+        inventory_collection.each do |inventory_object|
+          attributes = inventory_object.attributes(inventory_collection)
+          index      = inventory_object.manager_uuid
+
+          attributes_index[index]        = attributes
+          inventory_objects_index[index] = inventory_object
+          all_attribute_keys.merge(attributes_index[index].keys)
+        end
+
+        inventory_collection_size = inventory_collection.size
+        deleted_counter           = 0
+        created_counter           = 0
+        updated_counter           = 0
+        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} *************")
+        hashes_for_update = []
+        records_for_destroy = []
+
+        # Records that are in the DB, we will be updating or deleting them.
+        association.find_in_batches do |batch|
+          batch.each do |record|
+            next unless assert_distinct_relation(record)
+
+            index = inventory_collection.object_index_with_keys(unique_index_keys, record)
+
+            inventory_object = inventory_objects_index.delete(index)
+            hash             = attributes_index.delete(index)
+
+            if inventory_object.nil?
+              # Record was found in the DB but not sent for saving, that means it doesn't exist anymore and we should
+              # delete it from the DB.
+              if inventory_collection.delete_allowed?
+                records_for_destroy << record
+                deleted_counter += 1
+              end
+            else
+              # Record was found in the DB and sent for saving, we will be updating the DB.
+              next unless assert_referential_integrity(hash, inventory_object)
+              inventory_object.id = record.id
+
+              record.assign_attributes(hash.except(:id, :type))
+              if !inventory_collection.check_changed? || record.changed?
+                hashes_for_update << record.attributes.symbolize_keys
+              end
+            end
+          end
+
+          # Update in batches
+          if hashes_for_update.size >= batch_size
+            update_records!(inventory_collection, all_attribute_keys, hashes_for_update)
+            updated_counter += hashes_for_update.count
+
+            hashes_for_update = []
+          end
+
+          # Destroy in batches
+          if records_for_destroy.size >= batch_size
+            destroy_records(records)
+            records_for_destroy = []
+          end
+        end
+
+        # Update the last batch
+        update_records!(inventory_collection, all_attribute_keys, hashes_for_update)
+        updated_counter += hashes_for_update.count
+        hashes_for_update = [] # Cleanup so GC can release it sooner
+
+        # Destroy the last batch
+        destroy_records(records_for_destroy)
+        records_for_destroy = [] # Cleanup so GC can release it sooner
+
+        all_attribute_keys << :type if inventory_collection.supports_sti?
+        # Records that were not found in the DB but sent for saving, we will be creating these in the DB.
+        if inventory_collection.create_allowed?
+          inventory_objects_index.each_slice(batch_size) do |batch|
+            create_records!(inventory_collection, all_attribute_keys, batch, attributes_index)
+            created_counter += batch.size
+          end
+        end
+        _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
+                  "updated=#{updated_counter}, deleted=#{deleted_counter} *************")
+      end
+
+      def destroy_records(records)
+        # TODO(lsmola) we need at least batch disconnect. Batch destroy won't be probably possible because of the
+        # :dependent => :destroy.
+        ActiveRecord::Base.transaction do
+          records.each do |record|
+            delete_record!(inventory_collection, record)
+          end
+        end
+      end
+
+      def update_records!(inventory_collection, all_attribute_keys, hashes)
+        return if hashes.blank?
+
+        ActiveRecord::Base.connection.execute(build_update_query(inventory_collection, all_attribute_keys, hashes))
+      end
+
+      def create_records!(inventory_collection, all_attribute_keys, batch, attributes_index)
+        indexed_inventory_objects = {}
+        hashes = []
+        batch.each do |index, inventory_object|
+          hash = inventory_collection.model_class.new(attributes_index.delete(index)).attributes.symbolize_keys
+          next unless assert_referential_integrity(hash, inventory_object)
+
+          hashes << hash
+          # Index on Unique Columns values, so we can easily fill in the :id later
+          indexed_inventory_objects[inventory_collection.unique_index_columns.map { |x| hash[x] }] = inventory_object
+        end
+
+        return if hashes.blank?
+
+        ActiveRecord::Base.connection.execute(
+          build_insert_query(inventory_collection, all_attribute_keys, hashes)
+        )
+        # TODO(lsmola) we need to do the mapping only if this IC has dependents/dependees
+        map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
+      end
+
+      def map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
+        inventory_collection.model_class.where(
+          build_multi_selection_query(inventory_collection, hashes)
+        ).find_each do |inserted_record|
+          inventory_object = indexed_inventory_objects[inventory_collection.unique_index_columns.map { |x| inserted_record.public_send(x) }]
+          inventory_object.id = inserted_record.id if inventory_object
+        end
       end
     end
   end

--- a/app/models/manager_refresh/save_collection/saver/default.rb
+++ b/app/models/manager_refresh/save_collection/saver/default.rb
@@ -14,7 +14,7 @@ module ManagerRefresh::SaveCollection
           inventory_objects_index[index] = inventory_object
         end
 
-        unique_db_indexes      = Set.new
+        unique_db_indexes = Set.new
 
         inventory_collection_size = inventory_collection.size
         deleted_counter           = 0
@@ -64,12 +64,6 @@ module ManagerRefresh::SaveCollection
         end
         _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
                   "updated=#{inventory_collection_size - created_counter}, deleted=#{deleted_counter} *************")
-      end
-
-      def delete_record!(inventory_collection, record)
-        return false unless inventory_collection.delete_allowed?
-        record.public_send(inventory_collection.delete_method)
-        true
       end
 
       def update_record!(inventory_collection, record, hash, inventory_object)

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -1,0 +1,109 @@
+module ManagerRefresh::SaveCollection
+  module Saver
+    module SqlHelper
+      # TODO(lsmola) all below methods should be rewritten to arel, but we need to first extend arel to be able to do
+      # this
+      def build_insert_query(inventory_collection, all_attribute_keys, hashes)
+        all_attribute_keys_array = all_attribute_keys.to_a
+        table_name               = inventory_collection.model_class.table_name
+        values                   = hashes.map do |hash|
+          "(#{all_attribute_keys_array.map { |x| ActiveRecord::Base.connection.quote(hash[x]) }.join(",")})"
+        end.join(",")
+
+        insert_query = %{
+          INSERT INTO #{table_name} (#{all_attribute_keys_array.join(",")})
+            VALUES
+              #{values}
+          ON CONFLICT (#{inventory_collection.unique_index_columns.join(",")})
+            DO
+              UPDATE
+                SET #{all_attribute_keys_array.map { |x| "#{x} = EXCLUDED.#{x}" }.join(", ")}
+        }
+
+        # TODO(lsmola) do we want to exclude the ems_id from the UPDATE clause? Otherwise it might be difficult to change
+        # the ems_id as a cross manager migration, since ems_id should be there as part of the insert. The attempt of
+        # changing ems_id could lead to putting it back by a refresh.
+        # TODO(lsmola) should we add :deleted => false to the update clause? That should handle a reconnect, without a
+        # a need to list :deleted anywhere in the parser. We just need to check that a model has the :deleted attribute
+
+        # This conditional will avoid rewriting new data by old data. But we want it only when remote_data_timestamp is a
+        # part of the data, since for the fake records, we just want to update ems_ref.
+        if all_attribute_keys.include?(:remote_data_timestamp) # include? on Set is O(1)
+          insert_query += %{
+            WHERE EXCLUDED.remote_data_timestamp IS NULL OR (EXCLUDED.remote_data_timestamp > #{table_name}.remote_data_timestamp)
+          }
+        end
+        insert_query
+      end
+
+      def build_update_query(inventory_collection, all_attribute_keys, hashes)
+        all_attribute_keys_array = all_attribute_keys.to_a
+        table_name               = inventory_collection.model_class.table_name
+        values = hashes.map do |hash|
+          "(#{all_attribute_keys_array.map { |x| quote(hash[x], x, inventory_collection) }.join(",")})"
+        end.join(",")
+        cond = inventory_collection.unique_index_columns.map do |x|
+          "updated_values.#{x} = #{table_name}.#{x}"
+        end.join(" AND ")
+
+        update_query = %{
+          UPDATE #{table_name}
+            SET
+              #{all_attribute_keys_array.map { |key| "#{key} = updated_values.#{key}" }.join(",")}
+          FROM (
+            VALUES
+              #{values}
+          ) AS updated_values (#{all_attribute_keys_array.join(",")})
+          WHERE #{cond}
+        }
+
+        # TODO(lsmola) do we want to exclude the ems_id from the UPDATE clause? Otherwise it might be difficult to change
+        # the ems_id as a cross manager migration, since ems_id should be there as part of the insert. The attempt of
+        # changing ems_id could lead to putting it back by a refresh.
+
+        # This conditional will avoid rewriting new data by old data. But we want it only when remote_data_timestamp is a
+        # part of the data, since for the fake records, we just want to update ems_ref.
+        if all_attribute_keys.include?(:remote_data_timestamp) # include? on Set is O(1)
+          update_query += %{
+            AND (updated_values.remote_data_timestamp IS NULL OR (updated_values.remote_data_timestamp > #{table_name}.remote_data_timestamp))
+          }
+        end
+        update_query
+      end
+
+      def build_multi_selection_query(inventory_collection, hashes)
+        cond = hashes.map do |hash|
+          "(#{inventory_collection.unique_index_columns.map { |x| ActiveRecord::Base.connection.quote(hash[x]) }.join(",")})"
+        end.join(",")
+        "(#{inventory_collection.unique_index_columns.join(",")}) IN (#{cond})"
+      end
+
+      def quote(value, name = nil, inventory_collection = nil)
+        # TODO(lsmola) needed only because UPDATE FROM VALUES needs a specific PG typecasting, remove when fixed in PG
+        name.nil? ? ActiveRecord::Base.connection.quote(value) : quote_and_pg_type_cast(value, name, inventory_collection)
+      end
+
+      def quote_and_pg_type_cast(value, name, inventory_collection)
+        pg_type_cast(
+          ActiveRecord::Base.connection.quote(value),
+          inventory_collection.model_class.columns_hash[name.to_s].type
+        )
+      end
+
+      def pg_type_cast(value, type)
+        case type
+        when :string, :text        then value
+        when :integer              then value
+        when :float                then value
+        when :decimal              then value
+        when :datetime, :timestamp then "#{value}::timestamp"
+        when :time                 then "#{value}::time"
+        when :date                 then "#{value}::date"
+        when :binary               then "#{value}::binary"
+        when :boolean              then "#{value}::boolean"
+        else value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15229

Concurent batch safe saver strategy. Allowing us to do create&update in batched SQL queries, which will save a lot o time, using a remote db. (having 5ms network latency, we save ~1.5h on 1M of records being created/updated)

TBD:
A possbile candidate for replacing the INSERT ON CONFLICT UPDATE query is https://github.com/zdennis/activerecord-import/wiki/On-Duplicate-Key-Update

Also filled issue in Arel, since that would be the best to use:
https://github.com/rails/arel/issues/485
