### PR TITLE
Lower the report level of routine http errors in the Fog log

### DIFF
--- a/lib/vmdb/loggers/fog_logger.rb
+++ b/lib/vmdb/loggers/fog_logger.rb
@@ -14,7 +14,7 @@ module Vmdb::Loggers
         case name
         when "excon.request" then  [:debug, message_for_excon_request(params)]
         when "excon.response" then [:debug, message_for_excon_response(params)]
-        when "excon.error" then    [:error, message_for_excon_error(params)]
+        when "excon.error" then    [:debug, message_for_excon_error(params)]
         else                   [:debug, message_for_other(params)]
         end
 


### PR DESCRIPTION
The FogLogger was automatically reporting every Excon error (400+ status
code) as an ERROR level message, which was then getting mirrored without
context into the evm.log as an ERROR.  The application already catches,
handles, and logs these occurrences with relevant context, so the automatic
instrumentation only needs to report the gritty details of these events
at the DEBUG level.

For example, OpenstackHandle's `handled_list` totally assumes that it will get 404s for normal reasons and outputs WARNs with relevant messages explaining the occurrence in the Fog log. However, because the instrumentation was automatically reporting every lack of success as an ERROR, you get a WARN and an ERROR for the same thing in the Fog log, and a confusing ERROR by itself for a thing that didn't actually fail in the EVM log.

Fixes the log spam reported in https://bugzilla.redhat.com/show_bug.cgi?id=1447664