### PR TITLE
AuthenticationMixin McQ.put to use create_with

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -246,13 +246,13 @@ module AuthenticationMixin
     if force
       MiqQueue.put(options)
     else
-      MiqQueue.put_unless_exists(options.except(:args, :deliver_on)) do |msg|
+      MiqQueue.create_with(options.slice(:args, :deliver_on)).put_unless_exists(options.except(:args, :deliver_on)) do |msg|
         # TODO: Refactor the help in this and the ScheduleWorker#queue_work method into the merge method
         help = "Check for a running server"
         help << " in zone: [#{options[:zone]}]"   if options[:zone]
         help << " with role: [#{options[:role]}]" if options[:role]
         _log.warn("Previous authentication_check_types for [#{name}] [#{id}] with opts: [#{options[:args].inspect}] is still running, skipping...#{help}") unless msg.nil?
-        options
+        nil
       end
     end
   end


### PR DESCRIPTION
This is the last call to `MiqQueue.put_unless_exists` that modifies the queue options in the yielded block.

Having these values presented as a sql friendly hash (via `create_with`) simplifies the implementation code rather than allowing ruby manipulation.

It hopefully allows us to go towards a single sql statement for queue inserts. (or a simpler non-sql queue option)


followup to #15286 / #14569