### PR TITLE
Use MiqQueue.put for sync

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -147,7 +147,7 @@ class CloudTenant < ApplicationRecord
   def self.post_refresh_ems(ems_id, _)
     ems = ExtManagementSystem.find(ems_id)
 
-    MiqQueue.put_unless_exists(
+    MiqQueue.put(
       :class_name  => ems.class,
       :instance_id => ems_id,
       :method_name => 'sync_cloud_tenants_with_tenants',

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -562,7 +562,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def stop_event_monitor_queue
-    MiqQueue.put_unless_exists(
+    MiqQueue.put(
       :class_name  => self.class.name,
       :method_name => "stop_event_monitor",
       :instance_id => id,

--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -9,7 +9,7 @@ class IsoDatastore < ApplicationRecord
   end
 
   def synchronize_advertised_images_queue
-    MiqQueue.put_unless_exists(
+    MiqQueue.put(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "synchronize_advertised_images",

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -47,7 +47,7 @@ class PxeServer < ApplicationRecord
   end
 
   def synchronize_advertised_images_queue
-    MiqQueue.put_unless_exists(
+    MiqQueue.put(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "synchronize_advertised_images"
@@ -62,7 +62,7 @@ class PxeServer < ApplicationRecord
   end
 
   def sync_images_queue
-    MiqQueue.put_unless_exists(
+    MiqQueue.put(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "sync_images"

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -12,14 +12,6 @@ describe PxeServer do
       expect(msg.queue_name).to eq("generic")
       expect(msg.class_name).to eq("PxeServer")
     end
-
-    it "should not create a new queue entry when one already exists" do
-      @pxe_server.sync_images_queue
-      expect(MiqQueue.count).to eq(1)
-
-      @pxe_server.sync_images_queue
-      expect(MiqQueue.count).to eq(1)
-    end
   end
 
   context "pxelinux depot" do


### PR DESCRIPTION
A number of `MiqQueue.put_unless_exist` calls can be simplified to `MiqQueue.put`