### PR TITLE
Limit CloudTenants' related VMs to the non-archived ones

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -12,7 +12,7 @@ class CloudTenant < ApplicationRecord
   has_many   :cloud_subnets
   has_many   :network_ports
   has_many   :network_routers
-  has_many   :vms
+  has_many   :vms, -> { active }
   has_many   :vms_and_templates
   has_many   :miq_templates
   has_many   :floating_ips

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -185,6 +185,8 @@ class VmOrTemplate < ApplicationRecord
   before_validation :set_tenant_from_group
   after_save :save_genealogy_information
 
+  scope :active, -> { where.not(:ems_id => nil) }
+
   alias_method :datastores, :storages    # Used by web-services to return datastores as the property name
 
   alias_method :parent_cluster, :ems_cluster

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -600,14 +600,14 @@ describe ManagerRefresh::SaveInventory do
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
-              [Vm.all, cloud_tenant.vms],
+              [Vm.all],
               {:id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_changed_name_1", :location => "vm_location_1"},
               {:id => anything, :ems_ref => "vm_ems_ref_3", :name => "vm_changed_name_3", :location => "vm_location_3"}
             )
 
             # Assert that ems relation exists only for the updated VM
             assert_all_records_match_hashes(
-              @ems.vms,
+              [@ems.vms, cloud_tenant.vms],
               :id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_changed_name_1", :location => "vm_location_1"
             )
           end
@@ -639,7 +639,7 @@ describe ManagerRefresh::SaveInventory do
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(
-              [Vm.all, cloud_tenant.vms],
+              [Vm.all],
               {:id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_changed_name_1", :location => "vm_location_1"},
               {:id => @vm2.id, :ems_ref => "vm_ems_ref_2", :name => "vm_name_2", :location => "vm_location_2"},
               {:id => anything, :ems_ref => "vm_ems_ref_3", :name => "vm_changed_name_3", :location => "vm_location_3"}
@@ -647,9 +647,9 @@ describe ManagerRefresh::SaveInventory do
 
             # Assert that ems relation exists only for the updated VM
             assert_all_records_match_hashes(
-              @ems.vms,
+              [@ems.vms, cloud_tenant.vms],
               {:id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_changed_name_1", :location => "vm_location_1"},
-              {:id => @vm2.id, :ems_ref => "vm_ems_ref_2", :name => "vm_name_2", :location => "vm_location_2"}
+              {:id => @vm2.id, :ems_ref => "vm_ems_ref_2", :name => "vm_name_2", :location => "vm_location_2"},
             )
           end
         end


### PR DESCRIPTION
When archiving a cloud instance, its cloud tenant value does not get nullified. This causes the cloud topology screen to render unwanted archived VMs. This method filters out the archived VMs and I'm planning to use it in the [topology service](https://github.com/ManageIQ/manageiq-ui-classic/pull/1499).

https://bugzilla.redhat.com/show_bug.cgi?id=1456031