### PR TITLE
[FINE] Add previous migrations to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ public/pictures/
 public/ui/
 
 # spec/
-spec/replication/util/data/euwe_migrations
+spec/replication/util/data/*_migrations
 
 # tmp/
 tmp/*


### PR DESCRIPTION
Just a minor mod to the .gitignore file for the Fine branch so that I don't see `spec/replication/util/data/previous_migrations` as untracked files.

