### PR TITLE
[API] Allow multiple identifiers for collections

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1279,7 +1279,9 @@
       - :name: resolve
   :providers:
     :description: Providers
-    :identifier: ems_infra
+    :identifier:
+    - ems_infra
+    - ems_cloud
     :options:
     - :collection
     :verbs: *gpd
@@ -1296,62 +1298,102 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: ems_infra_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_cloud_show_list
       :post:
       - :name: query
-        :identifier: ems_infra_show_list
+        :identifier:
+        - ems_infra_show_list
+        - ems_cloud_show_list
       - :name: create
-        :identifier: ems_infra_new
+        :identifier:
+        - ems_infra_new
+        - ems_cloud_new
       - :name: edit
-        :identifier: ems_infra_edit
+        :identifier:
+        - ems_infra_edit
+        - ems_cloud_edit
       - :name: refresh
-        :identifier: ems_infra_refresh
+        :identifier:
+        - ems_infra_refresh
+        - ems_cloud_refresh
       - :name: delete
-        :identifier: ems_infra_delete
+        :identifier:
+        - ems_infra_delete
+        - ems_cloud_delete
     :resource_actions:
       :get:
       - :name: read
-        :identifier: ems_infra_show
+        :identifier:
+        - ems_infra_show
+        - ems_cloud_show
       :post:
       - :name: edit
-        :identifier: ems_infra_edit
+        :identifier:
+        - ems_infra_edit
+        - ems_cloud_edit
       - :name: refresh
-        :identifier: ems_infra_refresh
+        :identifier:
+        - ems_infra_refresh
+        - ems_cloud_refresh
       - :name: delete
-        :identifier: ems_infra_delete
+        :identifier:
+        - ems_infra_delete
+        - ems_cloud_delete
       - :name: import_vm
         :identifier: ems_infra_import_vm
         :options:
         - :validate_action
       :delete:
       - :name: delete
-        :identifier: ems_infra_delete
+        :identifier:
+        - ems_infra_delete
+        - ems_cloud_delete
     :tags_subcollection_actions:
       :post:
       - :name: assign
-        :identifier: ems_infra_tag
+        :identifier:
+        - ems_infra_tag
+        - ems_cloud_tag
       - :name: unassign
-        :identifier: ems_infra_tag
+        :identifier:
+        - ems_infra_tag
+        - ems_cloud_tag
     :custom_attributes_subcollection_actions:
       :post:
       - :name: add
-        :identifier: ems_infra_edit
+        :identifier:
+        - ems_infra_edit
+        - ems_cloud_edit
       - :name: edit
-        :identifier: ems_infra_edit
+        :identifier:
+        - ems_infra_edit
+        - ems_cloud_edit
       - :name: delete
-        :identifier: ems_infra_edit
+        :identifier:
+        - ems_infra_edit
+        - ems_cloud_edit
     :policies_subcollection_actions:
       :post:
       - :name: assign
-        :identifier: ems_infra_protect
+        :identifier:
+        - ems_infra_protect
+        - ems_cloud_protect
       - :name: unassign
-        :identifier: ems_infra_protect
+        :identifier:
+        - ems_infra_protect
+        - ems_cloud_protect
     :policy_profiles_subcollection_actions:
       :post:
       - :name: assign
-        :identifier: ems_infra_protect
+        :identifier:
+        - ems_infra_protect
+        - ems_cloud_protect
       - :name: unassign
-        :identifier: ems_infra_protect
+        :identifier:
+        - ems_infra_protect
+        - ems_cloud_protect
   :provision_dialogs:
     :description: Provisioning Dialogs
     :identifier: miq_ae_customization_explorer

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -12,9 +12,20 @@ describe 'API configuration (config/api.yml)' do
 
     describe 'identifiers' do
       let(:miq_product_features) { MiqProductFeature.seed.values.flatten.to_set }
+
+      def add_identifier_to_set(identifier, set)
+        if identifier
+          if identifier.kind_of?(Array)
+            identifier.each { |x| set.add(x) }
+          else
+            set.add(identifier)
+          end
+        end
+      end
+
       let(:api_feature_identifiers) do
         collection_settings.each_with_object(Set.new) do |(_, cfg), set|
-          set.add(cfg[:identifier]) if cfg[:identifier]
+          add_identifier_to_set(cfg[:identifier], set)
           keys = [:collection_actions, :resource_actions, :subcollection_actions, :subresource_actions]
           Array(cfg[:subcollections]).each do |s|
             keys << "#{s}_subcollection_actions" << "#{s}_subresource_actions"
@@ -23,7 +34,7 @@ describe 'API configuration (config/api.yml)' do
             next unless cfg[action_type]
             cfg[action_type].each do |_, method_cfg|
               method_cfg.each do |action_cfg|
-                set.add(action_cfg[:identifier]) if action_cfg[:identifier]
+                add_identifier_to_set(action_cfg[:identifier], set) if action_cfg[:identifier]
               end
             end
           end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -182,6 +182,15 @@ describe "Providers API" do
       cloud_tenant_ids = response.parsed_body['parent_manager']['cloud_tenants'].map { |x| x['id'] }
       expect([cloud_tenant_1.id, cloud_tenant_2.id]).to match_array(cloud_tenant_ids)
     end
+
+    context "when user's role has only allowed product feature 'ems_cloud'" do
+      it 'lists all providers' do
+        api_basic_authorize action_identifier(:providers, :read, :collection_actions, :get)[1] # take only `ems_cloud_show_list`
+        run_get('/api/providers')
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['resources'].count).to eq(ExtManagementSystem.count)
+      end
+    end
   end
 
   context "Provider custom_attributes" do


### PR DESCRIPTION
## Issue:
get providers, API request:
`
curl --user 1a:smartvm -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET http://localhost:3000/api/providers
`

for  the user with the role with product features:
![screen shot 2017-06-28 at 10 35 24](https://user-images.githubusercontent.com/14937244/27627946-bb9bb3d6-5bed-11e7-9024-b94b2ec2bfcb.png)

is failing with:
`{"error":{"kind":"forbidden","message":"Use of the read action is forbidden","klass":"Api::ForbiddenError"}}%
`

The reason is that for (any) collection (e.g. `/api/providers`) are allowed only roles for `infra_XXXX`. (not cloud_XXX ). So there is no mapping between role's product features(miq_product_features) and models (but is not needed results are filtered by RBAC)

## Solution
Allow multiple product features. it means that if user will have only `cloud_show_list` or only `infra_show_list` it will be possible to list providers and same for other features. After it, this list is going thru RBAC.

## Impact
It is a bug in API but also we are using API in UI then this bug is more visible, I saw form where was the select box with providers but empty - thanks to this bug.

@miq-bot assign @gtanzillo 

cc @abellotti @imtayadeway @jntullo 

@miq_bot add_label api, bug
