### PR TITLE
Extend the Vmdb::Plugins singleton with UI-specific plugin support

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -3,10 +3,12 @@ module Vmdb
     include Singleton
 
     attr_reader :registered_automate_domains
+    attr_reader :registered_ui_plugins
 
     def initialize
       @registered_automate_domains = []
       @registered_provider_plugin_map = {}
+      @registered_ui_plugins = []
       @vmdb_plugins = []
     end
 
@@ -28,6 +30,7 @@ module Vmdb
 
       register_automate_domains(engine)
       register_provider_plugin(engine)
+      register_ui_plugin(engine)
 
       # make sure STI models are recognized
       DescendantLoader.instance.descendants_paths << engine.root.join('app')
@@ -58,6 +61,10 @@ module Vmdb
       Dir.glob(engine.root.join("content", "automate", "*")).each do |domain_directory|
         @registered_automate_domains << AutomateDomain.new(domain_directory)
       end
+    end
+
+    def register_ui_plugin(engine)
+      @registered_ui_plugins << engine if engine.try(:ui_plugin)
     end
   end
 end


### PR DESCRIPTION
We need a way to mark rails engines as plugins related to the User Interface. I found out that there is already a structure holding provider plugins, so I'd like to extend this if possible. By declaring a `ui_plugin` method inside the engine, the plugin would be registered under the `@registered_ui_plugins` instance variable that we would use in the UI on some places.

For now I require both the `ui_plugin` and the `vmdb_plugin` methods to be declared and return true, but I'm not 100% sure if this is *The Right Way&trade;*. Renaming the method or requiring just one of the two methods are both an option, I just need some feedback :wink: 

ping @martinpovolny, @jrafanie, @Fryguy 