### PR TITLE
[FINE] Fix EmbeddedAnsibleWorker::Runner specs after backport

### DIFF
--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -85,7 +85,6 @@ describe EmbeddedAnsibleWorker::Runner do
       end
 
       it "creates a notification to inform the user that the role has been assigned" do
-        expect(EmbeddedAnsible).to receive(:configured?).and_return(true)
         expect(EmbeddedAnsible).to receive(:start)
 
         runner.setup_ansible


### PR DESCRIPTION
This was introduced in commit 70df9b70b9b5a0787cdefa052394023e1ce6d333 which was backported after 0ec1271fa9e3556e068a553accf7bf071422b030

Because these commits were originally written in the opposite order we could not remove this line from the spec in the same way it was removed in the master branch.