### PR TITLE
Remove miq_server

### DIFF
--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -247,17 +247,25 @@ module Api
     def set_miq_server_resource(type, id, data)
       vm = resource_search(id, type, collection_class(type))
 
-      miq_server_id = parse_id(data['miq_server'], :servers)
-      raise 'Must specify a valid miq_server href or id' unless miq_server_id
-      miq_server = resource_search(miq_server_id, :servers, collection_class(:servers))
+      miq_server = if data['miq_server'].empty?
+                     nil
+                   else
+                     miq_server_id = parse_id(data['miq_server'], :servers)
+                     raise 'Must specify a valid miq_server href or id' unless miq_server_id
+                     resource_search(miq_server_id, :servers, collection_class(:servers))
+                   end
 
       vm.miq_server = miq_server
-      action_result(true, "Set miq_server id:#{miq_server.id} for #{vm_ident(vm)}")
+      action_result(true, "#{miq_server_message(miq_server)} for #{vm_ident(vm)}")
     rescue => err
       action_result(false, "Failed to set miq_server - #{err}")
     end
 
     private
+
+    def miq_server_message(miq_server)
+      miq_server ? "Set miq_server id:#{miq_server.id}" : "Removed miq_server"
+    end
 
     def validate_edit_data(data)
       invalid_keys = data.keys - VALID_EDIT_ATTRS - valid_custom_attrs

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -1581,5 +1581,16 @@ describe "Vms API" do
       expect(response.parsed_body).to eq(expected)
       expect(response).to have_http_status(:ok)
     end
+
+    it "can unassign a server if an empty hash is passed" do
+      vm.miq_server = server
+      api_basic_authorize action_identifier(:vms, :set_miq_server)
+
+      run_post(vms_url(vm.id), :action => 'set_miq_server', :miq_server => {})
+
+      expected = {'success' => true, 'message' => "Removed miq_server for VM id:#{vm.id} name:'#{vm.name}'"}
+      expect(response.parsed_body).to eq(expected)
+      expect(vm.reload.miq_server).to be_nil
+    end
   end
 end


### PR DESCRIPTION
As a follow up #15262, the `set_miq_server` action needs to be able to set an `miq_server` to nil (removing the current `miq_server`). This PR updates the functionality by accepting an empty hash, ie:
```json
{ "action": "set_miq_server", "miq_server": {} } 
```
which will then set the `miq_server` to nil.

@miq-bot add_label api, enhancement, fine/no
@miq-bot assign @abellotti 

cc: @h-kataria 