### PR TITLE
Move AMQP stub from spec_helper to Openstack repo

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -123,12 +123,6 @@ module EvmSpecHelper
     end
   end
 
-  def self.stub_amqp_support
-    require 'openstack/events/openstack_rabbit_event_monitor'
-    allow(OpenstackRabbitEventMonitor).to receive(:available?).and_return(true)
-    allow(OpenstackRabbitEventMonitor).to receive(:test_connection).and_return(true)
-  end
-
   def self.import_yaml_model(dirname, domain, attrs = {})
     options = {'import_dir' => dirname, 'preview' => false, 'domain' => domain}
     yaml_import(domain, options, attrs)


### PR DESCRIPTION
stub_amqp_support method is Openstack specific, removing from main repo.

It is being imported to manageiq-providers-openstack repo in
https://github.com/ManageIQ/manageiq-providers-openstack/pull/48

Links
----------------

* https://github.com/ManageIQ/manageiq-providers-openstack/pull/48

Steps for Testing/QA
-------------------------------
This change should not fail the build.
