### PR TITLE
Updated the versions of Ruby we test against.

### DIFF
--- a/lib/generators/provider/templates/.travis.yml
+++ b/lib/generators/provider/templates/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - '2.3.1'
+- '2.4.1'
 sudo: false
 cache: bundler
 env:


### PR DESCRIPTION
This keeps the generator inline with ManageIQ main repo