### PR TITLE
Refactor Session specs

### DIFF
--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -26,7 +26,7 @@ describe Session do
 
   describe ".purge" do
     before do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid=>"admin"})
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
     end
 
     it "purges an old session" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -54,7 +54,6 @@ describe Session do
     end
 
     it "handles a session with bad data" do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       FactoryGirl.create(:session,
                          :updated_at => 1.year.ago,
                          :data       => "Data that can't be marshaled"
@@ -69,7 +68,6 @@ describe Session do
       around { |example| Timecop.freeze { example.run } }
 
       it "will purge an expired token" do
-        FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.ago})
 
         described_class.purge(0)
@@ -78,7 +76,6 @@ describe Session do
       end
 
       it "won't purge an unexpired token" do
-        FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.from_now})
 
         described_class.purge(0)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -26,9 +26,7 @@ describe Session do
 
   describe ".purge" do
     before do
-      2.times do
-        FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid=>"admin"})
-      end
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid=>"admin"})
     end
 
     it "purges an old session" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -33,8 +33,10 @@ describe Session do
 
     it "logs out users before destroying stale sessions" do
       FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(User).to receive(:where).and_return([User.new]).exactly(1).times
+      user = instance_double(User, :lastlogoff => 2.days.ago, :lastlogon => 1.day.ago)
+      allow(User).to receive(:where).with(:userid => ["admin"]).and_return([user])
 
+      expect(user).to receive(:logoff)
       expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
     end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -25,11 +25,8 @@ describe Session do
   end
 
   describe ".purge" do
-    before do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-    end
-
     it "purges an old session" do
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       expect(described_class.count).to eq(2)
 
       described_class.purge(0, 1)
@@ -38,6 +35,7 @@ describe Session do
     end
 
     it "purges one batch" do
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       expect(described_class.count).to eq(2)
 
       expect(described_class.purge_one_batch(0, 1)).to eq 1
@@ -46,6 +44,7 @@ describe Session do
     end
 
     it "logs out users before destroying stale sessions" do
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       expect(described_class.count).to eq(2)
       expect(User).to receive(:where).and_return([User.new]).exactly(1).times
 
@@ -55,6 +54,7 @@ describe Session do
     end
 
     it "handles a session with bad data" do
+      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       FactoryGirl.create(:session,
                          :updated_at => 1.year.ago,
                          :data       => "Data that can't be marshaled"
@@ -69,6 +69,7 @@ describe Session do
       around { |example| Timecop.freeze { example.run } }
 
       it "will purge an expired token" do
+        FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.ago})
 
         described_class.purge(0)
@@ -77,6 +78,7 @@ describe Session do
       end
 
       it "won't purge an unexpired token" do
+        FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.from_now})
 
         described_class.purge(0)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -45,10 +45,7 @@ describe Session do
     end
 
     it "handles a session with bad data" do
-      FactoryGirl.create(:session,
-                         :updated_at => 1.year.ago,
-                         :data       => "Data that can't be marshaled"
-                        )
+      FactoryGirl.create(:session, :updated_at => 1.year.ago, :data => "Data that can't be marshaled")
 
       described_class.purge(0)
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -37,7 +37,8 @@ describe Session do
       allow(User).to receive(:where).with(:userid => ["admin"]).and_return([user])
 
       expect(user).to receive(:logoff)
-      expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
+
+      described_class.purge(0)
     end
 
     it "handles a session with bad data" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -27,29 +27,21 @@ describe Session do
   describe ".purge" do
     it "purges an old session" do
       FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(described_class.count).to eq(1)
 
-      described_class.purge(0, 1)
-
-      expect(described_class.count).to be_zero
+      expect { described_class.purge(0, 1) }.to change { described_class.count }.from(1).to(0)
     end
 
     it "logs out users before destroying stale sessions" do
       FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(described_class.count).to eq(1)
       expect(User).to receive(:where).and_return([User.new]).exactly(1).times
 
-      described_class.purge(0)
-
-      expect(described_class.count).to eq 0
+      expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
     end
 
     it "handles a session with bad data" do
       FactoryGirl.create(:session, :updated_at => 1.year.ago, :data => "Data that can't be marshaled")
 
-      described_class.purge(0)
-
-      expect(described_class.count).to eq 0
+      expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
     end
 
     context "given some token store data" do
@@ -58,28 +50,23 @@ describe Session do
       it "will purge an expired token" do
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.ago})
 
-        described_class.purge(0)
-
-        expect(described_class.count).to eq(0)
+        expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
       end
 
       it "won't purge an unexpired token" do
         FactoryGirl.create(:session, :raw_data => {:expires_on => 1.second.from_now})
 
-        described_class.purge(0)
-
-        expect(described_class.count).to eq(1)
+        expect { described_class.purge(0) }.not_to change { described_class.count }
       end
     end
 
     describe ".purge_one_batch" do
       it "purges one batch" do
         FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-        expect(described_class.count).to eq(2)
 
-        expect(described_class.purge_one_batch(0, 1)).to eq 1
-
-        expect(described_class.count).to eq 1
+        expect do
+          expect(described_class.purge_one_batch(0, 1)).to eq 1
+        end.to change { described_class.count }.from(2).to(1)
       end
     end
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -34,15 +34,6 @@ describe Session do
       expect(described_class.count).to be_zero
     end
 
-    it "purges one batch" do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(described_class.count).to eq(2)
-
-      expect(described_class.purge_one_batch(0, 1)).to eq 1
-
-      expect(described_class.count).to eq 1
-    end
-
     it "logs out users before destroying stale sessions" do
       FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
       expect(described_class.count).to eq(2)
@@ -81,6 +72,17 @@ describe Session do
         described_class.purge(0)
 
         expect(described_class.count).to eq(1)
+      end
+    end
+
+    describe ".purge_one_batch" do
+      it "purges one batch" do
+        FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
+        expect(described_class.count).to eq(2)
+
+        expect(described_class.purge_one_batch(0, 1)).to eq 1
+
+        expect(described_class.count).to eq 1
       end
     end
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -26,8 +26,8 @@ describe Session do
 
   describe ".purge" do
     it "purges an old session" do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(described_class.count).to eq(2)
+      FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
+      expect(described_class.count).to eq(1)
 
       described_class.purge(0, 1)
 
@@ -35,8 +35,8 @@ describe Session do
     end
 
     it "logs out users before destroying stale sessions" do
-      FactoryGirl.create_list(:session, 2, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
-      expect(described_class.count).to eq(2)
+      FactoryGirl.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
+      expect(described_class.count).to eq(1)
       expect(User).to receive(:where).and_return([User.new]).exactly(1).times
 
       described_class.purge(0)


### PR DESCRIPTION
A few bits of housekeeping since I was here recently:

1. Creates fewer objects by inlining the before block and removing test fixtures that weren't necessary
1. Fewer roundtrips to the db
2. Use RSpec's `change` matcher to write some of these expectations more concisely
3. Mock the behavior being described by the "logs out users" example
4. The overall change is net :scissors: 

@miq-bot add-label test, refactoring
@miq-bot assign @gtanzillo 
