### PR TITLE
Increase timeout for metric purging

### DIFF
--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -40,11 +40,16 @@ module Metric::Purging
       :class_name  => name,
       :method_name => "purge_#{interval}",
       :args        => [ts],
+      :msg_timeout => msg_timeout
     )
   end
 
   def self.purge_window_size
     ::Settings.performance.history.purge_window_size
+  end
+
+  def self.msg_timeout
+    ::Settings.performance.history.queue_timeout.to_i_with_method
   end
 
   def self.purge_scope(older_than, interval)

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -32,12 +32,17 @@ module VmdbMetric::Purging
       MiqQueue.put(
         :class_name  => name,
         :method_name => "purge_#{interval}",
-        :args        => [value]
+        :args        => [value],
+        :msg_timeout => msg_timeout
       )
     end
 
     def purge_window_size
       ::Settings.database.metrics_history.purge_window_size
+    end
+
+    def msg_timeout
+      ::Settings.database.metrics_history.queue_timeout.to_i_with_method
     end
 
     def purge_count(mode, value, interval)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,6 +92,7 @@
     :keep_hourly_metrics: 6.months
     :purge_schedule: "50 * * * *"
     :purge_window_size: 10000
+    :queue_timeout: 20.minutes
 :drift_states:
   :history:
     :keep_drift_states: 6.months
@@ -895,6 +896,7 @@
     :keep_hourly_performances: 6.months
     :keep_realtime_performances: 4.hours
     :purge_window_size: 1000
+    :queue_timeout: 20.minutes
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1169,7 +1169,7 @@
       :orchestration_stack_retired_interval: 10.minutes
       :performance_collection_interval: 3.minutes
       :performance_collection_start_delay: 5.minutes
-      :performance_realtime_purging_interval: 15.minutes
+      :performance_realtime_purging_interval: 21.minutes
       :performance_realtime_purging_start_delay: 5.minutes
       :performance_rollup_purging_interval: 4.hours
       :performance_rollup_purging_start_delay: 5.minutes

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -1,4 +1,22 @@
 describe Metric::Purging do
+  let(:settings) do
+    {
+      :performance => {
+        :history => {
+          :keep_daily_performance    => "6.months",
+          :keep_hourly_performance   => "6.months",
+          :keep_realtime_performance => "4.hours",
+          :purge_window_size         => 1000,
+          :queue_timeout             => "20.minutes"
+        }
+      }
+    }
+  end
+
+  before do
+    stub_settings(settings)
+  end
+
   context "::Purging" do
     it "#purge_all_timer" do
       EvmSpecHelper.create_guid_miq_server_zone
@@ -12,6 +30,7 @@ describe Metric::Purging do
         q.each do |qi|
           expect(qi).to have_attributes(
             :class_name  => described_class.name,
+            :msg_timeout => 1200
           )
         end
 
@@ -23,22 +42,8 @@ describe Metric::Purging do
     context "with data" do
       let(:vm1) { FactoryGirl.create(:vm_vmware) }
       let(:vm2) { FactoryGirl.create(:vm_vmware) }
-      let(:settings) do
-        {
-          :performance => {
-            :history => {
-              :keep_daily_performance    => "6.months",
-              :keep_hourly_performance   => "6.months",
-              :keep_realtime_performance => "4.hours",
-              :purge_window_size         => 1000
-            }
-          }
-        }
-      end
 
       before do
-        stub_settings(settings)
-
         @metrics1 = [
           FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => vm1.id, :timestamp => (6.months + 1.days).ago.utc),
           FactoryGirl.create(:metric_rollup_vm_hr, :resource_id => vm1.id, :timestamp => (6.months - 1.days).ago.utc)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1445498

Metric purging currently uses the default timeout of 10 minutes which is not long enough for an environment with thousands of VMs. This is causing metrics tables to grow in size so large that they eventually fill the entire VMDB.

This PR adds a `queue_timeout`to the settings for `metrics_history` and `performance.history` so that it can be altered as needed, and increases it by default to "20.minutes" 

Thoughts @yrudman?
@miq-bot bug, core/queue

