### PR TITLE
Allow matching via descendants for CloudNetworks (via network manager)

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -359,7 +359,7 @@ module Rbac
     end
     #
     # Algorithm: filter = u_filtered_ids UNION (b_filtered_ids INTERSECTION m_filtered_ids)
-    #            filter = (filter UNION d_filtered_ids if filter is not nil)
+    #            filter = (filter UNION d_filtered_ids)
     #            filter = filter INTERSECTION tenant_filter_ids if tenant_filter_ids is not nil
     # a nil as input for any field means it does not apply
     # a nil as output means there is not filter
@@ -390,6 +390,8 @@ module Rbac
       if filtered_ids.kind_of?(Array)
         filtered_ids += d_filtered_ids if d_filtered_ids.kind_of?(Array)
         filtered_ids.uniq!
+      elsif d_filtered_ids.kind_of?(Array) && d_filtered_ids.present?
+        filtered_ids = d_filtered_ids
       end
 
       if filtered_ids.kind_of?(Array) && tenant_filter_ids

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -84,6 +84,7 @@ module Rbac
       "VmOrTemplate::ResourcePool"             => :resource_pool,
       "ConfiguredSystem::ExtManagementSystem"  => :ext_management_system,
       "ConfiguredSystem::ConfigurationProfile" => [:id, :configuration_profile_id],
+      "ExtManagementSystem::CloudNetwork"      => [:ems_id, :id]
     }
 
     # These classes should accept any of the relationship_mixin methods including:


### PR DESCRIPTION
- filter called 'matching via descendants' is not working when there is used the only this filter
- (related to BZ) we need to filter list in CloudNetwork controller according to the network provider :
<img width="1212" alt="screen shot 2017-06-01 at 18 34 07" src="https://cloud.githubusercontent.com/assets/14937244/26690333/30342e62-46f9-11e7-858e-0cce79771b76.png">
and the restriction is set in user's group setting in Host & Cluster tab


@miq-bot add_label bug, rbac
@miq-bot assign @gtanzillo 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1445163


