### PR TITLE
Add ManageIQ::ActiveRecordConnector for Rails-less ActiveRecord::Base connections

### DIFF
--- a/lib/manageiq/active_record_connector.rb
+++ b/lib/manageiq/active_record_connector.rb
@@ -1,0 +1,61 @@
+require "active_record"
+require_relative "../patches/database_configuration_patch.rb"
+
+module ManageIQ
+  class ActiveRecordConnector
+    # Helper class for getting the database config without needing Rails
+    #
+    # Makes use of the database_configuration_patch for the most part for
+    # grabbing this from the yaml file in config/database.yml
+    class ConnectionConfig
+      # Set a default method for handling super call in
+      # lib/patches/database_configuration_patch.rb
+      def self.database_configuration
+        if ENV["DATABASE_URL"]
+          {}
+        end
+      end
+
+      class << self
+        prepend DatabaseConfigurationPatch
+      end
+
+      def self.[](env)
+        database_configuration[env]
+      end
+    end
+
+    # Returns true if an ActiveRecord::Base.connection_config is present,
+    # otherwise returns false
+    def self.connection_exists?
+      true if ActiveRecord::Base.connection_config
+    rescue ActiveRecord::ConnectionNotEstablished
+      false
+    end
+
+    # Establishes a connection if one doesn't already exists.  If a block is
+    # passed in, run the code within the block, and then remove the
+    # connections that have been made by this method.
+    def self.establish_connection_if_needed(db_config, log_path = nil)
+      existing_connection = connection_exists?
+
+      unless existing_connection
+        ActiveRecord::Base.logger ||= get_logger_from log_path
+        ActiveRecord::Base.establish_connection(db_config)
+      end
+
+      if block_given?
+        begin
+          yield
+        ensure
+          ActiveRecord::Base.remove_connection unless existing_connection
+        end
+      end
+    end
+
+    def self.get_logger_from(log_path)
+      log_path ||= ManageIQ.root.join("log", "#{ManageIQ.env}.log")
+      Logger.new(log_path)
+    end
+  end
+end

--- a/lib/manageiq/active_record_connector.rb
+++ b/lib/manageiq/active_record_connector.rb
@@ -41,7 +41,8 @@ module ManageIQ
 
       unless existing_connection
         ActiveRecord::Base.logger ||= get_logger_from log_path
-        ActiveRecord::Base.establish_connection(db_config)
+        ActiveRecord::Base.configurations = connection_configurations_from db_config
+        ActiveRecord::Base.establish_connection
       end
 
       if block_given?
@@ -56,6 +57,18 @@ module ManageIQ
     def self.get_logger_from(log_path)
       log_path ||= ManageIQ.root.join("log", "#{ManageIQ.env}.log")
       Logger.new(log_path)
+    end
+
+    class << self
+      private
+
+      def connection_configurations_from(config)
+        if config[ManageIQ.env]
+          config
+        else
+          { ManageIQ.env => config }
+        end
+      end
     end
   end
 end

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,4 +1,4 @@
-require "manageiq"
+require_relative "../manageiq.rb"
 
 module DatabaseConfigurationPatch
   def database_configuration

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,4 +1,5 @@
 require_relative "../manageiq.rb"
+require_relative "../vmdb/settings_walker.rb"
 
 module DatabaseConfigurationPatch
   def database_configuration
@@ -27,7 +28,7 @@ module DatabaseConfigurationPatch
         raise e, "Cannot load `Rails.application.database_configuration`:\n#{e.message}", e.backtrace
       end
 
-      Vmdb::Settings.decrypt_passwords!(data)
+      Vmdb::SettingsWalker.decrypt_passwords!(data)
     else
       super
     end

--- a/lib/vmdb/settings_walker.rb
+++ b/lib/vmdb/settings_walker.rb
@@ -1,6 +1,8 @@
 module Vmdb
   module SettingsWalker
-    PASSWORD_FIELDS = %i(bind_pwd password amazon_secret ssh_key_data ssh_key_unlock become_password vault_password security_token).to_set.freeze
+    unless defined?(PASSWORD_FIELDS)
+      PASSWORD_FIELDS = %i(bind_pwd password amazon_secret ssh_key_data ssh_key_unlock become_password vault_password security_token).to_set.freeze
+    end
 
     module ClassMethods
       # Walks the settings and yields each value along the way

--- a/spec/lib/manageiq/active_record_connector_spec.rb
+++ b/spec/lib/manageiq/active_record_connector_spec.rb
@@ -1,0 +1,128 @@
+require 'manageiq/active_record_connector'
+
+describe ManageIQ::ActiveRecordConnector do
+  def without_rails(rb_cmd)
+    file = Rails.root.join("lib", "manageiq", "active_record_connector")
+    `#{Gem.ruby} -e "require '#{file}'; #{rb_cmd}"`.chomp
+  end
+
+  describe ".connection_exists" do
+    it "returns true when a connection is already established" do
+      expect(described_class.connection_exists?).to be true
+    end
+
+    it "returns false when a connection does already not exist" do
+      cmd = "print #{described_class}.connection_exists?"
+      expect(without_rails(cmd)).to eq("false")
+    end
+  end
+
+  describe ".establish_connection_if_needed" do
+    # Save off existing setup
+    let!(:config)     { ActiveRecord::Base.connection_config }
+    let!(:connection) { ActiveRecord::Base.connection }
+    let!(:logger)     { ActiveRecord::Base.logger }
+
+    it "doesn't create a new connection/logger if it doesn't need to" do
+      described_class.establish_connection_if_needed(config, logger.filename)
+
+      expect(ActiveRecord::Base.connection).to eq(connection)
+      expect(ActiveRecord::Base.logger).to     eq(logger)
+    end
+
+    it "creates a new connection as needed" do
+      cmd = [
+        "#{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")}, '#{logger.filename}')",
+        "puts #{described_class}.connection_exists?",
+        # We aren't using vmdb-logger in the without_rails section of the code,
+        # so the `filename` and `logdev` methods aren't available like they
+        # are in VmdbLogger, which is what our logger is for rails.  Have to
+        # do it this way in the script because of that.
+        "puts ActiveRecord::Base.logger.instance_variable_get(:@logdev).filename"
+      ].join("; ")
+
+      expected_output = "true\n#{logger.filename}"
+      expect(without_rails(cmd)).to eq(expected_output)
+    end
+
+    it "uses a default logger if a log path isn't supplied" do
+      cmd = [
+        "#{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")})",
+        "puts #{described_class}.connection_exists?",
+        "puts ActiveRecord::Base.logger.instance_variable_get(:@logdev).filename"
+      ].join("; ")
+
+      expected_output = "true\n#{ManageIQ.root.join "log", "test.log"}"
+      expect(without_rails(cmd)).to eq(expected_output)
+    end
+
+    it "reuses the existing logger if that is already set" do
+      cmd = [
+        "ActiveRecord::Base.logger = Logger.new '#{ManageIQ.root.join "log", "foobar.log"}'",
+        "#{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")})",
+        "puts #{described_class}.connection_exists?",
+        "puts ActiveRecord::Base.logger.instance_variable_get(:@logdev).filename"
+      ].join("; ")
+
+      expected_output = "true\n#{ManageIQ.root.join "log", "foobar.log"}"
+      expect(without_rails(cmd)).to eq(expected_output)
+    end
+
+    context "with a block passed" do
+      let!(:vm) { FactoryGirl.create(:vm) }
+      let(:query) do
+        <<-TABLE_CHECK_QUERY.lines.map(&:strip).join(" ")
+          SELECT COUNT(table_name)
+            FROM information_schema.tables
+           WHERE table_schema=\'public\'
+             AND table_type='BASE TABLE';
+        TABLE_CHECK_QUERY
+      end
+
+      it "runs the block and returns it's value" do
+        expected_id = described_class.establish_connection_if_needed(config, logger.filename) do
+          # Do the same things as we do in the next test for consistency
+          ActiveRecord::Base.connection.select_value("SELECT id FROM vms ORDER BY id DESC LIMIT 1")
+        end
+
+        expect(expected_id).to eq(vm.id)
+      end
+
+      # NOTE:  Because of transactional fixtures, it is impossible to use the
+      # `let!` block to test the connection having data in the DB as it doesn't
+      # really persist in the database.
+      #
+      # Time wasted figuring this out:  ~2hr
+      #
+      # Instead, we are just counting the database tables that exist
+      it "creates and closes a connection if needed" do
+        cmd = [
+          "result = #{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")}, '#{logger.filename}') do",
+          "  ActiveRecord::Base.connection.select_value(\\\"#{query}\\\")",
+          "end",
+          "puts result",
+          "puts #{described_class}.connection_exists?"
+        ].join("; ")
+
+        expected_output = "#{ActiveRecord::Base.connection.select_value(query)}\nfalse"
+        expect(without_rails(cmd)).to eq(expected_output)
+      end
+    end
+
+    describe "ConnectionConfig" do
+      describe ".database_configuration" do
+        it "finds the same config as would be by Rails" do
+          expected = ActiveRecord::Base.connection_config.stringify_keys
+          expect(described_class::ConnectionConfig.database_configuration[Rails.env]).to eq(expected)
+        end
+      end
+
+      describe ".[]" do
+        it "is a shorthand for database_configuration[env]" do
+          expected = ActiveRecord::Base.connection_config.stringify_keys
+          expect(described_class::ConnectionConfig[Rails.env]).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/manageiq/active_record_connector_spec.rb
+++ b/spec/lib/manageiq/active_record_connector_spec.rb
@@ -90,6 +90,23 @@ describe ManageIQ::ActiveRecordConnector do
       expect(JSON.parse(result)).to eq(expected_config)
     end
 
+    it "defaults to dev environment properly if Rails.env is not available" do
+      env = {
+        "RAILS_ENV" => nil,
+        "RACK_ENV"  => nil
+      }
+      cmd = [
+        "ActiveRecord::Base.logger = Logger.new '#{ManageIQ.root.join "log", "foobar.log"}'",
+        "config = #{described_class}::ConnectionConfig.database_configuration",
+        "#{described_class}.establish_connection_if_needed(config)",
+        "puts ActiveRecord::Base.connection_config.to_json"
+      ].join("; ")
+
+      expected_config = ActiveRecord::Base.configurations["development"]
+      result = without_rails(cmd, env)
+      expect(JSON.parse(result)).to eq(expected_config)
+    end
+
     context "with a block passed" do
       let!(:vm) { FactoryGirl.create(:vm) }
       let(:query) do


### PR DESCRIPTION
**NOTE:** Ideally, should be merged after https://github.com/ManageIQ/manageiq/pull/15414 is merged and integrated with this branch.  See https://github.com/ManageIQ/manageiq/pull/15336#discussion_r123114966

Adds an `ActiveRecord` connecting lib that only requires `active_record` to work, and establishes a connection if one doesn't exist already.

This pattern is already done in `tools/fix_auth/fix_auth.rb`, and that has been converted to use this shared lib.  This can also be used when converting workers to "slim workers" that don't rely on Rails app inilization to establish an `ActiveRecord` connection (see https://github.com/ManageIQ/manageiq/pull/15174 for a proof of concept in where it can be used).

Links
-----
* https://www.pivotaltracker.com/story/show/146814925
* ~~Depends on https://github.com/ManageIQ/manageiq/pull/15414.~~
* POC use case for this PR:  https://github.com/ManageIQ/manageiq/pull/15174

Steps for Testing/QA
--------------------

* [x] Tests pass
* [ ] Test that `tools/fix_auth` still functions properly
* [ ] Try using this in another script (optional)