### PR TITLE
RssFeed is the only caller of rss_feed_for

### DIFF
--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,6 +1,4 @@
-require 'resource_feeder/common'
 class RssFeed < ApplicationRecord
-  include ResourceFeeder
   include_concern 'ImportExport'
 
   validates_presence_of     :name
@@ -19,6 +17,8 @@ class RssFeed < ApplicationRecord
   end
 
   def generate(host = nil, local = false, proto = nil, user_or_group = nil)
+    require 'resource_feeder/lib/resource_feeder'
+
     proto ||= ::Settings.webservices.consume_protocol
     host_url = host.nil? ? "#{proto}://localhost:3000" : "#{proto}://" + host
 
@@ -43,7 +43,7 @@ class RssFeed < ApplicationRecord
     end
 
     filtered_items = Rbac::Filterer.filtered(find_items, rbac_options)
-    feed = Rss.rss_feed_for(filtered_items, options)
+    feed = ResourceFeeder::Rss.rss_feed_for(filtered_items, options)
     local ? feed : {:text => feed, :content_type => Mime[:rss]}
   end
 

--- a/config/initializers/rails2_plugins.rb
+++ b/config/initializers/rails2_plugins.rb
@@ -1,1 +1,0 @@
-require 'resource_feeder/init'

--- a/lib/resource_feeder/init.rb
+++ b/lib/resource_feeder/init.rb
@@ -1,2 +1,0 @@
-require 'resource_feeder/lib/resource_feeder'
-ActionController::Base.send(:include, ResourceFeeder::Rss, ResourceFeeder::Atom)


### PR DESCRIPTION
The AlertController and others don't call rss_feed_for,
render_rss_feed_for, or the atom variants so we don't need
to pollute ActionController, RssFeed, etc.

Instead, they call RssFeed.generate, such as [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/10d0ae2a2cdc3aa4fbc36e3e47e437b7b24114ba/app/controllers/alert_controller.rb#L48).