### PR TITLE
Allow overriding memcache server setting by environment variable

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -76,7 +76,7 @@ module MiqServer::EnvironmentManagement
       return unless ::Settings.server.session_store.to_s == 'cache'
       return unless MiqEnvironment::Command.supports_memcached?
       require "#{Rails.root}/lib/miq_memcached" unless Object.const_defined?(:MiqMemcached)
-      _svr, port = ::Settings.session.memcache_server.to_s.split(":")
+      _svr, port = MiqMemcached.server_address.to_s.split(":")
       opts = ::Settings.session.memcache_server_opts.to_s
       MiqMemcached::Control.restart!(:port => port, :options => opts)
       _log.info("Status: #{MiqMemcached::Control.status[1]}")

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -17,7 +17,7 @@ else
   if session_store == :mem_cache_store
     require 'dalli'
     session_options = session_options.merge(
-      :cache        => Dalli::Client.new(Settings.session.memcache_server, :namespace => "MIQ:VMDB", :value_max_bytes => 10.megabytes),
+      :cache        => Dalli::Client.new(MiqMemcached.server_address, :namespace => "MIQ:VMDB", :value_max_bytes => 10.megabytes),
       :expire_after => 24.hours,
       :key          => "_vmdb_session",
     )

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -2,6 +2,10 @@ require 'runcmd'
 require 'linux_admin'
 
 module MiqMemcached
+  def self.server_address
+    ENV["MEMCACHED_SERVER"] || ::Settings.session.memcache_server
+  end
+
   class Error < RuntimeError; end
   class ControlError < Error; end
 

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -11,8 +11,7 @@ class TokenStore
         ActiveSupport::Cache::MemoryStore.new(cache_store_options(namespace, token_ttl))
       when "cache"
         require 'active_support/cache/dalli_store'
-        memcache_server = ::Settings.session.memcache_server
-        ActiveSupport::Cache::DalliStore.new(memcache_server, cache_store_options(namespace, token_ttl))
+        ActiveSupport::Cache::DalliStore.new(MiqMemcached.server_address, cache_store_options(namespace, token_ttl))
       else
         raise "unsupported session store type: #{::Settings.server.session_store}"
       end


### PR DESCRIPTION
In a production container environment, we want to set an environment variable to give the app the memcached server address and port rather than writing `config/settings/production.yml` since that file is checked in and could conflict.