### PR TITLE
Remove dependency of UuidMixin in migrations

### DIFF
--- a/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
+++ b/db/migrate/20150224192716_migrate_configuration_manager_to_ems.rb
@@ -1,7 +1,12 @@
+require 'securerandom'
+
 class MigrateConfigurationManagerToEms < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
-    include UuidMixin
     self.inheritance_column = :_type_disabled
+
+    before_create do
+      self.guid ||= SecureRandom.uuid
+    end
   end
 
   class ConfigurationManager < ActiveRecord::Base

--- a/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
+++ b/db/migrate/20150224192816_migrate_provisioning_manager_to_ems.rb
@@ -1,7 +1,12 @@
+require 'securerandom'
+
 class MigrateProvisioningManagerToEms < ActiveRecord::Migration[4.2]
   class ExtManagementSystem < ActiveRecord::Base
-    include UuidMixin
     self.inheritance_column = :_type_disabled
+
+    before_create do
+      self.guid ||= SecureRandom.uuid
+    end
   end
 
   class ProvisioningManager < ActiveRecord::Base


### PR DESCRIPTION
@chessbyte Please review.  This is part of my commits on the schema extraction, but it's easier for me to push upstream and get it out of my way.