### PR TITLE
Handle setup playbook failure better

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -99,6 +99,10 @@ class EmbeddedAnsible
       }
       AwesomeSpawn.run!(SETUP_SCRIPT, :params => params)
     end
+  rescue AwesomeSpawn::CommandResultError => e
+    _log.error("EmbeddedAnsible setup script failed with: #{e.message}")
+    miq_database.ansible_secret_key = nil
+    raise
   end
   private_class_method :run_setup_script
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -28,6 +28,7 @@ class EmbeddedAnsible
   end
 
   def self.configured?
+    return false unless File.exist?(SECRET_KEY_FILE)
     key = miq_database.ansible_secret_key
     key.present? && key == File.read(SECRET_KEY_FILE)
   end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -262,10 +262,10 @@ describe EmbeddedAnsible do
       before do
         expect(described_class).to receive(:configured?).and_return(false)
         expect(described_class).to receive(:configure_secret_key)
-        expect(described_class).to receive(:alive?).and_return(true)
       end
 
       it "generates new passwords with no passwords set" do
+        expect(described_class).to receive(:alive?).and_return(true)
         expect(described_class).to receive(:generate_database_authentication).and_return(double(:userid => "awx", :password => "databasepassword"))
         expect(AwesomeSpawn).to receive(:run!) do |script_path, options|
           params                  = options[:params]
@@ -290,6 +290,7 @@ describe EmbeddedAnsible do
       end
 
       it "uses the existing passwords when they are set in the database" do
+        expect(described_class).to receive(:alive?).and_return(true)
         miq_database.set_ansible_admin_authentication(:password => "adminpassword")
         miq_database.set_ansible_rabbitmq_authentication(:userid => "rabbituser", :password => "rabbitpassword")
         miq_database.set_ansible_database_authentication(:userid => "databaseuser", :password => "databasepassword")
@@ -311,6 +312,15 @@ describe EmbeddedAnsible do
         end
 
         described_class.start
+      end
+
+      it "removes the secret key from the database when setup fails" do
+        miq_database.ansible_secret_key = "supersecretkey"
+        expect(described_class).to receive(:generate_database_authentication).and_return(double(:userid => "awx", :password => "databasepassword"))
+
+        expect(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new("error", 1))
+        expect { described_class.start }.to raise_error(AwesomeSpawn::CommandResultError)
+        expect(miq_database.reload.ansible_secret_key).not_to be_present
       end
     end
 

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -232,6 +232,12 @@ describe EmbeddedAnsible do
 
           expect(described_class.configured?).to be false
         end
+
+        it "returns false when the file doesn't exist and there is a value in the database" do
+          key_file.unlink
+          miq_database.ansible_secret_key = "password"
+          expect(described_class.configured?).to be false
+        end
       end
 
       describe ".configure_secret_key (private)" do


### PR DESCRIPTION
This PR allows us to re-run the setup playbook if we fail the first time around.

When https://github.com/ManageIQ/manageiq/pull/15225 made us run the setup playbook only once, it had a side-effect of not allowing us to run the playbook again if and when we failed the first time.

This PR handles that situation by removing the secret key from the database when the playbook run fails. This in turn causes `EmbeddedAnsible.configured?` to return false the next time we attempt to run the playbook.

https://bugzilla.redhat.com/show_bug.cgi?id=1439783
https://bugzilla.redhat.com/show_bug.cgi?id=1458886