### PR TITLE
Optimize concurrent batch safe saver

### DIFF
--- a/app/models/manager_refresh/application_record_iterator.rb
+++ b/app/models/manager_refresh/application_record_iterator.rb
@@ -1,0 +1,33 @@
+module ManagerRefresh
+  class ApplicationRecordIterator
+    attr_reader :inventory_collection, :manager_uuids_set, :iterator
+
+    # An iterator that can fetch batches of the AR objects based on a set of manager refs, or just mimics AR relation
+    # when given an iterator
+    def initialize(inventory_collection: nil, manager_uuids_set: nil, iterator: nil)
+      @inventory_collection = inventory_collection
+      @manager_uuids_set    = manager_uuids_set
+      @iterator             = iterator
+    end
+
+    def find_in_batches(batch_size: 1000)
+      if iterator
+        iterator.call do |batch|
+          yield(batch)
+        end
+      else
+        manager_uuids_set.each_slice(batch_size) do |batch|
+          yield(inventory_collection.db_collection_for_comparison_for(batch))
+        end
+      end
+    end
+
+    def find_each
+      find_in_batches do |batch|
+        batch.each do |item|
+          yield(item)
+        end
+      end
+    end
+  end
+end

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -1,6 +1,7 @@
 module ManagerRefresh
   class InventoryCollection
-    attr_accessor :saved, :references, :attribute_references, :data_collection_finalized, :all_manager_uuids
+    attr_accessor :saved, :references, :attribute_references, :data_collection_finalized, :all_manager_uuids,
+                  :dependees
 
     attr_reader :model_class, :strategy, :attributes_blacklist, :attributes_whitelist, :custom_save_block, :parent,
                 :internal_attributes, :delete_method, :data, :data_index, :dependency_attributes, :manager_ref,
@@ -379,6 +380,7 @@ module ManagerRefresh
       @attributes_blacklist             = Set.new
       @attributes_whitelist             = Set.new
       @transitive_dependency_attributes = Set.new
+      @dependees                        = Set.new
       @references                       = Set.new
       @attribute_references             = Set.new
       @loaded_references                = Set.new

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -851,7 +851,10 @@ module ManagerRefresh
           targeted_arel.call(self)
         else
           raise "Can't build :targeted_arel for #{self}, please provide it as an argument." if manager_ref.count > 1
-          db_collection_for_comparison_for((manager_uuids + skeletal_manager_uuids).to_a.flatten.compact)
+          ManagerRefresh::ApplicationRecordIterator.new(
+            :inventory_collection => self,
+            :manager_uuids_set    => (manager_uuids + skeletal_manager_uuids).to_a.flatten.compact
+          )
         end
       else
         full_collection_for_comparison

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -886,6 +886,9 @@ module ManagerRefresh
         references << manager_uuid unless references.include?(manager_uuid) # O(1) since references is Set
       end
 
+      # Put our existing data keys into loaded references
+      loaded_references.merge(data_index.keys)
+      # Load the rest of the references from the DB
       populate_db_data_index!
 
       db_data_index[manager_uuid]

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -841,6 +841,10 @@ module ManagerRefresh
       end
     end
 
+    def batch_size
+      1000
+    end
+
     def db_collection_for_comparison
       if targeted?
         if targeted_arel.respond_to?(:call)

--- a/app/models/manager_refresh/inventory_collection/scanner.rb
+++ b/app/models/manager_refresh/inventory_collection/scanner.rb
@@ -14,6 +14,12 @@ module ManagerRefresh
             inventory_collection.data_collection_finalized = true
             inventory_collection.scan!(indexed_inventory_collections)
           end
+
+          inventory_collections.each do |inventory_collection|
+            inventory_collection.dependencies.each do |dependency|
+              dependency.dependees << inventory_collection
+            end
+          end
         end
       end
     end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -33,7 +33,7 @@ module ManagerRefresh::SaveCollection
       attr_reader :unique_index_keys, :unique_db_primary_keys
 
       def batch_size
-        1000
+        inventory_collection.batch_size
       end
 
       def delete_complement(inventory_collection)

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -132,7 +132,7 @@ module ManagerRefresh::SaveCollection
       def map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
         inventory_collection.model_class.where(
           build_multi_selection_query(inventory_collection, hashes)
-        ).find_each do |inserted_record|
+        ).each do |inserted_record|
           inventory_object = indexed_inventory_objects[inventory_collection.unique_index_columns.map { |x| inserted_record.public_send(x) }]
           inventory_object.id = inserted_record.id if inventory_object
         end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -64,7 +64,7 @@ module ManagerRefresh::SaveCollection
 
           # Destroy in batches
           if records_for_destroy.size >= batch_size
-            destroy_records(records)
+            destroy_records(records_for_destroy)
             records_for_destroy = []
           end
         end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -123,8 +123,10 @@ module ManagerRefresh::SaveCollection
         ActiveRecord::Base.connection.execute(
           build_insert_query(inventory_collection, all_attribute_keys, hashes)
         )
-        # TODO(lsmola) we need to do the mapping only if this IC has dependents/dependees
-        map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
+        if inventory_collection.dependees.present?
+          # We need to get primary keys of the created objects, but only if there are dependees that would use them
+          map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
+        end
       end
 
       def map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -47,10 +47,7 @@ module ManagerRefresh::SaveCollection
               next unless assert_referential_integrity(hash, inventory_object)
               inventory_object.id = record.id
 
-              record.assign_attributes(hash.except(:id, :type))
-              if !inventory_collection.check_changed? || record.changed?
-                hashes_for_update << record.attributes.symbolize_keys
-              end
+              hashes_for_update << hash.symbolize_keys.except(:id, :type)
             end
           end
 
@@ -110,7 +107,8 @@ module ManagerRefresh::SaveCollection
         indexed_inventory_objects = {}
         hashes = []
         batch.each do |index, inventory_object|
-          hash = inventory_collection.model_class.new(attributes_index.delete(index)).attributes.symbolize_keys
+          hash = attributes_index.delete(index).symbolize_keys
+          hash[:type] = inventory_collection.model_class.name if inventory_collection.supports_sti? && hash[:type].blank?
           next unless assert_referential_integrity(hash, inventory_object)
 
           hashes << hash

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -130,7 +130,7 @@ module ManagerRefresh::SaveCollection
       def map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, hashes)
         inventory_collection.model_class.where(
           build_multi_selection_query(inventory_collection, hashes)
-        ).each do |inserted_record|
+        ).select(inventory_collection.unique_index_columns + [:id]).each do |inserted_record|
           inventory_object = indexed_inventory_objects[inventory_collection.unique_index_columns.map { |x| inserted_record.public_send(x) }]
           inventory_object.id = inserted_record.id if inventory_object
         end


### PR DESCRIPTION
Optimize concurrent batch safe saver. Loading only non-leaf nodes IDs back from the DB, while limiting the projected data. And a custom Iterator working with array of ems_refs that leads to much more effective queries.