### PR TITLE
[EUWE] [FINE] Add support for file share volumes to SCVMM

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
-  MT_POINT_REGEX = %r{file://.*/([A-Z][:].*)}i
+  MT_POINT_REGEX = %r{file://.*?/(.*)}i
 
   def log_clone_options(clone_options)
     _log.info("Provisioning [#{source.name}] to [#{clone_options[:name]}]")

--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -1,5 +1,6 @@
 import-module virtualmachinemanager
 $diskvols = @{}
+$sharevols = @{}
 
 function get_vms($vms){
   $results = @{}
@@ -45,6 +46,9 @@ function get_host_inventory($hosts) {
     $_.DiskVolumes | where-object VolumeLabel -ne "System Reserved" | ForEach {
       $diskvols[$_.ID]=$_
     }
+    $_.RegisteredStorageFileShares | ForEach {
+      $sharevols[$_.ID]=$_
+    }
   }
 
   return $results
@@ -73,6 +77,7 @@ $r["images"] = get_images($i)
 $h = Get-SCVMHost -VMMServer "localhost"
 $r["hosts"] = get_host_inventory($h)
 $r["datastores"] = $diskvols
+$r["sharevols"] = $sharevols
 
 $c = Get-SCVMHostCluster -VMMServer "localhost"
 $r["clusters"] = get_clusters($c)

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -12,6 +12,25 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     )
   end
 
+  let(:regex) { ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning::MT_POINT_REGEX }
+
+  context "MT_POINT_REGEX" do
+    it "matches a storage name with a drive letter" do
+      string = "file://foo.cfme-qe.redhat.com/J:/"
+      expect(string.scan(regex).flatten.first).to eql("J:/")
+    end
+
+    it "matches a storage name with a drive letter and path" do
+      string = "file://foo.cfme-qe.redhat.com/C:/ClusterStorage/netapp_crud_vol"
+      expect(string.scan(regex).flatten.first).to eql("C:/ClusterStorage/netapp_crud_vol")
+    end
+
+    it "matches a storage name without a drive letter" do
+      string = "file://foo123.redhat.com///clusterstore.xx-yy-redhat.com/cdrive"
+      expect(string.scan(regex).flatten.first).to eql("//clusterstore.xx-yy-redhat.com/cdrive")
+    end
+  end
+
   context "A new provision request," do
     before(:each) do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')


### PR DESCRIPTION
This adds support for file share volumes on the SCVMM provider.

This is a "backport" of https://github.com/ManageIQ/manageiq-providers-scvmm/pull/2 and https://github.com/ManageIQ/manageiq-providers-scvmm/pull/7 for the Euwe branch. A separate PR was required not only because of the repository split, but also because the underlying powershell script was heavily altered between 5.7 and 5.8.

Addresses this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1454963


