### PR TITLE
Soft delete instead of disconnect for containers models migrations

### DIFF
--- a/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
+++ b/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
@@ -5,5 +5,21 @@ class AddDeletedToContainersTables < ActiveRecord::Migration[5.0]
     add_column :container_images, :deleted, :boolean, :default => false, :null => false
     add_column :container_projects, :deleted, :boolean, :default => false, :null => false
     add_column :containers, :deleted, :boolean, :default => false, :null => false
+
+    add_index :container_definitions, :deleted,
+              :name  => "index_container_definitions_on_deleted_false",
+              :where => "NOT deleted"
+    add_index :container_groups, :deleted,
+              :name  => "container_groups_on_deleted_false",
+              :where => "NOT deleted"
+    add_index :container_images, :deleted,
+              :name  => "index_container_images_on_deleted_false",
+              :where => "NOT deleted"
+    add_index :container_projects, :deleted,
+              :name  => "index_container_projects_on_deleted_false",
+              :where => "NOT deleted"
+    add_index :containers, :deleted,
+              :name  => "index_containers_on_deleted_false",
+              :where => "NOT deleted"
   end
 end

--- a/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
+++ b/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
@@ -1,0 +1,9 @@
+class AddDeletedToContainersTables < ActiveRecord::Migration[5.0]
+  def change
+    add_column :container_definitions, :deleted, :boolean, :default => false, :null => false
+    add_column :container_groups, :deleted, :boolean, :default => false, :null => false
+    add_column :container_images, :deleted, :boolean, :default => false, :null => false
+    add_column :container_projects, :deleted, :boolean, :default => false, :null => false
+    add_column :containers, :deleted, :boolean, :default => false, :null => false
+  end
+end

--- a/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
+++ b/db/migrate/20170530102506_add_deleted_to_containers_tables.rb
@@ -1,25 +1,14 @@
 class AddDeletedToContainersTables < ActiveRecord::Migration[5.0]
   def change
-    add_column :container_definitions, :deleted, :boolean, :default => false, :null => false
-    add_column :container_groups, :deleted, :boolean, :default => false, :null => false
-    add_column :container_images, :deleted, :boolean, :default => false, :null => false
-    add_column :container_projects, :deleted, :boolean, :default => false, :null => false
-    add_column :containers, :deleted, :boolean, :default => false, :null => false
-
-    add_index :container_definitions, :deleted,
-              :name  => "index_container_definitions_on_deleted_false",
-              :where => "NOT deleted"
-    add_index :container_groups, :deleted,
-              :name  => "container_groups_on_deleted_false",
-              :where => "NOT deleted"
-    add_index :container_images, :deleted,
-              :name  => "index_container_images_on_deleted_false",
-              :where => "NOT deleted"
-    add_index :container_projects, :deleted,
-              :name  => "index_container_projects_on_deleted_false",
-              :where => "NOT deleted"
-    add_index :containers, :deleted,
-              :name  => "index_containers_on_deleted_false",
-              :where => "NOT deleted"
+    add_index :container_definitions, :deleted_on,
+              :name  => "index_container_definitions_on_deleted_on"
+    add_index :container_groups, :deleted_on,
+              :name  => "container_groups_on_deleted_on"
+    add_index :container_images, :deleted_on,
+              :name  => "index_container_images_on_deleted_on"
+    add_index :container_projects, :deleted_on,
+              :name  => "index_container_projects_on_deleted_on"
+    add_index :containers, :deleted_on,
+              :name  => "index_containers_on_deleted_on"
   end
 end

--- a/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
+++ b/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
@@ -48,23 +48,23 @@ class UseDeletedInContainersTables < ActiveRecord::Migration[5.0]
   end
 
   def down
-    say_with_time("Change :deleted => false to :ems_id => nil for ContainerDefinition") do
+    say_with_time("Change :deleted => true to :ems_id => nil for ContainerDefinition") do
       soft_delete_to_disconnect(ContainerDefinition)
     end
 
-    say_with_time("Change :deleted => false to :ems_id => nil for ContainerGroup") do
+    say_with_time("Change :deleted => true to :ems_id => nil for ContainerGroup") do
       soft_delete_to_disconnect(ContainerGroup)
     end
 
-    say_with_time("Change :deleted => false to :ems_id => nil for ContainerImages") do
+    say_with_time("Change :deleted => true to :ems_id => nil for ContainerImages") do
       soft_delete_to_disconnect(ContainerImage)
     end
 
-    say_with_time("Change :deleted => false to :ems_id => nil for ContainerProject") do
+    say_with_time("Change :deleted => true to :ems_id => nil for ContainerProject") do
       soft_delete_to_disconnect(ContainerProject)
     end
 
-    say_with_time("Change :deleted => false to :ems_id => nil for Container") do
+    say_with_time("Change :deleted => true to :ems_id => nil for Container") do
       soft_delete_to_disconnect(Container)
     end
   end

--- a/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
+++ b/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
@@ -1,0 +1,71 @@
+class UseDeletedInContainersTables < ActiveRecord::Migration[5.0]
+  class ContainerDefinition < ActiveRecord::Base; end
+
+  class ContainerGroup < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  class ContainerImage < ActiveRecord::Base; end
+
+  class ContainerProject < ActiveRecord::Base; end
+
+  class Container < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def disconnect_to_soft_delete(model)
+    model.where(:ems_id => nil).find_each do |rec|
+      rec.update_attributes!(:ems_id => rec.old_ems_id, :deleted => true)
+    end
+  end
+
+  def soft_delete_to_disconnect(model)
+    model.where(:deleted => true).find_each do |rec|
+      rec.update_attributes!(:ems_id => nil, :deleted => false)
+    end
+  end
+
+  def up
+    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerDefinition") do
+      disconnect_to_soft_delete(ContainerDefinition)
+    end
+
+    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerGroup") do
+      disconnect_to_soft_delete(ContainerGroup)
+    end
+
+    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerImages") do
+      disconnect_to_soft_delete(ContainerImage)
+    end
+
+    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerProject") do
+      disconnect_to_soft_delete(ContainerProject)
+    end
+
+    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for Container") do
+      disconnect_to_soft_delete(Container)
+    end
+  end
+
+  def down
+    say_with_time("Change :deleted => false to :ems_id => nil for ContainerDefinition") do
+      soft_delete_to_disconnect(ContainerDefinition)
+    end
+
+    say_with_time("Change :deleted => false to :ems_id => nil for ContainerGroup") do
+      soft_delete_to_disconnect(ContainerGroup)
+    end
+
+    say_with_time("Change :deleted => false to :ems_id => nil for ContainerImages") do
+      soft_delete_to_disconnect(ContainerImage)
+    end
+
+    say_with_time("Change :deleted => false to :ems_id => nil for ContainerProject") do
+      soft_delete_to_disconnect(ContainerProject)
+    end
+
+    say_with_time("Change :deleted => false to :ems_id => nil for Container") do
+      soft_delete_to_disconnect(Container)
+    end
+  end
+end

--- a/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
+++ b/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
@@ -22,45 +22,45 @@ class UseDeletedInContainersTables < ActiveRecord::Migration[5.0]
   end
 
   def up
-    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerDefinition") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerDefinition") do
       disconnect_to_soft_delete(ContainerDefinition)
     end
 
-    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerGroup") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerGroup") do
       disconnect_to_soft_delete(ContainerGroup)
     end
 
-    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerImages") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerImages") do
       disconnect_to_soft_delete(ContainerImage)
     end
 
-    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerProject") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerProject") do
       disconnect_to_soft_delete(ContainerProject)
     end
 
-    say_with_time("Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for Container") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to :old_ems_id for Container") do
       disconnect_to_soft_delete(Container)
     end
   end
 
   def down
-    say_with_time("Change :deleted => true to :ems_id => nil for ContainerDefinition") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to nil for ContainerDefinition") do
       soft_delete_to_disconnect(ContainerDefinition)
     end
 
-    say_with_time("Change :deleted => true to :ems_id => nil for ContainerGroup") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to nil for ContainerGroup") do
       soft_delete_to_disconnect(ContainerGroup)
     end
 
-    say_with_time("Change :deleted => true to :ems_id => nil for ContainerImages") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to nil for ContainerImages") do
       soft_delete_to_disconnect(ContainerImage)
     end
 
-    say_with_time("Change :deleted => true to :ems_id => nil for ContainerProject") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to nil for ContainerProject") do
       soft_delete_to_disconnect(ContainerProject)
     end
 
-    say_with_time("Change :deleted => true to :ems_id => nil for Container") do
+    say_with_time("Change ':deleted_on not nil' :ems_id to nil for Container") do
       soft_delete_to_disconnect(Container)
     end
   end

--- a/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
+++ b/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
@@ -14,15 +14,11 @@ class UseDeletedInContainersTables < ActiveRecord::Migration[5.0]
   end
 
   def disconnect_to_soft_delete(model)
-    model.where(:ems_id => nil).find_each do |rec|
-      rec.update_attributes!(:ems_id => rec.old_ems_id, :deleted => true)
-    end
+    model.where(:ems_id => nil).update_all("ems_id = old_ems_id, deleted = 't'")
   end
 
   def soft_delete_to_disconnect(model)
-    model.where(:deleted => true).find_each do |rec|
-      rec.update_attributes!(:ems_id => nil, :deleted => false)
-    end
+    model.where(:deleted => true).update_all(:ems_id => nil, :deleted => false)
   end
 
   def up

--- a/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
+++ b/db/migrate/20170530102536_use_deleted_in_containers_tables.rb
@@ -14,11 +14,11 @@ class UseDeletedInContainersTables < ActiveRecord::Migration[5.0]
   end
 
   def disconnect_to_soft_delete(model)
-    model.where(:ems_id => nil).update_all("ems_id = old_ems_id, deleted = 't'")
+    model.where.not(:deleted_on => nil).update_all("ems_id = old_ems_id")
   end
 
   def soft_delete_to_disconnect(model)
-    model.where(:deleted => true).update_all(:ems_id => nil, :deleted => false)
+    model.where.not(:deleted_on => nil).update_all(:ems_id => nil)
   end
 
   def up

--- a/spec/migrations/20170530102536_use_deleted_in_containers_tables_spec.rb
+++ b/spec/migrations/20170530102536_use_deleted_in_containers_tables_spec.rb
@@ -1,0 +1,99 @@
+require_migration
+
+describe UseDeletedInContainersTables do
+  let(:container_definitions_stub) { migration_stub(:ContainerDefinition) }
+  let(:container_groups_stub)      { migration_stub(:ContainerGroup) }
+  let(:container_images_stub)      { migration_stub(:ContainerImage) }
+  let(:container_projects_stub)    { migration_stub(:ContainerProject) }
+  let(:containers_stub)            { migration_stub(:Container) }
+
+  def create_before_migration_stub_data_for(model)
+    model.create!(:ems_id => 10, :old_ems_id => nil)
+    model.create!(:ems_id => 10, :old_ems_id => 10)
+    model.create!(:ems_id => nil, :old_ems_id => 10)
+    model.create!(:ems_id => nil, :old_ems_id => 20)
+    model.create!(:ems_id => nil, :old_ems_id => nil)
+  end
+
+  def create_after_migration_stub_data_for(model)
+    model.create!(:ems_id => 10, :old_ems_id => nil)
+    model.create!(:ems_id => 10, :old_ems_id => 10)
+    model.create!(:ems_id => 10, :old_ems_id => 10, :deleted => true)
+    model.create!(:ems_id => 20, :old_ems_id => 20, :deleted => true)
+    model.create!(:ems_id => nil, :old_ems_id => nil, :deleted => true)
+  end
+
+  def assert_before_migration_data_of(model)
+    expect(model.where(:deleted => true).count).to eq 0
+    expect(model.where(:deleted => false).count).to eq 5
+    expect(model.where(:ems_id => nil).count).to eq 3
+    expect(model.where.not(:ems_id => nil).count).to eq 2
+  end
+
+  def assert_after_migration_data_of(model)
+    expect(model.where(:deleted => true).count).to eq 3
+    expect(model.where(:deleted => false).count).to eq 2
+    expect(model.where(:ems_id => nil).count).to eq 1
+    expect(model.where.not(:ems_id => nil).count).to eq 4
+  end
+
+  def assert_up_migration_for(model)
+    create_before_migration_stub_data_for(model)
+
+    assert_before_migration_data_of(model)
+    migrate
+    assert_after_migration_data_of(model)
+  end
+
+  def assert_down_migration_for(model)
+    create_after_migration_stub_data_for(model)
+
+    assert_after_migration_data_of(model)
+    migrate
+    assert_before_migration_data_of(model)
+  end
+
+  migration_context :up do
+    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerDefinition" do
+      assert_up_migration_for(container_definitions_stub)
+    end
+
+    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerGroup" do
+      assert_up_migration_for(container_groups_stub)
+    end
+
+    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerImages" do
+      assert_up_migration_for(container_images_stub)
+    end
+
+    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerProjects" do
+      assert_up_migration_for(container_projects_stub)
+    end
+
+    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for Containers" do
+      assert_up_migration_for(containers_stub)
+    end
+  end
+
+  migration_context :down do
+    it "Change :deleted => true to :ems_id => nil for ContainerDefinition" do
+      assert_down_migration_for(container_definitions_stub)
+    end
+
+    it "Change :deleted => true to :ems_id => nil for ContainerGroup" do
+      assert_down_migration_for(container_groups_stub)
+    end
+
+    it "Change :deleted => true to :ems_id => nil for ContainerImages" do
+      assert_down_migration_for(container_images_stub)
+    end
+
+    it "Change :deleted => true to :ems_id => nil for ContainerProjects" do
+      assert_down_migration_for(container_projects_stub)
+    end
+
+    it "Change :deleted => true to :ems_id => nil for Containers" do
+      assert_down_migration_for(containers_stub)
+    end
+  end
+end

--- a/spec/migrations/20170530102536_use_deleted_in_containers_tables_spec.rb
+++ b/spec/migrations/20170530102536_use_deleted_in_containers_tables_spec.rb
@@ -10,29 +10,29 @@ describe UseDeletedInContainersTables do
   def create_before_migration_stub_data_for(model)
     model.create!(:ems_id => 10, :old_ems_id => nil)
     model.create!(:ems_id => 10, :old_ems_id => 10)
-    model.create!(:ems_id => nil, :old_ems_id => 10)
-    model.create!(:ems_id => nil, :old_ems_id => 20)
-    model.create!(:ems_id => nil, :old_ems_id => nil)
+    model.create!(:ems_id => nil, :old_ems_id => 10, :deleted_on => Time.now.utc)
+    model.create!(:ems_id => nil, :old_ems_id => 20, :deleted_on => Time.now.utc)
+    model.create!(:ems_id => nil, :old_ems_id => nil, :deleted_on => Time.now.utc)
   end
 
   def create_after_migration_stub_data_for(model)
     model.create!(:ems_id => 10, :old_ems_id => nil)
     model.create!(:ems_id => 10, :old_ems_id => 10)
-    model.create!(:ems_id => 10, :old_ems_id => 10, :deleted => true)
-    model.create!(:ems_id => 20, :old_ems_id => 20, :deleted => true)
-    model.create!(:ems_id => nil, :old_ems_id => nil, :deleted => true)
+    model.create!(:ems_id => 10, :old_ems_id => 10, :deleted_on => Time.now.utc)
+    model.create!(:ems_id => 20, :old_ems_id => 20, :deleted_on => Time.now.utc)
+    model.create!(:ems_id => nil, :old_ems_id => nil, :deleted_on => Time.now.utc)
   end
 
   def assert_before_migration_data_of(model)
-    expect(model.where(:deleted => true).count).to eq 0
-    expect(model.where(:deleted => false).count).to eq 5
+    expect(model.where.not(:deleted_on => nil).count).to eq 3
+    expect(model.where(:deleted_on => nil).count).to eq 2
     expect(model.where(:ems_id => nil).count).to eq 3
     expect(model.where.not(:ems_id => nil).count).to eq 2
   end
 
   def assert_after_migration_data_of(model)
-    expect(model.where(:deleted => true).count).to eq 3
-    expect(model.where(:deleted => false).count).to eq 2
+    expect(model.where.not(:deleted_on => nil).count).to eq 3
+    expect(model.where(:deleted_on => nil).count).to eq 2
     expect(model.where(:ems_id => nil).count).to eq 1
     expect(model.where.not(:ems_id => nil).count).to eq 4
   end
@@ -54,45 +54,45 @@ describe UseDeletedInContainersTables do
   end
 
   migration_context :up do
-    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerDefinition" do
+    it "Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerDefinition" do
       assert_up_migration_for(container_definitions_stub)
     end
 
-    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerGroup" do
+    it "Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerGroup" do
       assert_up_migration_for(container_groups_stub)
     end
 
-    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerImages" do
+    it "Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerImages" do
       assert_up_migration_for(container_images_stub)
     end
 
-    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for ContainerProjects" do
+    it "Change ':deleted_on not nil' :ems_id to :old_ems_id for ContainerProjects" do
       assert_up_migration_for(container_projects_stub)
     end
 
-    it "Change :ems_id => nil to :deleted => true and set :ems_id using :old_ems_id for Containers" do
+    it "Change ':deleted_on not nil' :ems_id to :old_ems_id for Containers" do
       assert_up_migration_for(containers_stub)
     end
   end
 
   migration_context :down do
-    it "Change :deleted => true to :ems_id => nil for ContainerDefinition" do
+    it "Change ':deleted_on not nil' :ems_id to nil for ContainerDefinition" do
       assert_down_migration_for(container_definitions_stub)
     end
 
-    it "Change :deleted => true to :ems_id => nil for ContainerGroup" do
+    it "Change ':deleted_on not nil' :ems_id to nil for ContainerGroup" do
       assert_down_migration_for(container_groups_stub)
     end
 
-    it "Change :deleted => true to :ems_id => nil for ContainerImages" do
+    it "Change ':deleted_on not nil' :ems_id to nil for ContainerImages" do
       assert_down_migration_for(container_images_stub)
     end
 
-    it "Change :deleted => true to :ems_id => nil for ContainerProjects" do
+    it "Change ':deleted_on not nil' :ems_id to nil for ContainerProjects" do
       assert_down_migration_for(container_projects_stub)
     end
 
-    it "Change :deleted => true to :ems_id => nil for Containers" do
+    it "Change ':deleted_on not nil' :ems_id to nil for Containers" do
       assert_down_migration_for(containers_stub)
     end
   end


### PR DESCRIPTION
Soft delete instead of disconnect for containers models migrations + data migration specs

Using partial indexes have actually a better cots than indexing :ems_id and using disconnect:

Testing on queries, on 20k deleted and 20k not deleted container images:
pp ems = ManageIQ::Providers::ContainerManager.find(26); pp ems.container_images.where("id > 1111").limit(1000).explain; pp ems.container_images.order(:name).limit(1000).explain; pp ContainerImage.not_deleted.limit(1000).explain; ContainerImage.not_deleted.order(:name).limit(1000).explain

The soft delete with partial index on :deleted => true:
```ruby
add_index :container_images, :deleted, name: "index_container_images_on_deleted_false", where: "NOT deleted"
----------------------------------------------------------------------
 ContainerImage Load (5.1ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND "container_images"."deleted" = $2 AND (id > 1111) LIMIT $3  [["ems_id", 26], ["deleted", "f"], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (16.2ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND "container_images"."deleted" = $2 AND (id > 1111) LIMIT $3 [["ems_id", 26], ["deleted", "f"], ["LIMIT", 1000]]
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..141.19 rows=1000 width=950)
   ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2749.01 rows=19508 width=950)
         Index Cond: (deleted = false)
         Filter: ((id > 1111) AND (ems_id = '26'::bigint))
(4 rows)

  ContainerImage Load (21.5ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND "container_images"."deleted" = $2 ORDER BY "container_images"."name" ASC LIMIT $3  [["ems_id", 26], ["deleted", "f"], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (19.8ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND "container_images"."deleted" = $2 ORDER BY "container_images"."name" ASC LIMIT $3 [["ems_id", 26], ["deleted", "f"], ["LIMIT", 1000]]
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3823.80..3826.30 rows=1000 width=950)
   ->  Sort  (cost=3823.80..3873.95 rows=20060 width=950)
         Sort Key: name
         ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2723.93 rows=20060 width=950)
               Index Cond: (deleted = false)
               Filter: (ems_id = '26'::bigint)
(6 rows)

  ContainerImage Load (3.4ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."deleted" = $1 LIMIT $2  [["deleted", "f"], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (12.0ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."deleted" = $1 LIMIT $2 [["deleted", "f"], ["LIMIT", 1000]]
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..134.81 rows=1000 width=950)
   ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2698.85 rows=20060 width=950)
         Index Cond: (deleted = false)
(3 rows)

  ContainerImage Load (19.0ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."deleted" = $1 ORDER BY "container_images"."name" ASC LIMIT $2  [["deleted", "f"], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (10.6ms - 1000rows)
 => EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."deleted" = $1 ORDER BY "container_images"."name" ASC LIMIT $2 [["deleted", "f"], ["LIMIT", 1000]]
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3798.72..3801.22 rows=1000 width=950)
   ->  Sort  (cost=3798.72..3848.87 rows=20060 width=950)
         Sort Key: name
         ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2698.85 rows=20060 width=950)
               Index Cond: (deleted = false)
(5 rows)

```

The :ems_id => nil disconnect
```ruby
add_index :container_images, :ems_id, name: "index_container_images_on_ems_id"
-------------------------------------------------------------------------------
ContainerImage Load (4.2ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND (id > 1111) LIMIT $2  [["ems_id", 26], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (40.4ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 AND (id > 1111) LIMIT $2 [["ems_id", 26], ["LIMIT", 1000]]
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..147.09 rows=1000 width=948)
   ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2882.43 rows=19633 width=948)
         Index Cond: (ems_id = '26'::bigint)
         Filter: (id > 1111)
(4 rows)

  ContainerImage Load (20.4ms)  SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 ORDER BY "container_images"."name" ASC LIMIT $2  [["ems_id", 26], ["LIMIT", 1000]]
  ContainerImage Inst Including Associations (14.2ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE "container_images"."ems_id" = $1 ORDER BY "container_images"."name" ASC LIMIT $2 [["ems_id", 26], ["LIMIT", 1000]]
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3939.84..3942.34 rows=1000 width=948)
   ->  Sort  (cost=3939.84..3990.36 rows=20207 width=948)
         Sort Key: name
         ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2831.91 rows=20207 width=948)
               Index Cond: (ems_id = '26'::bigint)
(5 rows)

  ContainerImage Load (3.2ms)  SELECT  "container_images".* FROM "container_images" WHERE ("container_images"."ems_id" IS NOT NULL) LIMIT $1  [["LIMIT", 1000]]
  ContainerImage Inst Including Associations (29.8ms - 1000rows)
EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE ("container_images"."ems_id" IS NOT NULL) LIMIT $1 [["LIMIT", 1000]]
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..140.42 rows=1000 width=948)
   ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2831.91 rows=20207 width=948)
         Index Cond: (ems_id IS NOT NULL)
(3 rows)

  ContainerImage Load (19.9ms)  SELECT  "container_images".* FROM "container_images" WHERE ("container_images"."ems_id" IS NOT NULL) ORDER BY "container_images"."name" ASC LIMIT $1  [["LIMIT", 1000]]
  ContainerImage Inst Including Associations (12.4ms - 1000rows)
 => EXPLAIN for: SELECT  "container_images".* FROM "container_images" WHERE ("container_images"."ems_id" IS NOT NULL) ORDER BY "container_images"."name" ASC LIMIT $1 [["LIMIT", 1000]]
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3939.84..3942.34 rows=1000 width=948)
   ->  Sort  (cost=3939.84..3990.36 rows=20207 width=948)
         Sort Key: name
         ->  Index Scan using index_container_images_on_deleted_false on container_images  (cost=0.29..2831.91 rows=20207 width=948)
               Index Cond: (ems_id IS NOT NULL)
(5 rows)
```