### PR TITLE
[EUWE] Lock down draper gem to fix rails runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "aws-sdk",                        "~>2.2.19",      :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
-gem "draper",                         "~>3.0.0.pre1"
+gem "draper",                         "=3.0.0.pre1"
 gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"


### PR DESCRIPTION
The draper bump from 3.0.0.pre1 to 3.0.0 breaks rails runner
This seems to have been introduced in https://github.com/drapergem/draper/pull/739

Fixes #15122