### PR TITLE
Update database schema for network adapter support

### DIFF
--- a/db/migrate/20170524173850_add_guest_device_id_to_firmwares.rb
+++ b/db/migrate/20170524173850_add_guest_device_id_to_firmwares.rb
@@ -1,0 +1,6 @@
+class AddGuestDeviceIdToFirmwares < ActiveRecord::Migration[5.0]
+  def change
+    add_column :firmwares, :guest_device_id, :bigint
+    add_index :firmwares, :guest_device_id, :name => "index_firmwares_on_guest_device_id"
+  end
+end

--- a/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
+++ b/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
@@ -1,0 +1,8 @@
+class AddManufacturerAndFruToGuestDevices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :guest_devices, :manufacturer, :string
+    add_column :guest_devices, :fru, :string
+    add_column :guest_devices, :guest_device_id, :bigint
+    add_index :guest_devices, :guest_device_id, :name => "index_guest_devices_on_guest_device_id"  
+  end
+end

--- a/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
+++ b/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
@@ -1,7 +1,7 @@
 class AddManufacturerAndFruToGuestDevices < ActiveRecord::Migration[5.0]
   def change
     add_column :guest_devices, :manufacturer, :string
-    add_column :guest_devices, :fru, :string
+    add_column :guest_devices, :field_replaceable_unit, :string
     add_column :guest_devices, :guest_device_id, :bigint
     add_index :guest_devices, :guest_device_id, :name => "index_guest_devices_on_guest_device_id"
   end

--- a/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
+++ b/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
@@ -3,6 +3,6 @@ class AddManufacturerAndFruToGuestDevices < ActiveRecord::Migration[5.0]
     add_column :guest_devices, :manufacturer, :string
     add_column :guest_devices, :fru, :string
     add_column :guest_devices, :guest_device_id, :bigint
-    add_index :guest_devices, :guest_device_id, :name => "index_guest_devices_on_guest_device_id"  
+    add_index :guest_devices, :guest_device_id, :name => "index_guest_devices_on_guest_device_id"
   end
 end

--- a/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
+++ b/db/migrate/20170530180114_add_manufacturer_and_fru_to_guest_devices.rb
@@ -2,7 +2,7 @@ class AddManufacturerAndFruToGuestDevices < ActiveRecord::Migration[5.0]
   def change
     add_column :guest_devices, :manufacturer, :string
     add_column :guest_devices, :field_replaceable_unit, :string
-    add_column :guest_devices, :guest_device_id, :bigint
-    add_index :guest_devices, :guest_device_id, :name => "index_guest_devices_on_guest_device_id"
+    add_column :guest_devices, :parent_device_id, :bigint
+    add_index :guest_devices, :parent_device_id, :name => "index_guest_devices_on_parent_device_id"
   end
 end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1435,7 +1435,7 @@ guest_devices:
 - uid_ems
 - chap_auth_enabled
 - manufacturer
-- fru
+- field_replaceable_unit
 - guest_device_id
 hardwares:
 - id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1323,6 +1323,7 @@ firmwares:
 - resource_type
 - created_at
 - updated_at
+- guest_device_id
 flavors:
 - id
 - ems_id
@@ -1433,6 +1434,9 @@ guest_devices:
 - auto_detect
 - uid_ems
 - chap_auth_enabled
+- manufacturer
+- fru
+- guest_device_id
 hardwares:
 - id
 - config_version

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1436,7 +1436,7 @@ guest_devices:
 - chap_auth_enabled
 - manufacturer
 - field_replaceable_unit
-- guest_device_id
+- parent_device_id
 hardwares:
 - id
 - config_version


### PR DESCRIPTION
This PR contains changes necessary to add physical network adapter details to the database. The network adapter and its port details are added to the guest_devices table. The network adapter firmware details are added to the firmwares table. There is a new foreign key named guest_device_id in the firmwares table, so a firmware entry can refer to a guest device. This allows a guest device to be associated with multiple firmware entries. In addition, there is a new foreign key named guest_device_id in the guest_devices table. This allows a guest device (such as a port) to be associated with another guest device (such as a network adapter).