### PR TITLE
Archive Container Nodes

### DIFF
--- a/app/models/container_node/purging.rb
+++ b/app/models/container_node/purging.rb
@@ -1,0 +1,20 @@
+class ContainerNode < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.container_entities.history.keep_archived_entities.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.container_entities.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        where(arel_table[:deleted_on].lteq(older_than))
+      end
+    end
+  end
+end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -112,7 +112,8 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(ems.container_nodes, hashes, :use_association, [:ems_ref],
                          [:labels, :tags, :computer_system, :container_conditions,
-                          :additional_attributes], [:namespace])
+                          :additional_attributes], [:namespace], true)
+
     store_ids_for_new_records(ems.container_nodes, hashes, :ems_ref)
   end
 

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers
     include HasMonitoringManagerMixin
     include SupportsFeatureMixin
 
-    has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_nodes, -> { active }, :foreign_key => :ems_id
     has_many :container_groups, -> { active }, :foreign_key => :ems_id
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
@@ -44,6 +44,7 @@ module ManageIQ::Providers
     has_many :all_container_groups, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerGroup"
     has_many :all_container_projects, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerProject"
     has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
+    has_many :all_container_nodes, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerNode"
 
 
     virtual_column :port_show, :type => :string

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -105,6 +105,7 @@ class MiqScheduleWorker::Jobs
 
   def archived_entities_purge_timer
     queue_work(:class_name => "Container", :method_name => "purge_timer", :zone => nil)
+    queue_work(:class_name => "ContainerNode", :method_name => "purge_timer", :zone => nil)
     queue_work(:class_name => "ContainerGroup", :method_name => "purge_timer", :zone => nil)
     queue_work(:class_name => "ContainerImage", :method_name => "purge_timer", :zone => nil)
     queue_work(:class_name => "ContainerProject", :method_name => "purge_timer", :zone => nil)

--- a/spec/models/container_node/purging_spec.rb
+++ b/spec/models/container_node/purging_spec.rb
@@ -1,0 +1,47 @@
+describe ContainerNode do
+  context "::Purging" do
+    context ".purge_queue" do
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+      end
+      let(:purge_time) { (Time.zone.now + 10).round }
+
+      it "submits to the queue" do
+        expect(described_class).to receive(:purge_date).and_return(purge_time)
+        described_class.purge_timer
+
+        q = MiqQueue.all
+        expect(q.length).to eq(1)
+        expect(q.first).to have_attributes(
+          :class_name  => described_class.name,
+          :method_name => "purge_by_date",
+          :args        => [purge_time]
+        )
+      end
+    end
+
+    context ".purge" do
+      let(:deleted_date) { 6.months.ago }
+
+      before do
+        @old_container_node        = FactoryGirl.create(:container_node, :deleted_on => deleted_date - 1.day)
+        @purge_date_container_node = FactoryGirl.create(:container_node, :deleted_on => deleted_date)
+        @new_container_node        = FactoryGirl.create(:container_node, :deleted_on => deleted_date + 1.day)
+      end
+
+      def assert_unpurged_ids(unpurged_ids)
+        expect(described_class.order(:id).pluck(:id)).to eq(Array(unpurged_ids).sort)
+      end
+
+      it "purge_date and older" do
+        described_class.purge(deleted_date)
+        assert_unpurged_ids(@new_container_node.id)
+      end
+
+      it "with a window" do
+        described_class.purge(deleted_date, 1)
+        assert_unpurged_ids(@new_container_node.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1460401

Depends on https://github.com/ManageIQ/manageiq-schema/pull/22

Changes included: 
<del>Adding `deleted_on` and `old_ems_id` columns to `container_nodes` table. </del> (Extracted) 
* Disconnecting container nodes instead of deleting them.
* Purging archived container nodes. 