### PR TITLE
Fix erratic spec for reports with custom attributes

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -896,7 +896,7 @@ describe MiqReport do
         container = FactoryGirl.create(:kubernetes_container, :container_group => group, :container_image => image)
         container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
                                                        :with_data,
-                                                       :timestamp     => 1.day.ago,
+                                                       :timestamp     => 1.day.ago.beginning_of_day,
                                                        :resource_id   => container.id,
                                                        :resource_name => container.name,
                                                        :parent_ems_id => ems.id,


### PR DESCRIPTION
`Consumption#consumed_hours_in_interval` regards the consumption start
as the greater of the passed in `@start_time`, or `born_at`, which
will be the timestamp of the first rollup for the resource. If this
test is run any time in the 23rd hour UTC, the consumption period will
be < 1 hour, causing this to return `0`, failing the test.

By creating the rollup at the start of day UTC, we avoid this edge
case, ensuring that this test passes at any time of day.

@miq-bot add-label bug/sporadic test failure
@miq-bot assign @isimluk 

I'm assuming here that this is an issue with the test setup and not an actual bug in the consumption logic....LMK if you think there is a better way to fix this.

EDIT: for an example, see here: https://travis-ci.org/ManageIQ/manageiq/jobs/237726365