### PR TITLE
Ensure report columns serialized as hashes have symbolized keys before importing

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -11,6 +11,9 @@ module MiqReport::ImportExport
         raise _("Incorrect format, only policy records can be imported.")
       end
 
+      # Ensure that all columns serialized as hashes in the report have keys that are symbols
+      self.column_names.each { |k| report[k].deep_symbolize_keys! if report[k].kind_of?(Hash) }
+
       user = options[:user] || User.find_by_userid(options[:userid])
       report.merge!("miq_group_id" => user.current_group_id, "user_id" => user.id)
 


### PR DESCRIPTION
This fixes a bug where a report imported via the Rest API, as json, fails to generate because the keys
in columns serialized as hashes are received as strings.

https://bugzilla.redhat.com/show_bug.cgi?id=1456742
