### PR TITLE
Return an empty relation instead of an array from db_relation()

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -938,7 +938,7 @@ module ManagerRefresh
                    rel
                  end
 
-      relation || []
+      relation || model_class.none
     end
 
     # Extracting references to a relation friendly format, or a format processable by a custom_db_finder


### PR DESCRIPTION
`db_relation()` returns an empty array if it couldn't determine another relation to use. This empty array doesn't work with chained activerecord methods like find_each, and breaks functions that assume they've been given an activerecord relation like `populate_db_data_index!` This PR fixes the problem by using the inventory collection's model class to return a null relation which behaves correctly with chained activerecord methods.