### PR TITLE
[POC][WIP] Slim evm rake tasks (alternative to #14916)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,13 +2,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+include Rake::DSL
 require File.expand_path('../lib/tasks/evm_rake_helper', __FILE__)
 
-include Rake::DSL
-Vmdb::Application.load_tasks
-
-# Clear noisy and unusable tasks added by rspec-rails
-if defined?(RSpec)
-  Rake::Task.tasks.select { |t| t.name =~ /^spec(:)?/ }.each(&:clear)
-end
+EvmRakeHelper.load_rake_environment

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -534,11 +534,7 @@ class MiqServer < ApplicationRecord
   # Zone and Role methods
   #
   def self.my_guid
-    @@my_guid_cache ||= begin
-      guid_file = Rails.root.join("GUID")
-      File.write(guid_file, SecureRandom.uuid) unless File.exist?(guid_file)
-      File.read(guid_file).strip
-    end
+    @@my_guid_cache ||= ManageIQ.my_guid
   end
 
   cache_with_timeout(:my_server) { find_by(:guid => my_guid) }

--- a/lib/manageiq.rb
+++ b/lib/manageiq.rb
@@ -23,4 +23,10 @@ module ManageIQ
       end
     end
   end
+
+  def self.my_guid
+    guid_file = root.join("GUID")
+    File.write(guid_file, SecureRandom.uuid) unless File.exist?(guid_file)
+    File.read(guid_file).strip
+  end
 end

--- a/lib/manageiq/active_record_connector.rb
+++ b/lib/manageiq/active_record_connector.rb
@@ -1,0 +1,60 @@
+require "active_record"
+unless defined? DatabaseConfigurationPatch
+  require_relative "../patches/database_configuration_patch.rb"
+end
+
+module ManageIQ
+  class ActiveRecordConnector
+    # Helper class for getting the database config without needing Rails
+    #
+    # Makes use of the database_configuration_patch for the most part for
+    # grabbing this from the yaml file in config/database.yml
+    class ConnectionConfig
+      # Set a default method for handling super call in
+      # lib/patches/database_configuration_patch.rb
+      def self.database_configuration
+        if ENV["DATABASE_URL"]
+          {}
+        end
+      end
+
+      class << self
+        prepend DatabaseConfigurationPatch
+      end
+
+      def self.[](env)
+        database_configuration[env]
+      end
+    end
+
+    # Returns true if an ActiveRecord::Base.connection_config is present,
+    # otherwise returns false
+    def self.connection_exists?
+      begin
+        true if ActiveRecord::Base.connection_config
+      rescue ActiveRecord::ConnectionNotEstablished
+        false
+      end
+    end
+
+    # Establishes a connection if one doesn't already exists.  If a block is
+    # passed in, run the code within the block, and then remove the
+    # connections that have been made by this method.
+    def self.establish_connection_if_needed(db_config, log_path)
+      existing_connection = connection_exists?
+
+      unless existing_connection
+        ActiveRecord::Base.logger = Logger.new(log_path)
+        ActiveRecord::Base.establish_connection(db_config)
+      end
+
+      if block_given?
+        begin
+          yield
+        ensure
+          ActiveRecord::Base.remove_connection unless existing_connection
+        end
+      end
+    end
+  end
+end

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -1,4 +1,4 @@
-require "manageiq"
+require_relative "../manageiq.rb"
 
 module DatabaseConfigurationPatch
   def database_configuration

--- a/lib/patches/database_configuration_patch.rb
+++ b/lib/patches/database_configuration_patch.rb
@@ -27,7 +27,7 @@ module DatabaseConfigurationPatch
         raise e, "Cannot load `Rails.application.database_configuration`:\n#{e.message}", e.backtrace
       end
 
-      Vmdb::Settings.decrypt_passwords!(data)
+      Vmdb::Settings::Walker.decrypt_passwords!(data)
     else
       super
     end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -25,12 +25,12 @@ namespace :evm do
   end
 
   desc "Report Status of the ManageIQ EVM Application"
-  task :status => :environment do
+  task :status => :evm_connect do
     EvmApplication.status
   end
 
   desc "Report Status of the ManageIQ EVM Application"
-  task :status_full => :environment do
+  task :status_full => :evm_connect do
     EvmApplication.status(true)
   end
 
@@ -83,5 +83,12 @@ namespace :evm do
       opt :event, "Server Event", :type => :string, :required => true
     end
     EvmDatabase.raise_server_event(opts[:event])
+  end
+
+  # Connects to the MIQ db
+  task :evm_connect do
+    db_config = ManageIQ::ActiveRecordConnector::ConnectionConfig[ManageIQ.env]
+    log_path  = ManageIQ.root.join "log", "evm.log"
+    ManageIQ::ActiveRecordConnector.establish_connection_if_needed db_config, log_path
   end
 end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -4,7 +4,7 @@ require 'evm_rake_helper'
 
 namespace :evm do
   desc "Start the ManageIQ EVM Application"
-  task :start => :environment do
+  task :start => :evm_connect do
     EvmApplication.start
   end
 

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -1,4 +1,10 @@
-require 'pid_file'
+require "manageiq/active_record_connector"
+
+require "pid_file"
+require "miq_environment"
+require "vmdb/logging"
+require "vmdb/settings/walker"
+require "more_core_extensions/core_ext/array/tableize"
 
 class EvmApplication
   include Vmdb::Logging
@@ -49,16 +55,11 @@ class EvmApplication
   def self.status(include_remotes = false)
     puts "Checking EVM status..."
 
-    server = MiqServer.my_server(true)
+    server = my_server
     servers = Set.new
     servers << server if server
     if include_remotes
-      all_servers =
-        MiqServer
-        .order(:zone_id, :status)
-        .includes(:active_roles, :miq_workers, :zone)
-        .all.to_a
-      servers.merge(all_servers)
+      servers.merge(all_other_servers(server))
     end
 
     if servers.empty?
@@ -72,17 +73,17 @@ class EvmApplication
 
   def self.output_servers_status(servers)
     data = servers.collect do |s|
-      [s.zone.name,
-       s.name,
-       s.status,
-       s.id,
-       s.pid,
-       s.sql_spid,
-       s.drb_uri,
-       s.started_on && s.started_on.iso8601,
-       s.last_heartbeat && s.last_heartbeat.iso8601,
-       s.is_master,
-       s.active_role_names.join(':'),
+      [s["zone"],
+       s["name"],
+       s["status"],
+       s["id"],
+       s["pid"],
+       s["sql_spid"],
+       s["drb_uri"],
+       s["started_on"] && Time.parse(s["started_on"]).iso8601,
+       s["last_heartbeat"] && Time.parse(s["last_heartbeat"]).iso8601,
+       s["is_master"],
+       s["active_role_names"],
       ]
     end
     header = ["Zone", "Server", "Status", "ID", "PID", "SPID", "URL", "Started On", "Last Heartbeat", "Master?", "Active Roles"]
@@ -91,19 +92,17 @@ class EvmApplication
 
   def self.output_workers_status(servers)
     data = []
-    servers.each do |s|
-      s.miq_workers.order(:type).each do |w|
-        data <<
-          [w.type,
-           w.status,
-           w.id,
-           w.pid,
-           w.sql_spid,
-           w.miq_server_id,
-           w.queue_name || w.uri,
-           w.started_on && w.started_on.iso8601,
-           w.last_heartbeat && w.last_heartbeat.iso8601]
-      end
+    workers_for_servers(servers).each do |w|
+      data <<
+        [w["type"],
+         w["status"],
+         w["id"],
+         w["pid"],
+         w["sql_spid"],
+         w["miq_server_id"],
+         w["queue_name"] || w["uri"],
+         w["started_on"] && Time.parse(w["started_on"]).iso8601,
+         w["last_heartbeat"] && Time.parse(w["last_heartbeat"]).iso8601]
     end
 
     header = ["Worker Type", "Status", "ID", "PID", "SPID", "Server id", "Queue Name / URL", "Started On", "Last Heartbeat"]
@@ -136,5 +135,92 @@ class EvmApplication
 
     _log.info("Changing REGION file from [#{old_region}] to [#{new_region}]. Restart to use the new region.")
     region_file.write(new_region)
+  end
+
+  def self.my_server
+    query = miq_server_query.where(miq_server_table[:guid].eq(ManageIQ.my_guid))
+    ActiveRecord::Base.connection.select_one(query)
+  end
+
+  def self.all_other_servers(server)
+    query = miq_server_query
+    query = query.where(miq_server_table[:id].not_eq(server["id"])) if server
+    ActiveRecord::Base.connection.select_all(query)
+  end
+
+  def self.workers_for_servers(servers)
+    server_ids = servers.collect {|s| s["id"]}
+    table      = Arel::Table.new(:miq_workers, :type_caster => typecaster)
+    query      = table.project(Arel.star)
+                      .where(table[:miq_server_id].in(server_ids))
+                      .order(table[:miq_server_id], table[:type])
+    ActiveRecord::Base.connection.select_all(query)
+  end
+
+  def self.miq_server_table
+    @miq_server_table ||= Arel::Table.new(:miq_servers, :type_caster => typecaster)
+  end
+
+  def self.miq_server_query
+    miq_server           = miq_server_table
+    zone                 = Arel::Table.new(:zones, :type_caster => typecaster)
+    assigned_server_role = Arel::Table.new(:assigned_server_roles, :type_caster => typecaster)
+    server_role          = Arel::Table.new(:server_roles, :type_caster => typecaster)
+
+    miq_server_columns = [
+       miq_server[:name],
+       miq_server[:status],
+       miq_server[:id],
+       miq_server[:pid],
+       miq_server[:sql_spid],
+       miq_server[:drb_uri],
+       miq_server[:started_on],
+       miq_server[:last_heartbeat],
+       miq_server[:is_master]
+    ]
+
+    miq_server.project(zone[:name].as("zone"))
+              .project(*miq_server_columns)
+              .project(aggregate_col server_role, :name)
+              .join(zone)
+                .on(miq_server[:zone_id].eq(zone[:id]))
+              .join(assigned_server_role)
+                .on(
+                  miq_server[:id].eq(assigned_server_role[:miq_server_id])
+                    .and(assigned_server_role[:active].eq(false))
+                )
+              .join(server_role)
+                .on(assigned_server_role[:server_role_id].eq(server_role[:id]))
+              .order(miq_server[:zone_id], miq_server[:status])
+              .group(miq_server[:id], zone[:name])
+  end
+
+  def self.aggregate_col(table, col, delimeter="':'")
+    Arel::Nodes::NamedFunction.new(
+      "array_to_string",
+      [
+        Arel::Nodes::NamedFunction.new("array_agg", [table[col]]),
+        Arel::Nodes::SqlLiteral.new(delimeter)
+      ]
+    )
+  end
+
+  def self.typecaster
+    return @typecaster if @typecaster
+
+    require "time"
+
+    @typecaster = Object.new
+
+    def @typecaster.type_cast_for_database(attr_name, val)
+      case attr_name
+      when /(^id$|_id$)/ then val.to_i
+      when %w[started_on last_heartbeat] then Time.parse(val)
+      else
+        val
+      end
+    end
+
+    @typecaster
   end
 end

--- a/lib/tasks/evm_rake_helper.rb
+++ b/lib/tasks/evm_rake_helper.rb
@@ -1,4 +1,10 @@
 module EvmRakeHelper
+
+  EVM_APPLIANCE_TASKS = %w[
+    evm:status
+    evm:status_full
+  ]
+
   # Loading environment will try to read database.yml unless DATABASE_URL is set.
   # For some rake tasks, the database.yml may not yet be setup and is not required anyway.
   # Note: Rails will not actually use the configuration and connect until you issue a query.
@@ -36,5 +42,48 @@ module EvmRakeHelper
   def self.extract_command_options
     i = ARGV.index("--")
     i ? ARGV.slice((i + 1)..-1) : ARGV.dup
+  end
+
+  # Loads the necessary rake task files given the ARGUMENTS passed to rake
+  #
+  # Tasks like like evm:status should be snappy, and don't really require a lot
+  # of depdendencies to function.  But by loading config/application.rb and
+  # using the Vmdb::Application.load_tasks interface, we boot up and configure
+  # the entire application to load every task that we need, when that is
+  # usually overkill.
+  #
+  # By doing a small of ARGV analysis, we can quickly determine what files are
+  # actually needed for the tasks being requested, and skip loading a large
+  # portion of the code base.
+  def self.load_rake_environment
+    if only_calling_evm_tasks
+      load_evm_rake_tasks
+    else
+      load_all_rake_tasks
+    end
+  end
+
+  # Loads everything normally via the Rails conventions
+  def self.load_all_rake_tasks
+    require File.expand_path("../../../config/application", __FILE__)
+
+    Vmdb::Application.load_tasks
+
+    # Clear noisy and unusable tasks added by rspec-rails
+    if defined?(RSpec)
+      Rake::Task.tasks.select { |t| t.name =~ /^spec(:)?/ }.each(&:clear)
+    end
+  end
+
+  # Loads only the evm.rake, and sets up the path for that
+  def self.load_evm_rake_tasks
+    $:.push(File.expand_path("../../", __FILE__))
+
+    load File.expand_path("../evm.rake", __FILE__)
+  end
+
+  # Determines if we are only using evm application tasks
+  def self.only_calling_evm_tasks
+    ARGV.all? {|arg| EVM_APPLIANCE_TASKS.include?(arg)}
   end
 end

--- a/lib/tasks/evm_rake_helper.rb
+++ b/lib/tasks/evm_rake_helper.rb
@@ -1,6 +1,10 @@
 module EvmRakeHelper
 
   EVM_APPLIANCE_TASKS = %w[
+    evm:start
+    evm:restart
+    evm:stop
+    evm:kill
     evm:status
     evm:status_full
   ]

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,7 +1,5 @@
 require 'util/vmdb-logger'
 
-Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }
-
 module Vmdb
   def self.logger
     $log
@@ -85,3 +83,5 @@ module Vmdb
     end
   end
 end
+
+Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }

--- a/spec/lib/manageiq/active_record_connector_spec.rb
+++ b/spec/lib/manageiq/active_record_connector_spec.rb
@@ -1,0 +1,108 @@
+require 'manageiq/active_record_connector'
+
+describe ManageIQ::ActiveRecordConnector do
+  def without_rails(rb_cmd)
+    file = Rails.root.join("lib", "manageiq", "active_record_connector")
+    `#{Gem.ruby} -e "require '#{file}'; #{rb_cmd}"`
+  end
+
+  describe ".connection_exists" do
+    it "returns true when a connection is already established" do
+      expect(described_class.connection_exists?).to be true
+    end
+
+    it "returns false when a connection does already not exist" do
+      cmd = "print #{described_class}.connection_exists?"
+      expect(without_rails(cmd)).to eq("false")
+    end
+  end
+
+  describe ".establish_connection_if_needed" do
+    # Save off existing setup
+    let!(:config)     { ActiveRecord::Base.connection_config }
+    let!(:connection) { ActiveRecord::Base.connection }
+    let!(:logger)     { ActiveRecord::Base.logger }
+
+    it "doesn't create a new connection/logger if it doesn't need to" do
+      described_class.establish_connection_if_needed(config, logger.filename)
+
+      expect(ActiveRecord::Base.connection).to eq(connection)
+      expect(ActiveRecord::Base.logger).to     eq(logger)
+    end
+
+    it "creates a new connection as needed" do
+      cmd_establish_connection   = "#{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")}, '#{logger.filename.to_s}')"
+      cmd_connection_exists      = "puts #{described_class}.connection_exists?"
+      # Not sure why this is a pain in the butt... but whatever...
+      cmd_connection_logger_path = "puts ActiveRecord::Base.logger.instance_variable_get(:@logdev).filename"
+
+      cmd = [
+        cmd_establish_connection,
+        cmd_connection_exists,
+        cmd_connection_logger_path
+      ]
+
+      expected_output = "true\n#{logger.filename}"
+      expect(without_rails(cmd.join("; ")).chomp).to eq(expected_output)
+    end
+
+    context "with a block passed" do
+      let!(:vm) { FactoryGirl.create(:vm) }
+      let(:query) do
+        <<-TABLE_CHECK_QUERY.lines.map {|l| l.strip }.join(" ")
+          SELECT COUNT(table_name)
+            FROM information_schema.tables
+           WHERE table_schema=\'public\'
+             AND table_type='BASE TABLE';
+        TABLE_CHECK_QUERY
+      end
+
+      it "runs the block and returns it's value" do
+        expected_id = described_class.establish_connection_if_needed(config, logger.filename) do
+                        # Do the same things as we do in the next test for consistency
+                        ActiveRecord::Base.connection.select_value("SELECT id FROM vms ORDER BY id DESC LIMIT 1")
+                      end
+
+        expect(expected_id).to eq(vm.id)
+      end
+
+      # NOTE:  Because of transactional fixtures, it is impossible to use the
+      # `let!` block to test the connection having data in the DB as it doesn't
+      # really persist in the database.
+      #
+      # Time wasted figuring this out:  ~2hr
+      #
+      # Instead, we are just counting the database tables that exist
+      it "creates and closes a connection if needed" do
+        cmd_establish_connection  = "#{described_class}.establish_connection_if_needed(#{config.inspect.gsub(/(")/, "\\\\\\1")}, '#{logger.filename.to_s}')"
+        cmd_database_table_count  = %Q{ActiveRecord::Base.connection.select_value(\\"#{query}\\")}
+        cmd_connection_block      = "puts #{cmd_establish_connection} { #{cmd_database_table_count} }"
+        cmd_confirm_no_connection = "puts #{described_class}.connection_exists?"
+
+        cmd = [
+          cmd_connection_block,
+          cmd_confirm_no_connection
+        ]
+
+        expected_output = "#{ActiveRecord::Base.connection.select_value(query)}\nfalse"
+        expect(without_rails(cmd.join("; ")).chomp).to eq(expected_output)
+      end
+    end
+
+    describe "ConnectionConfig" do
+      describe ".database_configuration" do
+        it "finds the same config as would be by Rails" do
+          expected = ActiveRecord::Base.connection_config.stringify_keys
+          expect(described_class::ConnectionConfig.database_configuration[Rails.env]).to eq(expected)
+        end
+      end
+
+      describe ".[]" do
+        it "is a shorthand for database_configuration[env]" do
+          expected = ActiveRecord::Base.connection_config.stringify_keys
+          expect(described_class::ConnectionConfig[Rails.env]).to eq(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
An alternative approach to #14916, which had a lot of model changes and mixin splitting.


Changes
-------

This approach does to major things differently:

* Uses the EvmRakeHelper to define helper methods for limiting what gets loaded (I prefer this method to what was done in #14916)
* Uses pure Arel for the queries made for the `evm:status` calls.  While gross, I admit, it completely removes the need to include the MiqServer at all

Currently, the tasks besides `evm:status` and `evm:status_full` are not updated, and that is a work in progress still.


Benchmarks
----------

**Before:**

```console
$ bundle exec miqperf profile -mt --rake evm:status_full
** Using session_store: ActionDispatch::Session::MemCacheStore
Checking EVM status...
 Zone    | Server | Status  | ID |   PID |  SPID | URL                     | Started On           | Last Heartbeat       | Master? | Active Roles
---------+--------+---------+----+-------+-------+-------------------------+----------------------+----------------------+---------+----------------
 default | EVM    | stopped |  1 | 50381 | 50479 | druby://127.0.0.1:60539 | 2017-06-07T21:20:56Z | 2017-06-07T21:22:46Z | false   | database_owner


TOTAL_MEMORY_USED: 164.75390625MiB

Timings
-------
real    0m5.196s
user    0m4.000s
sys     0m1.160s
cuser   0m0.000s
csys    0m0.000s
```


**After:**

```console
$ bundle exec miqperf profile -mt --rake evm:status_full
Checking EVM status...
 Zone    | Server | Status  | ID |   PID |  SPID | URL                     | Started On                | Last Heartbeat            | Master? | Active Roles
---------+--------+---------+----+-------+-------+-------------------------+---------------------------+---------------------------+---------+--------------
 default | EVM    | stopped |  1 | 50381 | 50479 | druby://127.0.0.1:60539 | 2017-06-07T21:20:56-05:00 | 2017-06-07T21:22:46-05:00 | false   |


TOTAL_MEMORY_USED: 58.84375MiB

Timings
-------
real    0m1.131s
user    0m0.740s
sys     0m0.380s
cuser   0m0.000s
csys    0m0.000s
```


Links
-----

* Old PR:  https://github.com/ManageIQ/manageiq/pull/14916
* Prerequisite PR:  https://github.com/ManageIQ/manageiq/pull/15336
* Profiling method used for taking benchmarks:  https://github.com/ManageIQ/manageiq-performance/pull/27
 

Steps for Testing/QA
--------------------
Mostly confirm the `rake evm:` based tasks still work as expected (depending on how many were converted in this PR).