### PR TITLE
Adding hawkular_key column to store id of created trigger in Hawkular

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -3,6 +3,7 @@ class MiqAlert < ApplicationRecord
 
   serialize :expression
   serialize :options
+  serialize :hawkular_keys
 
   validates_presence_of     :description, :guid
   validates_uniqueness_of   :description, :guid
@@ -843,5 +844,24 @@ class MiqAlert < ApplicationRecord
       _a, stat = import_from_hash(e[name])
       stat
     end
+  end
+
+  def hawkular_keys
+    aux = super
+
+    unless aux
+      aux = {}
+      self.hawkular_keys = aux
+    end
+
+    aux
+  end
+
+  def hawkular_key_for_ems(ems_id, hawkular_key = nil)
+    if hawkular_key
+      hawkular_keys["ems_#{ems_id}"] = hawkular_key
+    end
+
+    hawkular_keys["ems_#{ems_id}"]
   end
 end

--- a/db/migrate/20170523220843_add_hawkular_keys_to_miq_alerts.rb
+++ b/db/migrate/20170523220843_add_hawkular_keys_to_miq_alerts.rb
@@ -1,0 +1,27 @@
+class AddHawkularKeysToMiqAlerts < ActiveRecord::Migration[5.0]
+  class MiqAlert < ActiveRecord::Base
+    serialize :hawkular_keys
+  end
+
+  class ExtManagementSystem < ActiveRecord::Base
+    self.inheritance_column = '_disabled'
+  end
+
+  def change
+    add_column(:miq_alerts, :hawkular_keys, :text)
+
+    reversible do |direction|
+      direction.up do
+        MiqAlert.where(:db => 'MiddlewareServer').find_each do |alert|
+          alert.hawkular_keys = {}
+
+          ExtManagementSystem.where(:type => 'ManageIQ::Providers::Hawkular::MiddlewareManager').find_each do |ems|
+            alert.hawkular_keys["ems_#{ems.id}"] = "MiQ-#{alert.id}"
+          end
+
+          alert.save
+        end
+      end
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4863,6 +4863,7 @@ miq_alerts:
 - responds_to_events
 - enabled
 - read_only
+- hawkular_keys
 miq_approvals:
 - id
 - description

--- a/spec/lib/task_helpers/exports/alerts_spec.rb
+++ b/spec/lib/task_helpers/exports/alerts_spec.rb
@@ -12,7 +12,8 @@ describe TaskHelpers::Exports::Alerts do
           "expression"         => nil,
           "responds_to_events" => nil,
           "enabled"            => true,
-          "read_only"          => nil
+          "read_only"          => nil,
+          "hawkular_keys"      => nil
         }
       }
     ]

--- a/spec/migrations/20170523220843_add_hawkular_keys_to_miq_alerts_spec.rb
+++ b/spec/migrations/20170523220843_add_hawkular_keys_to_miq_alerts_spec.rb
@@ -1,0 +1,22 @@
+require_migration
+
+describe AddHawkularKeysToMiqAlerts do
+  let(:miq_alert_stub) { migration_stub(:MiqAlert) }
+  let(:miq_ems_stub) { migration_stub(:ExtManagementSystem) }
+
+  migration_context :up do
+    it "generates legacy hawkular keys" do
+      miq_alert_stub.create!(:id => '100', :db => 'MiddlewareServer', :description => 'Hawkular')
+      miq_alert_stub.create!(:id => '200', :db => 'Vm', :description => 'Not Hawkular')
+
+      miq_ems_stub.create!(:id => 1001, :type => 'ManageIQ::Providers::Hawkular::MiddlewareManager', :name => 'Hawkular')
+      miq_ems_stub.create!(:id => 1002, :type => 'SomethingElse', :name => 'Not Hawkular')
+
+      migrate
+
+      expect(miq_alert_stub.count).to eq(2)
+      expect(miq_alert_stub.find(100).hawkular_keys).to eq('ems_1001' => 'MiQ-100')
+      expect(miq_alert_stub.find(200).hawkular_keys).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
New column to allow seamless MiQ upgrade if database is not fresh.

Used to solve a border case discussed in ManageIQ/manageiq#10674
This PR is dependency of ManageIQ/manageiq-providers-hawkular#22