### PR TITLE
[EUWE] Do not calculate useless group metrics

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -218,8 +218,7 @@ class ChargebackRateDetail < ApplicationRecord
   private
 
   def metric_keys
-    ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
-     "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
+    ["#{rate_name}_metric"] # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
   def cost_keys

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -286,7 +286,6 @@ describe ChargebackVm do
       expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, hours_in_day)
       expect(subject.memory_used_metric).to eq(used_metric)
-      expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
       expect(subject.memory_allocated_cost).to eq(memory_available * hourly_rate * hours_in_day)
       expect(subject.memory_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
@@ -379,7 +378,6 @@ describe ChargebackVm do
       storage_allocated_cost = vm_allocated_disk_storage * count_hourly_rate * hours_in_day
       expect(subject.storage_allocated_cost).to eq(storage_allocated_cost)
 
-      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
 
@@ -420,7 +418,6 @@ describe ChargebackVm do
 
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_day)
       expect(subject.storage_used_metric).to eq(used_metric)
-      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
       expected_value = hourly_fixed_rate * hours_in_day
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
@@ -607,7 +604,6 @@ describe ChargebackVm do
       expect(subject.memory_allocated_metric).to eq(memory_available)
       used_metric = used_average_for(:derived_memory_used, hours_in_month)
       expect(subject.memory_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.memory_metric).to eq(subject.memory_allocated_metric + subject.memory_used_metric)
 
       memory_allocated_cost = memory_available * hourly_rate * hours_in_month
       expect(subject.memory_allocated_cost).to be_within(0.01).of(memory_allocated_cost)
@@ -693,7 +689,6 @@ describe ChargebackVm do
       expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
       expected_value = hourly_fixed_rate * hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)
@@ -736,7 +731,6 @@ describe ChargebackVm do
       expect(subject.storage_allocated_metric).to eq(vm_allocated_disk_storage.gigabytes)
       used_metric = used_average_for(:derived_vm_used_disk_storage, hours_in_month)
       expect(subject.storage_used_metric).to be_within(0.01).of(used_metric)
-      expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
       expected_value = vm_allocated_disk_storage * count_hourly_rate * hours_in_month
       expect(subject.storage_allocated_cost).to be_within(0.01).of(expected_value)


### PR DESCRIPTION
## Manual backport of #15260. To make the tests green.

https://bugzilla.redhat.com/show_bug.cgi?id=1455690
https://bugzilla.redhat.com/show_bug.cgi?id=1454456

 - cpu is useless as it counts usagemhz and vm_numvcpus together
 - cpu_cores is useless as it only reports cpu_cores
 - memory is useless as counts used and available together
 - net_io is useless as it only reports net_ui_rate_avg
 - disk_io is useless as it only reports disk_usage_rate_avg
 - storage is useless as it counts used and allocated together
 - fixed is useless as it counts all the fixed metrics together
   (that equals to 4 for each day, not useful)

(cherry picked from commit afb10c142b4aafd8136ef8e153e5704d2a15c888)

Conflicts:
	app/models/chargeable_field.rb
	spec/models/chargeback_vm_spec.rb