### PR TITLE
Include the font-fabulous gem as a plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ def manageiq_plugin(plugin_name)
   end
 end
 
+manageiq_plugin "font-fabulous" # FIXME: this is just a temporary solution and it'll go to the ui-classic later
 manageiq_plugin "manageiq-automation_engine"
 manageiq_plugin "manageiq-content"
 manageiq_plugin "manageiq-providers-amazon"


### PR DESCRIPTION
This is just a temporary solution until we push a release to Rubygems.
Unfortunately we can't link gems from github from rails engines :(

@miq-bot assign @simaishi 
cc @epwinchell 