### PR TITLE
Add dependency on openscap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem "net-ssh",                        "=3.2.0",        :require => false
 gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
+gem "openscap",                       "~>0.4.3",       :require => false
 gem "ovirt-engine-sdk",               "~>4.1.4",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.4.1",       :require => false
 gem "pg-pglogical",                   "~>1.1.0",       :require => false


### PR DESCRIPTION
Moving dependency from https://github.com/ManageIQ/manageiq-gems-pending to this repo, where it is used.