### PR TITLE
Workaround Rails.configuration.database_configuration being {}

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -95,11 +95,7 @@ class EvmDatabase
   end
 
   def self.host
-    if defined?(Rails)
-      Rails.configuration.database_configuration[Rails.env]['host']
-    else
-      ActiveRecord::Base.configurations[ENV['RAILS_ENV']]['host']
-    end
+    ActiveRecord::Base.configurations.fetch_path(ENV['RAILS_ENV'], 'host')
   end
 
   def self.local?


### PR DESCRIPTION
If you don't have a `config/database.yml` and only `ENV["DATABASE_URL"]`, `Rails.configuration.database_configuration` will be `{}`, so you'll get an `undefined [] for nil` error.

While attempting to fix that in https://github.com/rails/rails/pull/29305, I was told that it was not intended to be the public interface.  So I'm changing this PR to always use `ActiveRecord::Base.configurations` instead.
