### PR TITLE
More API Rubocop Fixes

### DIFF
--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -31,8 +31,7 @@ module Api
                                  :description => data.delete("description"),
                                  :towhat      => data.delete("towhat"),
                                  :mode        => data.delete("mode"),
-                                 :active      => true
-                                )
+                                 :active      => true)
       add_policies_content(data, policy)
       policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]
       policy

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:disable ClassLength
 module Api
   class ProvidersController < BaseController
     TYPE_ATTR         = "type".freeze

--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -66,7 +66,7 @@ module Api
 
       def find_custom_attribute(object, id, data)
         if object.respond_to?(:custom_attributes)
-          (id.present? && id > 0) ? object.custom_attributes.find(id) : find_custom_attribute_by_data(object, data)
+          id.present? && id > 0 ? object.custom_attributes.find(id) : find_custom_attribute_by_data(object, data)
         else
           raise BadRequestError, "#{object.class.name} does not support management of custom attributes"
         end
@@ -84,8 +84,7 @@ module Api
         CustomAttribute.new(:name    => name,
                             :value   => data["value"],
                             :source  => data["source"].blank? ? "EVM" : data["source"],
-                            :section => data["section"]
-                           )
+                            :section => data["section"])
       end
     end
   end

--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -22,7 +22,7 @@ module Api
       private
 
       def policy_ident(ctype, policy)
-        cdesc = (ctype == :policies) ? "Policy" : "Policy Profile"
+        cdesc = ctype == :policies ? "Policy" : "Policy Profile"
         "#{cdesc}: id:'#{policy.id}' description:'#{policy.description}' guid:'#{policy.guid}'"
       end
 
@@ -87,7 +87,7 @@ module Api
       end
 
       def policy_resolve(object, ctype, policy)
-        res = (ctype == :policies) ? object.resolve_policies([policy.name]) : object.resolve_profiles([policy.id])
+        res = ctype == :policies ? object.resolve_policies([policy.name]) : object.resolve_profiles([policy.id])
         action_result(true, "Resolving #{policy_ident(ctype, policy)}", :result => res)
       rescue => err
         action_result(false, err.to_s)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -35,7 +35,7 @@ module Api
     end
 
     def edit_resource(type, id, data)
-      (id == User.current_user.id) ? validate_self_user_data(data) : validate_user_data(data)
+      id == User.current_user.id ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
       parse_set_settings(data, resource_search(id, type, collection_class(type)))
       super


### PR DESCRIPTION
Just some Friday Fun with Rubocop 🎉 

Summary:
* puts parenthesis in their correct places
* removes unnecessary parenthesis 
* removes useless rubocop disable 

@miq-bot add_label refactoring