### PR TITLE
[EUWE] Add missing ownership_form_fields route for miq_template

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2077,6 +2077,7 @@ Vmdb::Application.routes.draw do
         edit
         show
         ownership
+        ownership_form_fields
       ),
       :post => %w(
         edit


### PR DESCRIPTION
Add missing ownership_form_fields route for miq_template

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1448073
