### PR TITLE
Add http-parser as a dependency for the monolithic container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    gdbm-devel              \
                    cronie                  \
                    logrotate               \
+                   http-parser             \
                    &&                      \
     yum clean all
 


### PR DESCRIPTION
A new version of nodejs needs this as a dependency
We need to explicitly add it otherwise we get the following error:

`node: error while loading shared libraries: libhttp_parser.so.2: cannot open shared object file: No such file or directory`

See also:

https://github.com/ManageIQ/manageiq-pods/pull/150
https://github.com/ManageIQ/manageiq-appliance-build/pull/211