### PR TITLE
VIEWS_FOLDER is now unused :fire: :scissors:

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -19,7 +19,6 @@ module MiqReport::ImportExport
       nil
     end
 
-    VIEWS_FOLDER = File.join(ManageIQ::UI::Classic::Engine.root, "product/views")
     def import_from_hash(report, options = nil)
       raise _("No Report to Import") if report.nil?
 


### PR DESCRIPTION
As of fbae08dd1c887bc5255f968c707bd2cd4e1cc36a, the constant is unused.
On top of that, removing it causes us not to autoload
manageiq-ui-classic gem!  :clap:

@martinpovolny :clap: 🙇 