### PR TITLE
DRY up marshaling/unmarshaling of session data

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -62,4 +62,12 @@ class Session < ApplicationRecord
     @@interval = int unless int.nil?
     @@interval
   end
+
+  def raw_data
+    Marshal.load(Base64.decode64(data.split("\n").join))
+  end
+
+  def raw_data=(d)
+    self.data = Base64.encode64(Marshal.dump(d))
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -28,7 +28,7 @@ class Session < ApplicationRecord
     sessions = where("updated_at <= ?", ttl.seconds.ago.utc).limit(batch_size)
     return 0 if sessions.size.zero?
     sessions = sessions.reject do |s|
-      expires_on = Marshal.load(Base64.decode64(s.data.split("\n").join))[:expires_on] rescue nil
+      expires_on = s.raw_data[:expires_on] rescue nil
       expires_on && expires_on >= Time.zone.now
     end
 
@@ -40,7 +40,7 @@ class Session < ApplicationRecord
     # Log off the users associated with the sessions that are eligible for deletion
     userids = sessions.each_with_object([]) do |s, a|
       begin
-        a << Marshal.load(Base64.decode64(s.data.split("\n").join))[:userid]
+        a << s.raw_data[:userid]
       rescue => err
         _log.warn("Error '#{err.message}', attempting to load session with id [#{s.id}]")
       end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 25,
-      "fingerprint": "0051a4e9b0e19666f13befb5a9522f07d8de4d6f05ccc6f594f15bf1b9578dc6",
-      "check_name": "Deserialize",
-      "message": "Marshal.load called with model attribute",
-      "file": "lib/token_store/sql_store.rb",
-      "line": 16,
-      "link": "http://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
-      "code": "Marshal.load(Base64.decode64(Session.find_by(:session_id => session_key(token)).data))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "TokenStore::SqlStore",
-        "method": "read"
-      },
-      "user_input": "Session.find_by(:session_id => session_key(token)).data",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "4e1918c2d5ff2beacc21db09f696af724d62f1a2a6a101e8e3cb564d0e8a94cd",
@@ -121,6 +101,6 @@
       "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
-  "updated": "2017-05-30 13:45:37 -0700",
+  "updated": "2017-05-30 16:04:08 -0700",
   "brakeman_version": "3.6.2"
 }

--- a/lib/token_store/sql_store.rb
+++ b/lib/token_store/sql_store.rb
@@ -6,14 +6,14 @@ class TokenStore
 
     def write(token, data, _options = nil)
       record = Session.find_or_create_by(:session_id => session_key(token))
-      record.data = Base64.encode64(Marshal.dump(data))
+      record.raw_data = data
       record.save!
     end
 
     def read(token, _options = nil)
       record = Session.find_by(:session_id => session_key(token))
       return nil unless record
-      data = Marshal.load(Base64.decode64(record.data))
+      data = record.raw_data
       if data[:expires_on] > Time.zone.now
         data
       else

--- a/spec/lib/token_store/sql_store_spec.rb
+++ b/spec/lib/token_store/sql_store_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe TokenStore::SqlStore do
       session = FactoryGirl.create(
         :session,
         :session_id => "TEST:#{token}",
-        :data       => serialize_data(:expires_on => 1.second.from_now)
+        :raw_data   => {:expires_on => 1.second.from_now}
       )
 
       store.write(token, :expires_on => 1.hour.from_now)
 
-      expect(deserialize_data(session.reload.data)[:expires_on]).to eq(1.hour.from_now)
+      expect(session.reload.raw_data[:expires_on]).to eq(1.hour.from_now)
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe TokenStore::SqlStore do
       FactoryGirl.create(
         :session,
         :session_id => "TEST:#{token}",
-        :data       => serialize_data(:userid => "alice", :expires_on => 1.second.from_now)
+        :raw_data   => {:userid => "alice", :expires_on => 1.second.from_now}
       )
 
       data = store.read(token)
@@ -50,7 +50,7 @@ RSpec.describe TokenStore::SqlStore do
       FactoryGirl.create(
         :session,
         :session_id => "TEST:#{token}",
-        :data       => serialize_data(:userid => "alice", :expires_on => 1.second.ago)
+        :raw_data   => {:userid => "alice", :expires_on => 1.second.ago}
       )
 
       data = store.read(token)
@@ -75,19 +75,11 @@ RSpec.describe TokenStore::SqlStore do
       FactoryGirl.create(
         :session,
         :session_id => "TEST:#{token}",
-        :data       => serialize_data(:userid => "alice", :expires_on => 1.hour.from_now)
+        :raw_data   => {:userid => "alice", :expires_on => 1.hour.from_now}
       )
 
       expect { store.delete(token) }.to change(Session, :count).by(-1)
     end
-  end
-
-  def serialize_data(data)
-    Base64.encode64(Marshal.dump(data))
-  end
-
-  def deserialize_data(data)
-    Marshal.load(Base64.decode64(data))
   end
 
   def build_sql_store(namespace = "FOO")

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,4 +1,29 @@
 describe Session do
+  describe "#raw_data" do
+    it "returns the unmarshaled data" do
+      session = FactoryGirl.build(:session, :data => "BAh7BjoLdXNlcmlkSSIKYWRtaW4GOgZFVA==\n")
+
+      expect(session.raw_data).to eq(:userid => "admin")
+    end
+
+    it "can handle newlines" do
+      session = FactoryGirl.build(
+        :session,
+        :data => "BAh7CDoIZm9vSSIIYmFyBjoGRVQ6CGJhekkiCHF1eAY7BlQ6CXF1dXhJIglx\ndXV6BjsGVA==\n"
+      )
+
+      expect(session.raw_data).to eq(:foo => "bar", :baz => "qux", :quux => "quuz")
+    end
+  end
+
+  describe "#raw_data=" do
+    it "marshals the data" do
+      session = FactoryGirl.build(:session, :raw_data => {:userid => "admin"})
+
+      expect(session.data).to eq("BAh7BjoLdXNlcmlkSSIKYWRtaW4GOgZFVA==\n")
+    end
+  end
+
   describe ".purge" do
     before do
       2.times do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -27,10 +27,7 @@ describe Session do
   describe ".purge" do
     before do
       2.times do
-        FactoryGirl.create(:session,
-                           :updated_at => 1.year.ago,
-                           :data       => Base64.encode64(Marshal.dump(:userid=>"admin"))
-                          )
+        FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid=>"admin"})
       end
     end
 
@@ -74,12 +71,7 @@ describe Session do
       around { |example| Timecop.freeze { example.run } }
 
       it "will purge an expired token" do
-        FactoryGirl.create(
-          :session,
-          :data => serialize_data(
-            :expires_on => 1.second.ago,
-          )
-        )
+        FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.ago})
 
         described_class.purge(0)
 
@@ -87,20 +79,11 @@ describe Session do
       end
 
       it "won't purge an unexpired token" do
-        FactoryGirl.create(
-          :session,
-          :data => serialize_data(
-            :expires_on => 1.second.from_now,
-          )
-        )
+        FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.from_now})
 
         described_class.purge(0)
 
         expect(described_class.count).to eq(1)
-      end
-
-      def serialize_data(data)
-        Base64.encode64(Marshal.dump(data))
       end
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq/pull/14947

The knowledge of how to marshal/unmarshal the session data is spread out in numerous places. I've tried to encapsulate that knowledge in `Session#raw_data` and `Session#raw_data=`. This also makes the brakeman ignore obsolete, even though nothing has technically changed, since it isn't smart enough to realize it's the same.

@miq-bot add-label core, refactoring
@miq-bot assign @gtanzillo 