### PR TITLE
Add AuthKeyPair to RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -6,6 +6,7 @@ module Rbac
     # 2. Tagging has been enabled in the UI
     # 3. Class contains acts_as_miq_taggable
     CLASSES_THAT_PARTICIPATE_IN_RBAC = %w(
+      Authentication
       AvailabilityZone
       CloudNetwork
       CloudSubnet

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -20,6 +20,27 @@ describe Rbac::Filterer do
   let(:child_openstack_vm) { FactoryGirl.create(:vm_openstack, :tenant => child_tenant, :miq_group => child_group) }
 
   describe ".search" do
+    context 'searching for instances of AuthKeyPair with tags' do
+      let(:role)                       { FactoryGirl.create(:miq_user_role) }
+      let(:tagged_group)               { FactoryGirl.create(:miq_group, :tenant => Tenant.root_tenant, :miq_user_role => role) }
+      let(:user)                       { FactoryGirl.create(:user, :miq_groups => [tagged_group]) }
+      let!(:auth_key_pair_cloud) { FactoryGirl.create_list(:auth_key_pair_cloud, 2).first }
+
+      before do
+        tagged_group.entitlement = Entitlement.new
+        tagged_group.entitlement.set_belongsto_filters([])
+        tagged_group.entitlement.set_managed_filters([["/managed/environment/prod"]])
+        tagged_group.save!
+      end
+
+      it 'lists only tagged AuthKeyPairs' do
+        auth_key_pair_cloud.tag_with('/managed/environment/prod', :ns => '*')
+
+        results = described_class.search(:class => ManageIQ::Providers::CloudManager::AuthKeyPair, :user => user).first
+        expect(results).to match_array [auth_key_pair_cloud]
+      end
+    end
+
     context 'with virtual custom attributes' do
       let(:virtual_custom_attribute_1) { "virtual_custom_attribute_attribute_1" }
       let(:virtual_custom_attribute_2) { "virtual_custom_attribute_attribute_2" }


### PR DESCRIPTION
`AuthKeyPair` is inherited from `AuthPrivateKey` and then from `Authentication`. (In `CLASSES_THAT_PARTICIPATE_IN_RBAC` is list of base classes)

In UI:
Compute -> Cloud -> Key Pairs

@miq-bot add_label bug, rbac

@miq-bot assign @gtanzillo 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1441637


