### PR TITLE
Drop support for MiqQueue.put(expires_on)

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -86,7 +86,6 @@ class MiqQueue < ApplicationRecord
   STATUS_WARN    = STATE_WARN
   STATUS_ERROR   = STATE_ERROR
   STATUS_TIMEOUT = STATE_TIMEOUT
-  STATUS_EXPIRED = STATE_EXPIRED
   DEFAULT_QUEUE  = "generic"
 
   def data
@@ -296,8 +295,6 @@ class MiqQueue < ApplicationRecord
     _log.info("#{MiqQueue.format_short_log_msg(self)}, Delivering...")
 
     begin
-      raise MiqException::MiqQueueExpired if expires_on && (Time.now.utc > expires_on)
-
       raise _("class_name cannot be nil") if class_name.nil?
 
       obj = class_name.constantize
@@ -341,10 +338,6 @@ class MiqQueue < ApplicationRecord
         _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
         status = STATUS_TIMEOUT
       end
-    rescue MiqException::MiqQueueExpired
-      message = "Expired on [#{expires_on}]"
-      _log.error("#{MiqQueue.format_short_log_msg(self)}, #{message}")
-      status = STATUS_EXPIRED
     rescue StandardError, SyntaxError => error
       _log.error("#{MiqQueue.format_short_log_msg(self)}, Error: [#{error}]")
       _log.log_backtrace(error) unless error.kind_of?(MiqException::Error)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -411,10 +411,6 @@ class VmOrTemplate < ApplicationRecord
     end
   end
 
-  def self.powerops_expiration
-    ::Settings.management_system.power_operation_expiration.to_i_with_method.seconds.from_now.utc
-  end
-
   # override
   def self.invoke_task_local(task, vm, options, args)
     cb = nil
@@ -447,7 +443,6 @@ class VmOrTemplate < ApplicationRecord
       :miq_callback => cb,
       :zone         => vm.my_zone,
       :role         => role,
-      :expires_on   => POWER_OPS.include?(options[:task]) ? powerops_expiration : nil
     )
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -872,8 +872,6 @@
   :level_vim_in_evm: error
   :level_websocket: info
   :level_websocket_in_evm: error
-:management_system:
-  :power_operation_expiration: 10.minutes
 :performance:
   :capture_threshold:
     :default: 10.minutes

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -27,20 +27,6 @@ describe MiqQueue do
       expect(msg.handler).to be_nil
     end
 
-    it "works with expires_on" do
-      allow(MiqServer).to receive(:foobar).and_return(0)
-
-      expires_on = 1.minute.from_now.utc
-      msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar', :expires_on => expires_on)
-      status, message, result = msg.deliver
-      expect(status).to eq(MiqQueue::STATUS_OK)
-
-      expires_on = 1.minute.ago.utc
-      msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar', :expires_on => expires_on)
-      status, message, result = msg.deliver
-      expect(status).to eq(MiqQueue::STATUS_EXPIRED)
-    end
-
     it "sets last_exception on raised Exception" do
       allow(MiqServer).to receive(:foobar).and_raise(StandardError)
       msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar')


### PR DESCRIPTION
`MiqQueue#expires_on` is only used for power ops in 1 place. Can we remove?

**NOTE:** This is a simplification only.
**REPEAT:** Keeping it does not hurt us for migrating to another queue implementation.

@chessbyte @fryguy Can we remove this feature?


Introduced by @chessbyte 6098d84d 3/22/2012

comments for that commit:

```
    VM Power Operations should be requeued when the broker is not available
    - Added Vm::POWER_OPS
    - Created Vm#powerops_callback that requeues the request (if broker is unavailable) for delivery 1.minute later
    - Created Vm#powerops_expiration that reads from config(:management_system, :power_operation_expiration) with default of 10.minutes
    BugzID:14454
    
    git-svn-id: http://miq-ubuntusub.manageiq.com/svn/svnrepos/Manageiq/trunk@34132 3c68ef56-dcc3-11dc-9475-a42b84ecc76f
```