### PR TITLE
Add encrypted column to CloudVolumeSnapshot

### DIFF
--- a/db/migrate/20170612051535_add_encrypted_to_cloud_volume_snapshot.rb
+++ b/db/migrate/20170612051535_add_encrypted_to_cloud_volume_snapshot.rb
@@ -1,0 +1,5 @@
+class AddEncryptedToCloudVolumeSnapshot < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cloud_volume_snapshots, :encrypted, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -405,6 +405,7 @@ cloud_volume_snapshots:
 - creation_time
 - size
 - cloud_tenant_id
+- encrypted
 cloud_volumes:
 - id
 - type


### PR DESCRIPTION
Amazon EBS provides information about snapshots's encryption
status as part of the cloud volume snapshot model so this patch extends the
existing cloud volume snapshot model to include this attribute.

@miq-bot add_label storage, sql migration