### PR TITLE
[POC] Try Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,9 @@ gem "ruport",                         "=1.7.0",                       :git => "h
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
 
+# Speed up boot time
+gem "bootsnap"
+
 group :ui_dependencies do # Added to Bundler.require in config/application.rb
   # Modified gems (forked on Github)
   gem "font-fabulous",                                                :git => "https://github.com/ManageIQ/font-fabulous.git", :branch => "master" # FIXME: this is just a temporary solution and it'll go to the ui-classic later

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,3 +6,15 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 # add the lib dir of the engine if we are running as a dummy app for an engine
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__) if defined?(ENGINE_ROOT)
+
+require 'bootsnap'
+
+Bootsnap.setup(
+  :cache_dir            => 'tmp/cache',
+  :development_mode     => ENV['RAILS_ENV'] == 'development',
+  :load_path_cache      => true,
+  :autoload_paths_cache => true,
+  :disable_trace        => false,
+  :compile_cache_iseq   => true,
+  :compile_cache_yaml   => true
+)


### PR DESCRIPTION
[Bootsnap](https://github.com/Shopify/bootsnap) has helped some Rails apps drastically improve boot time, so I gave it a whirl on ManageIQ.

With my naive (and maybe meaningless) testing with `time` I saw only minor improvements in total time, but what appear to be good benefits in user, system, and CPU.

```
# without Bootsnap
bin/rails s  8.94s user 2.23s system 54% cpu 20.607 total
bin/rails s  8.90s user 2.24s system 54% cpu 20.346 total
bin/rails s  9.33s user 2.50s system 54% cpu 21.531 total

# with Bootsnap
bin/rails s  6.54s user 0.79s system 36% cpu 20.085 total
bin/rails s  6.67s user 0.84s system 33% cpu 22.091 total
bin/rails s  6.76s user 0.98s system 29% cpu 26.509 total
```
🤷‍♂️  

This is development mode, maybe production is significantly better? Or maybe there are options to be tuned?


