### PR TITLE
[EUWE] Identify Cloud Tenants by Provider on the Cloud Volume Creation form

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -264,7 +264,7 @@ class CloudVolumeController < ApplicationController
     @volume = CloudVolume.new
     @in_a_form = true
     @cloud_tenant_choices = {}
-    Rbac.filtered(CloudTenant).each { |tenant| @cloud_tenant_choices[tenant.name] = tenant.id }
+    Rbac.filtered(CloudTenant).each { |tenant| @cloud_tenant_choices["#{tenant.ext_management_system.name} - #{tenant.name}"] = tenant.id }
     drop_breadcrumb(
       :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_volume')},
       :url  => "/cloud_volume/new"


### PR DESCRIPTION
The Cloud Volume creation form in Euwe lists cloud tenants from multiple providers together in the same dropdown, which can be confusing when tenants from different providers share names. This pull request is a low-impact fix to solve this confusion by including the provider name in the cloud tenant dropdown on that form. 

I did not opt for a more complex fix (such as refactoring the form to filter tenants based on a provider dropdown) because the behavior of the form is totally different from Fine onwards and the problem does not appear to exist there.

This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1457257

![volume_placement](https://user-images.githubusercontent.com/628956/26903334-bbd0f1a2-4baa-11e7-94e5-87cefeb36ff6.png)
