### PR TITLE
Add orchestration stack my_zone.

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -97,6 +97,10 @@ class OrchestrationStack < ApplicationRecord
     raise NotImplementedError, _("raw_update_stack must be implemented in a subclass")
   end
 
+  def my_zone
+    ext_management_system.try(:my_zone)
+  end
+
   def update_stack_queue(userid, template, options = {})
     task_opts = {
       :action => "updating Orchestration Stack for user #{userid}",

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -55,6 +55,17 @@ describe ServiceOrchestration do
     end
   end
 
+  describe "#my_zone" do
+    it "takes the zone from ext_management_system" do
+      deployed_stack.ext_management_system = manager_by_setter
+      expect(deployed_stack.my_zone).to eq(manager_by_setter.my_zone)
+    end
+
+    it "returns nil if ext_management_system is not valid" do
+      expect(deployed_stack.my_zone).to eq(nil)
+    end
+  end
+
   describe "#stack_options" do
     before do
       allow_any_instance_of(ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionConverter).to(


### PR DESCRIPTION
Orchestration stacks can be retired individually and/or from Services.  Retirement puts the retirement request event on the queue and supplies the zone if available.  Service retirement for Orchestration stacks has a zone, but the individual Orchestration stack doesn't not. 

https://bugzilla.redhat.com/show_bug.cgi?id=1458011

