### PR TITLE
Soft delete instead of disconnect for containers models

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -47,7 +47,6 @@ class Container < ApplicationRecord
     return if ems_id.nil?
     _log.info "Disconnecting Container [#{name}] id [#{id}] from EMS "
     self.deleted_on = Time.now.utc
-    self.deleted = true
     save
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -47,8 +47,7 @@ class Container < ApplicationRecord
     return if ems_id.nil?
     _log.info "Disconnecting Container [#{name}] id [#{id}] from EMS "
     self.deleted_on = Time.now.utc
-    self.old_ems_id = self.ems_id
-    self.ems_id = nil
+    self.deleted = true
     save
   end
 end

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -15,7 +15,6 @@ class ContainerDefinition < ApplicationRecord
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"
     self.container.try(:disconnect_inv)
     self.deleted_on = Time.now.utc
-    self.deleted = true
     save
   end
 end

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -15,8 +15,7 @@ class ContainerDefinition < ApplicationRecord
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"
     self.container.try(:disconnect_inv)
     self.deleted_on = Time.now.utc
-    self.old_ems_id = self.ems_id
-    self.ems_id = nil
+    self.deleted = true
     save
   end
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -85,8 +85,6 @@ class ContainerGroup < ApplicationRecord
     _log.info "Disconnecting Pod [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.container_definitions.each(&:disconnect_inv)
-    self.old_ems_id = ems_id
-    self.ext_management_system = nil
     self.container_node_id = nil
     self.container_services = []
     self.container_replicator_id = nil
@@ -94,6 +92,7 @@ class ContainerGroup < ApplicationRecord
     self.old_container_project_id = self.container_project_id
     self.container_project_id = nil
     self.deleted_on = Time.now.utc
+    self.deleted = true
     save
   end
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -92,7 +92,6 @@ class ContainerGroup < ApplicationRecord
     self.old_container_project_id = self.container_project_id
     self.container_project_id = nil
     self.deleted_on = Time.now.utc
-    self.deleted = true
     save
   end
 end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -106,9 +106,8 @@ class ContainerImage < ApplicationRecord
     _log.info "Disconnecting Image [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.container_image_registry = nil
-    self.old_ems_id = ems_id
-    self.ext_management_system = nil
     self.deleted_on = Time.now.utc
+    self.deleted = true
     save
   end
 

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -107,7 +107,6 @@ class ContainerImage < ApplicationRecord
     "id [#{ext_management_system.id}] "
     self.container_image_registry = nil
     self.deleted_on = Time.now.utc
-    self.deleted = true
     save
   end
 

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -65,7 +65,6 @@ class ContainerProject < ApplicationRecord
     _log.info "Disconnecting Container Project [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.deleted_on = Time.now.utc
-    self.deleted = true
     save
   end
 end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -64,9 +64,8 @@ class ContainerProject < ApplicationRecord
     return if ems_id.nil?
     _log.info "Disconnecting Container Project [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
-    self.old_ems_id = ems_id
-    self.ext_management_system = nil
     self.deleted_on = Time.now.utc
+    self.deleted = true
     save
   end
 end

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -27,7 +27,6 @@ module ManageIQ::Providers
     has_many :computer_system_hardwares, :through => :computer_systems, :source => :hardware
     has_many :computer_system_operating_systems, :through => :computer_systems, :source => :operating_system
     has_many :container_volumes, :through => :container_groups
-    has_many :container_definitions, :through => :container_groups
     has_many :container_port_configs, :through => :container_definitions
     has_many :container_env_vars, :through => :container_definitions
     has_many :security_contexts, :through => :container_definitions

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -4,15 +4,16 @@ module ManageIQ::Providers
     include SupportsFeatureMixin
 
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_groups, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_groups, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :containers, :foreign_key => :ems_id
-    has_many :container_projects, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :containers, -> { where(:deleted => false) }, :foreign_key => :ems_id
+    has_many :container_definitions, -> { where(:deleted => false) }, :foreign_key => :ems_id
+    has_many :container_projects, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_quotas, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_images, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_images, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :persistent_volumes, :as => :parent, :dependent => :destroy
     has_many :persistent_volume_claims, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_component_statuses, :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -4,16 +4,16 @@ module ManageIQ::Providers
     include SupportsFeatureMixin
 
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_groups, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_groups, -> { active }, :foreign_key => :ems_id
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
     has_many :containers, -> { active }, :foreign_key => :ems_id
     has_many :container_definitions, -> { active }, :foreign_key => :ems_id
-    has_many :container_projects, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_projects, -> { active }, :foreign_key => :ems_id
     has_many :container_quotas, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_images, -> { active }, :foreign_key => :ems_id
     has_many :persistent_volumes, :as => :parent, :dependent => :destroy
     has_many :persistent_volume_claims, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_component_statuses, :foreign_key => :ems_id, :dependent => :destroy
@@ -37,10 +37,13 @@ module ManageIQ::Providers
     has_many :container_limit_items, :through => :container_limits
     has_many :container_template_parameters, :through => :container_templates
 
-    # Archived entities to destroy when the container manager is deleted
-    has_many :old_container_groups, :foreign_key => :old_ems_id, :dependent => :destroy, :class_name => "ContainerGroup"
-    has_many :old_container_projects, :foreign_key => :old_ems_id, :dependent => :destroy, :class_name => "ContainerProject"
-    has_many :old_container_images, :foreign_key => :old_ems_id, :dependent => :destroy, :class_name => "ContainerImage"
+    # Archived and active entities to destroy when the container manager is deleted
+    has_many :all_containers, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "Container"
+    has_many :all_container_groups, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerGroup"
+    has_many :all_container_projects, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerProject"
+    has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
+    has_many :all_container_definitions, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerDefinition"
+
 
     virtual_column :port_show, :type => :string
 

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -4,16 +4,16 @@ module ManageIQ::Providers
     include SupportsFeatureMixin
 
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_groups, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_groups, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :containers, -> { where(:deleted => false) }, :foreign_key => :ems_id
-    has_many :container_definitions, -> { where(:deleted => false) }, :foreign_key => :ems_id
-    has_many :container_projects, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :containers, -> { active }, :foreign_key => :ems_id
+    has_many :container_definitions, -> { active }, :foreign_key => :ems_id
+    has_many :container_projects, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_quotas, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_images, -> { where(:deleted => false) }, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :persistent_volumes, :as => :parent, :dependent => :destroy
     has_many :persistent_volume_claims, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_component_statuses, :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -2,6 +2,9 @@ module ArchivedMixin
   extend ActiveSupport::Concern
 
   included do
+    scope :deleted, -> { where(:deleted => true) }
+    scope :not_deleted, -> { where(:deleted => false) }
+
     belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
   end
 

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -2,14 +2,18 @@ module ArchivedMixin
   extend ActiveSupport::Concern
 
   included do
-    scope :deleted, -> { where(:deleted => true) }
-    scope :not_deleted, -> { where(:deleted => false) }
+    scope :archived, -> { where.not(:deleted_on => nil) }
+    scope :active, -> { where(:deleted_on => nil) }
 
     belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
   end
 
   def archived?
-    deleted?
+    !active?
+  end
+
+  def active?
+    deleted_on.nil?
   end
 
   # Needed for metrics

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -9,7 +9,7 @@ module ArchivedMixin
   end
 
   def archived?
-    ems_id.nil?
+    deleted?
   end
 
   # Needed for metrics

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -2,18 +2,18 @@ module ArchivedMixin
   extend ActiveSupport::Concern
 
   included do
-    scope :archived, -> { where(:deleted => true) }
-    scope :active, -> { where(:deleted => false) }
+    scope :archived, -> { where.not(:deleted_on => nil) }
+    scope :active, -> { where(:deleted_on => nil) }
 
     belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
   end
 
   def archived?
-    deleted?
+    !active?
   end
 
   def active?
-    !deleted?
+    deleted_on.nil?
   end
 
   # Needed for metrics

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -2,18 +2,18 @@ module ArchivedMixin
   extend ActiveSupport::Concern
 
   included do
-    scope :archived, -> { where.not(:deleted_on => nil) }
-    scope :active, -> { where(:deleted_on => nil) }
+    scope :archived, -> { where(:deleted => true) }
+    scope :active, -> { where(:deleted => false) }
 
     belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
   end
 
   def archived?
-    !active?
+    deleted?
   end
 
   def active?
-    deleted_on.nil?
+    !deleted?
   end
 
   # Needed for metrics


### PR DESCRIPTION
Do soft delete using :deleted => true instead of doing ems disconnect by setting :ems_id => nil. And scope ems relations to show only :deleted => false, which mimics the missing :ems_id foreign key we had before, doing ems disconnect.

Related to https://github.com/ManageIQ/manageiq-schema/pull/18, which will make the queries faster by adding indexes