### PR TITLE
Add model associations for containers graph refresh

### DIFF
--- a/app/models/container_env_var.rb
+++ b/app/models/container_env_var.rb
@@ -1,2 +1,3 @@
 class ContainerEnvVar < ApplicationRecord
+  belongs_to :container_definition
 end

--- a/app/models/container_port_config.rb
+++ b/app/models/container_port_config.rb
@@ -1,3 +1,4 @@
 class ContainerPortConfig < ApplicationRecord
   # :port, :host_port, :protocol
+  belongs_to :container_definition
 end

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -20,7 +20,21 @@ module ManageIQ::Providers
     has_many :container_build_pods, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_templates, :foreign_key => :ems_id, :dependent => :destroy
     has_one :container_deployment, :foreign_key => :deployed_ems_id, :inverse_of => :deployed_ems
+
+    # Shortcuts to chained joins, mostly used by inventory refresh.
     has_many :computer_systems, :through => :container_nodes
+    has_many :computer_system_hardwares, :through => :computer_systems, :source => :hardware
+    has_many :computer_system_operating_systems, :through => :computer_systems, :source => :operating_system
+    has_many :container_volumes, :through => :container_groups
+    has_many :container_definitions, :through => :container_groups
+    has_many :container_port_configs, :through => :container_definitions
+    has_many :container_env_vars, :through => :container_definitions
+    has_many :security_contexts, :through => :container_definitions
+    has_many :container_service_port_configs, :through => :container_services
+    has_many :container_routes, :through => :container_services
+    has_many :container_quota_items, :through => :container_quotas
+    has_many :container_limit_items, :through => :container_limits
+    has_many :container_template_parameters, :through => :container_templates
 
     # Archived entities to destroy when the container manager is deleted
     has_many :old_container_groups, :foreign_key => :old_ems_id, :dependent => :destroy, :class_name => "ContainerGroup"


### PR DESCRIPTION
Extracted from ManageIQ/manageiq#14337.
(simplified a couple things, see https://github.com/ManageIQ/manageiq/pull/14337/commits/afe06d6b21ee93cad02e4618b2da429c807ac96f)

The plan is after this we can finish up
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/30

@agrare @Ladas @zeari please review.