### PR TITLE
[WIP] Use MiqTask in MiqQueue#put_unless_exists

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -135,16 +135,15 @@ class Job < ApplicationRecord
   end
 
   def timeout!
-    MiqQueue.put_unless_exists(
+    message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
+    MiqQueue.create_with(:args => [message, "error"]).put_unless_exists(
       :class_name  => self.class.base_class.name,
       :instance_id => id,
       :method_name => "signal_abort",
       :role        => "smartstate",
       :zone        => MiqServer.my_zone
     ) do |_msg, find_options|
-      message = "job timed out after #{Time.now - updated_on} seconds of inactivity.  Inactivity threshold [#{current_job_timeout} seconds]"
       _log.warn("Job: guid: [#{guid}], #{message}, aborting")
-      find_options.merge(:args => [message, "error"])
     end
   end
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -282,9 +282,9 @@ class MiqQueue < ApplicationRecord
   # Return task.id
   def self.put_unless_exists(find_options)
     find_options = default_get_options(find_options)
-    conds = find_options.dup
-    conds.delete(:state)
-    identifier = conds.hash.to_s
+    options = find_options.dup
+    options.delete(:state)
+    identifier = options.hash.to_s
 
     task = MiqTask.find_by(:identifier => identifier)
 
@@ -297,7 +297,7 @@ class MiqQueue < ApplicationRecord
         :message    => 'Queued'
       ).id
 
-      put(conds.merge(:miq_callback => {:class_name => MiqTask.class.name, :instance_id => task_id, :method_name => :destroy}))
+      put(options.merge(:miq_callback => {:class_name => MiqTask.class.name, :instance_id => task_id, :method_name => :destroy}))
     end
 
     yield(task, find_options) if block_given? # the block expects to see task to be nil if not already exist

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -284,7 +284,7 @@ class MiqQueue < ApplicationRecord
     find_options = default_get_options(find_options)
     conds = find_options.dup
 
-    task = MiqTask.where(:state => [MiqTask::STATE_INITIALIZED, MiqTask::STATE_QUEUED]).find_by(:identifier => conds.hash.to_s)
+    task = MiqTask.find_by(:identifier => conds.hash.to_s)
 
     save_options = block_given? ? yield(task, find_options) : nil
     save_options = save_options.dup unless save_options.nil?
@@ -304,7 +304,7 @@ class MiqQueue < ApplicationRecord
         :message    => 'Queued'
       )
 
-      MiqQueue.put(put_options)
+      MiqQueue.put(put_options.merge(:miq_callback => {:class_name => MiqTask.class.name, :instance_id => task.id, :method_name => :destroy}))
     end
     task.id
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -246,13 +246,12 @@ module AuthenticationMixin
     if force
       MiqQueue.put(options)
     else
-      MiqQueue.put_unless_exists(options.except(:args, :deliver_on)) do |msg|
+      MiqQueue.create_with(options.slice(:args, :deliver_on)).put_unless_exists(options.except(:args, :deliver_on)) do |msg|
         # TODO: Refactor the help in this and the ScheduleWorker#queue_work method into the merge method
         help = "Check for a running server"
         help << " in zone: [#{options[:zone]}]"   if options[:zone]
         help << " with role: [#{options[:role]}]" if options[:role]
         _log.warn("Previous authentication_check_types for [#{name}] [#{id}] with opts: [#{options[:args].inspect}] is still running, skipping...#{help}") unless msg.nil?
-        options
       end
     end
   end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -34,6 +34,7 @@ describe Job do
           @msg = MiqQueue.get(:role => "smartstate", :zone => @zone.name)
           status, message, result = @msg.deliver
           @msg.delivered(status, message, result)
+          MiqTask.where.not(:identifier => nil).delete_all
 
           @job.reload
         end
@@ -56,6 +57,7 @@ describe Job do
 
       it "should queue a timeout job if one is there, but it is failed" do
         MiqQueue.first.update_attributes(:state => MiqQueue::STATE_ERROR)
+        MiqTask.where.not(:identifier => nil).delete_all
         expect { @job.timeout! }.to change { MiqQueue.count }.by(1)
       end
     end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -514,19 +514,21 @@ describe MiqQueue do
     end
 
     it "should put a unique message on the queue if method_name is different" do
-      msg1 = MiqQueue.put(
+      options1 = {
         :class_name  => 'MyClass',
         :method_name => 'method1',
         :args        => [1, 2]
-      )
-      msg2 = MiqQueue.put_unless_exists(
+      }
+      options2 = {
         :class_name  => 'MyClass',
         :method_name => 'method2',
         :args        => [1, 2]
-      )
+      }
+      MiqQueue.put(options1)
+      MiqQueue.put_unless_exists(options2)
 
-      expect(MiqQueue.get).to eq(msg1)
-      expect(MiqQueue.get).to eq(msg2)
+      expect(MiqQueue.get).to have_attributes(options1)
+      expect(MiqQueue.get).to have_attributes(options2)
       expect(MiqQueue.get).to eq(nil)
     end
 
@@ -560,19 +562,15 @@ describe MiqQueue do
     end
 
     it "should not put duplicate messages on the queue" do
-      msg1 = MiqQueue.put_unless_exists(
+      options = {
         :class_name  => 'MyClass',
         :method_name => 'method2',
         :args        => [1, 2]
-      )
+      }
+      MiqQueue.put_unless_exists(options)
+      MiqQueue.put_unless_exists(options)
 
-      MiqQueue.put_unless_exists(
-        :class_name  => 'MyClass',
-        :method_name => 'method2',
-        :args        => [1, 2]
-      )
-
-      expect(MiqQueue.get).to eq(msg1)
+      expect(MiqQueue.get).to have_attributes(options)
       expect(MiqQueue.get).to eq(nil)
     end
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -137,7 +137,10 @@ describe AuthenticationMixin do
   context "#retry_scheduled_authentication_check" do
     let(:host) do
       EvmSpecHelper.local_miq_server
-      FactoryGirl.create(:host_with_authentication).tap { MiqQueue.destroy_all }
+      FactoryGirl.create(:host_with_authentication).tap do
+        MiqQueue.destroy_all
+        MiqTask.destroy_all
+      end
     end
 
     it "works" do
@@ -177,6 +180,7 @@ describe AuthenticationMixin do
 
         # Destroy any queued auth checks from creating the new CI's with authentications
         MiqQueue.destroy_all
+        MiqTask.destroy_all
       end
 
       context ".authentication_check_schedule" do
@@ -264,6 +268,7 @@ describe AuthenticationMixin do
         @host_no_auth = FactoryGirl.create(:host_vmware_esx)
         @ems          = FactoryGirl.create(:ems_vmware_with_authentication)
         MiqQueue.destroy_all
+        MiqTask.destroy_all
         @auth = @ems.authentication_type(:default)
         @orig_ems_user, @orig_ems_pwd = @ems.auth_user_pwd(:default)
       end

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -6,11 +6,8 @@ describe PxeServer do
 
   context "#sync_images_queue" do
     it "should create a queue entry with the correct parameters" do
-      msg = @pxe_server.sync_images_queue
-      expect(msg.method_name).to eq("sync_images")
-      expect(msg.priority).to eq(100)
-      expect(msg.queue_name).to eq("generic")
-      expect(msg.class_name).to eq("PxeServer")
+      task = @pxe_server.sync_images_queue
+      expect(MiqTask.find(task).identifier).not_to be_nil
     end
 
     it "should not create a new queue entry when one already exists" do

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -616,11 +616,11 @@ describe "Providers API" do
 
         it "schedules a new credentials check if endpoint change" do
           api_basic_authorize collection_action_identifier(:providers, :edit)
-
           provider = FactoryGirl.create(:ext_management_system, sample_containers_multi_end_point)
           MiqQueue.where(:method_name => "authentication_check_types",
                          :class_name  => "ExtManagementSystem",
                          :instance_id => provider.id).delete_all
+          MiqTask.where.not(:identifier => nil).delete_all
 
           run_post(providers_url(provider.id), gen_request(:edit,
                                                            "connection_configurations" => [updated_connection,

--- a/spec/support/examples_group/shared_examples_for_log_collection.rb
+++ b/spec/support/examples_group/shared_examples_for_log_collection.rb
@@ -36,7 +36,7 @@ end
 
 shared_examples_for "Log Collection should create 0 tasks and 0 queue items" do
   it "should create 0 unfinished tasks" do
-    expect(MiqTask.where("state != ?", "Finished").count).to eq(0)
+    expect(MiqTask.where("state != ?", "Finished").where(:identifier => nil).count).to eq(0)
   end
 
   it "should create 0 queue messages" do


### PR DESCRIPTION
This is an implementation to use `MiqTask` to detect whether a queue message (tied with the task) has existed.

/cc @kbrock @mkanoor  