### PR TITLE
Remove comment about participating models in RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -2,9 +2,8 @@ module Rbac
   class Filterer
     # This list is used to detemine whether RBAC, based on assigned tags, should be applied for a class in a search that is based on the class.
     # Classes should be added to this list ONLY after:
-    # 1. It has been added to the MiqExpression::BASE_TABLES list
-    # 2. Tagging has been enabled in the UI
-    # 3. Class contains acts_as_miq_taggable
+    # 1. Tagging has been enabled in the UI
+    # 2. Class contains acts_as_miq_taggable
     CLASSES_THAT_PARTICIPATE_IN_RBAC = %w(
       AvailabilityZone
       CloudNetwork


### PR DESCRIPTION
List BASE_TABLES is used only for listing base models in the report definition.

Maybe BASE_TABLES were somehow related to RBAC before? Now, it looks like there is no relation.

cc @imtayadeway 
@miq-bot assign @gtanzillo 
@miq-bot add_label technical-dept, rbac