### PR TITLE
Add explicit capture threshold for container

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -966,6 +966,9 @@
     :host: 50.minutes
     :storage: 60.minutes
     :vm: 50.minutes
+    :container: 50.minutes
+    :container_group: 50.minutes
+    :container_node: 50.minutes
   :capture_threshold_with_alerts:
     :default: 1.minutes
     :host: 20.minutes


### PR DESCRIPTION
**Description**

The default capture_threshold value for the OpenShift object types container, container_group and node is 10 minutes (since these object types don't have their own capture_threshold definition in advanced settings). To maintain this rate of ems_metrics_collector message processing requires a large number of C&U Data Collector worker processes, which results in scaling several CFME appliances just to manage OpenShift Metrics.

This PR update the capture_threshold to 50 minutes.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1457765