### PR TITLE
Put time back the way we found it

### DIFF
--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -287,6 +287,8 @@ describe Job do
         @queue_item = MiqQueue.put(:task_id => @job.guid)
       end
 
+      after { Timecop.return }
+
       context "job timed out" do
         it "calls 'job#timeout!' if server was not assigned to job" do
           Timecop.travel 5.minutes


### PR DESCRIPTION
These tests use `Timecop.travel` without `Timecop.return`, causing
another test in another part of the suite to fail. To reproduce:

```
SPEC_OPTS=--seed=30045 bundle exec rspec ./spec/models/job_spec.rb[1:1:7:1:1] ./spec/requests/api/logging_spec.rb[1:1:4]
```

Fixes https://github.com/ManageIQ/manageiq/issues/15290

@miq-bot add-label bug/sporadic test failure
@miq-bot assign @jrafanie 