### PR TITLE
Do not calculate useless group metrics

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -36,8 +36,7 @@ class ChargeableField < ApplicationRecord
   end
 
   def metric_keys
-    ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
-     "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
+    ["#{rate_name}_metric"] # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
   def cost_keys

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -35,8 +35,8 @@ class ChargeableField < ApplicationRecord
     UNITS[metric] ? detail_measure.adjust(target_unit, UNITS[metric]) : 1
   end
 
-  def metric_keys
-    ["#{rate_name}_metric"] # metric value (e.g. Storage [Used|Allocated|Fixed])
+  def metric_key
+    "#{rate_name}_metric" # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
   def cost_keys

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,7 +12,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true
 
-  delegate :metric_keys, :cost_keys, :to => :chargeable_field
+  delegate :metric_key, :cost_keys, :to => :chargeable_field
 
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id).freeze
   PER_TIME_TYPES = {
@@ -25,13 +25,13 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption)
     result = {}
-    if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?
+    if (relevant_fields & [metric_key, cost_keys[0]]).present?
       metric_value, cost = metric_and_cost_by(consumption)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0
       end
-      metric_keys.each { |field| result[field] = metric_value }
-      cost_keys.each   { |field| result[field] = cost }
+      result[metric_key] = metric_value
+      cost_keys.each { |field| result[field] = cost }
     end
     result
   end
@@ -85,7 +85,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def affects_report_fields(report_cols)
-    (metric_keys.to_set & report_cols).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
+    ([metric_key].to_set & report_cols).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
   end
 
   def friendly_rate

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -158,7 +158,6 @@ describe ChargebackVm do
         expect(subject.memory_allocated_metric).to eq(memory_available)
         used_metric = used_average_for(:derived_memory_used, hours_in_day, @vm1)
         expect(subject.memory_used_metric).to eq(used_metric)
-        expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
         expect(subject.memory_allocated_cost).to eq(memory_available * hourly_rate * hours_in_day)
         expect(subject.memory_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
@@ -186,7 +185,6 @@ describe ChargebackVm do
         storage_allocated_cost = vm_allocated_disk_storage * count_hourly_rate * hours_in_day
         expect(subject.storage_allocated_cost).to eq(storage_allocated_cost)
 
-        expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
         expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
       end
 
@@ -204,7 +202,6 @@ describe ChargebackVm do
           expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
           used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day, @vm1)
           expect(subject.storage_used_metric).to eq(used_metric)
-          expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
           expected_value = hourly_fixed_rate * hours_in_day
           expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
@@ -280,7 +277,6 @@ describe ChargebackVm do
         expect(subject.memory_allocated_metric).to eq(memory_available)
         used_metric = used_average_for(:derived_memory_used, hours_in_month, @vm1)
         expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
-        expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
         memory_allocated_cost = memory_available * hourly_rate * hours_in_month
         expect(subject.memory_allocated_cost).to be_within(0.01).of(memory_allocated_cost)
@@ -315,7 +311,6 @@ describe ChargebackVm do
           expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
           used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month, @vm1)
           expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
-          expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
           expected_value = hourly_fixed_rate * hours_in_month
           expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
@@ -330,7 +325,6 @@ describe ChargebackVm do
         expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
         used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month, @vm1)
         expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
-        expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
         expected_value = vm_allocated_disk_storage * count_hourly_rate * hours_in_month
         expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)


### PR DESCRIPTION
 - cpu is useless as it counts usagemhz and vm_numvcpus together
 - cpu_cores is useless as it only reports cpu_cores
 - memory is useless as counts used and available together
 - net_io is useless as it only reports net_ui_rate_avg
 - disk_io is useless as it only reports disk_usage_rate_avg
 - storage is useless as it counts used and allocated together
 - fixed is useless as it counts all the fixed metrics together    (that equals to 4 for each day, not useful)

https://bugzilla.redhat.com/show_bug.cgi?id=1455690
https://bugzilla.redhat.com/show_bug.cgi?id=1454456

Note this only fixes part of the upper mentioned bzs.
