### PR TITLE
Miq request dump obj

### DIFF
--- a/spec/models/miq_request_task/dumping_spec.rb
+++ b/spec/models/miq_request_task/dumping_spec.rb
@@ -31,6 +31,7 @@ describe MiqRequestTask do
           vh.capacityInKB = 100
         end
         expect(MiqRequestTask).to receive(:dump_hash)
+        expect(STDOUT).to receive(:puts).with(" (VimHash) xsiType: <VirtualDisk>  vimType: <>")
         task.dump_obj(data)
       end
 
@@ -46,6 +47,7 @@ describe MiqRequestTask do
           end
         end
         expect(MiqRequestTask).to receive(:dump_array)
+        expect(STDOUT).to receive(:puts).with(" (VimArray) xsiType: <ArrayOfHostInternetScsiHbaStaticTarget>  vimType: <>")
         task.dump_obj(array)
       end
     end

--- a/spec/models/miq_request_task/dumping_spec.rb
+++ b/spec/models/miq_request_task/dumping_spec.rb
@@ -2,18 +2,6 @@ describe MiqRequestTask do
   context "::Dumping" do
     let(:task) { FactoryGirl.create(:miq_request_task) }
 
-    describe '#dump_obj' do
-      it "calls .dump_obj" do
-        expect(task.class).to receive(:dump_obj)
-        task.dump_obj(:param_1 => 1)
-      end
-
-      it 'hides passwords' do
-        expect($log).to receive(:info).with(/<PROTECTED>/)
-        task.dump_obj({:my_password => "secret"}, "my choices: ", $log, :info, :protected => {:path => /[Pp]assword/})
-      end
-    end
-
     describe '.dump_obj' do
       it 'accepts a hash' do
         expect(task.class).to receive(:dump_hash)
@@ -26,28 +14,40 @@ describe MiqRequestTask do
       end
     end
 
-    it '#dump_vim_hash' do
-      data = VimHash.new('VirtualDisk') do |vh|
-        vh.backing = {'diskMode' => 'persistent', 'datastore' => 'datastore-001'}
-        vh.capacityInKB = 100
+    describe '#dump_obj' do
+      it "calls .dump_obj" do
+        expect(task.class).to receive(:dump_obj)
+        task.dump_obj(:param_1 => 1)
       end
-      expect(MiqRequestTask).to receive(:dump_hash)
-      task.dump_obj(data)
-    end
 
-    it '#dump_vim_array' do
-      array = VimArray.new("ArrayOfHostInternetScsiHbaStaticTarget") do |ta|
-        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
-          st.address    = "10.1.1.210"
-          st.iScsiName  = "iqn.1992-08.com.netapp:sn.135107242"
-        end
-        ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
-          st.address    = "10.1.1.100"
-          st.iScsiName  = "iqn.2008-08.com.starwindsoftware:starwindm1-starm1-test1"
-        end
+      it 'hides passwords' do
+        expect($log).to receive(:info).with(/<PROTECTED>/)
+        task.dump_obj({:my_password => "secret"}, "my choices: ", $log, :info, :protected => {:path => /[Pp]assword/})
       end
-      expect(MiqRequestTask).to receive(:dump_array)
-      task.dump_obj(array)
+
+      it 'with a VimHash' do
+        data = VimHash.new('VirtualDisk') do |vh|
+          vh.backing = {'diskMode' => 'persistent', 'datastore' => 'datastore-001'}
+          vh.capacityInKB = 100
+        end
+        expect(MiqRequestTask).to receive(:dump_hash)
+        task.dump_obj(data)
+      end
+
+      it 'with a VimArray' do
+        array = VimArray.new("ArrayOfHostInternetScsiHbaStaticTarget") do |ta|
+          ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+            st.address    = "10.1.1.210"
+            st.iScsiName  = "iqn.1992-08.com.netapp:sn.135107242"
+          end
+          ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
+            st.address    = "10.1.1.100"
+            st.iScsiName  = "iqn.2008-08.com.starwindsoftware:starwindm1-starm1-test1"
+          end
+        end
+        expect(MiqRequestTask).to receive(:dump_array)
+        task.dump_obj(array)
+      end
     end
   end
 end


### PR DESCRIPTION
- Nest tests in the correct context
- Describe what is being tested
- expect calls to `puts` to avoid extra output to STDOUT while running tests

Fixes #15292
cc @agrare 