### PR TITLE
Format trend max cpu usage rate with percent

### DIFF
--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -232,6 +232,7 @@
     :min_cpu_usagemhz_rate_average: :mhz_avg
     :trend_cpu_usagemhz_rate_average: :mhz_avg
     :trend_max_cpu_usagemhz_rate_average: :mhz_avg
+    :trend_max_cpu_usage_rate_average: :percent
 
     :max_sys_uptime_absolute_latest: :elapsed_time
     :min_sys_uptime_absolute_latest: :elapsed_time


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1451132

A percent sign is missing from values under Trend Max % Used column on the C&U CPU report.

**Before**
<img width="103" alt="screen shot 2017-06-01 at 1 13 08 pm" src="https://cloud.githubusercontent.com/assets/39493/26691853/b22a9064-46cc-11e7-838b-a7d1b506d93e.png">

**After**
<img width="103" alt="screen shot 2017-06-01 at 1 09 42 pm" src="https://cloud.githubusercontent.com/assets/39493/26691866/b9f46e8c-46cc-11e7-9e1a-8739b6d0008b.png">

@dclarizio @h-kataria 