### PR TITLE
Add project option to container template service dialog.

### DIFF
--- a/app/models/dialog/container_template_service_dialog.rb
+++ b/app/models/dialog/container_template_service_dialog.rb
@@ -8,12 +8,53 @@ class Dialog
     def create_dialog(label, parameters)
       Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
         tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
-        add_parameters_group(tab, 0, parameters)
+        add_options_group(tab, 0)
+        add_parameters_group(tab, 1, parameters)
         dialog.save!
       end
     end
 
     private
+
+    def add_options_group(tab, position)
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => "Options",
+        :position => position
+      ).tap do |dialog_group|
+        add_project_dropdown(dialog_group, 0)
+        add_project_textbox(dialog_group, 1)
+      end
+    end
+
+    def add_project_dropdown(group, position)
+      group.dialog_fields.build(
+        :type         => "DialogFieldDropDownList",
+        :name         => "existing_project_name",
+        :data_type    => "string",
+        :dynamic      => true,
+        :display      => "edit",
+        :label        => "Add To Existing Project",
+        :description  => "The desired existing project for the provisioning",
+        :position     => position,
+        :dialog_group => group
+      ).tap do |dialog_field|
+        dialog_field.resource_action.fqname = "Container/Openshift/Operations/Methods/Available_Projects"
+      end
+    end
+
+    def add_project_textbox(group, position)
+      group.dialog_fields.build(
+        :type         => "DialogFieldTextBox",
+        :name         => "new_project_name",
+        :data_type    => "string",
+        :display      => "edit",
+        :label        => "(or) Add To New Project",
+        :description  => "The desired new project for the provisioning",
+        :position     => position,
+        :dialog_group => group
+      )
+    end
 
     def add_parameters_group(tab, position, parameters)
       tab.dialog_groups.build(

--- a/spec/models/dialog/container_template_service_dialog_spec.rb
+++ b/spec/models/dialog/container_template_service_dialog_spec.rb
@@ -32,13 +32,22 @@ describe Dialog::ContainerTemplateServiceDialog do
     assert_tab_attributes(tab)
 
     groups = tab.dialog_groups
-    expect(groups.size).to eq(1)
+    expect(groups.size).to eq(2)
 
-    assert_parameters_group(groups[0])
+    assert_options_group(groups[0])
+    assert_parameters_group(groups[1])
   end
 
   def assert_tab_attributes(tab)
     expect(tab).to have_attributes(:label => "Basic Information", :display => "edit")
+  end
+
+  def assert_options_group(group)
+    expect(group).to have_attributes(:label => "Options", :display => "edit")
+    fields = group.dialog_fields
+    expect(fields.size).to eq(2)
+    assert_field(fields[0], DialogFieldDropDownList, :label => "Add To Existing Project", :name => "existing_project_name", :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox, :label => "(or) Add To New Project", :name => "new_project_name", :data_type => 'string')
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
The dynamic dropdown list would collect the available projects during service ordering.
The textbox field would allow the user to specify a new project for the provisioning which has higher priority over the dynamic dropdown field.

![screen shot 2017-06-08 at 4 54 43 pm](https://user-images.githubusercontent.com/2593270/26950359-5925e80c-4c6b-11e7-94a2-254037745aa5.png)

Depends on https://github.com/ManageIQ/manageiq-content/pull/127.
https://www.pivotaltracker.com/story/show/146528931

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement, services, providers/containers