### PR TITLE
Refactor combine_filtered_ids in RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -360,9 +360,9 @@ module Rbac
     end
 
     #
-    # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
+    # Algorithm: b_intersection_m        = (b_filtered_ids INTERSECTION m_filtered_ids)
     #            u_union_d_union_b_and_m = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
-    #            filter = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
+    #            filter                  = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
     #
     # a nil as input for any field means it DOES NOT apply the operation(INTERSECTION, UNION)
     # a nil as output means there is not filter
@@ -379,8 +379,9 @@ module Rbac
       intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
       union        = ->(operand1, operand2, operand3 = nil) { [operand1, operand2, operand3].compact.reduce(&:|) }
 
-      b_intersectionn_m = intersection.call(b_filtered_ids, m_filtered_ids)
-      u_union_d_union_b_intersection_m = union.call(u_filtered_ids, d_filtered_ids, b_intersectionn_m)
+      b_intersection_m                 = intersection.call(b_filtered_ids, m_filtered_ids)
+      u_union_d_union_b_intersection_m = union.call(u_filtered_ids, d_filtered_ids, b_intersection_m)
+
       intersection.call(u_union_d_union_b_intersection_m, tenant_filter_ids)
     end
 

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -358,8 +358,10 @@ module Rbac
 
       combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, scope_tenant_filter.try(:ids))
     end
+
     #
-    # Algorithm: filter = u_filtered_ids UNION (b_filtered_ids INTERSECTION m_filtered_ids)
+    # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
+    #            filter = u_filtered_ids UNION b_intersection_m
     #            filter = (filter UNION d_filtered_ids)
     #            filter = filter INTERSECTION tenant_filter_ids
     # a nil as input for any field means it does not apply

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -381,6 +381,7 @@ module Rbac
 
       b_intersectionn_m = intersection.call(b_filtered_ids, m_filtered_ids)
       u_union_d_union_b_intersection_m = union.call(u_filtered_ids, d_filtered_ids, b_intersectionn_m)
+      intersection.call(u_union_d_union_b_intersection_m, tenant_filter_ids)
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -376,6 +376,9 @@ module Rbac
     # @return [Array<Integer>] target ids for filter
 
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
+      intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
+      union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
+
       filtered_ids =
         if b_filtered_ids.nil?
           m_filtered_ids

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -377,9 +377,10 @@ module Rbac
 
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
       intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
-      union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
+      union        = ->(operand1, operand2, operand3 = nil) { [operand1, operand2, operand3].compact.reduce(&:|) }
 
       b_intersectionn_m = intersection.call(b_filtered_ids, m_filtered_ids)
+      u_union_d_union_b_intersection_m = union.call(u_filtered_ids, d_filtered_ids, b_intersectionn_m)
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -361,7 +361,7 @@ module Rbac
     #
     # Algorithm: filter = u_filtered_ids UNION (b_filtered_ids INTERSECTION m_filtered_ids)
     #            filter = (filter UNION d_filtered_ids)
-    #            filter = filter INTERSECTION tenant_filter_ids if tenant_filter_ids is not nil
+    #            filter = filter INTERSECTION tenant_filter_ids
     # a nil as input for any field means it does not apply
     # a nil as output means there is not filter
     #

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -378,35 +378,6 @@ module Rbac
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
       intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
       union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
-
-      filtered_ids =
-        if b_filtered_ids.nil?
-          m_filtered_ids
-        elsif m_filtered_ids.nil?
-          b_filtered_ids
-        else
-          b_filtered_ids & m_filtered_ids
-        end
-
-      if u_filtered_ids.kind_of?(Array)
-        filtered_ids ||= []
-        filtered_ids += u_filtered_ids
-      end
-
-      if filtered_ids.kind_of?(Array)
-        filtered_ids += d_filtered_ids if d_filtered_ids.kind_of?(Array)
-        filtered_ids.uniq!
-      elsif d_filtered_ids.kind_of?(Array) && d_filtered_ids.present?
-        filtered_ids = d_filtered_ids
-      end
-
-      if filtered_ids.kind_of?(Array) && tenant_filter_ids
-        filtered_ids & tenant_filter_ids.to_a
-      elsif filtered_ids.nil? && tenant_filter_ids.kind_of?(Array) && tenant_filter_ids.present?
-        tenant_filter_ids
-      else
-        filtered_ids
-      end
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -378,6 +378,8 @@ module Rbac
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
       intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
       union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
+
+      b_intersectionn_m = intersection.call(b_filtered_ids, m_filtered_ids)
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -361,8 +361,7 @@ module Rbac
 
     #
     # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
-    #            filter = u_filtered_ids UNION b_intersection_m
-    #            filter = (filter UNION d_filtered_ids)
+    #            filter = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
     #            filter = filter INTERSECTION tenant_filter_ids
     # a nil as input for any field means it does not apply
     # a nil as output means there is not filter

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -361,8 +361,8 @@ module Rbac
 
     #
     # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
-    #            filter = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
-    #            filter = filter INTERSECTION tenant_filter_ids
+    #            u_union_d_union_b_and_m = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
+    #            filter = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
     # a nil as input for any field means it does not apply
     # a nil as output means there is not filter
     #

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -363,7 +363,8 @@ module Rbac
     # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
     #            u_union_d_union_b_and_m = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
     #            filter = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
-    # a nil as input for any field means it does not apply
+    #
+    # a nil as input for any field means it DOES NOT apply the operation(INTERSECTION, UNION)
     # a nil as output means there is not filter
     #
     # @param u_filtered_ids [nil|Array<Integer>] self service user owned objects
@@ -371,7 +372,7 @@ module Rbac
     # @param m_filtered_ids [nil|Array<Integer>] managed filter object ids
     # @param d_filtered_ids [nil|Array<Integer>] ids from descendants
     # @param tenant_filter_ids [nil|Array<Integer>] ids
-    # @return nil if filters do not aply
+    # @return nil if filters do not apply
     # @return [Array<Integer>] target ids for filter
 
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)


### PR DESCRIPTION
### Goal :soccer:
make method `combine_filtered_ids` more understandable 

### Motivation :bulb:
there is needed some change and it was hard to do it with the previous state.

### Description :clipboard:
This method contained a lot of `ifs` and it was confusing.
- there  is  restructured algorithm in first commits with clarification of INTERSECTION and UNION operations here
- the algorithm is written with using those operators

See comments in commits for the whole story.

@miq-bot add_label refactoring, rbac

cc @kbrock 

@miq-bot assign @gtanzillo 