### PR TITLE
Include cloud instances in Powered On/Off Report

### DIFF
--- a/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
+++ b/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
@@ -67,12 +67,23 @@ headers:
 conditions: !ruby/object:MiqExpression 
   exp: 
     and:
-    - "STARTS WITH": 
-        field: EmsEvent-event_type
-        value: VmPowered
-    - "ENDS WITH": 
-        field: EmsEvent-event_type
-        value: Event
+    - "OR":
+      - "STARTS WITH":
+          field: EmsEvent-event_type
+          value: VmPowered
+      - "STARTS WITH":
+          field: EmsEvent-event_type
+          value: virtualMachines_powerOff
+      - "STARTS WITH":
+          field: EmsEvent-event_type
+          value: virtualMachines_start
+    - "OR":
+      - "ENDS WITH":
+          field: EmsEvent-event_type
+          value: Event
+      - "ENDS WITH":
+          field: EmsEvent-event_type
+          value: Request
     - "IS":
         field: EmsEvent-timestamp
         value: Last Week


### PR DESCRIPTION
**Issue Summary:**
Cloud instances are not appearing in the report "Operations VM Power On/Off Events for Last Week". This appears to be due to the filter, which is searching on `EmsEvent.event_type`s that begin with `VmPowered` and end with `Event`. 

For cloud instances, the `event_type`s are: `virtualMachines_powerOff_BeginRequest` and `virtualMachines_start_BeginRequest`, so with the existing filter on the report, these are not being included.

**Resolution:**
This PR updates the yaml file that generates the report so that the report expression is now:

```
#<MiqExpression:0x007fb789e4f898
 @exp=
  {"and"=>
    [{"OR"=>
       [{"STARTS WITH"=>{"field"=>"EmsEvent-event_type", "value"=>"VmPowered"}},
        {"STARTS WITH"=>{"field"=>"EmsEvent-event_type", "value"=>"virtualMachines_powerOff"}},
        {"STARTS WITH"=>{"field"=>"EmsEvent-event_type", "value"=>"virtualMachines_start"}}]},
     {"OR"=>[{"ENDS WITH"=>{"field"=>"EmsEvent-event_type", "value"=>"Event"}}, {"ENDS WITH"=>{"field"=>"EmsEvent-event_type", "value"=>"Request"}}]},
     {"IS"=>{"field"=>"EmsEvent-timestamp", "value"=>"Last Week"}}]}>
```
to include power events for cloud instances.

Would appreciate some 👀 from the provider team to ensure that the understanding around powered on/ off events is correct and that we should include these events in this report.

cc: @bronaghs @imtayadeway 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1451053

@miq-bot add_label wip, bug, reporting
