### PR TITLE
Allow updates to the ems to be sent with the hashes

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -16,6 +16,9 @@ module EmsRefresh::SaveInventory
     when ManageIQ::Providers::StorageManager                then save_ems_storage_inventory(ems, hashes, target)
     when ManageIQ::Providers::DatawarehouseManager          then save_ems_datawarehouse_inventory(ems, hashes, target)
     end
+
+    # Handle updates to the ext_management_system
+    update_attributes!(ems, hashes[:ems], [:type]) unless hashes[:ems].nil?
   end
 
   #


### PR DESCRIPTION
Currently updates directly to the EMS (e.g.: [ref](https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager/refresher.rb#L60) and [ref](https://github.com/ManageIQ/manageiq-providers-ovirt/blob/master/app/models/manageiq/providers/redhat/infra_manager/refresh/refresher.rb#L29-L30)) are saved directly in the parser instead of save_ems_inventory.  This will allow ems updates to be able to be passed to save_ems_inventory via `hashes[:ems]` instead of saved directly in the refresh_parser.

Related: 
1. https://github.com/ManageIQ/manageiq-providers-vmware/pull/62
2. https://github.com/ManageIQ/manageiq-providers-ovirt/pull/46

Part of https://github.com/ManageIQ/manageiq/pull/15105