### PR TITLE
[EUWE] Check for timed out active tasks

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -225,6 +225,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "Service", :method_name => "queue_chargeback_reports", :zone => nil, :args => args)
   end
 
+  def check_for_timed_out_active_tasks
+    queue_work(:class_name => "MiqTask", :method_name => "update_status_for_timed_out_active_tasks", :zone => nil)
+  end
+
   private
 
   def queue_work(options)

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -247,9 +247,20 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       end
     end
 
-    # run run chargeback generation every day at specific time
+    # run chargeback generation every day at specific time
     schedule_chargeback_report_for_service_daily
+
+    schedule_check_for_task_timeout
+
     @schedules[:scheduler]
+  end
+
+  def schedule_check_for_task_timeout
+    every = worker_settings[:task_timeout_check_frequency]
+    scheduler = scheduler_for(:scheduler)
+    scheduler.schedule_every(every, :first_at => Time.current + 1.minute) do
+      enqueue :check_for_timed_out_active_tasks
+    end
   end
 
   def schedule_chargeback_report_for_service_daily

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1165,6 +1165,8 @@
     :keep_hourly_metrics: 6.months
     :keep_realtime_metrics: 4.hours
     :purge_window_size: 1000
+:task:
+  :active_task_timeout: 6.hours
 :ui:
   :mark_translated_strings: false
 :webservices:
@@ -1413,6 +1415,7 @@
       :session_timeout_interval: 30.seconds
       :storage_file_collection_interval: 1.days
       :storage_file_collection_time_utc: 21600
+      :task_timeout_check_frequency: 1.hour
       :vm_retired_interval: 10.minutes
       :chargeback_generation_time_utc: 01:00:00
       :chargeback_generation_interval: 1.day

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -49,4 +49,15 @@ describe MiqScheduleWorker::Jobs do
       )
     end
   end
+
+  describe "#check_for_timed_out_active_tasks" do
+    it "enqueues update_status_for_timed_out_active_tasks" do
+      allow(MiqServer).to receive(:my_zone)
+      described_class.new.check_for_timed_out_active_tasks
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => "MiqTask",
+        :method_name => "update_status_for_timed_out_active_tasks"
+      )
+    end
+  end
 end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -475,15 +475,18 @@ describe MiqScheduleWorker::Runner do
           end
         end
 
-        context "Chargeback reports for Services" do
+        context "schedule for 'scheduler' role" do
           before do
             allow(@schedule_worker).to receive(:heartbeat)
             @schedule_worker.instance_variable_set(:@active_roles, ["scheduler"])
-            allow(@schedule_worker).to receive(:worker_settings).and_return(:ems_events_purge_interval => 1.day)
             @schedule_worker.instance_variable_set(:@schedules, :scheduler => [])
           end
 
           describe "#schedule_chargeback_report_for_service_daily" do
+            before do
+              allow(@schedule_worker).to receive(:worker_settings).and_return(:chargeback_generation_interval => 1.day)
+            end
+
             it "queues daily generation of Chargeback report for each service" do
               job = @schedule_worker.schedule_chargeback_report_for_service_daily[0]
               expect(job).to be_kind_of(Rufus::Scheduler::EveryJob)
@@ -495,6 +498,24 @@ describe MiqScheduleWorker::Runner do
               expect(queue.method_name).to eq "queue_chargeback_reports"
               expect(queue.class_name).to eq "Service"
               expect(queue.args[0][:report_source]).to eq "Daily scheduler"
+              MiqQueue.delete_all
+              job.unschedule
+            end
+          end
+
+          describe "#schedule_check_for_task_timeout" do
+            let(:interval) { 1.hour }
+            before do
+              allow(@schedule_worker).to receive(:worker_settings).and_return(:task_timeout_check_frequency => interval)
+            end
+
+            it "queues check for timed out tasks" do
+              job = @schedule_worker.schedule_check_for_task_timeout[0]
+              job.call
+              @schedule_worker.do_work
+              queue = MiqQueue.first
+              expect(queue.method_name).to eq "update_status_for_timed_out_active_tasks"
+              expect(queue.class_name).to eq "MiqTask"
               MiqQueue.delete_all
               job.unschedule
             end


### PR DESCRIPTION
**Issue:**
If reporting worker killed (kill -9 <pid>) when report is still running than task status stays Running forever.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1457979

merged PR on master: https://github.com/ManageIQ/manageiq/pull/15231

@miq-bot add-label bug, core
