### PR TITLE
set_miq_server Action

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -244,6 +244,19 @@ module Api
       end
     end
 
+    def set_miq_server_resource(type, id, data)
+      vm = resource_search(id, type, collection_class(type))
+
+      miq_server_id = parse_id(data['miq_server'], :servers)
+      raise 'Must specify a valid miq_server href or id' unless miq_server_id
+      miq_server = resource_search(miq_server_id, :servers, collection_class(:servers))
+
+      vm.miq_server = miq_server
+      action_result(true, "Set miq_server id:#{miq_server.id} for #{vm_ident(vm)}")
+    rescue => err
+      action_result(false, "Failed to set miq_server - #{err}")
+    end
+
     private
 
     def validate_edit_data(data)

--- a/config/api.yml
+++ b/config/api.yml
@@ -2357,6 +2357,8 @@
         :identifier: vm_edit
       - :name: set_ownership
         :identifier: vm_ownership
+      - :name: set_miq_server
+        :identifier: vm_edit
       - :name: scan
         :identifier: vm_scan
       - :name: delete
@@ -2406,6 +2408,8 @@
         :identifier: vm_edit
       - :name: set_ownership
         :identifier: vm_ownership
+      - :name: set_miq_server
+        :identifier: vm_edit
       - :name: scan
         :identifier: vm_scan
       :delete:


### PR DESCRIPTION
This adds a `set_miq_server` action to the API on both a VM resource and the VM collection for bulk setting of miq_servers.

This is needed for PV ticket https://www.pivotaltracker.com/n/projects/1613907/stories/146327113

@miq-bot add_label enhancement, api, fine/no
@miq-bot assign @abellotti 

cc: @h-kataria 